### PR TITLE
Implement continuous MP4 streaming

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -28,6 +28,7 @@ from flask import (
     session,
     url_for,
     Response,
+    stream_with_context,
 )
 
 from PIL import Image
@@ -266,17 +267,22 @@ def update_setting(name: str, value: str) -> bool:
 
 # TODO:
 def generate_video_stream(video_path: str):
+    """Yield video data in chunks, looping continuously."""
 
-    # TODO: make sure it exists
+    chunk_size = 1024 * 1024  # 1 MB
     while True:
+        if not os.path.exists(video_path):
+            logging.warning("Video path does not exist: %s", video_path)
+            break
+
         with open(video_path, "rb") as video:
-            chunk = video.read(1024 * 1024)  # Read 1 MB at a time
+            chunk = video.read(chunk_size)
             while chunk:
                 yield chunk
-                chunk = video.read(1024 * 1024)
-        #
-        logging.debug("sleeping...")
-        time.sleep(30)  # Wait for 5 minutes before streaming the video again
+                chunk = video.read(chunk_size)
+
+        logging.debug("Restarting video stream")
+        time.sleep(30)  # Wait before streaming again
 
 
 login_attempts = {}
@@ -950,9 +956,12 @@ def init_routes(app):
 
         if not os.path.exists(video_path):
             abort(404)
-        return send_file(video_path)
-        # TODO: implement slowstreaming and continuous streaming
-        # return Response(stream_with_context(generate_video_stream(video_path)), mimetype='video/mp4')
+
+        # Stream the video in small chunks for continuous playback
+        return Response(
+            stream_with_context(generate_video_stream(video_path)),
+            mimetype="video/mp4",
+        )
 
     @app.route("/stream.m3u8")
     @login_required

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -145,11 +145,12 @@ Return the settings page in HTML format.
 
 Submit form data to modify configuration values. A successful update redirects back to the settings page.
 
-### 7. Download MP4 Stream
+### 7. Stream MP4 Video
 
 **GET /stream.mp4**
 
-Download the most recent MP4 video for a group. Specify `group` as a query parameter.
+Stream the most recent MP4 video for a group. Specify `group` as a query parameter. The
+video is served in small chunks and loops continuously.
 
 Example: `/stream.mp4?group=frontdoor`
 

--- a/tests/test_routes_utils.py
+++ b/tests/test_routes_utils.py
@@ -3,6 +3,8 @@ import time
 import hashlib
 import sys
 import types
+import tempfile
+import os
 from unittest.mock import patch
 
 # Provide a dummy psutil module if it's not installed
@@ -94,7 +96,7 @@ for sub in ['scheduling', 'template_manager', 'video_archiver', 'screenshots', '
         if sub == 'email_alerts':
             mod.email_alert = lambda *a, **k: None
 
-from app.routes import generate_timed_hash, is_hash_valid
+from app.routes import generate_timed_hash, is_hash_valid, generate_video_stream
 
 
 class TestRoutesUtils(unittest.TestCase):
@@ -122,6 +124,21 @@ class TestRoutesUtils(unittest.TestCase):
             # Malformed strings -> invalid
             self.assertFalse(is_hash_valid("noperiod"))
             self.assertFalse(is_hash_valid("one.two.three"))
+
+
+class TestGenerateVideoStream(unittest.TestCase):
+    @patch("app.routes.time.sleep", return_value=None)
+    def test_generate_video_stream(self, _):
+        with tempfile.NamedTemporaryFile(delete=False) as temp:
+            temp.write(b"data")
+            temp.flush()
+            path = temp.name
+
+        gen = generate_video_stream(path)
+        chunk = next(gen)
+        self.assertEqual(chunk, b"data")
+        gen.close()
+        os.remove(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stream video using a generator for `/stream.mp4`
- document that `/stream.mp4` now streams continuously
- test the `generate_video_stream` helper

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The video streaming endpoint now streams MP4 video content in small chunks and loops playback continuously, improving continuous viewing experience.
- **Documentation**
  - Updated API documentation to clarify that the video endpoint streams and loops the video instead of providing a direct download.
- **Tests**
  - Added tests to verify the video streaming functionality and ensure correct chunked data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->