### PR TITLE
Add local camera detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
 - **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF or RTSP cameras.
+- **Local Cameras**: `/discover` also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.
 

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -5,6 +5,8 @@ import logging
 import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 from ipaddress import ip_network
+import os
+import glob
 from .screenshots import is_port_open
 
 
@@ -89,6 +91,14 @@ def _scan_rtsp_ports(subnets):
     return found
 
 
+def _local_video_devices(base_path="/dev"):
+    """List available local video devices like /dev/video0."""
+    devices = []
+    for path in sorted(glob.glob(os.path.join(base_path, "video*"))):
+        devices.append({"ip": path, "protocol": "local", "port": 0, "info": {}})
+    return devices
+
+
 def discover_cameras():
     """Discover cameras on the local network via ONVIF and RTSP scanning."""
     cameras = []
@@ -98,6 +108,10 @@ def discover_cameras():
         cameras.extend(_scan_rtsp_ports(subnets))
     except Exception as e:
         logging.warning("RTSP scan error: %s", e)
+    try:
+        cameras.extend(_local_video_devices())
+    except Exception as e:
+        logging.debug("local video scan error: %s", e)
     # remove duplicates
     unique = {}
     for cam in cameras:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -18,10 +18,11 @@ When you visit `/discover`, Glimpser calls `discover_cameras()` to scan the netw
 
 ## Camera scanning logic
 
-The discovery code combines two approaches:
+The discovery code combines multiple approaches:
 
 1. **ONVIF probe** – `_probe_onvif()` broadcasts a WS-Discovery probe and parses any replies to extract camera IP addresses and ONVIF service URLs.
 2. **RTSP port scan** – `_scan_rtsp_ports()` walks through the host's local subnets and checks common RTSP ports (`554` and `8554`) using `is_port_open`.
+3. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
 Both sets of results are merged and returned. The key parts of the implementation are shown below:
 
@@ -42,6 +43,11 @@ def _scan_rtsp_ports(subnets):
             for port in (554, 8554):
                 if is_port_open(ip, port, timeout=1):
                     found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": {}})
+
+
+def _local_video_devices(base_path="/dev"):
+    for path in glob.glob(os.path.join(base_path, "video*")):
+        found.append({"ip": path, "protocol": "local", "port": 0, "info": {}})
 ```
 
 After scanning, `discover_cameras()` removes duplicates and returns the final list of cameras.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -27,6 +27,16 @@ class TestCameraDiscovery(unittest.TestCase):
             ('10.0.0.6', 8554)
         }
 
+    @patch('app.utils.camera_discovery.glob.glob')
+    def test_local_video_devices(self, mock_glob):
+        mock_glob.return_value = ['/dev/video0', '/dev/video1']
+        result = camera_discovery._local_video_devices()
+        expected = [
+            {'ip': '/dev/video0', 'protocol': 'local', 'port': 0, 'info': {}},
+            {'ip': '/dev/video1', 'protocol': 'local', 'port': 0, 'info': {}}
+        ]
+        self.assertEqual(result, expected)
+
     @patch('app.utils.camera_discovery.psutil.net_if_addrs')
     def test_local_subnets(self, mock_addrs):
         mock_addrs.return_value = self._mock_interfaces()


### PR DESCRIPTION
## Summary
- add `_local_video_devices` function to discover `/dev/video` cameras
- include local cameras in `discover_cameras`
- update camera discovery docs and README
- test local video device support

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation and README to clarify that the discovery feature now includes detection of local webcams and other video devices in addition to network cameras.
- **New Features**
  - Added support for automatically discovering local video devices (e.g., webcams) alongside ONVIF and RTSP network cameras.
- **Tests**
  - Introduced new unit tests to verify detection of local video devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->