### PR TITLE
Improve live view recovery after backend restart

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -1,6 +1,10 @@
 {% include 'header.html' %}
 
 <body>
+    <script>
+        // Track the last time the health endpoint failed
+        window.lastHealthFailed = false;
+    </script>
     <header>
         {% include 'nav.html' %}
     </header>
@@ -200,7 +204,21 @@
         video.addEventListener('canplay', hideLoadingIndicator);
         video.addEventListener('play', () => showPlayPauseIndicator(false));
         video.addEventListener('pause', () => showPlayPauseIndicator(true));
-        video.addEventListener('error', (e) => showError('Error loading video: ' + e.target.error.message));
+        video.addEventListener('error', (e) => {
+            showError('Error loading video: ' + e.target.error.message);
+            setTimeout(() => {
+                if (typeof updateFeed === 'function') {
+                    updateFeed();
+                }
+            }, 2000);
+        });
+        image.addEventListener('error', () => {
+            setTimeout(() => {
+                if (typeof updateFeed === 'function') {
+                    updateFeed();
+                }
+            }, 2000);
+        });
 
 function changeCamera() {
     showLoadingIndicator();

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -21,7 +21,10 @@
 					    <div id="health-status" style="width: 15px; height: 15px; border-radius: 50%; background-color: grey;" title="System Performance"><a href='/status'></a></div>
 				    </td>
 	<script>
-		function checkHealth() {
+                if (typeof window.lastHealthFailed === 'undefined') {
+                    window.lastHealthFailed = false;
+                }
+                function checkHealth() {
     fetch('/health')
         .then(response => response.json())
         .then(data => {
@@ -38,12 +41,22 @@
             if (data.error_messages && data.error_messages.length > 0) {
                 healthStatus.title += '\nErrors:\n' + data.error_messages.join('\n');
             }
+
+            if (window.lastHealthFailed) {
+                if (typeof updateFeed === 'function') {
+                    updateFeed();
+                } else {
+                    window.location.reload();
+                }
+                window.lastHealthFailed = false;
+            }
         })
         .catch(error => {
             console.error('Error fetching health status:', error);
             const healthStatus = document.getElementById('health-status');
             healthStatus.style.backgroundColor = 'red';
             healthStatus.title = 'Error: Unable to fetch health status';
+            window.lastHealthFailed = true;
         });
 }
 


### PR DESCRIPTION
## Summary
- track `lastHealthFailed` in `live.html`
- reconnect when `/health` recovers using logic in `nav.html`
- retry the live feed if video or image elements emit `error` events

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement)*