### PR TITLE
Add architecture overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 Glimpser is a straightforward yet powerful real-time monitoring application designed to capture, analyze, and summarize live data from various sources such as cameras, dashboards, and video streams. Utilizing advanced image processing techniques and AI models, Glimpser provides insightful summaries and alerts. It’s highly configurable, allowing users to tailor it to their specific monitoring needs through an easy-to-use interface.
 
 For more documentation, see the [documentation index](docs/index.md).
+Read a high-level [Architecture Overview](docs/architecture_overview.md) to understand how the pieces fit together.
 
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,40 @@
+# Architecture Overview
+
+This guide provides a high-level look at Glimpser's core components and how they interact.
+
+## Flask Application Initialization (`app/__init__.py`)
+- Creates the Flask application instance.
+- Loads configuration values and sets up logging.
+- Initializes routes from `app/routes.py`.
+- Starts the background scheduler and optional watchdog thread.
+
+## Configuration Handling (`app/config.py`)
+- Loads environment variables and values stored in the database.
+- Exposes settings such as `SECRET_KEY`, database location and retention policy limits.
+- Includes helper functions to back up and restore configuration state.
+
+## Utility Modules (`app/utils/`)
+- Collection of helpers for image processing, database access, notifications and more.
+- Key modules include:
+  - `db.py` – SQLAlchemy setup and database initialization.
+  - `screenshots.py` – capturing or downloading images and videos.
+  - `template_manager.py` – management of capture templates.
+  - `email_alerts.py` and `sms_alerts.py` – sending notifications.
+
+## Scheduler Jobs (`app/utils/scheduling.py`)
+- Uses APScheduler to run periodic tasks.
+- Jobs include crawler scheduling, video archiving and summarization.
+- Exposes a `GracefulAPScheduler` instance used by the Flask app.
+
+## How Components Fit Together
+```
+ Client Request ---> Routes (app/routes.py) ----> Models (app/models/) ----> Database
+                           |                           |
+                           v                           v
+                     Utility Functions ----> Scheduler Jobs / Background Tasks
+```
+- Routes handle incoming API or web requests.
+- Models define the database schema.
+- Utility functions perform processing and are called by both routes and scheduled jobs.
+- Background tasks run outside request/response cycles to capture data and generate summaries.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,5 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Integration Guide](integration_guide.md)
 - [Recommendations](recommendations.md)
 - [Troubleshooting](troubleshooting.md)
+- [Architecture Overview](architecture_overview.md)
 


### PR DESCRIPTION
## Summary
- document a high-level architecture overview
- link to the new documentation from the README
- add entry to the documentation index

## Testing
- `pytest`