### PR TITLE
Add system status entry to camera discovery

### DIFF
--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -26,6 +26,9 @@
                         <input type="hidden" name="ip" value="{{ cam.ip }}">
                         <input type="hidden" name="protocol" value="{{ cam.protocol }}">
                         <input type="hidden" name="port" value="{{ cam.port }}">
+                        {% if cam.url %}
+                        <input type="hidden" name="url" value="{{ cam.url }}">
+                        {% endif %}
                         <input type="hidden" name="name" value="{{ cam.ip }}">
                         <button type="submit" title="Add this camera">Add</button>
                     </form>

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -157,6 +157,19 @@ def discover_cameras():
         cameras.extend(_local_video_devices())
     except Exception as e:
         logging.debug("local video scan error: %s", e)
+
+    # Always include the internal status page so the system can monitor itself
+    from app.config import PORT
+
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "System Status"},
+            "url": f"http://127.0.0.1:{PORT}/status",
+        }
+    )
     # remove duplicates
     unique = {}
     for cam in cameras:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -56,6 +56,11 @@ After scanning, `discover_cameras()` removes duplicates and returns the final li
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.
 
+The discovery list also shows a **System Status** entry pointing at your local
+`/status` page (`http://127.0.0.1:8082/status`). You can add this item like any
+other camera to have Glimpser periodically capture screenshots of its own
+metrics page.
+
 ## Common cameras to try
 
 Any IP camera that supports **ONVIF** or exposes an **RTSP** stream should show

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -37,3 +37,7 @@ To filter logs by level and message text, you could request:
 4. Results update automatically via `/stream_logs`.
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
+
+The `/status` page also appears on the `/discover` screen as a **System Status**
+camera. Adding it lets Glimpser capture periodic screenshots of its own health
+metrics.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -98,6 +98,12 @@ class TestCameraDiscovery(unittest.TestCase):
             {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
             {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
+            {
+                "ip": "127.0.0.1",
+                "protocol": "http",
+                "port": 8082,
+                "info": {"name": "System Status"},
+            },
         ]
         # convert to set of tuples for comparison ignoring order
         self.assertEqual(


### PR DESCRIPTION
## Summary
- make discovery list always include the `/status` page
- send `url` when adding a discovered camera
- describe new entry in discovery and system monitoring docs
- test that the discovery function returns the status entry

## Testing
- `flake8`
- `pytest -q`