### PR TITLE
Fix stylesheet and remove duplicate scripts

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -116,8 +116,12 @@ body {
 }
 
 
-.link color: {  rgb( 192, 192, 192) }
-.link:hover color: {  rgb( 193, 193, 193) }
+.link {
+    color: rgb(192, 192, 192);
+}
+.link:hover {
+    color: rgb(193, 193, 193);
+}
 
 h1, h2 {
     color: rgb(191, 191, 191);

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glimpser</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
      <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -133,47 +133,6 @@ function validateForm() {
 }
 
 
-function showStructuredInput(inputId) {
-    const input = document.getElementById(inputId);
-    const structuredInputHtml = `
-        <div class="structured-xpath-input">
-            <select id="${inputId}_tag">
-                <option value="div">div</option>
-                <option value="span">span</option>
-                <option value="a">a</option>
-                <option value="p">p</option>
-                <option value="*">*</option>
-            </select>
-            <select id="${inputId}_attribute">
-                <option value="class">class</option>
-                <option value="id">id</option>
-                <option value="name">name</option>
-                <option value="data-*">data-*</option>
-            </select>
-            <input type="text" id="${inputId}_value" placeholder="Attribute value">
-            <button type="button" onclick="generateXPath('${inputId}')">Generate XPath</button>
-        </div>
-    `;
-    input.insertAdjacentHTML('afterend', structuredInputHtml);
-    input.style.display = 'none';
-}
-
-function generateXPath(inputId) {
-    const tag = document.getElementById(`${inputId}_tag`).value;
-    const attribute = document.getElementById(`${inputId}_attribute`).value;
-    const value = document.getElementById(`${inputId}_value`).value;
-    
-    let xpath = `//${tag}`;
-    if (attribute === 'data-*') {
-        xpath += `[starts-with(@data-,'${value}')]`;
-    } else {
-        xpath += `[contains(@${attribute},'${value}')]`;
-    }
-    
-    document.getElementById(inputId).value = xpath;
-    document.getElementById(inputId).style.display = 'block';
-    document.querySelector(`#${inputId} + .structured-xpath-input`).remove();
-}
 </script>
 
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -257,47 +257,6 @@ function validateForm() {
     return true;
 }
 
-function showStructuredInput(inputId) {
-    const input = document.getElementById(inputId);
-    const structuredInputHtml = `
-        <div class="structured-xpath-input">
-            <select id="${inputId}_tag">
-                <option value="div">div</option>
-                <option value="span">span</option>
-                <option value="a">a</option>
-                <option value="p">p</option>
-                <option value="*">*</option>
-            </select>
-            <select id="${inputId}_attribute">
-                <option value="class">class</option>
-                <option value="id">id</option>
-                <option value="name">name</option>
-                <option value="data-*">data-*</option>
-            </select>
-            <input type="text" id="${inputId}_value" placeholder="Attribute value">
-            <button type="button" onclick="generateXPath('${inputId}')">Generate XPath</button>
-        </div>
-    `;
-    input.insertAdjacentHTML('afterend', structuredInputHtml);
-    input.style.display = 'none';
-}
-
-function generateXPath(inputId) {
-    const tag = document.getElementById(`${inputId}_tag`).value;
-    const attribute = document.getElementById(`${inputId}_attribute`).value;
-    const value = document.getElementById(`${inputId}_value`).value;
-
-    let xpath = `//${tag}`;
-    if (attribute === 'data-*') {
-        xpath += `[starts-with(@data-,'${value}')]`;
-    } else {
-        xpath += `[contains(@${attribute},'${value}')]`;
-    }
-
-    document.getElementById(inputId).value = xpath;
-    document.getElementById(inputId).style.display = 'block';
-    document.querySelector(`#${inputId} + .structured-xpath-input`).remove();
-}
 
 function confirmDelete(templateName) {
     const confirmed = confirm("Are you sure you want to delete this template?");


### PR DESCRIPTION
## Summary
- add meta viewport for responsive design
- fix invalid `.link` CSS rules
- remove duplicate `showStructuredInput` and `generateXPath` scripts

## Testing
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ip')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected link color styling and hover effects for improved visual consistency.

- **New Features**
  - Improved mobile responsiveness by adding a viewport meta tag.

- **Refactor**
  - Removed the structured XPath input interface and related interactive features, reverting to simple text input for XPath fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->