### PR TITLE
Add DEBUG_MODE alias

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -84,6 +84,8 @@ NAME = get_setting("NAME", "glimpser")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))
 DEBUG = get_setting("DEBUG", "True") == "True"
+# Provide a separate attribute for runtime checks
+DEBUG_MODE = DEBUG
 MAX_WORKERS = get_setting("MAX_WORKERS", 8)
 
 # Thresholds

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -28,6 +28,7 @@ can modify them in the application interface or directly in the database.
 - `HOST` – address to bind the server (default `0.0.0.0`)
 - `PORT` – port for the web interface (default `8082`)
 - `DEBUG` – enable debug mode (default `True`)
+- `DEBUG_MODE` – runtime alias of `DEBUG` used by the command-line interface
 - `MAX_WORKERS` – number of worker threads (default `8`)
 - `LOG_LEVEL` – logging level (`INFO`, `WARN`, `DEBUG`, etc.)
 


### PR DESCRIPTION
## Summary
- expose `DEBUG_MODE` alias in config
- document `DEBUG_MODE` in config guide

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ip')*