### PR TITLE
Increase test coverage

### DIFF
--- a/tests/test_network_testing.py
+++ b/tests/test_network_testing.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.utils.network_testing import network_idle_condition, check_network_errors, wait_for_element
+from selenium.webdriver.common.by import By
+
+class TestNetworkTesting(unittest.TestCase):
+    @patch('time.sleep', return_value=None)
+    def test_network_idle_condition_success(self, _):
+        driver = MagicMock()
+        log_entry = {'message': json.dumps({'message': {'params': {'response': {'url': 'http://example.com', 'status': 200}}}})}
+        driver.get_log.side_effect = [[log_entry], []]
+        ok, status = network_idle_condition(driver, 'http://example.com', timeout=0.1, idle_time=0)
+        self.assertTrue(ok)
+        self.assertEqual(status, 200)
+
+    @patch('time.sleep', return_value=None)
+    def test_network_idle_condition_error(self, _):
+        driver = MagicMock()
+        log_entry = {'message': json.dumps({'message': {'params': {'response': {'url': 'http://example.com', 'status': 404}}}})}
+        driver.get_log.return_value = [log_entry]
+        ok, status = network_idle_condition(driver, 'http://example.com', timeout=0.1, idle_time=0)
+        self.assertFalse(ok)
+        self.assertEqual(status, 404)
+
+    @patch('time.sleep', return_value=None)
+    def test_check_network_errors(self, _):
+        driver = MagicMock()
+        error_log = {'level': 'SEVERE', 'message': 'Failed to load resource'}
+        driver.get_log.side_effect = [[error_log], []]
+        found, errors = check_network_errors(driver, 'http://example.com', timeout=0.1)
+        self.assertTrue(found)
+        self.assertIn('Failed to load resource', errors[0])
+
+    @patch('time.sleep', return_value=None)
+    def test_wait_for_element(self, _):
+        driver = MagicMock()
+        element = object()
+        driver.find_element.return_value = element
+        result = wait_for_element(driver, '#id', timeout=0.1)
+        self.assertIs(result, element)
+        driver.find_element.assert_called_with(By.CSS_SELECTOR, '#id')
+
+        driver.find_element.side_effect = Exception()
+        result = wait_for_element(driver, '#id', timeout=0.1)
+        self.assertIsNone(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -7,7 +7,13 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.utils.retention_policy import delete_old_files
+from unittest.mock import patch
+
+from app.utils.retention_policy import (
+    delete_old_files,
+    get_files_sorted_by_creation_time,
+    retention_cleanup,
+)
 
 class TestRetentionPolicy(unittest.TestCase):
 
@@ -27,6 +33,33 @@ class TestRetentionPolicy(unittest.TestCase):
             # Check that only two files remain
             remaining_files = os.listdir(temp_dir)
             self.assertEqual(len(remaining_files), 2)
+
+    def test_get_files_sorted_by_creation_time(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            files = []
+            for i in range(3):
+                path = os.path.join(temp_dir, f"file{i}.txt")
+                with open(path, "w"):
+                    pass
+                os.utime(path, (100 + i, 100 + i))
+                files.append(path)
+
+            result = get_files_sorted_by_creation_time(temp_dir)
+            self.assertEqual(result, files)
+
+    @patch("app.utils.retention_policy.delete_old_files")
+    @patch("app.utils.retention_policy.get_files_sorted_by_creation_time", return_value=["a", "b"])
+    @patch("app.utils.retention_policy.os.listdir")
+    def test_retention_cleanup(self, mock_listdir, mock_get_files, mock_delete):
+        mock_listdir.side_effect = [["cam"], ["cam"]]
+        with tempfile.TemporaryDirectory() as vdir, tempfile.TemporaryDirectory() as sdir:
+            with patch("app.utils.retention_policy.VIDEO_DIRECTORY", vdir), patch(
+                "app.utils.retention_policy.SCREENSHOT_DIRECTORY", sdir
+            ):
+                retention_cleanup()
+
+        self.assertEqual(mock_get_files.call_count, 2)
+        self.assertEqual(mock_delete.call_count, 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add direct tests for network testing utilities
- expand retention policy tests to cover more functions

## Testing
- `pytest -q` *(fails: command not found)*