### PR TITLE
Fix log caching scheduling and adjust tests

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -936,14 +936,7 @@ def start_log_caching():
     log_caching_thread = threading.Thread(target=cache_logs, daemon=True)
     log_caching_thread.start()
 
-    # Ensure the job is only scheduled ONCE
-    if not scheduler.get_job('log_caching'):
-        scheduler.add_job(func=cache_logs, trigger='interval', hours=1, id='log_caching', replace_existing=True)
+    # No longer schedule cache_logs via the APScheduler.  The background thread
+    # itself handles continuous log caching and avoids spawning additional
+    # threads on scheduler restarts.
 
-
-'''
-def start_log_caching():
-    log_caching_thread = threading.Thread(target=cache_logs, daemon=True)
-    log_caching_thread.start()
-    scheduler.add_job(func=start_log_caching, trigger='interval', hours=1, id='log_caching', replace_existing=True)
-'''

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import socket
 import subprocess
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -28,24 +29,27 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(is_private_ip("8.8.8.8"))
         self.assertFalse(is_private_ip("1.1.1.1"))
 
-    def test_is_address_reachable(self):
-        # Test reachable address (assuming google.com is always reachable)
+    @patch('socket.gethostbyname')
+    @patch('socket.socket')
+    def test_is_address_reachable(self, mock_socket, mock_gethostbyname):
+        # Simulate DNS resolution success, failure, and success
+        mock_gethostbyname.side_effect = ['1.1.1.1', Exception('fail'), '1.1.1.1']
+        mock_instance = mock_socket.return_value
+        mock_instance.connect_ex.return_value = 0
+
         self.assertTrue(is_address_reachable("google.com"))
-
-        # Test unreachable address
         self.assertFalse(is_address_reachable("nonexistent.domain.com"))
-
-        # Test with different port
         self.assertTrue(is_address_reachable("google.com", port=443))
 
         # Test with timeout
         #self.assertFalse(is_address_reachable("10.255.255.255", timeout=1)) # for some reason this passes on my network...
 
-    def test_is_port_open(self):
-        # Test open port (assuming port 80 is open on google.com)
-        self.assertTrue(is_port_open("google.com", 80))
+    @patch('socket.socket')
+    def test_is_port_open(self, mock_socket):
+        mock_instance = mock_socket.return_value.__enter__.return_value
+        mock_instance.connect.side_effect = [None, socket.timeout()]
 
-        # Test closed port
+        self.assertTrue(is_port_open("google.com", 80))
         self.assertFalse(is_port_open("google.com", 12345))
 
         # Test with timeout
@@ -72,16 +76,11 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(domain, "2001:db8::1")
         self.assertEqual(port, 8080)
 
-    def test_get_arp_output(self):
-        # Test get_arp_output function
-        # Note: This test might need to be adjusted based on the actual implementation and system
-        try:
-            output = get_arp_output("127.0.0.1", timeout=1)
-            self.assertIsInstance(output, bytes)
-        except subprocess.TimeoutExpired:
-            self.skipTest("ARP command timed out")
-        except subprocess.CalledProcessError:
-            self.skipTest("ARP command failed")
+    @patch('subprocess.check_output')
+    def test_get_arp_output(self, mock_check_output):
+        mock_check_output.return_value = b'REACHABLE'
+        output = get_arp_output("127.0.0.1", timeout=1)
+        self.assertIsInstance(output, bytes)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -8,7 +8,7 @@ import logging
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.utils.scheduling import scheduler, schedule_crawlers
+from app.utils.scheduling import scheduler, schedule_crawlers, start_log_caching
 
 class TestScheduler(unittest.TestCase):
 
@@ -103,6 +103,17 @@ class TestScheduler(unittest.TestCase):
 
         # Verify the job is removed
         self.assertIsNone(scheduler.get_job('test_job'))
+
+    @patch('threading.Thread')
+    @patch('app.utils.scheduling.scheduler.add_job')
+    def test_start_log_caching_only_spawns_thread(self, mock_add_job, mock_thread):
+        mock_thread.return_value.start = MagicMock()
+
+        start_log_caching()
+
+        mock_thread.assert_called_once()
+        mock_thread.return_value.start.assert_called_once()
+        mock_add_job.assert_not_called()
 
     '''
     @patch('app.utils.scheduling.scheduler.add_job')


### PR DESCRIPTION
## Summary
- remove redundant scheduling for `cache_logs`
- test that `start_log_caching` only starts a thread
- patch network-related tests to avoid real network calls

## Testing
- `pytest -q`