### PR TITLE
Add optional S3 config backup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For more documentation, see the [documentation index](docs/index.md).
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
 - **Data Retention Policies**: Automatically manages storage by cleaning up old data, ensuring the system remains efficient without requiring constant manual intervention.
+- **Cloud Backup**: Optionally uploads configuration backups to an S3 bucket using your AWS credentials.
 - **HTTP Callbacks**: When a template specifies a callback URL, Glimpser sends a JSON webhook with caption or motion updates to that endpoint.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.

--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,11 @@ DATABASE_PATH = os.getenv("GLIMPSER_DATABASE_PATH", "data/glimpser.db")
 LOGGING_PATH = os.getenv("GLIMPSER_LOGGING_PATH", "logs/glimpser.log")
 BACKUP_PATH = os.getenv("GLIMPSER_BACKUP_PATH", "data/config_backup.json")
 
+# Optional AWS credentials for cloud backups
+AWS_ACCESS_KEY = os.getenv("GLIMPSER_AWS_ACCESS_KEY", "")
+AWS_SECRET_KEY = os.getenv("GLIMPSER_AWS_SECRET_KEY", "")
+AWS_BUCKET_NAME = os.getenv("GLIMPSER_AWS_BUCKET", "")
+
 # todo.. make sure this is not duplicate loading...
 engine = create_engine(f"sqlite:///{DATABASE_PATH}")
 SessionLocal = sessionmaker(
@@ -44,13 +49,41 @@ def backup_config() -> bool:
         config_dict = {name: value for name, value in settings}
         with open(BACKUP_PATH, 'w') as f:
             json.dump(config_dict, f)
+        success = True
     except Exception:
-        return False
+        success = False
     finally:
         session.close()
-        return True
+
+    if success and AWS_ACCESS_KEY and AWS_SECRET_KEY and AWS_BUCKET_NAME:
+        try:
+            import boto3
+
+            s3_client = boto3.client(
+                's3',
+                aws_access_key_id=AWS_ACCESS_KEY,
+                aws_secret_access_key=AWS_SECRET_KEY,
+            )
+            s3_client.upload_file(BACKUP_PATH, AWS_BUCKET_NAME, os.path.basename(BACKUP_PATH))
+        except Exception as e:
+            logging.warning("Failed to upload backup to S3: %s", e)
+
+    return success
 
 def restore_config():
+    if not os.path.exists(BACKUP_PATH) and AWS_ACCESS_KEY and AWS_SECRET_KEY and AWS_BUCKET_NAME:
+        try:
+            import boto3
+
+            s3_client = boto3.client(
+                's3',
+                aws_access_key_id=AWS_ACCESS_KEY,
+                aws_secret_access_key=AWS_SECRET_KEY,
+            )
+            s3_client.download_file(AWS_BUCKET_NAME, os.path.basename(BACKUP_PATH), BACKUP_PATH)
+        except Exception as e:
+            logging.warning("Failed to download backup from S3: %s", e)
+
     if os.path.exists(BACKUP_PATH):
         with open(BACKUP_PATH, 'r') as f:
             config_dict = json.load(f)
@@ -106,6 +139,9 @@ USER_NAME = get_setting("USER_NAME", "admin")
 USER_PASSWORD_HASH = get_setting("USER_PASSWORD_HASH", "")
 API_KEY = get_setting("API_KEY", "")
 CHATGPT_KEY = get_setting("CHATGPT_KEY", "")  # maybe generalize as LLM_KEY ?
+AWS_ACCESS_KEY = AWS_ACCESS_KEY or get_setting("AWS_ACCESS_KEY", "")
+AWS_SECRET_KEY = AWS_SECRET_KEY or get_setting("AWS_SECRET_KEY", "")
+AWS_BUCKET_NAME = AWS_BUCKET_NAME or get_setting("AWS_BUCKET_NAME", "")
 
 LLM_MODEL_VERSION = get_setting("LLM_MODEL_VERSION", "gpt-4.1-mini") # todo setup allowed models
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -15,6 +15,9 @@ are used.
 | `GLIMPSER_DATABASE_PATH` | `data/glimpser.db` | Location of the SQLite database file |
 | `GLIMPSER_LOGGING_PATH` | `logs/glimpser.log` | Path to the main log file |
 | `GLIMPSER_BACKUP_PATH` | `data/config_backup.json` | File used when backing up configuration |
+| `GLIMPSER_AWS_BUCKET` | *none* | S3 bucket used for configuration backups |
+| `GLIMPSER_AWS_ACCESS_KEY` | *none* | AWS access key for uploads |
+| `GLIMPSER_AWS_SECRET_KEY` | *none* | AWS secret key for uploads |
 
 ## Core Settings
 
@@ -64,6 +67,14 @@ To enable email notifications, configure the following:
 - `EMAIL_SMTP_PORT` – server port (default `587`)
 - `EMAIL_USE_TLS` – whether to use TLS (default `True`)
 - `EMAIL_USERNAME` and `EMAIL_PASSWORD` – authentication credentials (default user name `your-username`)
+
+## Cloud Backup
+
+If AWS credentials and a bucket name are provided, Glimpser uploads configuration backups to S3 when you perform a backup through the settings page.
+
+- `AWS_ACCESS_KEY` – AWS access key ID
+- `AWS_SECRET_KEY` – AWS secret key
+- `AWS_BUCKET_NAME` – S3 bucket to store backups
 
 ## Capture Parameters
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ webdriver-manager==4.0.2
 Werkzeug==3.0.3
 yt-dlp==2024.10.22
 pynput==1.7.7
+boto3
 python-dateutil
 nodriver
 pytest


### PR DESCRIPTION
## Summary
- allow specifying AWS credentials via env/DB settings
- upload backup files to S3 and optionally restore from S3
- document new cloud backup options
- note cloud backup feature in README
- add boto3 to dependencies

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional cloud backup capability, allowing configuration backups to be uploaded to an S3 bucket if AWS credentials are provided.
  - Configuration restore now supports downloading backups from S3 if local files are missing and AWS credentials are set.

- **Documentation**
  - Updated user and configuration guides to describe new cloud backup options and required AWS environment variables.

- **Chores**
  - Added the boto3 library as a dependency for AWS integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->