### PR TITLE
Increase test coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 
 - The Settings page now includes descriptive `title` attributes on form controls
   to improve accessibility.
+- Unit tests now cover configuration retrieval and Chrome debug port detection.
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -51,3 +51,4 @@ For more details, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 When adding new features, include corresponding tests under the `tests/` directory.
 - Utilities for network testing now have dedicated tests in `tests/test_network_testing_utils.py`.
+- Configuration lookup logic is verified by `tests/test_config_get_setting.py`.

--- a/tests/test_chrome_debug_port.py
+++ b/tests/test_chrome_debug_port.py
@@ -1,0 +1,26 @@
+import os
+import socket
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.screenshots import is_chrome_debug_port_open
+
+
+class TestChromeDebugPort(unittest.TestCase):
+    def test_detect_open_and_closed_port(self):
+        server = socket.socket()
+        server.bind(("127.0.0.1", 0))
+        port = server.getsockname()[1]
+        server.listen(1)
+        try:
+            self.assertTrue(is_chrome_debug_port_open("127.0.0.1", port, timeout=1))
+        finally:
+            server.close()
+        self.assertFalse(is_chrome_debug_port_open("127.0.0.1", port, timeout=1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_get_setting.py
+++ b/tests/test_config_get_setting.py
@@ -1,0 +1,67 @@
+import os
+import sqlite3
+import importlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+# ensure repo root in path
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class TestGetSetting(unittest.TestCase):
+    def _reload_config(self, db_path):
+        env = {
+            "GLIMPSER_DATABASE_PATH": db_path,
+            "GLIMPSER_BACKUP_PATH": os.path.join(
+                os.path.dirname(db_path), "backup.json"
+            ),
+        }
+        patcher = patch.dict(os.environ, env)
+        patcher.start()
+        import app.config as config
+        import app.utils.db as db
+
+        importlib.reload(config)
+        importlib.reload(db)
+        self.addCleanup(patcher.stop)
+        return config
+
+    def test_env_variable_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "t.db")
+            config = self._reload_config(db_path)
+            os.environ["FOO"] = "bar"
+            try:
+                self.assertEqual(config.get_setting("FOO", "default"), "bar")
+            finally:
+                del os.environ["FOO"]
+
+    def test_value_from_database(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "t.db")
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                """CREATE TABLE settings (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, value TEXT NOT NULL)"""
+            )
+            conn.execute(
+                "INSERT INTO settings (name, value) VALUES (?, ?)", ("FOO", "baz")
+            )
+            conn.commit()
+            conn.close()
+
+            config = self._reload_config(db_path)
+            self.assertEqual(config.get_setting("FOO", "default"), "baz")
+
+    def test_missing_table_returns_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = os.path.join(tmp, "t.db")
+            # no table created
+            config = self._reload_config(db_path)
+            self.assertEqual(config.get_setting("FOO", "default"), "default")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for config.get_setting
- add tests for Chrome debug port check
- document new tests in docs

## Testing
- `black tests/test_config_get_setting.py tests/test_chrome_debug_port.py`
- `flake8 tests/test_config_get_setting.py tests/test_chrome_debug_port.py`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to note expanded unit test coverage for configuration retrieval and Chrome debug port detection.

- **Tests**
  - Added new tests to verify configuration value retrieval from environment variables and databases.
  - Introduced tests to check detection of open and closed Chrome debug ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->