### PR TITLE
Add listing endpoints for videos and screenshots

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1517,6 +1517,18 @@ def init_routes(app):
             videos=lvideos,
         )
 
+    @app.route("/screenshots/<string:name>")
+    @login_required
+    def list_screenshots(name: TemplateName):
+        """Return a JSON list of screenshot files for ``name``."""
+
+        template_name = validate_template_name(name)
+        if template_name is None:
+            abort(404)
+
+        lscreens = template_manager.get_screenshots_for_template(template_name)
+        return jsonify({"screenshots": lscreens})
+
     @app.route("/screenshots/<string:name>/<string:filename>")
     @login_required
     def uploaded_file(name: TemplateName, filename: str):
@@ -1547,6 +1559,18 @@ def init_routes(app):
             session.close()
 
         return True
+
+    @app.route("/videos/<string:name>")
+    @login_required
+    def list_videos(name: TemplateName):
+        """Return a JSON list of video files for ``name``."""
+
+        template_name = validate_template_name(name)
+        if template_name is None:
+            abort(404)
+
+        lvideos = template_manager.get_videos_for_template(template_name)
+        return jsonify({"videos": lvideos})
 
     @app.route("/videos/<string:name>/<string:filename>")
     @login_required

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -110,6 +110,28 @@ Returns an HTML dashboard displaying metrics such as CPU, memory, and disk usage
 
 Streams log records via Server-Sent Events. Optional query parameters `level`, `source`, `start_date`, `end_date`, and `search` allow filtering. The `/logs` and `/status` pages use this endpoint for the live log viewer.
 
+### 8. List Stored Videos
+
+**GET /videos/<template_name>**
+
+Return a JSON array of archived MP4 filenames for the specified template. Combine with `/videos/<template_name>/<filename>` to download a particular file.
+
+Example response:
+```json
+{"videos": ["cam1_20240101.mp4", "cam1_20240102.mp4"]}
+```
+
+### 9. List Stored Screenshots
+
+**GET /screenshots/<template_name>**
+
+Return a JSON array of screenshot filenames for the specified template. Individual files can be downloaded via `/screenshots/<template_name>/<filename>`.
+
+Example response:
+```json
+{"screenshots": ["cam1_20240101.png", "cam1_20240102.png"]}
+```
+
 ## Error Handling
 
 All endpoints may return the following error responses:

--- a/tests/test_listing_endpoints.py
+++ b/tests/test_listing_endpoints.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestListingEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        # Bypass authentication for route registration
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.template_manager.get_videos_for_template")
+    def test_list_videos(self, mock_get_videos):
+        mock_get_videos.return_value = ["file1.mp4"]
+        resp = self.client.get("/videos/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"videos": ["file1.mp4"]})
+
+    @patch("app.routes.template_manager.get_screenshots_for_template")
+    def test_list_screenshots(self, mock_get_shots):
+        mock_get_shots.return_value = ["shot1.png"]
+        resp = self.client.get("/screenshots/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"screenshots": ["shot1.png"]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/videos/<name>` and `/screenshots/<name>` endpoints that return lists of files
- document new API routes
- test the endpoints

## Testing
- `flake8`
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added endpoints to retrieve lists of screenshot and video filenames for a specified template.
- **Documentation**
  - Updated API documentation to describe the new endpoints and provide example responses.
- **Tests**
  - Introduced tests to verify the correct behavior of the new listing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->