### PR TITLE
Add titles to settings page inputs

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -14,12 +14,12 @@
 
     <h3>Add New Setting</h3>
     <form method="POST" action="{{ url_for('settings') }}">
-        <input type="hidden" name="action" value="add">
-        <label for="new_name">Name:</label>
-        <input type="text" id="new_name" name="new_name" required>
-        <label for="new_value">Value:</label>
-        <input type="text" id="new_value" name="new_value" required>
-        <button type="submit">Add Setting</button>
+        <input type="hidden" name="action" value="add" title="Add setting action">
+        <label for="new_name" title="Setting name">Name:</label>
+        <input type="text" id="new_name" name="new_name" required title="Enter setting name">
+        <label for="new_value" title="Setting value">Value:</label>
+        <input type="text" id="new_value" name="new_value" required title="Enter setting value">
+        <button type="submit" title="Add setting">Add Setting</button>
     </form>
 
     <form method="POST" action="{{ url_for('settings') }}">
@@ -36,25 +36,25 @@
                 <tr>
                     <td>{{ setting.name }}</td>
                     <td>
-                        <input type="text" name="{{ setting.name }}" value="{{ setting.value }}">
+                        <input type="text" name="{{ setting.name }}" value="{{ setting.value }}" title="Edit value for {{ setting.name }}">
                     </td>
                     <td>
-                        <button type="submit" name="action" value="delete" onclick="document.getElementById('name_to_delete').value='{{ setting.name }}'">Delete</button>
+                        <button type="submit" name="action" value="delete" title="Delete {{ setting.name }}" onclick="document.getElementById('name_to_delete').value='{{ setting.name }}'">Delete</button>
                     </td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
-        <input type="hidden" id="name_to_delete" name="name_to_delete" value="">
-        <button type="submit">Save Changes</button>
+        <input type="hidden" id="name_to_delete" name="name_to_delete" value="" title="Name of setting to delete">
+        <button type="submit" title="Save all changes">Save Changes</button>
     </form>
 
     <h3>Configuration Management</h3>
     <form method="POST" action="{{ url_for('settings') }}" enctype="multipart/form-data">
-        <button type="submit" name="action" value="backup">Backup Configuration</button>
-        <button type="submit" name="action" value="download">Download Configuration</button>
-        <input type="file" name="file" accept=".json">
-        <button type="submit" name="action" value="upload">Upload Configuration</button>
+        <button type="submit" name="action" value="backup" title="Backup configuration">Backup Configuration</button>
+        <button type="submit" name="action" value="download" title="Download configuration">Download Configuration</button>
+        <input type="file" name="file" accept=".json" title="Select configuration file">
+        <button type="submit" name="action" value="upload" title="Upload configuration">Upload Configuration</button>
     </form>
 
     {% include 'footer.html' %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,6 @@
 This folder contains all the user and developer guides for Glimpser.
 If you're looking for the list of available documents, see [index.md](index.md).
 
+- The Settings page now includes descriptive `title` attributes on form controls
+  to improve accessibility.
+


### PR DESCRIPTION
## Summary
- add tooltips to form controls in `settings.html`
- note accessibility improvement in docs

## Testing
- `flake8`
- `pytest -q`