### PR TITLE
Add mDNS camera discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FFprobe path configuration
 - Live video streaming endpoint `/live_video`
 - Python 3.11 compatibility
+- mDNS/Zeroconf camera discovery
 
 ### Changed
 - Improved screenshot reliability

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -7,7 +7,13 @@ from urllib.parse import urlparse
 from ipaddress import ip_network
 import os
 import glob
+import time
 from .screenshots import is_port_open
+
+try:  # optional Zeroconf support
+    from zeroconf import ServiceBrowser, Zeroconf
+except Exception:  # pragma: no cover - optional dependency may be missing
+    Zeroconf = None
 
 
 def _local_subnets():
@@ -56,13 +62,15 @@ def _probe_onvif(timeout=2):
             info = {}
             try:
                 xml = ET.fromstring(data)
-                xaddr = xml.find('.//{http://schemas.xmlsoap.org/ws/2005/04/discovery}XAddrs')
+                xaddr = xml.find(
+                    ".//{http://schemas.xmlsoap.org/ws/2005/04/discovery}XAddrs"
+                )
                 if xaddr is not None:
                     uri = xaddr.text.split()[0]
                     parsed = urlparse(uri)
                     ip = parsed.hostname or ip
                     port = parsed.port or 80
-                    info['xaddr'] = uri
+                    info["xaddr"] = uri
                 else:
                     port = 80
             except Exception as e:
@@ -73,6 +81,37 @@ def _probe_onvif(timeout=2):
         logging.warning("ONVIF discovery error: %s", e)
     finally:
         sock.close()
+    return cameras
+
+
+def _probe_mdns(timeout=2):
+    """Discover cameras advertised via mDNS/Zeroconf."""
+    cameras = []
+    if Zeroconf is None:
+        return cameras
+
+    class _Listener:
+        def add_service(self, zc, service_type, name):  # pragma: no cover - network
+            info = zc.get_service_info(service_type, name)
+            if info and info.addresses:
+                ip = socket.inet_ntoa(info.addresses[0])
+                cameras.append(
+                    {
+                        "ip": ip,
+                        "protocol": "mdns",
+                        "port": info.port,
+                        "info": {"name": name},
+                    }
+                )
+
+    zc = Zeroconf()
+    listener = _Listener()
+    services = ["_onvif._tcp.local.", "_rtsp._tcp.local."]
+    browsers = [ServiceBrowser(zc, s, listener) for s in services]
+    time.sleep(timeout)
+    for b in browsers:  # pragma: no cover - network
+        b.cancel()
+    zc.close()
     return cameras
 
 
@@ -87,7 +126,9 @@ def _scan_rtsp_ports(subnets):
             checked.add(ip)
             for port in (554, 8554):
                 if is_port_open(ip, port, timeout=1):
-                    found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": {}})
+                    found.append(
+                        {"ip": ip, "protocol": "rtsp", "port": port, "info": {}}
+                    )
     return found
 
 
@@ -100,9 +141,13 @@ def _local_video_devices(base_path="/dev"):
 
 
 def discover_cameras():
-    """Discover cameras on the local network via ONVIF and RTSP scanning."""
+    """Discover cameras on the local network."""
     cameras = []
     cameras.extend(_probe_onvif())
+    try:
+        cameras.extend(_probe_mdns())
+    except Exception as e:
+        logging.debug("mDNS discovery error: %s", e)
     try:
         subnets = _local_subnets()
         cameras.extend(_scan_rtsp_ports(subnets))
@@ -115,7 +160,7 @@ def discover_cameras():
     # remove duplicates
     unique = {}
     for cam in cameras:
-        key = (cam['ip'], cam['protocol'], cam['port'])
+        key = (cam["ip"], cam["protocol"], cam["port"])
         if key not in unique:
             unique[key] = cam
     return list(unique.values())

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -22,9 +22,10 @@ The discovery code combines multiple approaches:
 
 1. **ONVIF probe** – `_probe_onvif()` broadcasts a WS-Discovery probe and parses any replies to extract camera IP addresses and ONVIF service URLs.
 2. **RTSP port scan** – `_scan_rtsp_ports()` walks through the host's local subnets and checks common RTSP ports (`554` and `8554`) using `is_port_open`.
-3. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+3. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
+4. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
-Both sets of results are merged and returned. The key parts of the implementation are shown below:
+All discovered entries are merged and returned. The key parts of the implementation are shown below:
 
 ```python
 # app/utils/camera_discovery.py
@@ -54,3 +55,22 @@ After scanning, `discover_cameras()` removes duplicates and returns the final li
 
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.
+
+## Common cameras to try
+
+Any IP camera that supports **ONVIF** or exposes an **RTSP** stream should show
+up in the discovery list. The following brands are frequently used and respond
+well to the existing discovery methods:
+
+- **Amcrest** – consumer-grade cameras with reliable ONVIF support.
+- **Hikvision/Dahua** – widely deployed security cameras that offer RTSP
+  streams.
+- **Axis** – enterprise cameras known for robust network features.
+- **Foscam** – budget-friendly cameras often found in home setups.
+
+Locally attached USB webcams (for example, Logitech devices) will appear under
+`/dev/video*`.
+
+Remote sources such as **GOES16**, **ZoomEarth**, and **Dopler** can be added
+manually, but they are not discovered automatically because they are hosted
+outside the local network.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -9,79 +9,102 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from app.utils import camera_discovery
 
+
 class TestCameraDiscovery(unittest.TestCase):
     def _mock_interfaces(self):
         snicaddr = camera_discovery.psutil._common.snicaddr
         return {
-            'eth0': [
-                snicaddr(family=socket.AF_INET, address='192.168.1.5', netmask='255.255.255.252', broadcast='192.168.1.7', ptp=None)
+            "eth0": [
+                snicaddr(
+                    family=socket.AF_INET,
+                    address="192.168.1.5",
+                    netmask="255.255.255.252",
+                    broadcast="192.168.1.7",
+                    ptp=None,
+                )
             ],
-            'wlan0': [
-                snicaddr(family=socket.AF_INET, address='10.0.0.5', netmask='255.255.255.252', broadcast='10.0.0.7', ptp=None)
-            ]
+            "wlan0": [
+                snicaddr(
+                    family=socket.AF_INET,
+                    address="10.0.0.5",
+                    netmask="255.255.255.252",
+                    broadcast="10.0.0.7",
+                    ptp=None,
+                )
+            ],
         }
 
     def _port_open_side_effect(self, ip, port, timeout=1):
-        return (ip, port) in {
-            ('192.168.1.6', 554),
-            ('10.0.0.6', 8554)
-        }
+        return (ip, port) in {("192.168.1.6", 554), ("10.0.0.6", 8554)}
 
-    @patch('app.utils.camera_discovery.glob.glob')
+    @patch("app.utils.camera_discovery.glob.glob")
     def test_local_video_devices(self, mock_glob):
-        mock_glob.return_value = ['/dev/video0', '/dev/video1']
+        mock_glob.return_value = ["/dev/video0", "/dev/video1"]
         result = camera_discovery._local_video_devices()
         expected = [
-            {'ip': '/dev/video0', 'protocol': 'local', 'port': 0, 'info': {}},
-            {'ip': '/dev/video1', 'protocol': 'local', 'port': 0, 'info': {}}
+            {"ip": "/dev/video0", "protocol": "local", "port": 0, "info": {}},
+            {"ip": "/dev/video1", "protocol": "local", "port": 0, "info": {}},
         ]
         self.assertEqual(result, expected)
 
-    @patch('app.utils.camera_discovery.psutil.net_if_addrs')
+    @patch("app.utils.camera_discovery.psutil.net_if_addrs")
     def test_local_subnets(self, mock_addrs):
         mock_addrs.return_value = self._mock_interfaces()
         result = camera_discovery._local_subnets()
         expected = {
-            ip_network('192.168.1.5/255.255.255.252', strict=False),
-            ip_network('10.0.0.5/255.255.255.252', strict=False)
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
         }
         self.assertEqual(set(result), expected)
 
-    @patch('app.utils.camera_discovery.is_port_open')
+    @patch("app.utils.camera_discovery.is_port_open")
     def test_scan_rtsp_ports(self, mock_port_open):
         mock_port_open.side_effect = self._port_open_side_effect
         subnets = [
-            ip_network('192.168.1.5/255.255.255.252', strict=False),
-            ip_network('10.0.0.5/255.255.255.252', strict=False)
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
         ]
         result = camera_discovery._scan_rtsp_ports(subnets)
         expected = [
-            {'ip': '192.168.1.6', 'protocol': 'rtsp', 'port': 554, 'info': {}},
-            {'ip': '10.0.0.6', 'protocol': 'rtsp', 'port': 8554, 'info': {}}
+            {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
+            {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
         ]
         self.assertEqual(result, expected)
 
-    @patch('app.utils.camera_discovery._probe_onvif')
-    @patch('app.utils.camera_discovery.is_port_open')
-    @patch('app.utils.camera_discovery.psutil.net_if_addrs')
-    def test_discover_cameras_merge(self, mock_addrs, mock_port_open, mock_probe):
+    @patch("app.utils.camera_discovery._probe_mdns")
+    @patch("app.utils.camera_discovery._probe_onvif")
+    @patch("app.utils.camera_discovery.is_port_open")
+    @patch("app.utils.camera_discovery.psutil.net_if_addrs")
+    def test_discover_cameras_merge(
+        self, mock_addrs, mock_port_open, mock_onvif, mock_mdns
+    ):
         mock_addrs.return_value = self._mock_interfaces()
         mock_port_open.side_effect = self._port_open_side_effect
-        mock_probe.return_value = [
-            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}},
-            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}}  # duplicate
+        mock_onvif.return_value = [
+            {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
+            {
+                "ip": "192.168.1.6",
+                "protocol": "onvif",
+                "port": 80,
+                "info": {},
+            },  # duplicate
+        ]
+        mock_mdns.return_value = [
+            {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}}
         ]
         result = camera_discovery.discover_cameras()
         expected = [
-            {'ip': '192.168.1.6', 'protocol': 'onvif', 'port': 80, 'info': {}},
-            {'ip': '192.168.1.6', 'protocol': 'rtsp', 'port': 554, 'info': {}},
-            {'ip': '10.0.0.6', 'protocol': 'rtsp', 'port': 8554, 'info': {}}
+            {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
+            {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
+            {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
+            {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
         ]
         # convert to set of tuples for comparison ignoring order
         self.assertEqual(
-            { (c['ip'], c['protocol'], c['port']) for c in result },
-            { (c['ip'], c['protocol'], c['port']) for c in expected }
+            {(c["ip"], c["protocol"], c["port"]) for c in result},
+            {(c["ip"], c["protocol"], c["port"]) for c in expected},
         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support Zeroconf discovery in `camera_discovery`
- document optional mDNS scanning
- track new capability in changelog
- adjust camera discovery tests

## Testing
- `flake8`
- `pytest -q`