### PR TITLE
Fix retention policy sorting logic

### DIFF
--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -34,12 +34,13 @@ def delete_old_files(file_list, max_age, max_size, minimum=10):
     current_time = time.time()
     total_size = 0
 
-    # sort the list so we keep it in the right date order (it should already be sorted)
-    file_list = sorted(file_list, reverse=True)[minimum:]
+    # `get_files_sorted_by_creation_time` already returns files oldest->newest.
+    # Skip the newest `minimum` files so they are preserved.
+    files_to_check = file_list[:-minimum] if minimum else file_list
 
     # Delete files if total size exceeds the maximum size or they are older than max_age
     # start from oldest to newest
-    for file_path in file_list:
+    for file_path in files_to_check:
         if (
             "in_process." in file_path
             or "last_motion." in file_path

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -4,6 +4,7 @@ import unittest
 import tempfile
 import os
 import sys
+import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -13,20 +14,21 @@ class TestRetentionPolicy(unittest.TestCase):
 
     def test_delete_old_files(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            # Create dummy files with different ages
+            # Create dummy files in sequence so creation times increase
+            file_paths = []
             for i in range(5):
                 file_path = os.path.join(temp_dir, f"file{i}.txt")
                 with open(file_path, 'w') as f:
                     f.write("Some content")
-                os.utime(file_path, (i * 1000, i * 1000))  # Modify file creation time
+                file_paths.append(file_path)
+                time.sleep(0.01)  # ensure distinct timestamps
             
             # Run the delete function
-            files = os.listdir(temp_dir)
-            delete_old_files([os.path.join(temp_dir, f) for f in files], max_age=0, max_size=0, minimum=2)
-            
-            # Check that only two files remain
+            delete_old_files(file_paths, max_age=0, max_size=0, minimum=2)
+
+            # Check that only the two newest files remain
             remaining_files = os.listdir(temp_dir)
-            self.assertEqual(len(remaining_files), 2)
+            self.assertEqual(set(remaining_files), {"file3.txt", "file4.txt"})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- keep newest files by slicing instead of resorting
- adjust retention policy unit test to ensure newest files remain

## Testing
- `pytest -q`