### PR TITLE
Add SIP and WebRTC discovery

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -147,6 +147,42 @@ def _scan_rtmp_ports(subnets):
     return found
 
 
+def _scan_sip_ports(subnets):
+    """Scan common SIP ports across subnets."""
+    found = []
+    checked = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            for port in (5060, 5061):
+                if is_port_open(ip, port, timeout=1):
+                    found.append(
+                        {"ip": ip, "protocol": "sip", "port": port, "info": {}}
+                    )
+    return found
+
+
+def _scan_webrtc_ports(subnets):
+    """Scan common WebRTC/STUN ports across subnets."""
+    found = []
+    checked = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            for port in (3478, 5349):
+                if is_port_open(ip, port, timeout=1):
+                    found.append(
+                        {"ip": ip, "protocol": "webrtc", "port": port, "info": {}}
+                    )
+    return found
+
+
 def _local_video_devices(base_path="/dev"):
     """List available local video devices like /dev/video0."""
     devices = []
@@ -167,6 +203,8 @@ def discover_cameras():
         subnets = _local_subnets()
         cameras.extend(_scan_rtsp_ports(subnets))
         cameras.extend(_scan_rtmp_ports(subnets))
+        cameras.extend(_scan_sip_ports(subnets))
+        cameras.extend(_scan_webrtc_ports(subnets))
     except Exception as e:
         logging.warning("RTSP scan error: %s", e)
     try:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -23,8 +23,10 @@ The discovery code combines multiple approaches:
 1. **ONVIF probe** – `_probe_onvif()` broadcasts a WS-Discovery probe and parses any replies to extract camera IP addresses and ONVIF service URLs.
 2. **RTSP port scan** – `_scan_rtsp_ports()` walks through the host's local subnets and checks common RTSP ports (`554` and `8554`) using `is_port_open`.
 3. **RTMP port scan** – `_scan_rtmp_ports()` checks each subnet for the default RTMP port (`1935`).
-4. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
-5. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+4. **SIP port scan** – `_scan_sip_ports()` looks for SIP endpoints on ports `5060` and `5061`.
+5. **WebRTC/STUN scan** – `_scan_webrtc_ports()` detects WebRTC servers by checking ports `3478` and `5349`.
+6. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
+7. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
 All discovered entries are merged and returned. The key parts of the implementation are shown below:
 
@@ -53,6 +55,24 @@ def _scan_rtmp_ports(subnets):
             ...
             if is_port_open(ip, 1935, timeout=1):
                 found.append({"ip": ip, "protocol": "rtmp", "port": 1935, "info": {}})
+
+
+def _scan_sip_ports(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            for port in (5060, 5061):
+                if is_port_open(ip, port, timeout=1):
+                    found.append({"ip": ip, "protocol": "sip", "port": port, "info": {}})
+
+
+def _scan_webrtc_ports(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            for port in (3478, 5349):
+                if is_port_open(ip, port, timeout=1):
+                    found.append({"ip": ip, "protocol": "webrtc", "port": port, "info": {}})
 
 
 def _local_video_devices(base_path="/dev"):

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -39,6 +39,8 @@ class TestCameraDiscovery(unittest.TestCase):
             ("192.168.1.6", 554),
             ("10.0.0.6", 8554),
             ("192.168.1.6", 1935),
+            ("192.168.1.6", 5060),
+            ("10.0.0.6", 5349),
         }
 
     @patch("app.utils.camera_discovery.glob.glob")
@@ -88,6 +90,32 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery.is_port_open")
+    def test_scan_sip_ports(self, mock_port_open):
+        mock_port_open.side_effect = self._port_open_side_effect
+        subnets = [
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
+        ]
+        result = camera_discovery._scan_sip_ports(subnets)
+        expected = [
+            {"ip": "192.168.1.6", "protocol": "sip", "port": 5060, "info": {}},
+        ]
+        self.assertEqual(result, expected)
+
+    @patch("app.utils.camera_discovery.is_port_open")
+    def test_scan_webrtc_ports(self, mock_port_open):
+        mock_port_open.side_effect = self._port_open_side_effect
+        subnets = [
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
+        ]
+        result = camera_discovery._scan_webrtc_ports(subnets)
+        expected = [
+            {"ip": "10.0.0.6", "protocol": "webrtc", "port": 5349, "info": {}},
+        ]
+        self.assertEqual(result, expected)
+
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery.is_port_open")
@@ -115,6 +143,8 @@ class TestCameraDiscovery(unittest.TestCase):
             {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}},
             {"ip": "10.0.0.6", "protocol": "rtsp", "port": 8554, "info": {}},
             {"ip": "192.168.1.6", "protocol": "rtmp", "port": 1935, "info": {}},
+            {"ip": "192.168.1.6", "protocol": "sip", "port": 5060, "info": {}},
+            {"ip": "10.0.0.6", "protocol": "webrtc", "port": 5349, "info": {}},
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
             {
                 "ip": "127.0.0.1",


### PR DESCRIPTION
## Summary
- discover SIP/VoIP endpoints and WebRTC servers
- test new discovery helpers
- document SIP/WebRTC discovery feature

## Testing
- `flake8`
- `pytest -q`