### PR TITLE
Implement HTTP callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For more documentation, see the [documentation index](docs/index.md).
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
 - **Data Retention Policies**: Automatically manages storage by cleaning up old data, ensuring the system remains efficient without requiring constant manual intervention.
+- **HTTP Callbacks**: When a template specifies a callback URL, Glimpser sends a JSON webhook with caption or motion updates to that endpoint.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.
 

--- a/app/utils/http_callbacks.py
+++ b/app/utils/http_callbacks.py
@@ -1,0 +1,15 @@
+import logging
+import requests
+
+
+def send_http_callback(url, event_type, payload):
+    """Send an HTTP POST callback if a URL is provided."""
+    if not url:
+        return
+    try:
+        data = {"event": event_type, "payload": payload}
+        requests.post(url, json=data, timeout=5)
+        logging.info("HTTP callback sent to %s", url)
+    except Exception as e:
+        logging.error("HTTP callback error: %s", e)
+

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -31,6 +31,7 @@ from .screenshots import (
 )
 from .template_manager import get_template, get_templates, save_template
 from .email_alerts import email_alert
+from .http_callbacks import send_http_callback
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from concurrent.futures import ProcessPoolExecutor, TimeoutError
@@ -495,6 +496,15 @@ def update_camera(name, template, image_file=None):
                 add_motion_and_caption(lpath, caption=lcap, motion=lsum)
 
             save_template(name, template)
+            if template.get("callback_url"):
+                payload = {
+                    "name": name,
+                    "caption": template.get("last_caption"),
+                    "timestamp": lctime,
+                    "motion": bool(lsum),
+                }
+                event = "caption" if last_caption_trigger else "motion"
+                send_http_callback(template.get("callback_url"), event, payload)
 
             if last_motion_trigger or lsum:
                 if os.path.exists(
@@ -550,6 +560,14 @@ def update_camera(name, template, image_file=None):
             lctime = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
             template["last_motion_time"] = lctime
             save_template(name, template)
+            if template.get("callback_url"):
+                payload = {
+                    "name": name,
+                    "caption": template.get("last_caption"),
+                    "timestamp": lctime,
+                    "motion": True,
+                }
+                send_http_callback(template.get("callback_url"), "motion", payload)
 
             if os.path.exists(prev_motion):
                 destination = os.readlink(prev_motion)

--- a/tests/test_http_callbacks.py
+++ b/tests/test_http_callbacks.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import patch
+
+from app.utils.http_callbacks import send_http_callback
+
+
+class TestHttpCallbacks(unittest.TestCase):
+    def test_send_http_callback_no_url(self):
+        with patch('requests.post') as mock_post:
+            send_http_callback('', 'event', {})
+            mock_post.assert_not_called()
+
+    def test_send_http_callback_posts(self):
+        with patch('requests.post') as mock_post:
+            mock_post.return_value.status_code = 200
+            send_http_callback('http://example.com', 'event', {'a': 1})
+            mock_post.assert_called_once_with('http://example.com', json={'event': 'event', 'payload': {'a': 1}}, timeout=5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new utility to send HTTP callbacks
- trigger callbacks when motion or caption updates occur
- document callback feature in README
- test the callback helper

## Testing
- `pytest -q`