### PR TITLE
Fix tag creation permissions

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   tag_release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push release tags

## Testing
- `black . --check` *(fails: would reformat many files)*
- `flake8` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.