### PR TITLE
Add user model and database-backed authentication

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .user import User
+
+__all__ = ["User"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String
+
+from app.utils.db import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String, unique=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    role = Column(String, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<User id={self.id} username={self.username}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -42,14 +42,13 @@ import app.config as config
 from app.config import (
     API_KEY,
     SCREENSHOT_DIRECTORY,
-    USER_NAME,
-    USER_PASSWORD_HASH,
     VIDEO_DIRECTORY,
     VERSION,
     BACKUP_PATH,
     backup_config,
     restore_config
 )
+from app.models import User
 from app.utils import (
     scheduling,
     template_manager,
@@ -139,13 +138,25 @@ def login_required(f):
             return f(*args, **kwargs)
 
         # Check for valid session
-        elif "logged_in" in session:
-            # Check for session expiry
+        elif session.get("user_id"):
             expiry = session.get("expiry")
             if expiry and datetime.now() > datetime.strptime(expiry, '%Y-%m-%d %H:%M:%S'):
-                session.pop("logged_in", None)  # Clear session
+                session.pop("user_id", None)
                 flash("Session expired. Please log in again.")
                 return redirect(url_for("login", next=request.url))
+
+            db_session = SessionLocal()
+            try:
+                user = db_session.query(User).filter_by(id=session["user_id"]).first()
+            finally:
+                db_session.close()
+
+            if not user:
+                session.pop("user_id", None)
+                flash("Session expired. Please log in again.")
+                return redirect(url_for("login", next=request.url))
+
+            # Optional role checks could be added here
             return f(*args, **kwargs)
 
         # Handle missing or invalid authentication
@@ -635,10 +646,14 @@ def init_routes(app):
             username = request.form["username"]
             password = request.form["password"]
 
-            if username == USER_NAME and check_password_hash(
-                USER_PASSWORD_HASH, password
-            ):
-                session["logged_in"] = True
+            db_session = SessionLocal()
+            try:
+                user = db_session.query(User).filter_by(username=username).first()
+            finally:
+                db_session.close()
+
+            if user and check_password_hash(user.password_hash, password):
+                session["user_id"] = user.id
                 login_attempts.pop(
                     ip_address, None
                 )  # Reset attempts on successful login
@@ -673,7 +688,7 @@ def init_routes(app):
     @app.route("/logout")
     @login_required
     def logout():
-        session.pop("logged_in", None)
+        session.pop("user_id", None)
         flash("You have been logged out successfully.", "success")
         return redirect(url_for("login"))
 

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -12,4 +12,8 @@ Base = declarative_base()
 
 
 def init_db():
+    # Import models here so that SQLAlchemy is aware of them before creating
+    # tables. This prevents circular import issues at module load time.
+    import app.models  # noqa: F401
+
     Base.metadata.create_all(bind=engine)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -45,6 +45,11 @@ updated with `generate_credentials.py` or through the web interface.
 - `CHATGPT_KEY` – API key for AI captioning and summarization (empty by
   default)
 
+User accounts are stored in the `users` table. Each record contains the
+`username`, `password_hash`, and an optional `role` that can be used for future
+permission checks. The `generate_credentials.py` utility keeps the settings and
+user table in sync.
+
 ## File Locations
 
 - `SCREENSHOT_DIRECTORY` – directory for raw screenshots (default `data/screenshots/`)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,7 +72,7 @@ This guide addresses common issues that users might encounter while using Glimps
 
 **Solution:**
 - Ensure you're using the correct username and password
-- Check if the `USER_NAME` setting is correctly configured
+- Verify that the account exists in the `users` table
 - Try resetting your password through the recovery process
 
 ## Getting Further Help

--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -41,6 +41,33 @@ def create_settings(conn):
     conn.commit()
 
 
+def create_users(conn):
+    create_users_table = '''
+    CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT NOT NULL UNIQUE,
+        password_hash TEXT NOT NULL,
+        role TEXT
+    );
+    '''
+    cursor = conn.cursor()
+    cursor.execute(create_users_table)
+    conn.commit()
+
+
+def upsert_user(username, password_hash, role, conn):
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (username, password_hash, role)
+        VALUES (?, ?, ?)
+        ON CONFLICT(username) DO UPDATE SET password_hash=excluded.password_hash, role=excluded.role;
+        """,
+        (username, password_hash, role),
+    )
+    conn.commit()
+
+
 def generate_credentials(args):
     # Use the provided or default database path
     database_path = app.config.get_setting("DATABASE_PATH", "data/glimpser.db")
@@ -51,6 +78,8 @@ def generate_credentials(args):
 
     if args is None or (not args.update_password and not args.update_key):
         create_settings(conn)
+
+    create_users(conn)
 
     # Handle each setting individually
     if args is None or args.username:
@@ -63,7 +92,7 @@ def generate_credentials(args):
             else:
                 username = app.config.get_setting("USER_NAME", "admin")
         upsert_setting("USER_NAME", username.strip(), conn)
-
+    
     if args is None or args.password or args.update_password:
         password = "" # maybe populate with garbage
         if args:
@@ -77,12 +106,17 @@ def generate_credentials(args):
 
         password_hash = generate_password_hash(password.strip())
         upsert_setting("USER_PASSWORD_HASH", password_hash, conn)
+    else:
+        password_hash = app.config.get_setting("USER_PASSWORD_HASH", "")
 
     if args is None or args.update_key or not args.update_password:
         secret_key = app.config.get_setting("SECRET_KEY", secrets.token_hex(16))
         if args and args.secret_key:
              secret_key = args.secret_key
         upsert_setting("SECRET_KEY", secret_key, conn)
+
+    # Mirror settings into the users table
+    upsert_user(username.strip(), password_hash, "admin", conn)
 
     conn.close()
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import datetime
 import unittest
 from unittest.mock import patch
+from types import SimpleNamespace
 from app.config import USER_NAME, API_KEY
 from app.routes import login_required, login_attempts
 from app import create_app
@@ -32,7 +33,23 @@ class TestAuthentication(unittest.TestCase):
         self.app_context.pop()
 
     def test_login_success(self):
-        with patch("app.routes.login_attempts", {}):  # Reset login attempts to avoid lockout
+        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.login_attempts", {}), patch("app.routes.check_password_hash", return_value=True):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
             response = self.client.post(
                 "/login",
                 data={
@@ -40,32 +57,87 @@ class TestAuthentication(unittest.TestCase):
                     "password": "correct_password",
                 },
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 302)
             # seems sus... 
             #self.assertIn("/", response.headers["Path"])
 
     def test_login_failure(self):
-        response = self.client.post(
-            "/login", data={"username": USER_NAME, "password": "wrong_password"}
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Enter your credentials", response.data)
+        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.post(
+                "/login", data={"username": USER_NAME, "password": "wrong_password"}
+            )
+            self.assertEqual(response.status_code, 200)
 
     def test_login_failure_lockout(self):
         # Simulate multiple failed login attempts to trigger lockout
         login_attempts = {} # reset 
         for _ in range(5):  # Assuming lockout occurs after 5 attempts
-            self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
+            with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
+                dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+                class DummyQuery:
+                    def filter_by(self, **kwargs):
+                        return self
+                    def first(self):
+                        return dummy_user
+                class DummySession:
+                    def query(self, model):
+                        return DummyQuery()
+                    def close(self):
+                        pass
+                mock_session_local.return_value = DummySession()
+                self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
 
-        response = self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
+        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+                def first(self):
+                    return dummy_user
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+                def close(self):
+                    pass
+            mock_session_local.return_value = DummySession()
+            response = self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
         self.assertEqual(response.status_code, 429)  # Expecting lockout response
         login_attempts = {} # reset 
 
     def test_logout(self):
-        login_attempts = {} # reset 
-        self.client.post(
-            "/login", data={"username": USER_NAME, "password": "correct_password"}
-        )
+        login_attempts = {} # reset
+        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=True):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+                def first(self):
+                    return dummy_user
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+                def close(self):
+                    pass
+            mock_session_local.return_value = DummySession()
+            self.client.post(
+                "/login", data={"username": USER_NAME, "password": "correct_password"}
+            )
         response = self.client.get("/logout")
         self.assertEqual(response.status_code, 302)
         self.assertIn("/login", response.headers["Location"])
@@ -78,7 +150,18 @@ class TestAuthentication(unittest.TestCase):
 
     def test_login_required_with_login(self):
         login_attempts = {} # reset 
-        with patch("app.routes.session", {"logged_in": True}):
+        dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.SessionLocal", return_value=DummySession()):
             response = self.client.get("/protected")
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"Protected Content", response.data)
@@ -87,7 +170,18 @@ class TestAuthentication(unittest.TestCase):
         login_attempts = {} # reset 
         # Set an expiry date that is in the past
         expired_time = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
-        with patch("app.routes.session", {"logged_in": True, "expiry": expired_time}):
+        dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+        with patch("app.routes.session", {"user_id": 1, "expiry": expired_time}), patch("app.routes.SessionLocal", return_value=DummySession()):
             response = self.client.get("/protected")
             self.assertEqual(response.status_code, 302)
             self.assertIn("/login", response.headers["Location"])
@@ -129,7 +223,18 @@ class TestAuthentication(unittest.TestCase):
         # Test with both session and API key
         mock_api_key = "mock_api_key_for_testing"
         with patch("app.routes.API_KEY", mock_api_key):
-            with patch("app.routes.session", {"logged_in": True}):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+                def first(self):
+                    return dummy_user
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+                def close(self):
+                    pass
+            with patch("app.routes.session", {"user_id": 1}), patch("app.routes.SessionLocal", return_value=DummySession()):
                 response = self.client.get("/protected", headers={"X-API-Key": mock_api_key})
                 self.assertEqual(response.status_code, 200)
                 self.assertIn(b"Protected Content", response.data)
@@ -137,7 +242,7 @@ class TestAuthentication(unittest.TestCase):
     def test_invalid_session_data(self):
         login_attempts = {} # reset 
         # Test with invalid session data
-        with patch("app.routes.session", {"logged_in": "not_a_boolean"}):
+        with patch("app.routes.session", {"user_id": "not_a_boolean"}):
             response = self.client.get("/protected")
             # TODO: fix these
             #self.assertEqual(response.status_code, 302)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,6 +9,7 @@ from flask import Flask
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.routes import init_routes, login_attempts
+from types import SimpleNamespace
 
 class TestRoutes(unittest.TestCase):
     def setUp(self):
@@ -26,10 +27,26 @@ class TestRoutes(unittest.TestCase):
         #self.assertEqual(response.json, {"status": "healthy"})
 
     @patch("app.routes.check_password_hash")
-    @patch("app.routes.USER_NAME", "testuser")
-    def test_login_success(self, mock_check_password):
+    @patch("app.routes.SessionLocal")
+    def test_login_success(self, mock_session_local, mock_check_password):
         login_attempts = {} # reset
         mock_check_password.return_value = True
+        dummy_user = SimpleNamespace(id=1, username="testuser", password_hash="hash")
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+
+        mock_session_local.return_value = DummySession()
+
         response = self.client.post(
             "/login", data={"username": "testuser", "password": "testpassword"}
         )
@@ -38,10 +55,26 @@ class TestRoutes(unittest.TestCase):
         #self.assertIn("/", response.headers["Location"])
 
     @patch("app.routes.check_password_hash")
-    @patch("app.routes.USER_NAME", "testuser")
-    def test_login_failure(self, mock_check_password):
+    @patch("app.routes.SessionLocal")
+    def test_login_failure(self, mock_session_local, mock_check_password):
         login_attempts = {} # reset
         mock_check_password.return_value = False
+        dummy_user = SimpleNamespace(id=1, username="testuser", password_hash="hash")
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+
+        mock_session_local.return_value = DummySession()
+
         response = self.client.post(
             "/login", data={"username": "testuser", "password": "wrongpassword"}
         )
@@ -56,7 +89,7 @@ class TestRoutes(unittest.TestCase):
         # not sure why this one isnt working ! 
         with self.client as c:
             with c.session_transaction() as sess:
-                sess['logged_in'] = True
+                sess['user_id'] = 1
             #response = c.get("/logout")
             #self.assertEqual(response.status_code, 302)  # Redirect status code
             #self.assertIn("/login", response.headers["Location"])
@@ -146,22 +179,50 @@ class TestRoutes(unittest.TestCase):
             self.assertIn("description", endpoint)
             self.assertIn("authentication_required", endpoint)
 
+    @patch("app.routes.SessionLocal")
     @patch("app.routes.camera_discovery.discover_cameras")
     @patch("app.routes.render_template")
-    def test_discover_route(self, mock_render_template, mock_discover):
+    def test_discover_route(self, mock_render_template, mock_discover, mock_session_local):
         mock_discover.return_value = [{"ip": "1.2.3.4", "protocol": "rtsp", "port": 554, "info": {}}]
+        dummy_user = SimpleNamespace(id=1)
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+        mock_session_local.return_value = DummySession()
+
         with self.client.session_transaction() as sess:
-            sess['logged_in'] = True
+            sess['user_id'] = 1
         response = self.client.get("/discover")
         self.assertEqual(response.status_code, 200)
         mock_render_template.assert_called_with("discover.html", cameras=mock_discover.return_value)
 
+    @patch("app.routes.SessionLocal")
     @patch("app.routes.template_manager.save_template")
-    def test_discover_add(self, mock_save_template):
+    def test_discover_add(self, mock_save_template, mock_session_local):
         mock_save_template.return_value = True
         payload = {"name": "cam", "ip": "1.2.3.4", "protocol": "rtsp", "port": 554}
+        dummy_user = SimpleNamespace(id=1)
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+            def first(self):
+                return dummy_user
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+            def close(self):
+                pass
+        mock_session_local.return_value = DummySession()
+
         with self.client.session_transaction() as sess:
-            sess['logged_in'] = True
+            sess['user_id'] = 1
         response = self.client.post("/discover/add", json=payload)
         self.assertEqual(response.status_code, 200)
         mock_save_template.assert_called()

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -77,7 +77,7 @@ class TestSettingsRoute(unittest.TestCase):
         return row[0] if row else None
 
     def test_add_and_delete_setting(self):
-        with patch("app.routes.session", {"logged_in": True}):
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
             response = self.client.post(
                 "/settings",
                 data={"action": "add", "new_name": "TEST", "new_value": "1"},
@@ -86,7 +86,7 @@ class TestSettingsRoute(unittest.TestCase):
         self.assertIn("/settings", response.headers["Location"])
         self.assertEqual(self._get_value("TEST"), "1")
 
-        with patch("app.routes.session", {"logged_in": True}):
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
             response = self.client.post(
                 "/settings", data={"action": "delete", "name_to_delete": "TEST"}
             )
@@ -105,7 +105,7 @@ class TestSettingsRoute(unittest.TestCase):
             "EMAIL_USERNAME": "user",
             "EMAIL_PASSWORD": "pass",
         }
-        with patch("app.routes.session", {"logged_in": True}):
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
             response = self.client.post("/settings", data=payload)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self._get_value("EMAIL_SENDER"), "user@example.com")
@@ -118,7 +118,7 @@ class TestSettingsRoute(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        with patch("app.routes.session", {"logged_in": True}):
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
             response = self.client.post("/settings", data={"action": "backup"})
         self.assertEqual(response.status_code, 302)
         self.assertTrue(os.path.exists(self.backup_path))
@@ -133,7 +133,7 @@ class TestSettingsRoute(unittest.TestCase):
         with open(upload_path, "w") as f:
             json.dump(config, f)
 
-        with patch("app.routes.session", {"logged_in": True}):
+        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
             with open(upload_path, "rb") as file_data:
                 response = self.client.post(
                     "/settings",


### PR DESCRIPTION
## Summary
- add `User` ORM model and create users table
- use DB-backed authentication storing `user_id` in session
- extend credential generator to populate users table
- update tests for new login behavior
- document user accounts and role support

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a database-backed user management system with a dedicated users table, supporting usernames, password hashes, and user roles.
  - Login, logout, and authentication now operate using database-stored user accounts instead of static credentials.

- **Bug Fixes**
  - Improved session handling and user authentication checks for enhanced security and reliability.

- **Documentation**
  - Updated guides to reflect the new user management system and provide troubleshooting steps for user account issues.

- **Tests**
  - Enhanced test coverage and updated authentication tests to align with the new database-backed user system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->