### PR TITLE
Add init file for utils package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
 - Application version bumped to `v0.2.4`.
-
+- `app/utils/` now includes an `__init__.py` so utility modules can be imported as a package.


### PR DESCRIPTION
## Summary
- mark `app/utils` as a package
- document utility package change

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to note that the utility modules directory now includes an initialization file, allowing it to be imported as a package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->