### PR TITLE
Add optional AWS S3 backup support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,11 +11,16 @@ load_dotenv(find_dotenv())
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
+from app.utils import s3_backup
 
 # TODO: also consider argparse...
 DATABASE_PATH = os.getenv("GLIMPSER_DATABASE_PATH", "data/glimpser.db")
 LOGGING_PATH = os.getenv("GLIMPSER_LOGGING_PATH", "logs/glimpser.log")
 BACKUP_PATH = os.getenv("GLIMPSER_BACKUP_PATH", "data/config_backup.json")
+S3_BUCKET = os.getenv("GLIMPSER_S3_BUCKET")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+AWS_REGION = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
 
 # todo.. make sure this is not duplicate loading...
 engine = create_engine(f"sqlite:///{DATABASE_PATH}")
@@ -55,6 +60,11 @@ def backup_config() -> bool:
         config_dict = {name: value for name, value in settings}
         with open(BACKUP_PATH, 'w') as f:
             json.dump(config_dict, f)
+        if S3_BUCKET:
+            s3_backup.upload_file(BACKUP_PATH, 'config_backup.json')
+            if os.path.exists(DATABASE_PATH):
+                s3_backup.upload_file(DATABASE_PATH, os.path.basename(DATABASE_PATH))
+            s3_backup.upload_media_archive()
     except Exception:
         return False
     finally:
@@ -62,6 +72,9 @@ def backup_config() -> bool:
         return True
 
 def restore_config():
+    if not os.path.exists(BACKUP_PATH) and S3_BUCKET:
+        s3_backup.download_file('config_backup.json', BACKUP_PATH)
+
     if os.path.exists(BACKUP_PATH):
         with open(BACKUP_PATH, 'r') as f:
             config_dict = json.load(f)

--- a/app/utils/s3_backup.py
+++ b/app/utils/s3_backup.py
@@ -1,0 +1,82 @@
+import os
+import tarfile
+import tempfile
+import logging
+
+try:
+    import boto3
+except Exception:  # boto3 might not be installed
+    boto3 = None
+
+
+def _env(var, default=None):
+    return os.getenv(var, default)
+
+
+def _get_s3_client():
+    bucket = _env("GLIMPSER_S3_BUCKET")
+    access_key = _env("AWS_ACCESS_KEY_ID")
+    secret_key = _env("AWS_SECRET_ACCESS_KEY")
+    region = _env("AWS_DEFAULT_REGION", "us-east-1")
+    if not (boto3 and bucket and access_key and secret_key):
+        return None, None
+    try:
+        client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=region,
+        )
+        return client, bucket
+    except Exception as exc:
+        logging.error("Failed to create S3 client: %s", exc)
+        return None, None
+
+
+def upload_file(path: str, key: str) -> bool:
+    client, bucket = _get_s3_client()
+    if client is None:
+        return False
+    try:
+        client.upload_file(path, bucket, key)
+        return True
+    except Exception as exc:
+        logging.error("Failed to upload %s to S3: %s", path, exc)
+        return False
+
+
+def download_file(key: str, path: str) -> bool:
+    client, bucket = _get_s3_client()
+    if client is None:
+        return False
+    try:
+        client.download_file(bucket, key, path)
+        return True
+    except Exception as exc:
+        logging.error("Failed to download %s from S3: %s", key, exc)
+        return False
+
+
+def upload_media_archive() -> bool:
+    client, bucket = _get_s3_client()
+    if client is None:
+        return False
+    screenshot_dir = _env("SCREENSHOT_DIRECTORY", "data/screenshots/")
+    video_dir = _env("VIDEO_DIRECTORY", "data/video/")
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz")
+    archive_path = temp_file.name
+    temp_file.close()
+    try:
+        with tarfile.open(archive_path, "w:gz") as tar:
+            if os.path.isdir(screenshot_dir):
+                tar.add(screenshot_dir, arcname=os.path.basename(screenshot_dir))
+            if os.path.isdir(video_dir):
+                tar.add(video_dir, arcname=os.path.basename(video_dir))
+        client.upload_file(archive_path, bucket, "media_backup.tar.gz")
+        return True
+    except Exception as exc:
+        logging.error("Failed to create/upload media archive: %s", exc)
+        return False
+    finally:
+        if os.path.exists(archive_path):
+            os.remove(archive_path)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -15,6 +15,10 @@ are used.
 | `GLIMPSER_DATABASE_PATH` | `data/glimpser.db` | Location of the SQLite database file |
 | `GLIMPSER_LOGGING_PATH` | `logs/glimpser.log` | Path to the main log file |
 | `GLIMPSER_BACKUP_PATH` | `data/config_backup.json` | File used when backing up configuration |
+| `GLIMPSER_S3_BUCKET` | *(empty)* | S3 bucket for backups |
+| `AWS_ACCESS_KEY_ID` | *(empty)* | AWS access key for S3 backups |
+| `AWS_SECRET_ACCESS_KEY` | *(empty)* | AWS secret key for S3 backups |
+| `AWS_DEFAULT_REGION` | `us-east-1` | AWS region for S3 |
 
 ## Core Settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ python-dateutil
 python-dotenv
 nodriver
 pytest
+boto3

--- a/tests/test_s3_backup.py
+++ b/tests/test_s3_backup.py
@@ -1,0 +1,42 @@
+import os
+import importlib
+
+
+def test_backup_config_s3(monkeypatch, tmp_path):
+    bucket = "test-bucket"
+    backup_path = tmp_path / "config.json"
+    db_path = tmp_path / "db.sqlite"
+
+    monkeypatch.setenv("GLIMPSER_S3_BUCKET", bucket)
+    monkeypatch.setenv("GLIMPSER_BACKUP_PATH", str(backup_path))
+    monkeypatch.setenv("GLIMPSER_DATABASE_PATH", str(db_path))
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "s")
+
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE settings (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE, value TEXT)")
+    conn.execute("INSERT INTO settings (name, value) VALUES ('TEST','value')")
+    conn.commit()
+    conn.close()
+
+    from app import config
+    importlib.reload(config)
+
+    calls = []
+
+    def fake_upload_file(path, key):
+        calls.append((path, key))
+        return True
+
+    def fake_upload_media_archive():
+        calls.append(("media", None))
+        return True
+
+    monkeypatch.setattr(config.s3_backup, "upload_file", fake_upload_file)
+    monkeypatch.setattr(config.s3_backup, "upload_media_archive", fake_upload_media_archive)
+
+    assert config.backup_config() is True
+    assert (str(config.BACKUP_PATH), "config_backup.json") in calls
+    assert (str(config.DATABASE_PATH), os.path.basename(str(config.DATABASE_PATH))) in calls
+    assert ("media", None) in calls


### PR DESCRIPTION
## Summary
- add boto3 requirement
- add optional S3 environment variables documentation
- implement `s3_backup` utility with upload/download helpers
- update config backup/restore to use S3 when configured
- test S3 backup behavior

## Testing
- `flake8`
- `pytest -q`