### PR TITLE
Improve FFmpeg error handling

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import time
 import logging
+from enum import Enum, auto
 
 from .validators import validate_template_name
 
@@ -23,6 +24,14 @@ from app.config import (
 )
 
 from .template_manager import get_templates
+
+
+class ConcatStatus(Enum):
+    """Return codes for concatenation handling."""
+
+    RECOVERED = auto()
+    RETRY = auto()
+    FATAL = auto()
 
 
 
@@ -169,7 +178,7 @@ def get_video_duration(video_path):
     return duration
 
 
-def concatenate_videos(in_process_video, temp_video, video_path) -> bool:
+def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> bool:
     """Concatenate the temporary video with the existing in-process video."""
     if (
         os.path.exists(in_process_video)
@@ -235,7 +244,15 @@ def concatenate_videos(in_process_video, temp_video, video_path) -> bool:
                 )
 
             except Exception as e:
-                handle_concat_error(e, temp_video, in_process_video)
+                status = handle_concat_error(e, temp_video, in_process_video)
+                if status == ConcatStatus.RETRY and retries > 0:
+                    logging.info("Retrying concatenation due to transient error")
+                    time.sleep(1)
+                    return concatenate_videos(in_process_video, temp_video, video_path, retries=retries - 1)
+                elif status == ConcatStatus.RECOVERED:
+                    return True
+                else:
+                    return False
         elif os.path.exists(temp_video) and os.path.getsize(temp_video) > 0:
             os.rename(temp_video, in_process_video)
     elif os.path.exists(temp_video) and os.path.getsize(temp_video) > 0:
@@ -247,18 +264,28 @@ def concatenate_videos(in_process_video, temp_video, video_path) -> bool:
     return False
 
 
-def handle_concat_error(e, temp_video, in_process_video) -> bool:
-    """Handle errors that occur during the concatenation process."""
+def handle_concat_error(e, temp_video, in_process_video) -> ConcatStatus:
+    """Handle errors that occur during the concatenation process.
 
-    if "/in_process.mp4: Invalid data found" in str(e):
-        logging.warning("invalid in_process file %s", e)
+    Returns a :class:`ConcatStatus` indicating how the caller should proceed.
+    """
+
+    message = str(e)
+
+    if "Invalid data found" in message:
+        logging.warning("invalid in_process file %s", message)
         if os.path.getsize(temp_video) > 0:
             os.rename(temp_video, in_process_video)
-            # TODO: consider truth
-    else:
-        logging.error("FFmpeg concat command failed: %s", e) # TODO: handle this better... why non zero exit?
-        if os.path.getsize(temp_video) > 0:
-            os.rename(temp_video, in_process_video)
+        return ConcatStatus.RECOVERED
+
+    if "temporarily unavailable" in message or "Resource busy" in message:
+        logging.warning("transient ffmpeg error: %s", message)
+        return ConcatStatus.RETRY
+
+    logging.error("FFmpeg concat command failed: %s", message)
+    if os.path.getsize(temp_video) > 0:
+        os.rename(temp_video, in_process_video)
+    return ConcatStatus.FATAL
 
 
 def compile_to_video(camera_path, video_path) -> bool:

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -15,6 +15,7 @@ from app.utils.video_archiver import (
     get_video_duration,
     concatenate_videos,
     handle_concat_error,
+    ConcatStatus,
     compile_to_video,
     archive_screenshots,
 )
@@ -103,17 +104,51 @@ class TestVideoArchiver(unittest.TestCase):
         mock_get_video_duration.return_value = 10
         mock_subprocess_run.return_value.returncode = 0
         result = concatenate_videos("in_process.mp4", "temp.mp4", self.temp_dir)
-        # Note - TODO: this returns None because the files do not exist.  May have to patch os.path.exists 
+        # Note - TODO: this returns None because the files do not exist.  May have to patch os.path.exists
         #self.assertTrue(result)
+
+    @patch("app.utils.video_archiver.get_video_duration")
+    @patch("subprocess.run")
+    def test_concatenate_videos_retry(self, mock_subprocess_run, mock_get_video_duration):
+        mock_get_video_duration.return_value = 10
+        mock_subprocess_run.side_effect = [RuntimeError("Resource temporarily unavailable"), None]
+        with (
+            patch("app.utils.video_archiver.handle_concat_error", return_value=ConcatStatus.RETRY) as mock_handle,
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=1),
+            patch("os.rename"),
+            patch("os.symlink"),
+        ):
+            result = concatenate_videos("in.mp4", "tmp.mp4", self.temp_dir)
+        self.assertEqual(mock_subprocess_run.call_count, 2)
 
     def test_handle_concat_error(self):
         with patch("os.path.getsize", return_value=100), patch(
             "os.rename"
         ) as mock_rename:
-            handle_concat_error(
+            status = handle_concat_error(
                 Exception("Invalid data found"), "temp.mp4", "in_process.mp4"
             )
             mock_rename.assert_called_once_with("temp.mp4", "in_process.mp4")
+            self.assertEqual(status, ConcatStatus.RECOVERED)
+
+        with patch("os.path.getsize", return_value=100), patch(
+            "os.rename"
+        ) as mock_rename:
+            status = handle_concat_error(
+                Exception("Resource temporarily unavailable"), "temp.mp4", "in_process.mp4"
+            )
+            mock_rename.assert_not_called()
+            self.assertEqual(status, ConcatStatus.RETRY)
+
+        with patch("os.path.getsize", return_value=100), patch(
+            "os.rename"
+        ) as mock_rename:
+            status = handle_concat_error(
+                Exception("Some fatal error"), "temp.mp4", "in_process.mp4"
+            )
+            mock_rename.assert_called_once_with("temp.mp4", "in_process.mp4")
+            self.assertEqual(status, ConcatStatus.FATAL)
 
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("app.utils.video_archiver.concatenate_videos")


### PR DESCRIPTION
## Summary
- introduce `ConcatStatus` enum
- implement retry/handling logic for FFmpeg concat errors
- test recoverable, retry, and fatal scenarios

## Testing
- `pytest -q tests/test_video_archiver.py::TestVideoArchiver::test_concatenate_videos_retry -s`
- `pytest -q tests/test_video_archiver.py::TestVideoArchiver::test_handle_concat_error -s`
- `pytest -q tests/test_video_archiver.py -s`
- `pytest -q`