### PR TITLE
Bump version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Addressed Python build issues and string concatenation errors
 - Fixed screenshot timeouts and setup script problems
 
+## [0.2.4] - 2025-05-28
+
+### Changed
+- Bumped package version in setup.py to 0.2.4.
+
 ## [0.2.3] - 2025-05-27
 
 ### Changed
@@ -60,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.4
 [0.2.3]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.3
 [0.2.2]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.2
 [1.0.0]: https://github.com/KristopherKubicki/glimpser/releases/tag/v1.0.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
+- Application version bumped to `v0.2.4`.
 

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -11,12 +11,12 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 PyPI.
 
 Tags are normally created automatically when the version in `setup.py` is bumped
-on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.3`
+on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.4`
 and pushes it to GitHub, which then triggers the build jobs above.
 
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.3
-git push origin v0.2.3
+git tag v0.2.4
+git push origin v0.2.4
 ```

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="glimpser",
-    version="0.2.3",
+    version="0.2.4",
     author="Kristopher Kubicki",
     author_email="kristopher@glimser.net",
     description="A real-time monitoring application for capturing and analyzing live data from various sources",


### PR DESCRIPTION
## Summary
- bump version in setup.py
- document new version in docs
- update release workflow instructions
- note release in CHANGELOG

## Testing
- `black setup.py`
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated documentation and changelog to reflect the new application version 0.2.4.
  - Incremented the application version number to 0.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->