### PR TITLE
Fix license filename in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
-include LICENSE
+include LICENSE.md
 include requirements.txt
 recursive-include glimpser/static *
 recursive-include glimpser/templates *


### PR DESCRIPTION
## Summary
- reference `LICENSE.md` in MANIFEST
- ensure MANIFEST ends with a newline

## Testing
- `pytest -q` *(fails: `FileNotFoundError: [Errno 2] No such file or directory: 'ip'`)*