### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,8 +1,9 @@
 name: Build Release Packages
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -15,16 +16,25 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      - name: Install build dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          pytest
       - name: Build packages
         run: |
           ./build_packages.sh
-      - name: Upload release assets
+      - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.ref_name }}
           files: |
             debian/glimpser.deb
             dist/Glimpser.exe

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ To set up the project for development:
    ```
 
 ## Releases
-Release packages are built automatically by GitHub Actions.
-When a release is published, the workflow runs `build_packages.sh`
-to create a Debian package and, if possible, a Windows executable.
-These files are attached to the GitHub release and can be downloaded
-from the Releases page.
+Release packages are built automatically when a version tag is pushed.
+The release workflow installs dependencies, runs the tests, and then executes
+`build_packages.sh`. If all steps succeed, a GitHub release is created for that
+tag and the resulting Debian package and Windows executable are uploaded.
+These files can be downloaded from the Releases page.
 
 ## Contributing
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants and how to report issues.


### PR DESCRIPTION
## Summary
- run lint, tests, and build when tagging a release
- automatically create a release if all steps succeed
- document the new release process

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*