### PR TITLE
Add SNMP discovery support

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -215,6 +215,53 @@ def _scan_webrtc_ports(subnets):
     return found
 
 
+def _fetch_snmp_sysname(ip, timeout=2):
+    """Attempt to retrieve the SNMP sysName value."""
+    # Minimal SNMPv1 GET request for OID 1.3.6.1.2.1.1.5.0 (sysName)
+    request = bytes.fromhex(
+        "30 2a 02 01 00 04 06 70 75 62 6c 69 63 A0 1d "
+        "02 04 00 00 00 01 02 01 00 02 01 00 30 0f 30 0d "
+        "06 08 2b 06 01 02 01 01 05 00 05 00"
+    )
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(timeout)
+    try:
+        sock.sendto(request, (ip, 161))
+        resp, _ = sock.recvfrom(4096)
+        oid = b"\x06\x08\x2b\x06\x01\x02\x01\x01\x05\x00"
+        idx = resp.find(oid)
+        if idx != -1:
+            start = idx + len(oid)
+            if start + 2 <= len(resp) and resp[start] == 0x04:
+                length = resp[start + 1]
+                end = start + 2 + length
+                return resp[start + 2 : end].decode(errors="ignore")
+    except Exception as e:  # pragma: no cover - network
+        logging.debug("SNMP fetch error for %s: %s", ip, e)
+    finally:
+        sock.close()
+    return None
+
+
+def _scan_snmp_ports(subnets):
+    """Scan SNMP port 161 across subnets."""
+    found = []
+    checked = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            if is_port_open(ip, 161, timeout=1):
+                info = {}
+                name = _fetch_snmp_sysname(ip)
+                if name:
+                    info["name"] = name
+                found.append({"ip": ip, "protocol": "snmp", "port": 161, "info": info})
+    return found
+
+
 def _local_video_devices(base_path="/dev"):
     """List available local video devices like /dev/video0."""
     devices = []
@@ -237,6 +284,7 @@ def discover_cameras():
         cameras.extend(_scan_rtmp_ports(subnets))
         cameras.extend(_scan_sip_ports(subnets))
         cameras.extend(_scan_webrtc_ports(subnets))
+        cameras.extend(_scan_snmp_ports(subnets))
     except Exception as e:
         logging.warning("RTSP scan error: %s", e)
     try:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -26,7 +26,8 @@ The discovery code combines multiple approaches:
 4. **SIP port scan** – `_scan_sip_ports()` looks for SIP endpoints on ports `5060` and `5061`.
 5. **WebRTC/STUN scan** – `_scan_webrtc_ports()` detects WebRTC servers by checking ports `3478` and `5349`.
 6. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
-7. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+7. **SNMP scan** – `_scan_snmp_ports()` checks port `161` for SNMP agents and reads the device name if possible.
+8. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
 All discovered entries are merged and returned. The key parts of the implementation are shown below:
 
@@ -77,6 +78,16 @@ def _scan_webrtc_ports(subnets):
             for port in (3478, 5349):
                 if is_port_open(ip, port, timeout=1):
                     found.append({"ip": ip, "protocol": "webrtc", "port": port, "info": {}})
+
+
+def _scan_snmp_ports(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            if is_port_open(ip, 161, timeout=1):
+                name = _fetch_snmp_sysname(ip)
+                info = {"name": name} if name else {}
+                found.append({"ip": ip, "protocol": "snmp", "port": 161, "info": info})
 
 
 def _local_video_devices(base_path="/dev"):

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -41,6 +41,7 @@ class TestCameraDiscovery(unittest.TestCase):
             ("192.168.1.6", 1935),
             ("192.168.1.6", 5060),
             ("10.0.0.6", 5349),
+            ("192.168.1.6", 161),
         }
 
     @patch("app.utils.camera_discovery.glob.glob")
@@ -128,17 +129,45 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery._fetch_snmp_sysname")
+    @patch("app.utils.camera_discovery.is_port_open")
+    def test_scan_snmp_ports(self, mock_port_open, mock_fetch_name):
+        mock_port_open.side_effect = self._port_open_side_effect
+        mock_fetch_name.return_value = "cam1"
+        subnets = [
+            ip_network("192.168.1.5/255.255.255.252", strict=False),
+            ip_network("10.0.0.5/255.255.255.252", strict=False),
+        ]
+        result = camera_discovery._scan_snmp_ports(subnets)
+        expected = [
+            {
+                "ip": "192.168.1.6",
+                "protocol": "snmp",
+                "port": 161,
+                "info": {"name": "cam1"},
+            },
+        ]
+        self.assertEqual(result, expected)
+
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery.is_port_open")
+    @patch("app.utils.camera_discovery._fetch_snmp_sysname")
     @patch("app.utils.camera_discovery._fetch_sdp")
     @patch("app.utils.camera_discovery.psutil.net_if_addrs")
     def test_discover_cameras_merge(
-        self, mock_addrs, mock_fetch_sdp, mock_port_open, mock_onvif, mock_mdns
+        self,
+        mock_addrs,
+        mock_fetch_sdp,
+        mock_fetch_snmp,
+        mock_port_open,
+        mock_onvif,
+        mock_mdns,
     ):
         mock_addrs.return_value = self._mock_interfaces()
         mock_port_open.side_effect = self._port_open_side_effect
         mock_fetch_sdp.return_value = "v=0"
+        mock_fetch_snmp.return_value = "cam1"
         mock_onvif.return_value = [
             {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
             {
@@ -169,6 +198,12 @@ class TestCameraDiscovery(unittest.TestCase):
             {"ip": "192.168.1.6", "protocol": "rtmp", "port": 1935, "info": {}},
             {"ip": "192.168.1.6", "protocol": "sip", "port": 5060, "info": {}},
             {"ip": "10.0.0.6", "protocol": "webrtc", "port": 5349, "info": {}},
+            {
+                "ip": "192.168.1.6",
+                "protocol": "snmp",
+                "port": 161,
+                "info": {"name": "cam1"},
+            },
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
             {
                 "ip": "127.0.0.1",


### PR DESCRIPTION
## Summary
- extend camera discovery with SNMP scanning
- document SNMP discovery
- cover SNMP logic with tests

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SNMP scanning to camera discovery, enabling detection of cameras using the SNMP protocol and displaying their system names.
- **Documentation**
  - Updated camera discovery documentation to include SNMP scanning details and process.
- **Tests**
  - Extended test coverage to verify SNMP camera discovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->