### PR TITLE
Fix Codecov coverage upload

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -34,10 +34,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Test with coverage
       run: |
-        pytest
+        python -m coverage run -m pytest
+        python -m coverage xml
     - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}        
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- install `coverage` when setting up Python
- run tests using `coverage` to produce `coverage.xml`
- upload coverage report with correct indentation

## Testing
- `pytest -q`
- `flake8`
- `python -m coverage run -m pytest` *(fails: `No module named coverage`)*