### PR TITLE
Extend RTSP server features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
 - **Auto-captioning**: Automatically generates concise and informative captions for images and videos, providing quick insights into the content.
 
 - **Auto-summarization**: Summarizes data from multiple sources into a coherent and concise format, highlighting the most important information.
-- **RTSP Streaming**: Exposes a basic RTSP endpoint (`/test.rtsp`) so external NVRs can ingest the MJPEG stream.
+- **RTSP Streaming**: Exposes a basic RTSP endpoint (`/test.rtsp`) so external NVRs can ingest the MJPEG stream. Supported verbs are `OPTIONS`, `DESCRIBE`, `SETUP`, `PLAY`, `PAUSE`, `GET_PARAMETER`, and `TEARDOWN`.
 
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
@@ -107,7 +107,19 @@ Using advanced AI models, Glimpser generates concise and informative captions fo
 Glimpser can summarize data from multiple sources into a coherent and concise format. The summaries highlight the most important information, making it easier for users to stay informed.
 
 ### RTSP Streaming
-Glimpser exposes a simple RTSP endpoint at `/test.rtsp`. When a client issues the standard RTSP verbs (`OPTIONS`, `DESCRIBE`, `SETUP`, `PLAY`), the `/rtsp_stream` route serves MJPEG frames packetized with RTP headers. This allows external NVR software to ingest the stream as a basic camera source.
+Glimpser exposes a simple RTSP endpoint at `/test.rtsp`. When a client issues the standard RTSP verbs, the `/rtsp_stream` route serves MJPEG frames packetized with RTP headers.
+
+Typical sequence:
+
+1. `OPTIONS`
+2. `DESCRIBE`
+3. `SETUP`
+4. `PLAY`
+5. (optional) `PAUSE` / `PLAY`
+6. Periodic `GET_PARAMETER` to keep the session alive
+7. `TEARDOWN` to close the session
+
+This allows external NVR software to ingest the stream as a basic camera source.
 
 ## Development
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -884,7 +884,7 @@ def init_routes(app):
             return send_file(most_recent_file)
         return send_file(last_file)  # better than nothing
 
-    @app.route("/test.rtsp", methods=["OPTIONS", "DESCRIBE", "SETUP", "PLAY", "TEARDOWN"])
+    @app.route("/test.rtsp", methods=["OPTIONS", "DESCRIBE", "SETUP", "PLAY", "PAUSE", "GET_PARAMETER", "TEARDOWN"])
     def handle_rtsp():
         
         session_id = request.headers.get("Session", str(uuid.uuid4()))
@@ -892,7 +892,7 @@ def init_routes(app):
 
         if request.method == "OPTIONS":
             return Response(
-                "Public: OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY",
+                "Public: OPTIONS, DESCRIBE, SETUP, PLAY, PAUSE, GET_PARAMETER, TEARDOWN",
                 headers={"CSeq": cseq},
             )
 
@@ -920,12 +920,32 @@ def init_routes(app):
                     "timestamp": random.randint(0, 0xFFFFFFFF),
                     "ssrc": random.randint(0, 0xFFFFFFFF),
                 }
+
             transport = request.headers.get("Transport", "")
+            client_ports = (0, 0)
+            match = re.search(r"client_port=(\d+)(?:-(\d+))?", transport)
+            if match:
+                first = int(match.group(1))
+                second = int(match.group(2) or first + 1)
+                client_ports = (first, second)
+
+            server_ports = (5004, 5005)
+            session = rtsp_sessions[session_id]
+            session["client_ports"] = client_ports
+            session["server_ports"] = server_ports
+
+            transport_response = transport
+            if transport_response and not transport_response.endswith(";"):
+                transport_response += ";"
+            transport_response += (
+                f"server_port={server_ports[0]}-{server_ports[1]};ssrc={session['ssrc']}"
+            )
+
             return Response(
                 headers={
                     "CSeq": cseq,
                     "Session": session_id,
-                    "Transport": transport,
+                    "Transport": transport_response,
                 }
             )
 
@@ -939,6 +959,18 @@ def init_routes(app):
                     "Session": session_id,
                     "RTP-Info": "url=rtsp://example.com/test.rtsp/streamid=0;seq=0;rtptime=0",
                 }
+            )
+
+        elif request.method == "PAUSE":
+            if session_id not in rtsp_sessions:
+                abort(454)
+            rtsp_sessions[session_id]["state"] = "PAUSED"
+            return Response(headers={"CSeq": cseq, "Session": session_id})
+
+        elif request.method == "GET_PARAMETER":
+            return Response(
+                "session=alive",
+                headers={"CSeq": cseq, "Session": session_id}
             )
 
         elif request.method == "TEARDOWN":


### PR DESCRIPTION
## Summary
- parse `Transport` header during `SETUP` and advertise `server_port` and `ssrc`
- support `PAUSE` and `GET_PARAMETER` verbs
- always echo the `CSeq` header in responses
- document new RTSP verbs and client sequence in README

## Testing
- `pytest -q`