### PR TITLE
Add camera discovery tests

### DIFF
--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -1,0 +1,77 @@
+import unittest
+import socket
+import os
+import sys
+from ipaddress import ip_network
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import camera_discovery
+
+class TestCameraDiscovery(unittest.TestCase):
+    def _mock_interfaces(self):
+        snicaddr = camera_discovery.psutil._common.snicaddr
+        return {
+            'eth0': [
+                snicaddr(family=socket.AF_INET, address='192.168.1.5', netmask='255.255.255.252', broadcast='192.168.1.7', ptp=None)
+            ],
+            'wlan0': [
+                snicaddr(family=socket.AF_INET, address='10.0.0.5', netmask='255.255.255.252', broadcast='10.0.0.7', ptp=None)
+            ]
+        }
+
+    def _port_open_side_effect(self, ip, port, timeout=1):
+        return (ip, port) in {
+            ('192.168.1.6', 554),
+            ('10.0.0.6', 8554)
+        }
+
+    @patch('app.utils.camera_discovery.psutil.net_if_addrs')
+    def test_local_subnets(self, mock_addrs):
+        mock_addrs.return_value = self._mock_interfaces()
+        result = camera_discovery._local_subnets()
+        expected = {
+            ip_network('192.168.1.5/255.255.255.252', strict=False),
+            ip_network('10.0.0.5/255.255.255.252', strict=False)
+        }
+        self.assertEqual(set(result), expected)
+
+    @patch('app.utils.camera_discovery.is_port_open')
+    def test_scan_rtsp_ports(self, mock_port_open):
+        mock_port_open.side_effect = self._port_open_side_effect
+        subnets = [
+            ip_network('192.168.1.5/255.255.255.252', strict=False),
+            ip_network('10.0.0.5/255.255.255.252', strict=False)
+        ]
+        result = camera_discovery._scan_rtsp_ports(subnets)
+        expected = [
+            {'ip': '192.168.1.6', 'protocol': 'rtsp', 'port': 554, 'info': {}},
+            {'ip': '10.0.0.6', 'protocol': 'rtsp', 'port': 8554, 'info': {}}
+        ]
+        self.assertEqual(result, expected)
+
+    @patch('app.utils.camera_discovery._probe_onvif')
+    @patch('app.utils.camera_discovery.is_port_open')
+    @patch('app.utils.camera_discovery.psutil.net_if_addrs')
+    def test_discover_cameras_merge(self, mock_addrs, mock_port_open, mock_probe):
+        mock_addrs.return_value = self._mock_interfaces()
+        mock_port_open.side_effect = self._port_open_side_effect
+        mock_probe.return_value = [
+            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}},
+            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}}  # duplicate
+        ]
+        result = camera_discovery.discover_cameras()
+        expected = [
+            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}},
+            {'ip': '192.168.1.6', 'protocol': 'rtsp', 'port': 554, 'info': {}},
+            {'ip': '10.0.0.6', 'protocol': 'rtsp', 'port': 8554, 'info': {}}
+        ]
+        # convert to set of tuples for comparison ignoring order
+        self.assertEqual(
+            { (c['ip'], c['protocol'], c['port']) for c in result },
+            { (c['ip'], c['protocol'], c['port']) for c in expected }
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- test camera discovery utility functions

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new unit tests for camera discovery features, including subnet detection, RTSP port scanning, and camera discovery logic. These tests improve reliability by simulating various network scenarios and verifying correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->