### PR TITLE
Fix duplicate title attribute

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -86,7 +86,7 @@ checkHealth();
                     </div>
                 </a>
 				    </td><td>
-                <a href='/settings' class="settings-icon" title="Settings" title='Update settings'>&#9881;</a>
+                <a href='/settings' class="settings-icon" title="Update settings">&#9881;</a>
 				    </td>
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 
 - The Settings page now includes descriptive `title` attributes on form controls
   to improve accessibility.
+- The navigation bar's Settings link now uses a single descriptive `title` attribute.
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -5,3 +5,4 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - Navigation and login logos include descriptive `alt` attributes.
 - The live feed image has both `alt` text and a tooltip.
 - The footer Help link displays a tooltip describing its purpose.
+- The navigation Settings link has a single descriptive `title` attribute.


### PR DESCRIPTION
## Summary
- keep a single `title` on the Settings link
- document accessibility update

## Testing
- `black --check app/templates/nav.html` *(fails: Cannot parse)*
- `flake8`
- `pytest -q`