### PR TITLE
Centralize template name validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,6 +58,7 @@ from app.utils import (
 from app.utils.db import SessionLocal
 #from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
+from app.utils.validators import validate_template_name
 
 def restart_server():
     print("Restarting server...")
@@ -70,40 +71,6 @@ def restart_server():
     restart_thread = Thread(target=delayed_restart)
     restart_thread.start()
 
-# todo: add this to utils so it is not duplicated in utils/video_archiver.py
-def validate_template_name(template_name: str):
-    if template_name is None or not isinstance(template_name, str):
-        return None
-
-    # Strict whitelist of allowed characters
-    allowed_chars = set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.')
-
-    # Check if all characters are in the allowed set
-    if not all(char in allowed_chars for char in template_name):
-        return None
-
-    # Check length
-    if len(template_name) == 0 or len(template_name) > 32:
-        return None
-
-    # Ensure the name doesn't start or end with a dash or underscore
-    if template_name[0] in '-_.' or template_name[-1] in '-_.':
-        return None
-    if '..' in template_name:
-        return None
-    if '--' in template_name:
-        return None
-    if '__' in template_name:
-        return None
-
-    # Use secure_filename as an additional safety measure
-    sanitized_name = secure_filename(template_name)
-
-    # Ensure secure_filename didn't change the name (which would indicate it found something suspicious)
-    if sanitized_name != template_name:
-        return None
-
-    return sanitized_name
 
 
 class TemplateName:

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -1,0 +1,33 @@
+# app/utils/validators.py
+
+from werkzeug.utils import secure_filename
+
+
+def validate_template_name(template_name: str):
+    """Return sanitized template name if valid, otherwise ``None``."""
+    if template_name is None or not isinstance(template_name, str):
+        return None
+
+    allowed_chars = set(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-." 
+    )
+    if not all(char in allowed_chars for char in template_name):
+        return None
+
+    if len(template_name) == 0 or len(template_name) > 32:
+        return None
+
+    if template_name[0] in "-_." or template_name[-1] in "-_.":
+        return None
+    if ".." in template_name:
+        return None
+    if "--" in template_name:
+        return None
+    if "__" in template_name:
+        return None
+
+    sanitized_name = secure_filename(template_name)
+    if sanitized_name != template_name:
+        return None
+
+    return sanitized_name

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 import time
 
-from werkzeug.utils import secure_filename
+from .validators import validate_template_name
 
 from app.config import (
     MAX_COMPRESSED_VIDEO_AGE,
@@ -22,42 +22,6 @@ from app.config import (
 )
 
 from .template_manager import get_templates
-
-
-# TODO: move this to utils so it is not duplicated in routes.py
-def validate_template_name(template_name: str):
-    if template_name is None or not isinstance(template_name, str):
-        return None
-
-    # Strict whitelist of allowed characters
-    allowed_chars = set('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.')
-
-    # Check if all characters are in the allowed set
-    if not all(char in allowed_chars for char in template_name):
-        return None
-
-    # Check length
-    if len(template_name) == 0 or len(template_name) > 32:
-        return None
-
-    # Ensure the name doesn't start or end with a dash or underscore
-    if template_name[0] in '-_.' or template_name[-1] in '-_.':
-        return None
-    if '..' in template_name:
-        return None
-    if '--' in template_name:
-        return None
-    if '__' in template_name:
-        return None
-
-    # Use secure_filename as an additional safety measure
-    sanitized_name = secure_filename(template_name)
-
-    # Ensure secure_filename didn't change the name (which would indicate it found something suspicious)
-    if sanitized_name != template_name:
-        return None
-
-    return sanitized_name
 
 
 

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from app.utils.validators import validate_template_name
 from app.utils.video_archiver import (
-    validate_template_name,
     touch,
     trim_group_name,
     compile_to_teaser,


### PR DESCRIPTION
## Summary
- add `app/utils/validators.py` containing shared `validate_template_name`
- import the shared validator in `app/routes.py` and `app/utils/video_archiver.py`
- update tests to use the new module

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized template name validation logic to a shared utility, ensuring consistent validation across the application.

- **Tests**
  - Updated import paths in tests to reflect the new location of the template name validation function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->