### PR TITLE
Fix requirements package names

### DIFF
--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -16,7 +16,7 @@ def get_latest_file(directory, ext="png"):
         return None
 
     # rather than search through the files, lets just check the symlink
-    lpath = os.path.join(directory + "latest_camera." + ext)
+    lpath = os.path.join(directory, f"latest_camera.{ext}")
     if os.path.exists(lpath):
         return lpath
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==1.13.2
 APScheduler==3.10.4
 fake-useragent==1.4.0
 Flask==3.0.3
-flask_apscheduler==1.13.1
+Flask-APScheduler==1.13.1
 Flask-Login==0.6.3
 Jinja2==3.1.4
 numpy==1.24.4
@@ -11,14 +11,14 @@ Pillow==10.4.0
 psutil==6.0.0
 pysqlite3==0.5.3
 pyvirtualdisplay==3.0
-scikit_image==0.21.0
+scikit-image==0.21.0
 selenium==4.23.1
 SQLAlchemy==2.0.32
 torch==2.4.0
 transformers==4.44.0
 undetected-chromedriver==3.5.5
-webdriver_manager==4.0.2
+webdriver-manager==4.0.2
 Werkzeug==3.0.3
-yt-dlp-2024.10.22
+yt-dlp==2024.10.22
 pynput==1.7.7
-dateutil
+python-dateutil

--- a/tests/test_video_details.py
+++ b/tests/test_video_details.py
@@ -2,16 +2,22 @@ import unittest
 import tempfile
 import os
 import sys
+import importlib.util
 from datetime import datetime, timedelta
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-from app.utils.video_details import (
-    get_latest_video_date,
-    get_latest_screenshot_date,
-    get_latest_file,
-    get_latest_date,
+# Dynamically load the video_details module without importing the full
+# ``app`` package and its heavy dependencies.
+module_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "app", "utils", "video_details.py")
 )
+spec = importlib.util.spec_from_file_location("video_details", module_path)
+video_details = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(video_details)
+
+get_latest_video_date = video_details.get_latest_video_date
+get_latest_screenshot_date = video_details.get_latest_screenshot_date
+get_latest_file = video_details.get_latest_file
+get_latest_date = video_details.get_latest_date
 
 
 class TestVideoDetails(unittest.TestCase):
@@ -65,11 +71,14 @@ class TestVideoDetails(unittest.TestCase):
 
         latest_file = get_latest_file(self.temp_dir, ext="txt")
         self.assertEqual(latest_file, "file2.txt")
+
         self.create_dummy_file("latest_camera.png", days_ago=5)
         latest_file = get_latest_file(self.temp_dir, ext="txt")
         self.assertEqual(latest_file, "file2.txt")
+
         latest_file = get_latest_file(self.temp_dir, ext="png")
-        self.assertEqual(latest_file, "latest_camera.png")
+        expected_path = os.path.join(self.temp_dir, "latest_camera.png")
+        self.assertEqual(latest_file, expected_path)
 
     def test_get_latest_date(self):
         self.create_dummy_file("file1.txt", days_ago=2)


### PR DESCRIPTION
## Summary
- fix invalid package names in `requirements.txt`
- keep path join fix for `get_latest_file`
- update tests for new path

## Testing
- `python3 tests/test_video_details.py`
- `python3 -m unittest tests.test_video_details`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file path handling to prevent potential path errors when accessing symlink files.
  - Updated tests to correctly compare full file paths, ensuring more accurate test validation.

- **Chores**
  - Standardized package names and version specifications in dependencies for better consistency and compatibility.
  - Adjusted test imports to avoid unnecessary dependencies during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->