### PR TITLE
Add HTTP callback documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ For more documentation, see the [documentation index](docs/index.md).
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
 - **Data Retention Policies**: Automatically manages storage by cleaning up old data, ensuring the system remains efficient without requiring constant manual intervention.
-- **HTTP Callbacks**: When a template specifies a callback URL, Glimpser sends a JSON webhook with caption or motion updates to that endpoint.
+- **HTTP Callbacks**: When a template specifies a callback URL, Glimpser sends a
+  JSON webhook with caption or motion updates to that endpoint. See the
+  [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
+  examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.

--- a/docs/http_callbacks.md
+++ b/docs/http_callbacks.md
@@ -1,0 +1,63 @@
+# HTTP Callback Guide
+
+Glimpser can notify external services when motion is detected or when a
+new caption is generated. This is handled by the `send_http_callback`
+function in `app/utils/http_callbacks.py`.
+
+## How Callbacks Work
+
+Whenever a template has a `callback_url` defined, Glimpser sends an HTTP
+`POST` request to that URL. The request body is JSON with two fields:
+
+- `event` – either `"caption"` or `"motion"`
+- `payload` – a dictionary containing details about the event
+
+The relevant code is shown below:
+
+```python
+# app/utils/http_callbacks.py
+send_http_callback(url, event_type, payload)
+```
+
+Scheduling tasks assemble the payload and call this function whenever an
+image is processed or motion is detected.
+
+Example payload from `app/utils/scheduling.py`:
+
+```python
+payload = {
+    "name": name,
+    "caption": template.get("last_caption"),
+    "timestamp": lctime,
+    "motion": bool(lsum),
+}
+send_http_callback(template.get("callback_url"), event, payload)
+```
+
+## Configuring a Callback URL
+
+1. Open the Glimpser web interface and edit a template.
+2. Enter the destination URL in the **Callback URL** field.
+3. Save the template. Glimpser will begin posting events to that URL.
+
+You can also set `callback_url` directly in the settings database if you
+manage templates programmatically.
+
+## Example JSON Payload
+
+A caption event might look like this:
+
+```json
+{
+  "event": "caption",
+  "payload": {
+    "name": "front_door",
+    "caption": "No activity detected",
+    "timestamp": "2024-08-30 12:00:00",
+    "motion": false
+  }
+}
+```
+
+Use this structure to integrate Glimpser with home automation systems,
+webhooks, or other services.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Getting Started](getting_started.md)
 - [Installation Guide](installation.md)
 - [Integration Guide](integration_guide.md)
+- [HTTP Callback Guide](http_callbacks.md)
 - [Recommendations](recommendations.md)
 - [Troubleshooting](troubleshooting.md)
 


### PR DESCRIPTION
## Summary
- document how `send_http_callback` delivers webhook events
- link to new doc from README and docs index

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`