### PR TITLE
Automate binary builds on release

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,0 +1,31 @@
+name: Build Release Packages
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Build packages
+        run: |
+          ./build_packages.sh
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            debian/glimpser.deb
+            dist/Glimpser.exe
+

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ To set up the project for development:
    pytest
    ```
 
+## Releases
+Release packages are built automatically by GitHub Actions.
+When a release is published, the workflow runs `build_packages.sh`
+to create a Debian package and, if possible, a Windows executable.
+These files are attached to the GitHub release and can be downloaded
+from the Releases page.
+
 ## Contributing
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants and how to report issues.
 


### PR DESCRIPTION
## Summary
- create `release-packages.yml` workflow to build Debian and Windows binaries
- document automatic release packages in README

## Testing
- `pytest -q`
- `flake8` *(fails: numerous style violations)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated building and attachment of Debian and Windows release packages when a new release is published.
- **Documentation**
  - Added a "Releases" section to the README with information on how release packages are generated and where to download them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->