### PR TITLE
Fix duplicate License section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,6 @@ To set up the project for development:
 ## Contributing
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants and how to report issues.
 
-## License
-This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.
-
 ### Steps to Contribute
 1. Fork the repository.
 2. Create a feature branch.


### PR DESCRIPTION
## Summary
- remove duplicate License heading
- move contribution steps under Contributing

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to remove a duplicate "License" section, ensuring license information is only presented once at the end of the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->