### PR TITLE
Unify camera name validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -792,7 +792,9 @@ def init_routes(app):
         most_recent_file = None
         last_file = None
         for template in sorted_templates:
-            name = secure_filename(template.get("name"))
+            name = validate_template_name(template.get("name"))
+            if name is None:
+                continue
             path = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "..",
@@ -981,7 +983,9 @@ def init_routes(app):
         )
 
         for camera_id, template in sorted_templates:
-            camera_name = template.get("name")
+            camera_name = validate_template_name(template.get("name"))
+            if camera_name is None:
+                continue
             # Assuming the MP4 file is the segment
             lkey = generate_timed_hash()
             video_path = f"{request.url_root}last_video/{camera_name}?timed_key={lkey}"

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from werkzeug.utils import secure_filename
+from .validators import validate_template_name
 
 from app.config import SCREENSHOT_DIRECTORY, VIDEO_DIRECTORY
 
@@ -102,11 +103,8 @@ class TemplateManager:
 
     def save_template(self, name, details):
 
-        # embed the validators here... 
-        # TODO: replace this with validate_template_name instead
-        if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
-            return False
-        if '..' in name:
+        name = validate_template_name(name)
+        if name is None:
             return False
 
         session = self.get_session()
@@ -175,7 +173,8 @@ class TemplateManager:
             session.close()
 
     def get_template(self, name):
-        if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+        name = validate_template_name(name)
+        if name is None:
             return False
 
         session = self.get_session()
@@ -189,7 +188,8 @@ class TemplateManager:
             session.close()
 
     def delete_template(self, name):
-        if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+        name = validate_template_name(name)
+        if name is None:
             return False
 
         session = self.get_session()
@@ -222,15 +222,19 @@ def get_templates():
     for template_name, details in templates.items():
         if template_name is None or template_name == "":
             continue
-        camera_path = os.path.join(SCREENSHOT_DIRECTORY, secure_filename(template_name))
-        video_path = os.path.join(VIDEO_DIRECTORY, secure_filename(template_name))
+        valid_name = validate_template_name(template_name)
+        if valid_name is None:
+            continue
+        camera_path = os.path.join(SCREENSHOT_DIRECTORY, secure_filename(valid_name))
+        video_path = os.path.join(VIDEO_DIRECTORY, secure_filename(valid_name))
         details["last_screenshot_time"] = get_latest_screenshot_date(camera_path)
         details["last_video_time"] = get_latest_video_date(video_path)
     return templates
 
 
 def get_template(name):
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return None
 
     manager = TemplateManager()
@@ -238,7 +242,8 @@ def get_template(name):
 
 
 def save_template(name: str, template_data) -> bool:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return False
 
     manager = TemplateManager()
@@ -252,7 +257,8 @@ def save_template(name: str, template_data) -> bool:
 
 
 def delete_template(name: str) -> bool:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return False
 
     manager = TemplateManager()
@@ -273,7 +279,8 @@ def get_template_by_id(template_id: int):
 
 
 def get_screenshots_for_template(name: str) -> list:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return []
     if not os.path.exists(os.path.join(SCREENSHOT_DIRECTORY, name)):
         return []
@@ -297,7 +304,8 @@ def get_screenshots_for_template(name: str) -> list:
 
 
 def get_videos_for_template(name: str):
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return []
     if not os.path.exists(os.path.join(VIDEO_DIRECTORY, name)):
         return []
@@ -313,7 +321,8 @@ def get_videos_for_template(name: str):
     return sorted_videos[:10]
 
 def get_screenshot_count(name: str) -> int:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return 0
     screenshot_path = os.path.join(SCREENSHOT_DIRECTORY, name)
     if not os.path.exists(screenshot_path):
@@ -321,7 +330,8 @@ def get_screenshot_count(name: str) -> int:
     return len([f for f in os.listdir(screenshot_path) if f.endswith('.png')])
 
 def get_video_count(name: str) -> int:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return 0
     video_path = os.path.join(VIDEO_DIRECTORY, name)
     if not os.path.exists(video_path):
@@ -329,7 +339,8 @@ def get_video_count(name: str) -> int:
     return len([f for f in os.listdir(video_path) if f.endswith('.mp4')])
 
 def get_storage_usage(name: str) -> str:
-    if not re.findall(r"^[a-zA-Z0-9_\-\.]{1,32}$", name):
+    name = validate_template_name(name)
+    if name is None:
         return "0 B"
     screenshot_path = os.path.join(SCREENSHOT_DIRECTORY, name)
     video_path = os.path.join(VIDEO_DIRECTORY, name)


### PR DESCRIPTION
## Summary
- reuse `validate_template_name` in template manager
- sanitize camera names when building playlist and selecting latest screenshot

## Testing
- `python -m py_compile app/utils/template_manager.py app/routes.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*