### PR TITLE
Add status and log docs

### DIFF
--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -174,6 +174,18 @@ Example response:
 {"status": "success", "message": "Screenshot for camera1 taken"}
 ```
 
+### 10. View System Status
+
+**GET /status**
+
+Returns an HTML dashboard displaying metrics such as CPU, memory, and disk usage along with open file count, thread count, and uptime. These metrics are gathered in a background thread (see `app/utils/scheduling.py`).
+
+### 11. Stream Logs
+
+**GET /stream_logs**
+
+Streams log records via Server-Sent Events. Optional query parameters `level`, `source`, `start_date`, `end_date`, and `search` allow filtering. The `/logs` and `/status` pages use this endpoint for the live log viewer.
+
 ## Error Handling
 
 All endpoints may return the following error responses:

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Capture Process](capture_process.md)
 - [Configuration Guide](configuration_guide.md)
 - [Developer Guide](developer_guide.md)
+- [System Monitoring and Logs](system_monitoring.md)
 - [FAQ](faq.md)
 - [Getting Started](getting_started.md)
 - [Installation Guide](installation.md)

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -1,0 +1,38 @@
+# System Monitoring and Logs
+
+This guide explains how to check Glimpser's health metrics and view live logs.
+
+## System Status Endpoint
+
+**GET /status**
+
+The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details.
+
+### Metrics
+
+- **CPU Usage** – percentage of CPU time used by the process
+- **Memory Usage** – percentage of system memory in use
+- **Disk Usage** – percentage of disk space used on the main volume
+- **Open Files** – number of file descriptors opened by the process
+- **Thread Count** – active thread count for the application
+- **Uptime** – elapsed time since the app started
+
+## Streaming Logs
+
+**GET /stream_logs**
+
+This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` and `/status` pages consume this endpoint to display updates in real time.
+
+To filter logs by level and message text, you could request:
+
+```
+/stream_logs?level=INFO&search=camera
+```
+
+## Using the Live Log Viewer
+
+1. Navigate to `/status` or `/logs` after logging in.
+2. Use the search box and dropdowns to filter log output.
+3. Results update automatically via `/stream_logs`.
+
+The log viewer reads log lines from memory, ensuring minimal disk overhead.


### PR DESCRIPTION
## Summary
- document `/status` and `/stream_logs` endpoints
- describe metrics and live log viewer usage
- link new docs from the index

## Testing
- `pytest -q`