### PR TITLE
Increase credential helper test coverage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,3 +9,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
+- Credential management helpers are validated by tests.

--- a/tests/test_generate_credentials.py
+++ b/tests/test_generate_credentials.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 import tempfile
 import sqlite3
+import argparse
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -18,13 +19,13 @@ class TestGenerateCredentials(unittest.TestCase):
         config.DATABASE_PATH = os.path.join(self.temp_dir, "test.db")
         self.conn = sqlite3.connect(config.DATABASE_PATH)
 
-        create_settings_table = '''
+        create_settings_table = """
         CREATE TABLE IF NOT EXISTS settings (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL UNIQUE,
             value TEXT NOT NULL
         );
-        '''
+        """
         cursor = self.conn.cursor()
         cursor.execute(create_settings_table)
         self.conn.commit()
@@ -56,6 +57,27 @@ class TestGenerateCredentials(unittest.TestCase):
         result = cursor.fetchone()
         self.assertIsNotNone(result)
 
+    def test_create_users(self):
+        """The users table should be created if missing."""
+        generate_credentials.create_users(self.conn)
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='users'"
+        )
+        self.assertIsNotNone(cursor.fetchone())
+
+    def test_upsert_user(self):
+        """Inserting and updating users should modify the table."""
+        generate_credentials.create_users(self.conn)
+        generate_credentials.upsert_user("alice", "hash1", "admin", self.conn)
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT password_hash, role FROM users WHERE username='alice'")
+        self.assertEqual(cursor.fetchone(), ("hash1", "admin"))
+
+        generate_credentials.upsert_user("alice", "hash2", "user", self.conn)
+        cursor.execute("SELECT password_hash, role FROM users WHERE username='alice'")
+        self.assertEqual(cursor.fetchone(), ("hash2", "user"))
+
     @patch("generate_credentials.input")
     @patch("generate_credentials.getpass.getpass")
     @patch("generate_credentials.secrets.token_hex")
@@ -69,20 +91,48 @@ class TestGenerateCredentials(unittest.TestCase):
         mock_hash.return_value = "hashed_password"
 
         # something wrong with previous mocks is messing this one up
-        #generate_credentials.generate_credentials(args=None)
+        # generate_credentials.generate_credentials(args=None)
 
         cursor = self.conn.cursor()
         cursor.execute("SELECT value FROM settings WHERE name='USER_NAME'")
-        #self.assertEqual(cursor.fetchone()[0], "testuser")
+        # self.assertEqual(cursor.fetchone()[0], "testuser")
 
         cursor.execute("SELECT value FROM settings WHERE name='USER_PASSWORD_HASH'")
-        #self.assertEqual(cursor.fetchone()[0], "hashed_password")
+        # self.assertEqual(cursor.fetchone()[0], "hashed_password")
 
         cursor.execute("SELECT value FROM settings WHERE name='SECRET_KEY'")
-        #self.assertEqual(cursor.fetchone()[0], "secretkey")
+        # self.assertEqual(cursor.fetchone()[0], "secretkey")
 
         cursor.execute("SELECT value FROM settings WHERE name='API_KEY'")
-        #self.assertEqual(cursor.fetchone()[0], "apikey")
+        # self.assertEqual(cursor.fetchone()[0], "apikey")
+
+    @patch("generate_credentials.generate_password_hash", return_value="h")
+    @patch(
+        "generate_credentials.app.config.get_setting", side_effect=lambda n, d=None: d
+    )
+    def test_generate_credentials_args(self, mock_get, mock_hash):
+        """Non-interactive credentials creation should populate both tables."""
+        generate_credentials.create_settings(self.conn)
+        args = argparse.Namespace(
+            db_path=config.DATABASE_PATH,
+            username="bob",
+            password="secret",
+            update_password=True,
+            secret_key="xyz",
+            update_key=True,
+        )
+        generate_credentials.generate_credentials(args)
+        self.conn.close()
+        self.conn = sqlite3.connect(config.DATABASE_PATH)
+        cur = self.conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE name='USER_NAME'")
+        self.assertEqual(cur.fetchone()[0], "bob")
+        cur.execute("SELECT value FROM settings WHERE name='USER_PASSWORD_HASH'")
+        self.assertEqual(cur.fetchone()[0], "h")
+        cur.execute("SELECT value FROM settings WHERE name='SECRET_KEY'")
+        self.assertEqual(cur.fetchone()[0], "xyz")
+        cur.execute("SELECT username, password_hash FROM users WHERE username='bob'")
+        self.assertEqual(cur.fetchone(), ("bob", "h"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- test create_users and upsert_user helpers
- exercise generate_credentials with arguments
- document new credential tests

## Testing
- `flake8`
- `pytest -q`