### PR TITLE
Improve retention policy test coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The Settings page now includes descriptive `title` attributes on form controls
   to improve accessibility.
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
+- Retention policy file sorting is also verified by tests.
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -52,3 +52,4 @@ For more details, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 When adding new features, include corresponding tests under the `tests/` directory.
 - Utilities for network testing now have dedicated tests in `tests/test_network_testing_utils.py`.
 - Configuration lookup logic is verified by `tests/test_config_get_setting.py`.
+- Retention policy behavior is checked by tests in `tests/test_retention_policy.py`.

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -6,9 +6,17 @@ import os
 import sys
 import time
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.utils.retention_policy import delete_old_files
+from unittest.mock import patch
+
+from app.utils.retention_policy import (
+    delete_old_files,
+    get_files_sorted_by_creation_time,
+    retention_cleanup,
+)
+import app.utils.retention_policy as retention_policy
+
 
 class TestRetentionPolicy(unittest.TestCase):
 
@@ -18,11 +26,11 @@ class TestRetentionPolicy(unittest.TestCase):
             file_paths = []
             for i in range(5):
                 file_path = os.path.join(temp_dir, f"file{i}.txt")
-                with open(file_path, 'w') as f:
+                with open(file_path, "w") as f:
                     f.write("Some content")
                 file_paths.append(file_path)
                 time.sleep(0.01)  # ensure distinct timestamps
-            
+
             # Run the delete function
             delete_old_files(file_paths, max_age=0, max_size=0, minimum=2)
 
@@ -30,6 +38,42 @@ class TestRetentionPolicy(unittest.TestCase):
             remaining_files = os.listdir(temp_dir)
             self.assertEqual(set(remaining_files), {"file3.txt", "file4.txt"})
 
-if __name__ == '__main__':
-    unittest.main()
+    def test_get_files_sorted_by_creation_time(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_paths = []
+            for name in ["a.txt", "b.txt", "c.txt"]:
+                path = os.path.join(temp_dir, name)
+                with open(path, "w"):
+                    pass
+                file_paths.append(path)
+                time.sleep(0.01)
 
+            # Add a symlink which should be ignored
+            os.symlink(file_paths[0], os.path.join(temp_dir, "link"))
+
+            result = get_files_sorted_by_creation_time(temp_dir)
+            # Symlinks are excluded and files are sorted oldest -> newest
+            self.assertEqual(result, file_paths)
+
+    @patch("app.utils.retention_policy.os.listdir")
+    @patch("app.utils.retention_policy.get_files_sorted_by_creation_time")
+    @patch("app.utils.retention_policy.delete_old_files")
+    def test_retention_cleanup_invokes_deletion(
+        self, mock_delete, mock_get_files, mock_listdir
+    ):
+        mock_listdir.side_effect = [["cam1"], ["cam1"]]
+        mock_get_files.return_value = ["f1", "f2"]
+
+        retention_cleanup()
+
+        self.assertEqual(mock_get_files.call_count, 2)
+        mock_delete.assert_called_with(
+            ["f1", "f2"],
+            retention_policy.MAX_COMPRESSED_VIDEO_AGE,
+            retention_policy.MAX_RAW_DATA_SIZE,
+        )
+        self.assertEqual(mock_delete.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for retention policy sorting and cleanup
- document the new tests in the docs

## Testing
- `flake8 tests/test_retention_policy.py`
- `pytest -q`
- `coverage run -m pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README and developer guide to mention expanded unit test coverage for retention policy file sorting and behavior.
- **Tests**
  - Added new tests to verify retention policy file sorting and cleanup logic, including improved test coverage and use of mocks for robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->