### PR TITLE
Add documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 ## Introduction
 Glimpser is a straightforward yet powerful real-time monitoring application designed to capture, analyze, and summarize live data from various sources such as cameras, dashboards, and video streams. Utilizing advanced image processing techniques and AI models, Glimpser provides insightful summaries and alerts. It’s highly configurable, allowing users to tailor it to their specific monitoring needs through an easy-to-use interface.
 
+For more documentation, see the [documentation index](docs/index.md).
+
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)
 
 ## Features

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Glimpser Documentation
+
+Glimpser is a monitoring platform that captures images and video streams, using advanced image processing and AI to summarize and alert on changes. This page links to the guides and references available in the repository.
+
+- [API Documentation](api_documentation.md)
+- [Capture Process](capture_process.md)
+- [Configuration Guide](configuration_guide.md)
+- [Developer Guide](developer_guide.md)
+- [FAQ](faq.md)
+- [Getting Started](getting_started.md)
+- [Installation Guide](installation.md)
+- [Integration Guide](integration_guide.md)
+- [Recommendations](recommendations.md)
+- [Troubleshooting](troubleshooting.md)
+


### PR DESCRIPTION
## Summary
- add `docs/index.md` with links to all docs
- link to `docs/index.md` from the introduction in `README.md`

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m coverage run -m pytest` *(fails: No module named coverage)*