### PR TITLE
Add architecture overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ## Introduction
 Glimpser is a straightforward yet powerful real-time monitoring application designed to capture, analyze, and summarize live data from various sources such as cameras, dashboards, and video streams. Utilizing advanced image processing techniques and AI models, Glimpser provides insightful summaries and alerts. It’s highly configurable, allowing users to tailor it to their specific monitoring needs through an easy-to-use interface.
+For a high-level look at how Glimpser works, see the [Architecture Overview](docs/architecture_overview.md). The full documentation is available in the [docs directory](docs/index.md).
+
 
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,26 @@
+# Glimpser Architecture Overview
+
+This document provides a high level overview of the major components of Glimpser and describes how data flows from capture to summary.
+
+## Key Components
+
+- **Web server (`app/routes.py`)**: Flask application that exposes the web interface and REST API. It handles user authentication, template management, status pages, and endpoints for retrieving screenshots and summaries.
+- **Utility modules (`app/utils/`)**: Collection of helpers responsible for capturing data, processing images, interacting with LLMs, and scheduling jobs. Important modules include:
+  - `screenshots.py` – capture or download screenshots and video frames.
+  - `image_processing.py` and `detect.py` – analyze images and detect motion.
+  - `llm.py` – generate captions and summaries using language models.
+  - `scheduling.py` – orchestrate periodic jobs via APScheduler.
+  - `db.py` – initialize the SQLite database connection.
+- **Scheduler**: The background APScheduler instance defined in `scheduling.py` runs capture and summarization jobs on a defined interval.
+- **Database**: A lightweight SQLite database stores template details and other persistent metadata.
+
+## Data Flow
+
+1. **Template Configuration** – Users define capture templates in the web interface. Each template specifies the source to capture and how frequently it should run.
+2. **Scheduled Capture** – The scheduler triggers `update_camera` for each template. `screenshots.py` grabs an image or frame based on the template settings.
+3. **Processing and Detection** – Captured data is analyzed with `detect.py` and `image_processing.py`. When motion or changes are detected, captions are generated with `llm.py`.
+4. **Database and Storage** – Metadata is written to the database while screenshots and videos are saved under the `data/` directory.
+5. **Summaries** – Periodically, `update_summary` compiles recent captions and uses the language model to generate a textual summary saved in `data/summaries/`.
+6. **Presentation** – Routes in `app/routes.py` serve screenshots, summaries, and system status through the web interface and API.
+
+This flow allows Glimpser to continuously monitor sources, analyze results, and provide human‑readable summaries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Glimpser Documentation
+
+Welcome to the Glimpser documentation. The pages below provide instructions for installing, using, and extending the project.
+
+- [Getting Started](getting_started.md)
+- [Installation Guide](installation.md)
+- [Configuration Guide](configuration_guide.md)
+- [Architecture Overview](architecture_overview.md)
+- [Capture Process](capture_process.md)
+- [Integration Guide](integration_guide.md)
+- [Developer Guide](developer_guide.md)
+- [API Documentation](api_documentation.md)
+- [Troubleshooting](troubleshooting.md)
+- [Recommendations](recommendations.md)
+- [FAQ](faq.md)


### PR DESCRIPTION
## Summary
- document overall architecture and data flow
- add docs index with links to all guides
- link architecture overview and docs index from README

## Testing
- `python -m coverage run -m pytest` *(fails: No module named coverage)*
- `pytest` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the README with direct links to the Architecture Overview and full documentation index.
  - Added a high-level Architecture Overview document outlining system components and data flow.
  - Introduced a comprehensive documentation index for easier navigation of project resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->