### PR TITLE
Add standalone unit tests

### DIFF
--- a/tests/test_retention_policy_utils.py
+++ b/tests/test_retention_policy_utils.py
@@ -1,0 +1,55 @@
+import unittest
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+from unittest.mock import patch
+
+class TestRetentionPolicyUtils(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # stub app.config required by the module
+        sys.modules['app'] = types.ModuleType('app')
+        utils_pkg = types.ModuleType('app.utils'); utils_pkg.__path__ = []
+        sys.modules['app'].utils = utils_pkg
+        sys.modules['app.utils'] = utils_pkg
+        cfg = types.ModuleType('app.config')
+        cfg.MAX_COMPRESSED_VIDEO_AGE = 1
+        cfg.MAX_RAW_DATA_SIZE = 100
+        cfg.SCREENSHOT_DIRECTORY = ''
+        cfg.VIDEO_DIRECTORY = ''
+        sys.modules['app.config'] = cfg
+
+        module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app', 'utils', 'retention_policy.py'))
+        spec = importlib.util.spec_from_file_location('retention', module_path)
+        cls.retention = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.retention)
+
+    def test_get_files_sorted_by_creation_time(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            f1 = os.path.join(temp_dir, 'a')
+            f2 = os.path.join(temp_dir, 'b')
+            f3 = os.path.join(temp_dir, 'c')
+            for f in (f1, f2, f3):
+                open(f, 'w').close()
+            ctime_map = {f1:3, f2:1, f3:2}
+            with patch('os.path.getctime', side_effect=lambda p: ctime_map[p]):
+                files = self.retention.get_files_sorted_by_creation_time(temp_dir)
+        expected = [os.path.join(temp_dir,'b'), os.path.join(temp_dir,'c'), os.path.join(temp_dir,'a')]
+        self.assertEqual(files, expected)
+
+    def test_delete_old_files(self):
+        files = ['f0','f1','f2']
+        ctime_map = {'f0':900, 'f1':800, 'f2':700}
+        size_map = {'f0':10, 'f1':20, 'f2':30}
+        removed = []
+        with patch('os.path.getctime', side_effect=lambda p: ctime_map[p]), \
+             patch('os.path.getsize', side_effect=lambda p: size_map[p]), \
+             patch('os.remove', side_effect=lambda p: removed.append(p)), \
+             patch('time.time', return_value=1000):
+            self.retention.delete_old_files(files, max_age=0, max_size=0, minimum=0)
+        self.assertEqual(set(removed), set(files))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validators_dynamic.py
+++ b/tests/test_validators_dynamic.py
@@ -1,0 +1,36 @@
+import unittest
+import importlib.util
+import os
+import sys
+import types
+
+class TestValidateTemplateName(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # provide minimal werkzeug.utils.secure_filename
+        wu_mod = types.ModuleType('werkzeug.utils')
+        wu_mod.secure_filename = lambda x: x
+        w_mod = types.ModuleType('werkzeug')
+        w_mod.utils = wu_mod
+        sys.modules.setdefault('werkzeug', w_mod)
+        sys.modules.setdefault('werkzeug.utils', wu_mod)
+
+        module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app', 'utils', 'validators.py'))
+        spec = importlib.util.spec_from_file_location('validators', module_path)
+        cls.validators = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.validators)
+
+    def test_validate_template_name_valid(self):
+        func = self.validators.validate_template_name
+        self.assertEqual(func('valid-name_123'), 'valid-name_123')
+
+    def test_validate_template_name_invalid(self):
+        func = self.validators.validate_template_name
+        self.assertIsNone(func('invalid name'))
+        self.assertIsNone(func('../escape'))
+        self.assertIsNone(func('-start'))
+        self.assertIsNone(func('end-'))
+        self.assertIsNone(func('a'*33))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_archiver_unit.py
+++ b/tests/test_video_archiver_unit.py
@@ -1,0 +1,61 @@
+import unittest
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import patch
+
+class TestVideoArchiverUnit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # minimal dependency stubs
+        sys.modules['app'] = types.ModuleType('app')
+        utils_pkg = types.ModuleType('app.utils'); utils_pkg.__path__ = []
+        sys.modules['app'].utils = utils_pkg
+        sys.modules['app.utils'] = utils_pkg
+        cfg = types.ModuleType('app.config')
+        cfg.MAX_COMPRESSED_VIDEO_AGE = 1
+        cfg.MAX_IN_PROCESS_VIDEO_SIZE = 100
+        cfg.NAME = ''
+        cfg.SCREENSHOT_DIRECTORY = ''
+        cfg.VERSION = ''
+        cfg.VIDEO_DIRECTORY = ''
+        cfg.FFMPEG_PATH = 'ffmpeg'
+        cfg.FFPROBE_PATH = 'ffprobe'
+        cfg.FFMPEG_HWACCEL = ''
+        sys.modules['app.config'] = cfg
+        tm = types.ModuleType('app.utils.template_manager')
+        tm.get_templates = lambda: {}
+        sys.modules['app.utils.template_manager'] = tm
+        # validators dependency
+        wu_mod = types.ModuleType('werkzeug.utils'); wu_mod.secure_filename=lambda x:x
+        w_mod = types.ModuleType('werkzeug'); w_mod.utils = wu_mod
+        sys.modules['werkzeug']=w_mod; sys.modules['werkzeug.utils']=wu_mod
+        spec_val = importlib.util.spec_from_file_location('app.utils.validators', os.path.join(os.path.dirname(__file__), '..','app','utils','validators.py'))
+        val_mod = importlib.util.module_from_spec(spec_val)
+        spec_val.loader.exec_module(val_mod)
+        sys.modules['app.utils.validators'] = val_mod
+        module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'app', 'utils', 'video_archiver.py'))
+        spec = importlib.util.spec_from_file_location('app.utils.video_archiver', module_path)
+        cls.va = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.va)
+
+    def test_trim_group_name(self):
+        self.assertEqual(self.va.trim_group_name('Hello World'), 'hello_world')
+
+    def test_handle_concat_error(self):
+        with patch('os.path.getsize', return_value=1), patch('os.rename') as rn:
+            status = self.va.handle_concat_error(Exception('Invalid data found'), 't.mp4','in.mp4')
+            self.assertEqual(status, self.va.ConcatStatus.RECOVERED)
+            rn.assert_called_once_with('t.mp4','in.mp4')
+        with patch('os.path.getsize', return_value=1), patch('os.rename') as rn:
+            status = self.va.handle_concat_error(Exception('Resource busy'), 't.mp4','in.mp4')
+            self.assertEqual(status, self.va.ConcatStatus.RETRY)
+            rn.assert_not_called()
+        with patch('os.path.getsize', return_value=1), patch('os.rename') as rn:
+            status = self.va.handle_concat_error(Exception('other'), 't.mp4','in.mp4')
+            self.assertEqual(status, self.va.ConcatStatus.FATAL)
+            rn.assert_called_once_with('t.mp4','in.mp4')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add validator tests that load the module directly and stub Werkzeug
- cover retention policy utility functions with dynamic import and patches
- add video_archiver unit tests with stubbed dependencies

## Testing
- `pytest tests/test_validators_dynamic.py tests/test_retention_policy_utils.py tests/test_video_archiver_unit.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new unit tests for retention policy utilities, including file sorting and deletion logic.
  - Introduced tests for template name validation, covering both valid and invalid cases.
  - Added unit tests for video archiver utilities, verifying group name formatting and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->