### PR TITLE
Add titles to discovery page

### DIFF
--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -6,7 +6,13 @@
     <h2>Discovered Cameras</h2>
     <table>
         <thead>
-            <tr><th>IP</th><th>Protocol</th><th>Port</th><th>Info</th><th></th></tr>
+            <tr>
+                <th title="Camera IP address">IP</th>
+                <th title="Protocol type">Protocol</th>
+                <th title="Port number">Port</th>
+                <th title="Additional information">Info</th>
+                <th title="Add camera"></th>
+            </tr>
         </thead>
         <tbody>
         {% for cam in cameras %}
@@ -21,7 +27,7 @@
                         <input type="hidden" name="protocol" value="{{ cam.protocol }}">
                         <input type="hidden" name="port" value="{{ cam.port }}">
                         <input type="hidden" name="name" value="{{ cam.ip }}">
-                        <button type="submit">Add</button>
+                        <button type="submit" title="Add this camera">Add</button>
                     </form>
                 </td>
             </tr>

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -53,3 +53,4 @@ def _local_video_devices(base_path="/dev"):
 After scanning, `discover_cameras()` removes duplicates and returns the final list of cameras.
 
 You can then add a discovered camera to your configuration directly from the `/discover` page.
+The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.


### PR DESCRIPTION
## Summary
- add titles to discovery page table headers
- add tooltip to the Add button for accessibility
- document the new button title in the camera discovery guide

## Testing
- `flake8`
- `pytest -q`
- `black app/templates/discover.html docs/camera_discovery.md` *(fails: cannot parse HTML/MD)*