### PR TITLE
Add README for docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 Glimpser is a straightforward yet powerful real-time monitoring application designed to capture, analyze, and summarize live data from various sources such as cameras, dashboards, and video streams. Utilizing advanced image processing techniques and AI models, Glimpser provides insightful summaries and alerts. It’s highly configurable, allowing users to tailor it to their specific monitoring needs through an easy-to-use interface.
 
 For more documentation, see the [documentation index](docs/index.md).
+You can find an overview of the docs folder in [docs/README.md](docs/README.md).
 Read a high-level [Architecture Overview](docs/architecture_overview.md) to understand how the pieces fit together.
 
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation Overview
+
+This folder contains all the user and developer guides for Glimpser.
+If you're looking for the list of available documents, see [index.md](index.md).
+


### PR DESCRIPTION
## Summary
- add a short README to `docs/`
- link to the new docs README from project root README

## Testing
- `black . --check` *(fails: would reformat a lot of files)*
- `flake8` *(fails: many style violations)*
- `pytest -q`