### PR TITLE
Add RTMP discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
   [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
-- **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF or RTSP cameras.
+- **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF, RTSP, and RTMP cameras.
 - **Local Cameras**: `/discover` also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -132,6 +132,21 @@ def _scan_rtsp_ports(subnets):
     return found
 
 
+def _scan_rtmp_ports(subnets):
+    """Scan common RTMP port 1935 across subnets."""
+    found = []
+    checked = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            if is_port_open(ip, 1935, timeout=1):
+                found.append({"ip": ip, "protocol": "rtmp", "port": 1935, "info": {}})
+    return found
+
+
 def _local_video_devices(base_path="/dev"):
     """List available local video devices like /dev/video0."""
     devices = []
@@ -151,6 +166,7 @@ def discover_cameras():
     try:
         subnets = _local_subnets()
         cameras.extend(_scan_rtsp_ports(subnets))
+        cameras.extend(_scan_rtmp_ports(subnets))
     except Exception as e:
         logging.warning("RTSP scan error: %s", e)
     try:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -22,8 +22,9 @@ The discovery code combines multiple approaches:
 
 1. **ONVIF probe** – `_probe_onvif()` broadcasts a WS-Discovery probe and parses any replies to extract camera IP addresses and ONVIF service URLs.
 2. **RTSP port scan** – `_scan_rtsp_ports()` walks through the host's local subnets and checks common RTSP ports (`554` and `8554`) using `is_port_open`.
-3. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
-4. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+3. **RTMP port scan** – `_scan_rtmp_ports()` checks each subnet for the default RTMP port (`1935`).
+4. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
+5. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
 All discovered entries are merged and returned. The key parts of the implementation are shown below:
 
@@ -46,6 +47,14 @@ def _scan_rtsp_ports(subnets):
                     found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": {}})
 
 
+def _scan_rtmp_ports(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            if is_port_open(ip, 1935, timeout=1):
+                found.append({"ip": ip, "protocol": "rtmp", "port": 1935, "info": {}})
+
+
 def _local_video_devices(base_path="/dev"):
     for path in glob.glob(os.path.join(base_path, "video*")):
         found.append({"ip": path, "protocol": "local", "port": 0, "info": {}})
@@ -63,7 +72,7 @@ metrics page.
 
 ## Common cameras to try
 
-Any IP camera that supports **ONVIF** or exposes an **RTSP** stream should show
+Any IP camera that supports **ONVIF**, **RTSP**, or **RTMP** streams should show
 up in the discovery list. The following brands are frequently used and respond
 well to the existing discovery methods:
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -35,7 +35,11 @@ class TestCameraDiscovery(unittest.TestCase):
         }
 
     def _port_open_side_effect(self, ip, port, timeout=1):
-        return (ip, port) in {("192.168.1.6", 554), ("10.0.0.6", 8554)}
+        return (ip, port) in {
+            ("192.168.1.6", 554),
+            ("10.0.0.6", 8554),
+            ("192.168.1.6", 1935),
+        }
 
     @patch("app.utils.camera_discovery.glob.glob")
     def test_local_video_devices(self, mock_glob):
@@ -71,6 +75,19 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery.is_port_open")
+    def test_scan_rtmp_ports(self, mock_port_open):
+        mock_port_open.side_effect = self._port_open_side_effect
+        subnets = [
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
+        ]
+        result = camera_discovery._scan_rtmp_ports(subnets)
+        expected = [
+            {"ip": "192.168.1.6", "protocol": "rtmp", "port": 1935, "info": {}},
+        ]
+        self.assertEqual(result, expected)
+
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery.is_port_open")
@@ -97,6 +114,7 @@ class TestCameraDiscovery(unittest.TestCase):
             {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
             {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
             {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
+            {"ip": "192.168.1.6", "protocol": "rtmp", "port": 1935, "info": {}},
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
             {
                 "ip": "127.0.0.1",


### PR DESCRIPTION
## Summary
- support RTMP port scanning in camera discovery
- document the new RTMP discovery method
- update docs and README bullet about discovery
- test RTMP discovery logic

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Camera discovery now supports automatic scanning for RTMP cameras in addition to ONVIF and RTSP cameras.

- **Documentation**
  - Updated user and developer documentation to reflect RTMP camera discovery support and provide new example usage.

- **Tests**
  - Added and updated tests to ensure RTMP camera detection is properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->