### PR TITLE
Add Twilio SMS alert functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For more documentation, see the [documentation index](docs/index.md).
 
 - **Data Retention Policies**: Automatically manages storage by cleaning up old data, ensuring the system remains efficient without requiring constant manual intervention.
 - **HTTP Callbacks**: When a template specifies a callback URL, Glimpser sends a JSON webhook with caption or motion updates to that endpoint.
+- **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.
 
@@ -67,7 +68,7 @@ For more documentation, see the [documentation index](docs/index.md).
 ## Usage
 
 ### Configuration
-Glimpser uses a database-driven configuration to manage data sources and processing rules. Users can easily add, update, or remove configurations through the web interface.
+Glimpser uses a database-driven configuration to manage data sources and processing rules. Users can easily add, update, or remove configurations through the web interface. SMS alerts can be enabled by setting `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration.
 
 ### Capturing Screenshots
 The preferred method for capturing screenshots is through the Glimpser web interface. Simply navigate to the capture section, select your desired source, and click the capture button. This ensures a seamless and user-friendly experience.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,6 +13,7 @@ from app.utils.scheduling import schedule_crawlers, schedule_summarization, sche
 from app.utils.video_archiver import archive_screenshots, compile_to_teaser
 from app.config import backup_config, restore_config
 from app.utils.email_alerts import email_alert
+from app.utils.sms_alerts import sms_alert
 #from app.utils.db import SessionLocal
 #from app.models.log import Log
 
@@ -174,8 +175,9 @@ def create_app(watchdog=True, schedule=True):
 
     start_log_caching()
 
-    # Send an email alert when the application starts
+    # Send alerts when the application starts
     email_alert("Application Start", "The Glimpser application has been started successfully.")
+    sms_alert("Application Start", "The Glimpser application has been started successfully.")
 
     # Make scheduler accessible globally
     app.scheduler = scheduler

--- a/app/config.py
+++ b/app/config.py
@@ -158,7 +158,8 @@ EMAIL_USERNAME = get_setting("EMAIL_USERNAME", "your-username")
 EMAIL_PASSWORD = get_setting("EMAIL_PASSWORD", "")
 
 
-# experimental
-# TWILIO_SID = get_setting("TWILIO_SID","")
-# TWILIO_TOKEN = get_setting("TWILIO_TOKEN","")
-# TWILIO_NUMBER = get_setting("TWILIO_NUMBER","")
+
+# SMS/Twilio settings
+TWILIO_SID = get_setting("TWILIO_SID", "")
+TWILIO_TOKEN = get_setting("TWILIO_TOKEN", "")
+TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -31,6 +31,7 @@ from .screenshots import (
 )
 from .template_manager import get_template, get_templates, save_template
 from .email_alerts import email_alert
+from .sms_alerts import sms_alert
 from .http_callbacks import send_http_callback
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -737,9 +738,10 @@ def update_summary():
     if lsuc is False:
         logging.warning("MISSED CAPTION ($$$) %s", lsum)
 
-    # Send email alert with the summary
+    # Send alerts with the summary
     if lsuc:
         email_alert("LLM Summary Update", f"New summary generated:\n\n{lsum}")
+        sms_alert("LLM Summary Update", f"New summary generated:\n\n{lsum}")
 
 
 def schedule_summarization():

--- a/app/utils/sms_alerts.py
+++ b/app/utils/sms_alerts.py
@@ -1,0 +1,28 @@
+import logging
+
+from app.config import TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER
+
+
+def send_sms_alert(message):
+    """Send an SMS alert using Twilio if credentials are configured."""
+    if not all([TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER]):
+        logging.info("SMS alerts are disabled.")
+        return
+
+    try:
+        from twilio.rest import Client
+    except Exception as exc:  # ImportError or others
+        logging.error("Twilio client not available: %s", exc)
+        return
+
+    try:
+        client = Client(TWILIO_SID, TWILIO_TOKEN)
+        client.messages.create(body=message, from_=TWILIO_NUMBER, to=TWILIO_NUMBER)
+        logging.info("SMS alert sent successfully")
+    except Exception as exc:
+        logging.error("Error sending SMS alert: %s", exc)
+
+
+def sms_alert(event_type, details):
+    body = f"Glimpser Alert: {event_type}\n\nDetails:\n{details}"
+    send_sms_alert(body)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -65,6 +65,14 @@ To enable email notifications, configure the following:
 - `EMAIL_USE_TLS` – whether to use TLS (default `True`)
 - `EMAIL_USERNAME` and `EMAIL_PASSWORD` – authentication credentials (default user name `your-username`)
 
+## SMS Settings
+
+Configure these values to enable Twilio SMS alerts:
+
+- `TWILIO_SID` – your Twilio account SID
+- `TWILIO_TOKEN` – your Twilio auth token
+- `TWILIO_NUMBER` – phone number that receives alerts
+
 ## Capture Parameters
 
 Settings controlling how frames are captured from video sources:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,9 @@ Set the `GLIMPSER_DATABASE_PATH` environment variable before starting the app. T
 ### How do I enable email notifications?
 Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining email settings (SMTP server, username, password). These options can be adjusted from the web interface or the configuration file.
 
+### How do I enable SMS alerts?
+Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
+
 ## Troubleshooting
 
 ### I'm unable to log in

--- a/tests/test_sms_alerts.py
+++ b/tests/test_sms_alerts.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.sms_alerts import send_sms_alert, sms_alert
+
+
+class TestSMSAlerts(unittest.TestCase):
+    def test_send_sms_alert_disabled(self):
+        with patch('app.utils.sms_alerts.TWILIO_SID', ''), \
+             patch('app.utils.sms_alerts.TWILIO_TOKEN', ''), \
+             patch('app.utils.sms_alerts.TWILIO_NUMBER', ''), \
+             patch.dict('sys.modules', {'twilio': MagicMock(), 'twilio.rest': MagicMock()}), \
+             patch('twilio.rest.Client') as mock_client:
+            send_sms_alert('body')
+            mock_client.assert_not_called()
+
+    def test_send_sms_alert_enabled(self):
+        client_instance = MagicMock()
+        mock_client_class = MagicMock(return_value=client_instance)
+        dummy_twilio_rest = MagicMock(Client=mock_client_class)
+        with patch.dict('sys.modules', {'twilio': MagicMock(rest=dummy_twilio_rest), 'twilio.rest': dummy_twilio_rest}):
+            with patch('app.utils.sms_alerts.TWILIO_SID', 'sid'), \
+                 patch('app.utils.sms_alerts.TWILIO_TOKEN', 'token'), \
+                 patch('app.utils.sms_alerts.TWILIO_NUMBER', '+123'): 
+                send_sms_alert('Body')
+                mock_client_class.assert_called_once_with('sid', 'token')
+                client_instance.messages.create.assert_called_once_with(body='Body', from_='+123', to='+123')
+
+    def test_sms_alert_wrapper(self):
+        with patch('app.utils.sms_alerts.send_sms_alert') as mock_send:
+            sms_alert('Test', 'Details')
+            mock_send.assert_called_once_with('Glimpser Alert: Test\n\nDetails:\nDetails')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new Twilio configuration settings
- implement sms_alerts helper
- hook SMS alerts into scheduling and app startup workflows
- document SMS options
- add tests for sms alerts

## Testing
- `pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SMS alert functionality, allowing users to receive notifications via text message when Twilio credentials are configured.
- **Documentation**
  - Updated user guides and FAQs to include instructions and configuration details for enabling SMS alerts.
- **Tests**
  - Introduced new tests to verify SMS alert behavior and ensure reliability of the new SMS notification feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->