### PR TITLE
Add base template layout

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,11 @@
+{% include 'header.html' %}
+<body>
+    <header>
+        {% include 'nav.html' %}
+    </header>
+
+    {% block content %}{% endblock %}
+
+    {% include 'footer.html' %}
+</body>
+</html>

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -1,12 +1,7 @@
 
 
- {% include 'header.html' %}
-
- <body>
-     <header>
-         {% include 'nav.html' %}
-
-     </header>
+{% extends 'base.html' %}
+{% block content %}
 
      <script>
          function updateTemplate(templateName) {
@@ -155,9 +150,5 @@
     </tbody>
 </table>
 
-    {% include 'footer.html' %}
-
-</body>
-
-</html>
+{% endblock %}
 

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -1,8 +1,5 @@
-{% include 'header.html' %}
-<body>
-    <header>
-        {% include 'nav.html' %}
-    </header>
+{% extends 'base.html' %}
+{% block content %}
     <h2>Discovered Cameras</h2>
     <table>
         <thead>
@@ -34,4 +31,4 @@
         {% endfor %}
         </tbody>
     </table>
-</body>
+{% endblock %}

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -1,10 +1,6 @@
 
-{% include 'header.html' %}
-
-<body>
-    <header>
-        {% include 'nav.html' %}
-    </header>
+{% extends 'base.html' %}
+{% block content %}
 
     <main class="container">
         <h2 class="page-title">Glimpser Help</h2>
@@ -83,10 +79,5 @@
         </section>
     </main>
 
-    <footer>
-        {% include 'footer.html' %}
-    </footer>
-
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,11 +1,7 @@
 <!-- app/templates/index.html -->
 
-	{% include 'header.html' %} 
-
-<body>
-	<header>
-	{% include 'nav.html' %}
-	</header>
+{% extends 'base.html' %}
+{% block content %}
 
 <details title="Expand to add a new template">
     <summary>Add Template</summary>
@@ -156,7 +152,5 @@ function validateForm() {
     </div>
 
 
-    {% include 'footer.html' %}
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -1,6 +1,5 @@
-{% include 'header.html' %}
-
-<body>
+{% extends 'base.html' %}
+{% block content %}
     <script>
         // Track the last time the health endpoint failed
         window.lastHealthFailed = false;
@@ -605,7 +604,5 @@ function playMotion() {
         playMP4();
     </script>
 
-    {% include 'footer.html' %}
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Login</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body>
-	<header>
-
-        <h1><a href='/'><img src='{{ url_for('static', filename='img/glimpser_small.png') }}' alt='Glimpser logo' title='Glimpser'></a></h1>
-	</header>
-
-	<center>
+{% extends 'base.html' %}
+{% block content %}
+    <center>
     <div class="login-container" title="Login form">
         <h2>Login Required</h2>
         <form method="post" title="Enter your credentials to log in">
@@ -25,9 +15,6 @@
             <input type="submit" value="Login" title="Click to log in">
         </form>
     </div>
-	</center>
-
-    {% include 'footer.html' %}
-</body>
-</html>
+        </center>
+{% endblock %}
 

--- a/app/templates/player.html
+++ b/app/templates/player.html
@@ -1,13 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Live Camera Feed</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body>
-	<header>
-    {% include 'nav.html' %} 
-	</header>
+{% extends 'base.html' %}
+{% block content %}
+    <h2>Live Camera Feed</h2>
     <h2>Live Feed
     </h2>
 
@@ -46,6 +39,5 @@
         // Start playing the first camera
         playNextCamera();
     </script>
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,10 +1,6 @@
 
-{% include 'header.html' %}
-
-<body>
-    <header>
-        {% include 'nav.html' %}
-    </header>
+{% extends 'base.html' %}
+{% block content %}
 
 
         <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger">Logout</a>
@@ -57,9 +53,6 @@
         <button type="submit" name="action" value="upload" title="Upload configuration">Upload Configuration</button>
     </form>
 
-    {% include 'footer.html' %}
-
     <script src="{{ url_for('static', filename='js/performance.js') }}"></script>
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/settings_explanation.html
+++ b/app/templates/settings_explanation.html
@@ -1,13 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Settings Explanation</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
-<body>
-    <header>
-        {% include 'nav.html' %}
+{% extends 'base.html' %}
+{% block content %}
+    <h1>Settings Explanation</h1>
     </header>
 
     <h1>Settings Explanation</h1>
@@ -131,6 +124,4 @@
         </tbody>
     </table>
 
-    {% include 'footer.html' %}
-</body>
-</html>
+{% endblock %}

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,12 +1,7 @@
 
 
-{% include 'header.html' %}
-
-<body>
-    <header>
-        {% include 'nav.html' %}
-
-    </header>
+{% extends 'base.html' %}
+{% block content %}
 
 <div class="scheduler-controls">
     <button id="toggle-scheduler" class="btn btn-primary">
@@ -29,13 +24,5 @@
 </ul>
 
 
-{% include 'logs.html' %} 
-
-
-<footer>
-{% include 'footer.html' %} 
-</footer>
-
-</body>
-
-</html>
+{% include 'logs.html' %}
+{% endblock %}

--- a/app/templates/stream.html
+++ b/app/templates/stream.html
@@ -1,16 +1,6 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Live Camera Feed</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
-
-</head>
-<body>
-    <header>
-	{% include 'nav.html' %} 
-    </header>
-    <h2>Live Feed</h2>
+{% extends 'base.html' %}
+{% block content %}
+    <h2>Live Camera Feed</h2>
 
     <div class="video-container">
         <div id="camera-name" class="camera-name"></div>
@@ -33,7 +23,5 @@
             });
         }
     </script>
-
-</body>
-</html>
+{% endblock %}
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -1,11 +1,7 @@
 <!-- app/templates/template_details.html -->
 
-{% include 'header.html' %} 
-
-<body>
-	<header>
-    {% include 'nav.html' %} 
-	</header>
+{% extends 'base.html' %}
+{% block content %}
 
 
 
@@ -328,7 +324,6 @@ function closeModal() {
     <br/>
 
 
-  {% include 'footer.html' %}
 
   <div id="camera-details-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
     <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
@@ -336,6 +331,5 @@ function closeModal() {
       <div id="camera-details-content"></div>
     </div>
   </div>
-</body>
-</html>
+{% endblock %}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
+- HTML templates share a new `base.html` that includes the header and footer.


### PR DESCRIPTION
## Summary
- create base.html with standard header and footer
- refactor templates to extend base.html
- document new shared layout in README

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified base layout for all HTML templates, providing consistent header, navigation, and footer across pages.

- **Refactor**
  - Updated all page templates to extend the new base layout, simplifying individual templates and centralizing page structure.

- **Documentation**
  - Added documentation noting the adoption of the shared base layout for HTML templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->