### PR TITLE
Add tests for templates, screenshots and API routes

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -25,6 +25,18 @@ pytest
 ```
 Running the full test suite helps ensure that your changes do not introduce regressions.
 
+### Test Fixtures
+
+Reusable pytest fixtures are defined in `tests/conftest.py`. A helpful one is
+`temp_media_dirs`, which creates temporary screenshot and video directories and
+patches the configuration paths. Use it in your tests by accepting the fixture
+as an argument:
+
+```python
+def test_something(temp_media_dirs):
+    pass
+```
+
 ## Contribution Workflow
 
 We follow a standard GitHub Flow:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import tempfile
+import shutil
+import pytest
+
+@pytest.fixture
+def temp_media_dirs(monkeypatch):
+    screenshot_dir = tempfile.mkdtemp()
+    video_dir = tempfile.mkdtemp()
+    monkeypatch.setattr('app.config.SCREENSHOT_DIRECTORY', screenshot_dir, raising=False)
+    monkeypatch.setattr('app.config.VIDEO_DIRECTORY', video_dir, raising=False)
+    yield {'screenshots': screenshot_dir, 'videos': video_dir}
+    shutil.rmtree(screenshot_dir, ignore_errors=True)
+    shutil.rmtree(video_dir, ignore_errors=True)

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,53 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app
+
+class TestAPIRoutes(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(watchdog=False, schedule=False)
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    def test_health_requires_auth(self):
+        resp = self.client.get('/health')
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn('/login', resp.headers['Location'])
+
+    @patch('app.routes.SessionLocal')
+    @patch('app.routes.scheduling')
+    def test_health_with_key(self, mock_sched, mock_session):
+        mock_sched.get_system_metrics.return_value = {
+            'cpu_usage': 1,
+            'memory_usage': 1,
+            'thread_count': 1,
+            'open_files': 1,
+            'disk_usage': 1,
+            'uptime': '1h 0m 0s'
+        }
+        mock_sched.scheduler.running = True
+        mock_session.return_value.execute.return_value = None
+        mock_session.return_value.close.return_value = None
+        with patch('app.routes.API_KEY', 'secret'):
+            resp = self.client.get('/health', headers={'X-API-Key': 'secret'})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn('status', data)
+        self.assertIn('metrics', data)
+
+    @patch('app.routes.template_manager.get_templates', return_value={'t1': {}})
+    def test_templates_endpoint(self, mock_get):
+        with patch('app.routes.API_KEY', 'secret'):
+            resp = self.client.get('/templates?group=all', headers={'X-API-Key': 'secret'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {'t1': {}})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_capture_or_download.py
+++ b/tests/test_capture_or_download.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest.mock import patch
+from app.utils.screenshots import capture_or_download
+
+class TestCaptureOrDownload(unittest.TestCase):
+    @patch('app.utils.screenshots.cas_error')
+    @patch('app.utils.screenshots.download_image')
+    @patch('app.utils.screenshots.get_content_type')
+    @patch('app.utils.screenshots.is_address_reachable')
+    def test_capture_success(self, mock_reachable, mock_content, mock_download, mock_cas):
+        mock_reachable.return_value = True
+        mock_content.return_value = ('image/png', True)
+        mock_download.return_value = True
+        template = {'url': 'http://example.com/test.png', 'timeout': 1}
+        self.assertTrue(capture_or_download('cam', template))
+        mock_download.assert_called_once()
+
+    @patch('app.utils.screenshots.cas_error')
+    @patch('app.utils.screenshots.download_image')
+    @patch('app.utils.screenshots.get_content_type')
+    @patch('app.utils.screenshots.is_address_reachable')
+    def test_capture_unreachable(self, mock_reachable, mock_content, mock_download, mock_cas):
+        mock_reachable.return_value = False
+        template = {'url': 'http://badhost/test.png'}
+        self.assertFalse(capture_or_download('cam', template))
+        mock_download.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_template_manager_metadata.py
+++ b/tests/test_template_manager_metadata.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+from app.utils.template_manager import get_templates
+from app.utils.validators import validate_template_name
+
+class TestGetTemplatesWrapper(unittest.TestCase):
+    @patch('app.utils.template_manager.get_latest_video_date')
+    @patch('app.utils.template_manager.get_latest_screenshot_date')
+    @patch('app.utils.template_manager.TemplateManager.get_templates')
+    def test_sanitized_and_metadata(self, mock_get, mock_screenshot, mock_video):
+        mock_get.return_value = {
+            'valid_name': {'name': 'valid_name'}
+        }
+        mock_screenshot.return_value = 's_time'
+        mock_video.return_value = 'v_time'
+
+        result = get_templates()
+        self.assertIn('valid_name', result)
+        self.assertEqual(validate_template_name('valid_name'), 'valid_name')
+        self.assertEqual(result['valid_name']['last_screenshot_time'], 's_time')
+        self.assertEqual(result['valid_name']['last_video_time'], 'v_time')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure developer guide shows pytest fixtures
- add pytest fixture for temporary media directories
- test template metadata retrieval
- unit test capture_or_download
- exercise health and templates API endpoints

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a section on test fixtures to the developer guide, including usage examples for temporary media directories in tests.

- **Tests**
  - Introduced new unit tests for API routes, screenshot capture or download functionality, and template metadata retrieval.
  - Added reusable test fixtures for creating and cleaning up temporary directories during tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->