### PR TITLE
Add real live video streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LLM summary generation with email alerts
 - Capture time tracking for templates
 - FFprobe path configuration
+- Live video streaming endpoint `/live_video`
 
 ### Changed
 - Improved screenshot reliability

--- a/app/routes.py
+++ b/app/routes.py
@@ -35,6 +35,7 @@ from PIL import Image
 from sqlalchemy import text
 from werkzeug.security import check_password_hash
 from werkzeug.utils import secure_filename
+import subprocess
 
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
@@ -284,6 +285,39 @@ def generate_video_stream(video_path: str):
 
         logging.debug("Restarting video stream")
         time.sleep(30)  # Wait before streaming again
+
+
+def generate_live_stream(url: str):
+    """Yield video data directly from a remote URL using ffmpeg."""
+
+    command = [
+        config.FFMPEG_PATH,
+        "-i",
+        url,
+        "-loglevel",
+        "error",
+        "-an",
+        "-c:v",
+        "copy",
+        "-f",
+        "mp4",
+        "-movflags",
+        "frag_keyframe+empty_moov",
+        "pipe:1",
+    ]
+
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+
+    try:
+        while True:
+            chunk = process.stdout.read(1024 * 1024)
+            if not chunk:
+                break
+            yield chunk
+    except GeneratorExit:
+        pass
+    finally:
+        process.kill()
 
 
 login_attempts = {}
@@ -961,6 +995,23 @@ def init_routes(app):
         # Stream the video in small chunks for continuous playback
         return Response(
             stream_with_context(generate_video_stream(video_path)),
+            mimetype="video/mp4",
+        )
+
+    @app.route("/live_video")
+    @login_required
+    def live_video():
+        camera = request.args.get("camera")
+        if not camera:
+            abort(400, "camera parameter required")
+        details = template_manager.get_template(camera)
+        if not details:
+            abort(404)
+        url = details.get("url")
+        if not url:
+            abort(404)
+        return Response(
+            stream_with_context(generate_live_stream(url)),
             mimetype="video/mp4",
         )
 

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -106,6 +106,7 @@
 	<!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
         <option value="loop" title="Loop through available video clips">Loop Videos</option>
         <option value="mp4" selected title="View an MP4 video stream">MP4 Stream</option>
+        <option value="live" title="View the direct live stream">Live Video</option>
         <option value="motion" title="View motion-detected frames">Motion</option>
         <option value="mjpg" title="View an MJPEG (Motion JPEG) stream">MJPG</option>
     </select>
@@ -315,6 +316,9 @@ function changeCamera() {
                 case 'mp4':
                     playMP4();
                     break;
+                case 'live':
+                    playLive();
+                    break;
                 case 'mjpg':
                     playMJPG();
                     break;
@@ -465,6 +469,23 @@ function handleVideoEnded() {
         video.src = '/last_video/' + nextCamera;
         video.dataset.currentCamera = nextCamera;
     }
+    video.load();
+    video.play();
+}
+
+function playLive() {
+    video.style.display = 'block';
+    image.style.display = 'none';
+    document.getElementById("seek-bar").style.display = "block";
+    clearInterval(pngInterval);
+
+    if (currentCamera.startsWith('group-') || currentCamera === 'All') {
+        // Fallback to MP4 streaming for groups or All
+        playMP4();
+        return;
+    }
+
+    video.src = '/live_video?camera=' + encodeURIComponent(currentCamera);
     video.load();
     video.play();
 }

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -154,7 +154,15 @@ video is served in small chunks and loops continuously.
 
 Example: `/stream.mp4?group=frontdoor`
 
-### 8. Trigger Screenshot Capture
+### 8. Stream Live Video
+
+**GET /live_video**
+
+Stream a camera directly from its configured URL in real time. Specify `camera` as a query parameter.
+
+Example: `/live_video?camera=frontdoor`
+
+### 9. Trigger Screenshot Capture
 
 **GET /take_screenshot/<template_name>**
 **POST /take_screenshot/<template_name>**


### PR DESCRIPTION
## Summary
- implement ffmpeg-based live streaming generator and `/live_video` route
- add new Live Video option on the live page
- update API documentation
- note live video feature in changelog

## Testing
- `pytest -q`