### PR TITLE
Fix double port check in debug mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,9 +226,20 @@ if __name__ == "__main__":
     logging.info("Initializing...")
     app = create_application()
 
-    # Check if the port is already in use
-    if is_port_in_use(config.PORT):
-        logging.error("Error: Port %s is already in use. Please choose a different port.", config.PORT)
+    # Check if the port is already in use. When debug mode is enabled, Flask's
+    # reloader will execute this block twice. The WERKZEUG_RUN_MAIN environment
+    # variable is only set for the reloader's second (real) run, so we skip the
+    # check on the initial bootstrap to avoid false positives.
+    should_check_port = (
+        not config.DEBUG_MODE
+        or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
+    )
+
+    if should_check_port and is_port_in_use(config.PORT):
+        logging.error(
+            "Error: Port %s is already in use. Please choose a different port.",
+            config.PORT,
+        )
         sys.exit(1)
 
     # Register the cleanup function to be called at exit


### PR DESCRIPTION
## Summary
- fix port check to run only once when using Flask debug mode

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of port-in-use checks when running in debug mode, preventing unnecessary errors during application startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->