### PR TITLE
Add .env support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,11 @@ import os
 import json
 import logging
 
+from dotenv import load_dotenv, find_dotenv
+
+# Load variables from a `.env` file if present
+load_dotenv(find_dotenv())
+
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
@@ -19,10 +24,16 @@ SessionLocal = sessionmaker(
 )  # settings only thread
 
 def get_setting(name, default=None):
+    """Return a setting from the environment or the database."""
+    env_val = os.getenv(name)
+    if env_val is not None:
+        return env_val
+
     session = SessionLocal()
     try:
         result = session.execute(
-            text("SELECT value FROM settings WHERE name = '%s'" % name)
+            text("SELECT value FROM settings WHERE name = :name"),
+            {"name": name},
         ).fetchone()
         return result[0] if result else default
     except Exception as e:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,7 +54,16 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
-### 6. Set Up the Database
+### 6. (Optional) Configure Environment Variables
+
+Copy `.env.example` to `.env` and adjust values to override defaults:
+
+```sh
+cp .env.example .env
+# edit .env as needed
+```
+
+### 7. Set Up the Database
 
 Initialize the local SQLite database:
 
@@ -64,7 +73,7 @@ python3 main.py
 
 You will be prompted to create a secret key. Follow the guided setup to complete the database initialization.
 
-### 7. Run the Application
+### 8. Run the Application
 
 After completing the setup, you can run the application:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ Werkzeug==3.0.3
 yt-dlp==2024.10.22
 pynput==1.7.7
 python-dateutil
+python-dotenv
 nodriver
 pytest


### PR DESCRIPTION
## Summary
- load `.env` files via python-dotenv
- allow environment variables to override settings before DB defaults
- document optional `.env` usage in installation guide
- include python-dotenv in requirements

## Testing
- `pytest tests/test_env.py -q`
- `pytest tests/test_settings_route.py::TestSettingsRoute::test_add_and_delete_setting -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Application now supports loading configuration from environment variables via a `.env` file.

- **Documentation**
  - Updated installation guide to include instructions for setting up environment variables with a `.env` file.

- **Chores**
  - Added `python-dotenv` as a required dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->