### PR TITLE
Add template ID validation

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -205,7 +205,12 @@ class TemplateManager:
             session.close()
 
     def get_template_by_id(self, template_id):
-        # TODO: validate id
+        """Return template details for ``template_id`` if valid."""
+
+        # Validate ``template_id`` before opening a session
+        if not isinstance(template_id, int) or template_id <= 0:
+            return {}
+
         session = self.get_session()
         try:
             template = session.query(Template).filter_by(id=template_id).first()
@@ -275,6 +280,11 @@ def delete_template(name: str) -> bool:
 
 
 def get_template_by_id(template_id: int):
+    """Return template details by ``template_id`` if ``template_id`` is valid."""
+
+    if not isinstance(template_id, int) or template_id <= 0:
+        return {}
+
     manager = TemplateManager()
     return manager.get_template_by_id(template_id)
 

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -201,6 +201,25 @@ class TestTemplateManager(unittest.TestCase):
 
         self.assertEqual(result, {})
 
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_get_template_by_id_invalid(self, mock_session):
+        """Invalid IDs should short circuit and not hit the DB."""
+
+        # Negative ID
+        result = self.template_manager.get_template_by_id(-1)
+        self.assertEqual(result, {})
+        mock_session.assert_not_called()
+
+        # Zero ID
+        result = self.template_manager.get_template_by_id(0)
+        self.assertEqual(result, {})
+        mock_session.assert_not_called()
+
+        # Non integer ID
+        result = self.template_manager.get_template_by_id("abc")
+        self.assertEqual(result, {})
+        mock_session.assert_not_called()
+
 
 class TestValidateTemplateName(unittest.TestCase):
     """Tests for the ``validate_template_name`` utility."""


### PR DESCRIPTION
## Summary
- validate `template_id` input in `TemplateManager.get_template_by_id`
- add wrapper validation for `get_template_by_id`
- test invalid ID cases

## Testing
- `pytest -q`