### PR TITLE
Add SDP probe to discovery

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -115,6 +115,34 @@ def _probe_mdns(timeout=2):
     return cameras
 
 
+def _fetch_sdp(ip, port, timeout=2):
+    """Attempt to retrieve an SDP description from an RTSP endpoint."""
+    request = (
+        f"DESCRIBE rtsp://{ip}:{port}/ RTSP/1.0\r\n"
+        "CSeq: 1\r\n"
+        "Accept: application/sdp\r\n\r\n"
+    )
+    try:
+        with socket.create_connection((ip, port), timeout=timeout) as sock:
+            sock.sendall(request.encode())
+            response = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                response += chunk
+                if b"\r\n\r\n" in response:
+                    # headers done; assume SDP follows
+                    break
+        header, _, body = response.partition(b"\r\n\r\n")
+        if b"200" not in header.split(b"\r\n")[0]:
+            return None
+        return body.decode(errors="ignore")
+    except Exception as e:  # pragma: no cover - network
+        logging.debug("SDP fetch error for %s:%s: %s", ip, port, e)
+        return None
+
+
 def _scan_rtsp_ports(subnets):
     found = []
     checked = set()
@@ -126,8 +154,12 @@ def _scan_rtsp_ports(subnets):
             checked.add(ip)
             for port in (554, 8554):
                 if is_port_open(ip, port, timeout=1):
+                    info = {}
+                    sdp = _fetch_sdp(ip, port)
+                    if sdp:
+                        info["sdp"] = sdp
                     found.append(
-                        {"ip": ip, "protocol": "rtsp", "port": port, "info": {}}
+                        {"ip": ip, "protocol": "rtsp", "port": port, "info": info}
                     )
     return found
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -21,7 +21,7 @@ When you visit `/discover`, Glimpser calls `discover_cameras()` to scan the netw
 The discovery code combines multiple approaches:
 
 1. **ONVIF probe** – `_probe_onvif()` broadcasts a WS-Discovery probe and parses any replies to extract camera IP addresses and ONVIF service URLs.
-2. **RTSP port scan** – `_scan_rtsp_ports()` walks through the host's local subnets and checks common RTSP ports (`554` and `8554`) using `is_port_open`.
+2. **RTSP port scan** – `_scan_rtsp_ports()` checks common RTSP ports (`554` and `8554`). When a port is open it sends a DESCRIBE request to retrieve the stream's SDP, if available.
 3. **RTMP port scan** – `_scan_rtmp_ports()` checks each subnet for the default RTMP port (`1935`).
 4. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
 5. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
@@ -44,7 +44,11 @@ def _scan_rtsp_ports(subnets):
             ...
             for port in (554, 8554):
                 if is_port_open(ip, port, timeout=1):
-                    found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": {}})
+                    info = {}
+                    sdp = _fetch_sdp(ip, port)
+                    if sdp:
+                        info["sdp"] = sdp
+                    found.append({"ip": ip, "protocol": "rtsp", "port": port, "info": info})
 
 
 def _scan_rtmp_ports(subnets):

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -61,17 +61,29 @@ class TestCameraDiscovery(unittest.TestCase):
         }
         self.assertEqual(set(result), expected)
 
+    @patch("app.utils.camera_discovery._fetch_sdp")
     @patch("app.utils.camera_discovery.is_port_open")
-    def test_scan_rtsp_ports(self, mock_port_open):
+    def test_scan_rtsp_ports(self, mock_port_open, mock_fetch_sdp):
         mock_port_open.side_effect = self._port_open_side_effect
+        mock_fetch_sdp.return_value = "v=0"  # simplified SDP
         subnets = [
             ip_network("192.168.1.5/255.255.255.252", strict=False),
             ip_network("10.0.0.5/255.255.255.252", strict=False),
         ]
         result = camera_discovery._scan_rtsp_ports(subnets)
         expected = [
-            {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
-            {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
+            {
+                "ip": "192.168.1.6",
+                "protocol": "rtsp",
+                "port": 554,
+                "info": {"sdp": "v=0"},
+            },
+            {
+                "ip": "10.0.0.6",
+                "protocol": "rtsp",
+                "port": 8554,
+                "info": {"sdp": "v=0"},
+            },
         ]
         self.assertEqual(result, expected)
 
@@ -91,12 +103,14 @@ class TestCameraDiscovery(unittest.TestCase):
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery.is_port_open")
+    @patch("app.utils.camera_discovery._fetch_sdp")
     @patch("app.utils.camera_discovery.psutil.net_if_addrs")
     def test_discover_cameras_merge(
-        self, mock_addrs, mock_port_open, mock_onvif, mock_mdns
+        self, mock_addrs, mock_fetch_sdp, mock_port_open, mock_onvif, mock_mdns
     ):
         mock_addrs.return_value = self._mock_interfaces()
         mock_port_open.side_effect = self._port_open_side_effect
+        mock_fetch_sdp.return_value = "v=0"
         mock_onvif.return_value = [
             {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
             {
@@ -112,8 +126,18 @@ class TestCameraDiscovery(unittest.TestCase):
         result = camera_discovery.discover_cameras()
         expected = [
             {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
-            {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
-            {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
+            {
+                "ip": "192.168.1.6",
+                "protocol": "rtsp",
+                "port": 554,
+                "info": {"sdp": "v=0"},
+            },
+            {
+                "ip": "10.0.0.6",
+                "protocol": "rtsp",
+                "port": 8554,
+                "info": {"sdp": "v=0"},
+            },
             {"ip": "192.168.1.6", "protocol": "rtmp", "port": 1935, "info": {}},
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
             {


### PR DESCRIPTION
## Summary
- fetch SDP description during RTSP scan
- document SDP probe in camera discovery guide
- test SDP retrieval integration

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Camera discovery now attempts to retrieve and include SDP (Session Description Protocol) data from RTSP streams, providing more detailed stream information when available.

- **Documentation**
  - Updated documentation to describe the enhanced RTSP port scanning behavior and inclusion of SDP data in discovery results.

- **Tests**
  - Improved tests to verify inclusion of SDP data during camera discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->