### PR TITLE
Add proxy support for image downloader

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -553,9 +553,27 @@ def add_timestamp(image_path, name="unknown", invert=False):
 
 
 def download_image(
-    url, output_path, timeout=CAPTURE_TIMEOUT, name="unknown", invert=False, dark=False, stealth=False
+    url,
+    output_path,
+    timeout=CAPTURE_TIMEOUT,
+    name="unknown",
+    invert=False,
+    dark=False,
+    stealth=False,
+    proxy=None,
 ):
-    """Attempt to download an image directly from the URL and convert it to PNG format."""
+    """Attempt to download an image directly from the URL and convert it to PNG format.
+
+    Args:
+        url (str): Image URL.
+        output_path (str): Where to save the PNG.
+        timeout (int): Timeout in seconds.
+        name (str): Friendly name for logging.
+        invert (bool): If True, invert timestamp colors.
+        dark (bool): Apply dark mode.
+        stealth (bool): Use stealth user agent.
+        proxy (str, optional): Proxy to use for the HTTP request.
+    """
 
     # ideally the timeout should be pretty high, its an image, and it could be real big
     if timeout < 10:
@@ -569,31 +587,40 @@ def download_image(
             cv = get_chrome_version(chrome_path)
             lua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s.0.0.0 Safari/537.36" % cv
         headers = {"user-agent": lua}
-
-        # TODO: apply proxy here
+        proxies = {"http": proxy, "https": proxy} if proxy else None
 
         auth = None
         for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
             auth = requests.auth.HTTPBasicAuth(leach[0], leach[1])
 
         # TODO: cache the response status_code
-        #response = requests.get(
-        response = http_session().get(
-            url, stream=True, timeout=(timeout, timeout*3), verify=False, headers=headers, auth=auth
+        request_kwargs = dict(
+            stream=True,
+            timeout=(timeout, timeout * 3),
+            verify=False,
+            headers=headers,
+            auth=auth,
         )
+        if proxies:
+            request_kwargs["proxies"] = proxies
+
+        response = http_session().get(url, **request_kwargs)
         if (
             response.status_code == 401 and auth is not None
         ):  # Unauthorized, try Digest Authentication
             for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
                 auth = requests.auth.HTTPDigestAuth(leach[0], leach[1])
-            response = http_session().get(
-                url,
+            request_kwargs = dict(
                 stream=True,
-                timeout=(timeout,timeout*3),
+                timeout=(timeout, timeout * 3),
                 verify=False,
                 headers=headers,
                 auth=auth,
             )
+            if proxies:
+                request_kwargs["proxies"] = proxies
+
+            response = http_session().get(url, **request_kwargs)
 
         if response.status_code == 200:
             # Open the image directly from the response bytes
@@ -890,7 +917,16 @@ def capture_or_download(name: str, template: dict) -> bool:
 
     # Attempt to download or capture based on content type and URL
     if is_image_url(url, content_type) and not danger and not browser:
-        lsuc = download_image(url, output_path, timeout, name, invert)
+        lsuc = download_image(
+            url,
+            output_path,
+            timeout,
+            name,
+            invert,
+            dark,
+            stealth,
+            template.get("proxy"),
+        )
         if lsuc is True:
             return lsuc
         cas_error(url)

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -6,10 +6,12 @@ import tempfile
 import os
 import sys
 import logging
+import io
+from PIL import Image
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.utils.screenshots import capture_screenshot_and_har
+from app.utils.screenshots import capture_screenshot_and_har, download_image
 
 class TestScreenshotCapture(unittest.TestCase):
     def setUp(self):
@@ -110,6 +112,31 @@ class TestScreenshotCapture(unittest.TestCase):
         #mock_driver.execute_cdp_cmd.assert_called_with(
         #    "Emulation.setAutoDarkModeOverride", {"enabled": True}
         #)
+
+    @patch("app.utils.screenshots.http_session")
+    def test_download_image_uses_proxy(self, mock_session_factory):
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        # create a tiny valid PNG
+        img_bytes = io.BytesIO()
+        Image.new("RGB", (1, 1)).save(img_bytes, format="PNG")
+        mock_response.status_code = 200
+        mock_response.content = img_bytes.getvalue()
+        mock_session.get.return_value = mock_response
+        mock_session_factory.return_value = mock_session
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+            download_image(
+                "http://example.com/test.png",
+                tmp.name,
+                proxy="http://proxy:8080",
+            )
+
+        kwargs = mock_session.get.call_args.kwargs
+        self.assertEqual(
+            kwargs.get("proxies"),
+            {"http": "http://proxy:8080", "https": "http://proxy:8080"},
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `download_image` to accept a `proxy` parameter
- send proxy settings to the requests session
- forward template proxy when downloading images
- test proxy handling for image downloads

## Testing
- `pytest tests/test_screenshot_capture.py::TestScreenshotCapture::test_download_image_uses_proxy -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ip', AssertionError: google.com not reachable)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for using a proxy server when downloading images.
- **Tests**
  - Introduced a new test to verify that image downloads correctly utilize the specified proxy settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->