### PR TITLE
Fix backup_config success tracking

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,16 +50,17 @@ def get_setting(name, default=None):
 
 def backup_config() -> bool:
     session = SessionLocal()
+    success = True
     try:
         settings = session.execute(text("SELECT name, value FROM settings")).fetchall()
         config_dict = {name: value for name, value in settings}
-        with open(BACKUP_PATH, 'w') as f:
+        with open(BACKUP_PATH, "w") as f:
             json.dump(config_dict, f)
     except Exception:
-        return False
+        success = False
     finally:
         session.close()
-        return True
+    return success
 
 def restore_config():
     if os.path.exists(BACKUP_PATH):

--- a/tests/test_config_backup.py
+++ b/tests/test_config_backup.py
@@ -1,0 +1,68 @@
+import os
+import sqlite3
+import importlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class TestBackupConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        self.backup_path = os.path.join(self.temp_dir.name, "backup.json")
+        self.env_patch = patch.dict(
+            os.environ,
+            {
+                "GLIMPSER_DATABASE_PATH": self.db_path,
+                "GLIMPSER_BACKUP_PATH": self.backup_path,
+            },
+        )
+        self.env_patch.start()
+
+        import app.config as config
+        import app.utils.db as db
+        importlib.reload(config)
+        importlib.reload(db)
+        self.config = config
+
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            """CREATE TABLE settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                value TEXT NOT NULL
+            )"""
+        )
+        conn.execute("INSERT INTO settings (name, value) VALUES (?, ?)", ("A", "1"))
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        self.env_patch.stop()
+        import app.config as config
+        import app.utils.db as db
+        importlib.reload(config)
+        importlib.reload(db)
+        self.temp_dir.cleanup()
+
+    def test_backup_config_success(self):
+        result = self.config.backup_config()
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(self.backup_path))
+
+    def test_backup_config_returns_false_on_exception(self):
+        class DummySession:
+            def execute(self, *a, **kw):
+                raise Exception("boom")
+
+            def close(self):
+                pass
+
+        with patch.object(self.config, "SessionLocal", return_value=DummySession()):
+            result = self.config.backup_config()
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `backup_config` reports failures via a `success` variable
- add unit tests covering success and failure cases for backing up the config

## Testing
- `flake8`
- `pytest -q`