### PR TITLE
Improve RTSP streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
 - **Auto-captioning**: Automatically generates concise and informative captions for images and videos, providing quick insights into the content.
 
 - **Auto-summarization**: Summarizes data from multiple sources into a coherent and concise format, highlighting the most important information.
+- **RTSP Streaming**: Exposes a basic RTSP endpoint (`/test.rtsp`) so external NVRs can ingest the MJPEG stream.
 
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
@@ -91,6 +92,9 @@ Using advanced AI models, Glimpser generates concise and informative captions fo
 
 ### Auto-summarization
 Glimpser can summarize data from multiple sources into a coherent and concise format. The summaries highlight the most important information, making it easier for users to stay informed.
+
+### RTSP Streaming
+Glimpser exposes a simple RTSP endpoint at `/test.rtsp`. When a client issues the standard RTSP verbs (`OPTIONS`, `DESCRIBE`, `SETUP`, `PLAY`), the `/rtsp_stream` route serves MJPEG frames packetized with RTP headers. This allows external NVR software to ingest the stream as a basic camera source.
 
 ## Development
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -36,6 +36,8 @@ from sqlalchemy import text
 from werkzeug.security import check_password_hash
 from werkzeug.utils import secure_filename
 import subprocess
+import struct
+import random
 
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
@@ -380,7 +382,7 @@ def resize_and_pad(img, size, color=(0, 0, 0)):
 lock = Lock()
 
 
-def generate(group=None, filename="latest_camera.png", rtsp=False):
+def generate(group=None, filename="latest_camera.png", rtsp=False, session_id=None):
     # pretty hacky but it works ok
     global last_time, last_shot
     boundary = b"frame"
@@ -497,9 +499,16 @@ def generate(group=None, filename="latest_camera.png", rtsp=False):
 
         if frame:
             if rtsp:
-                # For RTSP, we need to add RTP headers and packetize the frame
-                # This is a simplified version and may need to be adjusted based on your exact requirements
-                rtp_header = b"\x80\x60\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"
+                if session_id and session_id in rtsp_sessions:
+                    session = rtsp_sessions[session_id]
+                    seq = session.get("seq", 0)
+                    timestamp = session.get("timestamp", 0)
+                    ssrc = session.get("ssrc", 0)
+                    rtp_header = struct.pack("!BBHII", 0x80, 96, seq, timestamp, ssrc)
+                    session["seq"] = (seq + 1) % 65536
+                    session["timestamp"] = (timestamp + 3600) % 0x100000000
+                else:
+                    rtp_header = b"\x80\x60\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"
                 yield rtp_header + frame
             else:
                 yield b"--" + boundary + b"\r\n"
@@ -893,8 +902,8 @@ def init_routes(app):
                 "o=- 0 0 IN IP4 127.0.0.1\r\n"
                 "s=Glimpser RTSP Stream\r\n"
                 "t=0 0\r\n"
-                "m=video 0 RTP/AVP 96\r\n"
-                "a=rtpmap:96 H264/90000\r\n"
+                "m=video 0 RTP/AVP 26\r\n"
+                "a=rtpmap:26 JPEG/90000\r\n"
                 "a=control:streamid=0\r\n"
             )
             return Response(
@@ -905,7 +914,12 @@ def init_routes(app):
 
         elif request.method == "SETUP":
             if session_id not in rtsp_sessions:
-                rtsp_sessions[session_id] = {"state": "READY"}
+                rtsp_sessions[session_id] = {
+                    "state": "READY",
+                    "seq": random.randint(0, 65535),
+                    "timestamp": random.randint(0, 0xFFFFFFFF),
+                    "ssrc": random.randint(0, 0xFFFFFFFF),
+                }
             transport = request.headers.get("Transport", "")
             return Response(
                 headers={
@@ -979,7 +993,7 @@ def init_routes(app):
         if session_id not in rtsp_sessions or rtsp_sessions[session_id]["state"] != "PLAYING":
             abort(400, "Invalid session or session not in PLAYING state")
         return Response(
-            generate(rtsp=True),
+            generate(rtsp=True, session_id=session_id),
             mimetype="application/x-rtp"
         )
 


### PR DESCRIPTION
## Summary
- add random RTP header tracking to RTSP sessions
- expose RTSP streaming in README
- document `/test.rtsp` usage

## Testing
- `python -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced RTSP streaming capability, allowing external NVR software to ingest the stream as a basic camera source.
  - RTSP endpoint now serves MJPEG frames with session-specific RTP headers for improved compatibility.

- **Documentation**
  - Updated the README to describe the new RTSP Streaming feature, including endpoint details and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->