### PR TITLE
Add nodriver to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ Werkzeug==3.0.3
 yt-dlp==2024.10.22
 pynput==1.7.7
 python-dateutil
+
+nodriver


### PR DESCRIPTION
## Summary
- include nodriver in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement alembic==1.13.2)*
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new dependency to the application requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->