### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Addressed Python build issues and string concatenation errors
 - Fixed screenshot timeouts and setup script problems
 
+## [0.2.2] - 2025-05-26
+
+### Changed
+- Bumped package version in setup.py to 0.2.2.
+
 ## [1.0.0] - 2023-06-15
 
 ### Added
@@ -50,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.2
 [1.0.0]: https://github.com/KristopherKubicki/glimpser/releases/tag/v1.0.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
+- Application version bumped to `v0.2.2`.

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -13,6 +13,6 @@ PyPI.
 To trigger a new release, create a tag and push it to GitHub:
 
 ```sh
-git tag v1.0.0
-git push origin v1.0.0
+git tag v0.2.2
+git push origin v0.2.2
 ```

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="glimpser",
-    version="0.1.0",
+    version="0.2.2",
     author="Kristopher Kubicki",
     author_email="kristopher@glimser.net",
     description="A real-time monitoring application for capturing and analyzing live data from various sources",
@@ -35,4 +35,3 @@ setup(
         ],
     },
 )
-


### PR DESCRIPTION
## Summary
- bump package version to 0.2.2
- note new version in documentation
- update release workflow example
- record release in changelog

## Testing
- `flake8` *(fails: many existing issues)*
- `pytest -q`