### PR TITLE
Fix broken license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To set up the project for development:
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request.
 
 ## License
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.
 
 ### Steps to Contribute
 1. Fork the repository.
@@ -133,7 +133,7 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 For detailed suggestions on how to use Glimpser effectively, please check out our [Recommendations](docs/recommendations.md) guide.
 
 ## License
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.
 
 ## Acknowledgements
 We are grateful to the contributors and the open-source community. Special thanks to OpenAI for their powerful models that enable Glimpser's advanced features.


### PR DESCRIPTION
## Summary
- fix broken license link in README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `flake8` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated license file references in the README to point to "LICENSE.md" instead of "LICENSE".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->