### PR TITLE
Fix repo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,5 +32,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-[Unreleased]: https://github.com/yourusername/glimpser/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/yourusername/glimpser/releases/tag/v1.0.0
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/KristopherKubicki/glimpser/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ Pull requests are the best way to propose changes to the codebase. We actively w
 
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issues](https://github.com/yourusername/glimpser/issues)
+## Report bugs using Github's [issues](https://github.com/KristopherKubicki/glimpser/issues)
 
-We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/yourusername/glimpser/issues/new); it's that easy!
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/KristopherKubicki/glimpser/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,7 +11,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 1. Clone the Glimpser repository:
    ```
-   git clone https://github.com/yourusername/glimpser.git
+   git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ This guide provides detailed instructions for installing and setting up Glimpser
 ### 1. Clone the Repository
 
 ```sh
-git clone https://github.com/yourusername/glimpser.git
+git clone https://github.com/KristopherKubicki/glimpser.git
 cd glimpser
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,7 +80,7 @@ This guide addresses common issues that users might encounter while using Glimps
 If you're still experiencing issues after trying these solutions, please:
 
 1. Check our [FAQ](faq.md) for more information
-2. Search for similar issues in our [GitHub Issues](https://github.com/yourusername/glimpser/issues)
+2. Search for similar issues in our [GitHub Issues](https://github.com/KristopherKubicki/glimpser/issues)
 3. Post a new issue on GitHub with detailed information about your problem
 4. Reach out to our community support forum for assistance
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description="A real-time monitoring application for capturing and analyzing live data from various sources",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/glimpser",
+    url="https://github.com/KristopherKubicki/glimpser",
     packages=find_packages(),
     install_requires=requirements,
     classifiers=[


### PR DESCRIPTION
## Summary
- update repository URL in contributing and changelog
- use correct clone URL in docs
- fix project URL in setup.py

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all documentation and instructions to reference the correct GitHub repository URL and owner.
  - Bug reporting and troubleshooting links now direct users to the appropriate repository.
  - Installation and getting started guides now include the accurate repository clone URL.

- **Chores**
  - Updated project metadata to reflect the correct repository URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->