### PR TITLE
Add FFPROBE_PATH setting and update video_archiver

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -121,8 +121,9 @@ LLM_CAPTION_PROMPT = get_setting(
     #"Write a concise caption that highlights the most significant or unique aspect of this image in 10 words or less. Avoid general descriptions, and focus on noteworthy details or anomalies. Then, provide a brief, more detailed description in a couple of sentences. The time is $datetime UTC.",
 )
 
-# FFMPEG path setting
+# FFMPEG/FFPROBE path settings
 FFMPEG_PATH = get_setting("FFMPEG_PATH", "ffmpeg")
+FFPROBE_PATH = get_setting("FFPROBE_PATH", "ffprobe")
 
 
 # New settings for capture_frame_from_stream function

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -17,6 +17,8 @@ from app.config import (
     SCREENSHOT_DIRECTORY,
     VERSION,
     VIDEO_DIRECTORY,
+    FFMPEG_PATH,
+    FFPROBE_PATH,
 )
 
 from .template_manager import get_templates
@@ -133,7 +135,7 @@ def compile_videos(input_file, output_file):
         return False
 
     create_command = [
-        "ffmpeg", # TODO make this a config value
+        FFMPEG_PATH,
         "-threads",
         "5",
         "-err_detect",
@@ -182,7 +184,7 @@ def get_video_duration(video_path):
 
     """Get the duration of a video in seconds."""
     command = [
-        "ffprobe", # TODO: make this a config 
+        FFPROBE_PATH,
         "-v",
         "error",
         "-show_entries",
@@ -216,7 +218,7 @@ def concatenate_videos(in_process_video, temp_video, video_path) -> bool:
         if in_process_duration > 0 and temp_video_duration > 0:
             concat_video = os.path.join(video_path, "in_process.concat.mp4")
             concat_command = [
-                "ffmpeg",
+                FFMPEG_PATH,
                 "-threads",
                 "5", # todo, make this a config
                 #"-safe",  Option not found?  But it is found and used elsewhere?  Not surewhy this is..
@@ -384,7 +386,7 @@ def compile_to_video(camera_path, video_path) -> bool:
         temp_video = os.path.join(video_path, "in_process.tmp.mp4")
 
         create_command = [
-            "ffmpeg",
+            FFMPEG_PATH,
             "-threads",
             "5",
             "-f",


### PR DESCRIPTION
## Summary
- add `FFPROBE_PATH` config setting
- use `FFMPEG_PATH`/`FFPROBE_PATH` in video_archiver

## Testing
- `python -m py_compile app/config.py app/utils/video_archiver.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the path to the FFPROBE executable in addition to FFMPEG.

- **Chores**
  - Improved flexibility by allowing the use of custom paths for FFMPEG and FFPROBE executables instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->