### PR TITLE
Add camera discovery feature

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -53,7 +53,8 @@ from app.utils import (
     scheduling,
     template_manager,
     video_archiver,
-    screenshots
+    screenshots,
+    camera_discovery
 )
 from app.utils.db import SessionLocal
 #from app.models.log import Log
@@ -1628,6 +1629,29 @@ def init_routes(app):
                 return jsonify({"message": "Template updated successfully!"})
 
             return redirect("/templates/" + template_name)
+
+    @app.route('/discover', methods=['GET'])
+    @login_required
+    def discover_cameras_route():
+        cameras = camera_discovery.discover_cameras()
+        return render_template('discover.html', cameras=cameras)
+
+    @app.route('/discover/add', methods=['POST'])
+    @login_required
+    def add_discovered_camera():
+        data = request.form if request.form else request.get_json(force=True)
+        name = data.get('name') or data.get('ip')
+        protocol = data.get('protocol', 'rtsp')
+        port = int(data.get('port', 554))
+        url = data.get('url') or f"{protocol}://{data.get('ip')}:{port}"
+        template = {
+            'name': name,
+            'url': url,
+            'frequency': data.get('frequency', 30),
+            'timeout': data.get('timeout', 10)
+        }
+        template_manager.save_template(name, template)
+        return jsonify({'status': 'success'})
 
     @app.route("/status")
     @login_required

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -1,0 +1,31 @@
+{% include 'header.html' %}
+<body>
+    <header>
+        {% include 'nav.html' %}
+    </header>
+    <h2>Discovered Cameras</h2>
+    <table>
+        <thead>
+            <tr><th>IP</th><th>Protocol</th><th>Port</th><th>Info</th><th></th></tr>
+        </thead>
+        <tbody>
+        {% for cam in cameras %}
+            <tr>
+                <td>{{ cam.ip }}</td>
+                <td>{{ cam.protocol }}</td>
+                <td>{{ cam.port }}</td>
+                <td>{{ cam.info }}</td>
+                <td>
+                    <form action="/discover/add" method="post">
+                        <input type="hidden" name="ip" value="{{ cam.ip }}">
+                        <input type="hidden" name="protocol" value="{{ cam.protocol }}">
+                        <input type="hidden" name="port" value="{{ cam.port }}">
+                        <input type="hidden" name="name" value="{{ cam.ip }}">
+                        <button type="submit">Add</button>
+                    </form>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -5,6 +5,7 @@
                 {% for ag in active_groups %}
                 <a href='/group/{{ag}}'>{{ag}}</a>
                 {% endfor %}
+                <a href='/discover'>Discover Cameras</a>
             </div>
 
 	    <div class="nav-center" style='text-align:center;'>

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -1,0 +1,107 @@
+import socket
+import uuid
+import psutil
+import logging
+import xml.etree.ElementTree as ET
+from urllib.parse import urlparse
+from ipaddress import ip_network
+from .screenshots import is_port_open
+
+
+def _local_subnets():
+    subnets = []
+    for iface, addrs in psutil.net_if_addrs().items():
+        for addr in addrs:
+            if addr.family == socket.AF_INET:
+                ip = addr.address
+                netmask = addr.netmask
+                if ip and netmask:
+                    try:
+                        subnets.append(ip_network(f"{ip}/{netmask}", strict=False))
+                    except Exception:
+                        pass
+    return subnets
+
+
+def _probe_onvif(timeout=2):
+    cameras = []
+    message_id = uuid.uuid4()
+    probe = f"""<?xml version='1.0' encoding='UTF-8'?>
+        <e:Envelope xmlns:e='http://www.w3.org/2003/05/soap-envelope' xmlns:w='http://schemas.xmlsoap.org/ws/2004/08/addressing' xmlns:d='http://schemas.xmlsoap.org/ws/2005/04/discovery'>
+            <e:Header>
+                <w:MessageID>uuid:{message_id}</w:MessageID>
+                <w:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</w:To>
+                <w:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action>
+            </e:Header>
+            <e:Body>
+                <d:Probe>
+                    <d:Types>dn:NetworkVideoTransmitter</d:Types>
+                </d:Probe>
+            </e:Body>
+        </e:Envelope>"""
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+    sock.settimeout(timeout)
+    try:
+        sock.sendto(probe.encode(), ("239.255.255.250", 3702))
+        while True:
+            try:
+                data, addr = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            ip = addr[0]
+            info = {}
+            try:
+                xml = ET.fromstring(data)
+                xaddr = xml.find('.//{http://schemas.xmlsoap.org/ws/2005/04/discovery}XAddrs')
+                if xaddr is not None:
+                    uri = xaddr.text.split()[0]
+                    parsed = urlparse(uri)
+                    ip = parsed.hostname or ip
+                    port = parsed.port or 80
+                    info['xaddr'] = uri
+                else:
+                    port = 80
+            except Exception as e:
+                logging.debug("parse error: %s", e)
+                port = 80
+            cameras.append({"ip": ip, "protocol": "onvif", "port": port, "info": info})
+    except Exception as e:
+        logging.warning("ONVIF discovery error: %s", e)
+    finally:
+        sock.close()
+    return cameras
+
+
+def _scan_rtsp_ports(subnets):
+    found = []
+    checked = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            for port in (554, 8554):
+                if is_port_open(ip, port, timeout=1):
+                    found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": {}})
+    return found
+
+
+def discover_cameras():
+    """Discover cameras on the local network via ONVIF and RTSP scanning."""
+    cameras = []
+    cameras.extend(_probe_onvif())
+    try:
+        subnets = _local_subnets()
+        cameras.extend(_scan_rtsp_ports(subnets))
+    except Exception as e:
+        logging.warning("RTSP scan error: %s", e)
+    # remove duplicates
+    unique = {}
+    for cam in cameras:
+        key = (cam['ip'], cam['protocol'], cam['port'])
+        if key not in unique:
+            unique[key] = cam
+    return list(unique.values())

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -146,6 +146,26 @@ class TestRoutes(unittest.TestCase):
             self.assertIn("description", endpoint)
             self.assertIn("authentication_required", endpoint)
 
+    @patch("app.routes.camera_discovery.discover_cameras")
+    @patch("app.routes.render_template")
+    def test_discover_route(self, mock_render_template, mock_discover):
+        mock_discover.return_value = [{"ip": "1.2.3.4", "protocol": "rtsp", "port": 554, "info": {}}]
+        with self.client.session_transaction() as sess:
+            sess['logged_in'] = True
+        response = self.client.get("/discover")
+        self.assertEqual(response.status_code, 200)
+        mock_render_template.assert_called_with("discover.html", cameras=mock_discover.return_value)
+
+    @patch("app.routes.template_manager.save_template")
+    def test_discover_add(self, mock_save_template):
+        mock_save_template.return_value = True
+        payload = {"name": "cam", "ip": "1.2.3.4", "protocol": "rtsp", "port": 554}
+        with self.client.session_transaction() as sess:
+            sess['logged_in'] = True
+        response = self.client.post("/discover/add", json=payload)
+        self.assertEqual(response.status_code, 200)
+        mock_save_template.assert_called()
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement camera discovery utilities for ONVIF probing and RTSP port scanning
- expose new `/discover` and `/discover/add` routes
- show discovered cameras in `discover.html`
- link discovery page from the nav bar
- test the discovery endpoints

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Discover Cameras" page accessible from the navigation menu, allowing users to view and add cameras detected on the local network.
  - Users can add discovered cameras directly from the discovery page using a simple form.
- **Bug Fixes**
  - None.
- **Tests**
  - Introduced tests to verify the camera discovery and addition features work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->