### PR TITLE
Fix missing nav clock hand styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -432,6 +432,32 @@ button, a {
     position: absolute;
 }
 
+.hand {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform-origin: 50% 0;
+    transform: translateX(-50%);
+    background-color: #333;
+    pointer-events: none;
+}
+
+.hour-hand {
+    width: 2px;
+    height: 30%;
+}
+
+.minute-hand {
+    width: 2px;
+    height: 40%;
+}
+
+.second-hand {
+    width: 1px;
+    height: 45%;
+    background-color: #ff0000;
+}
+
 /* Template Form Styles */
 #template-form, #edit-template {
     background-color: #222;


### PR DESCRIPTION
## Summary
- add styles for analog clock hands in nav bar

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added visual styles for clock hands, including hour, minute, and second hands, to enhance the appearance of the clock component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->