### PR TITLE
Add JavaScript tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,11 +23,16 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "18"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        npm install
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -37,3 +42,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+    - name: Run JavaScript tests
+      run: |
+        npm test

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -533,3 +533,12 @@ function startCasting() {
   }
 }
 
+// Export functions for Node-based tests
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    loadTemplates,
+    updateGridLayout,
+    timeAgo,
+  };
+}
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testMatch: ['**/tests/js/**/*.test.js'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "glimpser",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}


### PR DESCRIPTION
## Summary
- export helper functions from script.js for Node-based testing
- add package.json and Jest config for JavaScript tests
- extend GitHub Actions workflow to run JS tests with Node

## Testing
- `npm test` *(fails: jest not installed)*
- `pytest` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.