### PR TITLE
Fix RTSP GET_PARAMETER status

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -972,10 +972,7 @@ def init_routes(app):
             return Response(headers={"CSeq": cseq, "Session": session_id})
 
         elif request.method == "GET_PARAMETER":
-            return Response(
-                "session=alive",
-                headers={"CSeq": cseq, "Session": session_id}
-            )
+            return "Method Not Allowed", 405
 
         elif request.method == "TEARDOWN":
             if session_id in rtsp_sessions:


### PR DESCRIPTION
## Summary
- handle RTSP `GET_PARAMETER` with 405

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "GET_PARAMETER" RTSP method now correctly returns a "Method Not Allowed" response with status code 405.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->