### PR TITLE
Add Python 3.11 support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Capture time tracking for templates
 - FFprobe path configuration
 - Live video streaming endpoint `/live_video`
+- Python 3.11 compatibility
 
 ### Changed
 - Improved screenshot reliability

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
 ## Installation
 
 ### Prerequisites
-- Python 3.8 or higher
+- Python 3.8 to 3.11
 
 ### Steps
 1. **Install the Package**

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 ## Prerequisites
 
-- Python 3.8 or higher
+- Python 3.8 to 3.11
 - Git (for cloning the repository)
 
 ## Installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This guide provides detailed instructions for installing and setting up Glimpser
 - **Architecture**: Glimpser is primarily designed for x86 architecture.
   - ARM support may require additional work and is not guaranteed.
 - **Operating System**: Linux (Ubuntu 20.04 LTS or later recommended)
-- **Python**: Version 3.8 or higher
+- **Python**: Version 3.8 to 3.11
 
 ## Installation Steps
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Dependencies fail to install
 
 **Solution:**
-- Ensure you're using Python 3.8 or higher: `python --version`
+- Ensure you're using Python 3.8 or newer (tested up to 3.11): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     python_requires=">=3.8",
     entry_points={


### PR DESCRIPTION
## Summary
- support Python 3.11 in setup classifiers
- update Dockerfile to python:3.11-slim
- run CI and lint with Python 3.11
- document Python 3.11 support
- note Python 3.11 compatibility in changelog

## Testing
- `pytest -q`
- `pip install pylint` *(fails: Could not find a version that satisfies the requirement)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added compatibility with Python 3.11.

- **Documentation**
  - Updated documentation and installation guides to specify support for Python versions 3.8 to 3.11.
  - Clarified tested Python version range in troubleshooting and setup instructions.
  - Updated changelog to reflect Python 3.11 compatibility.

- **Chores**
  - Updated workflows and Docker configuration to use Python 3.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->