### PR TITLE
Add ffmpeg hardware acceleration option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,7 @@ EMAIL_PASSWORD=
 # External binaries
 FFMPEG_PATH=ffmpeg
 FFPROBE_PATH=ffprobe
+FFMPEG_HWACCEL=False
 
 # LLM configuration
 LLM_MODEL_VERSION=gpt-4.1-mini

--- a/app/config.py
+++ b/app/config.py
@@ -138,6 +138,8 @@ LLM_CAPTION_PROMPT = get_setting(
 # FFMPEG/FFPROBE path settings
 FFMPEG_PATH = get_setting("FFMPEG_PATH", "ffmpeg")
 FFPROBE_PATH = get_setting("FFPROBE_PATH", "ffprobe")
+# Enable GPU acceleration if supported (e.g. "auto", "cuda", etc.)
+FFMPEG_HWACCEL = get_setting("FFMPEG_HWACCEL", "False")
 
 
 # New settings for capture_frame_from_stream function

--- a/app/routes.py
+++ b/app/routes.py
@@ -303,8 +303,10 @@ def generate_video_stream(video_path: str):
 def generate_live_stream(url: str):
     """Yield video data directly from a remote URL using ffmpeg."""
 
-    command = [
-        config.FFMPEG_PATH,
+    command = [config.FFMPEG_PATH]
+    if config.FFMPEG_HWACCEL and config.FFMPEG_HWACCEL.lower() != "false":
+        command.extend(["-hwaccel", config.FFMPEG_HWACCEL])
+    command.extend([
         "-i",
         url,
         "-loglevel",
@@ -317,7 +319,7 @@ def generate_live_stream(url: str):
         "-movflags",
         "frag_keyframe+empty_moov",
         "pipe:1",
-    ]
+    ])
 
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
 

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -54,7 +54,7 @@ except Exception as e:  # pragma: no cover - optional dependency
 
 
 from app.config import (
-    DEBUG, LANG, SCREENSHOT_DIRECTORY, UA, FFMPEG_PATH,
+    DEBUG, LANG, SCREENSHOT_DIRECTORY, UA, FFMPEG_PATH, FFMPEG_HWACCEL,
     NUM_FRAMES, CAPTURE_TIMEOUT, PROBE_SIZE_DEFAULT,
     PROBE_SIZE_RTSP, PROBE_SIZE_OTHER, TZ
 )
@@ -1278,8 +1278,10 @@ def capture_frame_with_ytdlp(url, output_path, name="unknown", invert=False):
         lurl_cache[url] = "good"
         video_url = result.stdout.decode().strip()
         # 2) Use ffmpeg to capture a single frame
-        ffmpeg_command = [
-            "ffmpeg",
+        ffmpeg_command = [FFMPEG_PATH]
+        if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":
+            ffmpeg_command += ["-hwaccel", FFMPEG_HWACCEL]
+        ffmpeg_command += [
             "-analyzeduration",
             "20M",
             "-probesize",
@@ -1353,8 +1355,9 @@ def capture_frame_from_stream(
         command = [
             FFMPEG_PATH,  # Use the configurable FFMPEG_PATH
             "-hide_banner",
-            #'-hwaccel', 'auto',  #TODO add support
         ]
+        if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":
+            command.extend(["-hwaccel", FFMPEG_HWACCEL])
 
         lua = UA
         if stealth:

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -21,6 +21,7 @@ from app.config import (
     VIDEO_DIRECTORY,
     FFMPEG_PATH,
     FFPROBE_PATH,
+    FFMPEG_HWACCEL,
 )
 
 from .template_manager import get_templates
@@ -108,8 +109,10 @@ def compile_videos(input_file, output_file):
     if not os.path.exists(input_file):
         return False
 
-    create_command = [
-        FFMPEG_PATH,
+    create_command = [FFMPEG_PATH]
+    if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":
+        create_command.extend(["-hwaccel", FFMPEG_HWACCEL])
+    create_command.extend([
         "-threads",
         "5",
         "-err_detect",
@@ -130,7 +133,7 @@ def compile_videos(input_file, output_file):
         "+faststart",
         "-y",
         os.path.abspath(output_file),
-    ]
+    ])
 
     try:
         subprocess.run(
@@ -191,8 +194,10 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
         temp_video_duration = get_video_duration(temp_video)
         if in_process_duration > 0 and temp_video_duration > 0:
             concat_video = os.path.join(video_path, "in_process.concat.mp4")
-            concat_command = [
-                FFMPEG_PATH,
+            concat_command = [FFMPEG_PATH]
+            if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":
+                concat_command.extend(["-hwaccel", FFMPEG_HWACCEL])
+            concat_command.extend([
                 "-threads",
                 "5", # todo, make this a config
                 #"-safe",  Option not found?  But it is found and used elsewhere?  Not surewhy this is..
@@ -221,7 +226,7 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
                 "+faststart",
                 "-y",
                 os.path.abspath(concat_video),  # Overwrite the in-process video
-            ]
+            ])
             try:
                 # TODO: check stdout and stderr
                 subprocess.run(
@@ -377,8 +382,10 @@ def compile_to_video(camera_path, video_path) -> bool:
         # Create a temporary video with the new frames
         temp_video = os.path.join(video_path, "in_process.tmp.mp4")
 
-        create_command = [
-            FFMPEG_PATH,
+        create_command = [FFMPEG_PATH]
+        if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":
+            create_command.extend(["-hwaccel", FFMPEG_HWACCEL])
+        create_command.extend([
             "-threads",
             "5",
             "-f",
@@ -407,7 +414,7 @@ def compile_to_video(camera_path, video_path) -> bool:
             "fps=30,scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2",
             "-movflags",
             "+faststart",
-        ]
+        ])
         create_command.extend(
             ["-metadata", "creation_time=%sZ" % datetime.datetime.utcnow()]
         )

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -97,5 +97,6 @@ Additional variables control AI behaviour and external tools:
 - `LLM_CAPTION_PROMPT` – default prompt used for image captions
 - `FFMPEG_PATH` – path to the `ffmpeg` binary (default `ffmpeg`)
 - `FFPROBE_PATH` – path to the `ffprobe` binary (default `ffprobe`)
+- `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (`False` disables)
 
 Refer to the code comments in `app/config.py` for full details on each setting.


### PR DESCRIPTION
## Summary
- support optional GPU accel via `FFMPEG_HWACCEL`
- document the new variable
- enable hw acceleration for screenshot capture, live streams and video archiving

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for optional hardware acceleration in video processing and streaming tasks using ffmpeg, configurable via a new environment variable.
- **Documentation**
  - Updated configuration guide to document the new hardware acceleration option for ffmpeg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->