### PR TITLE
Add PyPI publish step

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Build packages
         run: |
           ./build_packages.sh
+      - name: Build Python distributions
+        run: |
+          python -m pip install build
+          python -m build
+      - name: Publish to PyPI
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create Release and Upload Assets
         uses: softprops/action-gh-release@v1
         with:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ Release packages are built automatically when a version tag is pushed.
 The release workflow installs dependencies, runs the tests, and then executes
 `build_packages.sh`. If all steps succeed, a GitHub release is created for that
 tag and the resulting Debian package and Windows executable are uploaded.
-These files can be downloaded from the Releases page.
+If the repository contains a `PYPI_API_TOKEN` secret, the workflow also
+builds Python distributions and publishes them to PyPI. These files can be
+downloaded from the Releases page or installed with `pip`.
 
 ## Contributing
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants and how to report issues.


### PR DESCRIPTION
## Summary
- build Python distributions in release workflow
- publish to PyPI when `PYPI_API_TOKEN` secret is available
- update README with PyPI publish details

## Testing
- `pytest -q`