### PR TITLE
Add automatic release tagging

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -1,0 +1,35 @@
+name: Tag Release
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  tag_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect version change
+        id: detect
+        run: |
+          git fetch --tags
+          NEW_VERSION=$(grep -oP '(?<=version=")[^"]+' setup.py)
+          OLD_VERSION=$(git show ${{ github.event.before }}:setup.py 2>/dev/null | grep -oP '(?<=version=")[^"]+' || echo "")
+          echo "old=$OLD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create tag
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          VERSION=${{ steps.detect.outputs.new }}
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists" && exit 0
+          fi
+          git tag "v$VERSION"
+          git push origin "v$VERSION"

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -10,7 +10,11 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 `PYPI_API_TOKEN` secret is available, Python distributions are also published to
 PyPI.
 
-To trigger a new release, create a tag and push it to GitHub:
+Tags are normally created automatically when the version in `setup.py` is bumped
+on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.3`
+and pushes it to GitHub, which then triggers the build jobs above.
+
+You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
 git tag v0.2.2


### PR DESCRIPTION
## Summary
- auto-create release tags when version changes
- document auto-tagging in release workflow

## Testing
- `flake8` *(fails: E265 block comment should start with '# ' and many others)*
- `pytest -q`