### PR TITLE
Implement offline camera handling

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -258,9 +258,7 @@ function changeCamera() {
         isConnected = checkCameraConnection(currentCamera);
     }
 
-    if (1==2) {
-	// TODO: even if the camera is offline, we still want to display the old stuff
-        // Display a placeholder for disconnected cameras
+    if (!isConnected) {
         const videoContainer = document.querySelector('.video-container');
         videoContainer.innerHTML = `
             <div class="placeholder">
@@ -291,7 +289,7 @@ function changeCamera() {
             const source = document.getElementById('video-source').value;
             const isConnected = checkCameraConnection(currentCamera);
 
-		if (1==2) { 
+            if (!isConnected) {
                 const videoContainer = document.querySelector('.video-container');
                 videoContainer.innerHTML = `
                     <div class="placeholder">
@@ -584,13 +582,19 @@ function playMotion() {
     // todo: stop the old playing png stream
 
     function checkCameraConnection(cameraName) {
-        // Check if the camera has a last_screenshot_time
         const camera = templateDetails[cameraName];
-        if (!camera || !camera.last_screenshot_time) {
+        if (!camera) {
             return false;
         }
 
-        // Check if the last screenshot is within the last hour
+        if (camera.offline_since && camera.offline_since !== "") {
+            return false;
+        }
+
+        if (!camera.last_screenshot_time) {
+            return false;
+        }
+
         const lastScreenshotTime = new Date(camera.last_screenshot_time);
         const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
         return lastScreenshotTime > oneHourAgo;

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -29,7 +29,13 @@ from .screenshots import (
     add_timestamp,
     is_mostly_blank,
 )
-from .template_manager import get_template, get_templates, save_template
+from .template_manager import (
+    get_template,
+    get_templates,
+    save_template,
+    update_last_screenshot_time,
+    mark_offline,
+)
 from .email_alerts import email_alert
 from .sms_alerts import sms_alert
 from .http_callbacks import send_http_callback
@@ -212,6 +218,17 @@ def update_camera(name, template, image_file=None):
                 add_timestamp(output_path, name, invert=template.get('invert',False))
                 os.rename(output_path, output_path.replace(".tmp.png", ".png"))
                 lsuc = True
+
+    url = template.get("url")
+
+    if lsuc is True:
+        update_last_screenshot_time(name)
+    else:
+        entry = throttle_cache.get(url)
+        if entry and entry.get("errors", 0) >= 10 and time.time() - entry.get(
+            "first", time.time()
+        ) > 60 * 60 * 24:
+            mark_offline(name)
 
     if lsuc is True:
         directory = os.path.join(SCREENSHOT_DIRECTORY, name)

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -881,19 +881,18 @@ def parse_url(url):
 
 def cas_error(url):
 
-        if throttle_cache.get(url) is None:
-            throttle_cache[url] = {}
-            throttle_cache[url]['errors'] = 1
-        else:
-            if throttle_cache[url].get('last',0) > time.time() - 60*5: # happened in the last 5 minutes?  Error again
-                throttle_cache[url]['errors'] += 1
-            else:
-                throttle_cache[url]['errors'] = 1
-            throttle_cache[url]['last'] = time.time()
+        entry = throttle_cache.setdefault(url, {'errors': 0, 'first': time.time()})
 
-        if throttle_cache[url]['errors'] > 2:
-            logging.error(f"Could not reach host: {url} {throttle_cache[url]['errors']} times")
-            throttle_cache[url]['timeout'] = time.time() + 60*60 # 1 hour timeout
+        if entry.get('last', 0) > time.time() - 60 * 5:
+            entry['errors'] += 1
+        else:
+            entry['errors'] = 1
+            entry['first'] = time.time()
+        entry['last'] = time.time()
+
+        if entry['errors'] > 2:
+            logging.error(f"Could not reach host: {url} {entry['errors']} times")
+            entry['timeout'] = time.time() + 60 * 60  # 1 hour timeout
 
 
 

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -34,6 +34,7 @@ class Template(Base):
     last_motion_time = Column(Text, default="")
     last_screenshot_time = Column(Text, default="")
     last_video_time = Column(Text, default="")
+    offline_since = Column(Text, default="")
     object_filter = Column(String, default="")
     object_confidence = Column(Float, default=0.5)
     popup_xpath = Column(String, default="")
@@ -382,3 +383,42 @@ def get_llm_cost_estimate(name: str) -> str:
     # For now, we'll return a random cost as an example.
     cost = random.uniform(0.5, 5.0)
     return f"${cost:.2f}"
+
+
+def update_last_screenshot_time(name: str) -> None:
+    """Set ``last_screenshot_time`` to now and clear ``offline_since``."""
+    name = validate_template_name(name)
+    if name is None:
+        return
+
+    manager = TemplateManager()
+    session = manager.get_session()
+    try:
+        template = session.query(Template).filter_by(name=name).first()
+        if template:
+            template.last_screenshot_time = datetime.utcnow().strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            template.offline_since = ""
+            session.commit()
+    finally:
+        session.close()
+
+
+def mark_offline(name: str) -> None:
+    """Record the time a camera was first detected offline."""
+    name = validate_template_name(name)
+    if name is None:
+        return
+
+    manager = TemplateManager()
+    session = manager.get_session()
+    try:
+        template = session.query(Template).filter_by(name=name).first()
+        if template and not template.offline_since:
+            template.offline_since = datetime.utcnow().strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            session.commit()
+    finally:
+        session.close()

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -5,7 +5,12 @@ from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.utils.template_manager import TemplateManager, Template
+from app.utils.template_manager import (
+    TemplateManager,
+    Template,
+    mark_offline,
+    update_last_screenshot_time,
+)
 from app.utils.validators import validate_template_name
 
 
@@ -247,6 +252,33 @@ class TestValidateTemplateName(unittest.TestCase):
                 validate_template_name(name),
                 msg=f"{name} should be invalid",
             )
+
+
+class TestOfflineHandling(unittest.TestCase):
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_mark_offline_sets_timestamp(self, mock_session):
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        template = Template(name="cam1")
+        mock_sess.query.return_value.filter_by.return_value.first.return_value = template
+
+        mark_offline("cam1")
+
+        self.assertNotEqual(template.offline_since, "")
+        mock_sess.commit.assert_called_once()
+
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_update_last_screenshot_time_clears_offline(self, mock_session):
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        template = Template(name="cam1", offline_since="yesterday")
+        mock_sess.query.return_value.filter_by.return_value.first.return_value = template
+
+        update_last_screenshot_time("cam1")
+
+        self.assertEqual(template.offline_since, "")
+        self.assertNotEqual(template.last_screenshot_time, "")
+        mock_sess.commit.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track long term failures with a new `offline_since` column
- mark cameras offline after repeated failures and clear on success
- show offline placeholder in live view when camera disconnected
- expose helper methods to update screenshot time and mark offline
- test offline handling

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cameras now display a placeholder in the interface when offline, based on improved connectivity checks.
  - Offline status and the time a camera went offline are now tracked and visible in the system.

- **Bug Fixes**
  - Enhanced logic ensures more accurate detection and display of camera connectivity status.

- **Tests**
  - Added tests to verify correct handling of camera offline status and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->