### PR TITLE
Add allowed_filename docstring

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -524,8 +524,16 @@ def generate(group=None, filename="latest_camera.png", rtsp=False, session_id=No
         time.sleep(1 - (time.time() - ltime))
 
 def allowed_filename(filename: str) -> bool:
+    r"""Return ``True`` when ``filename`` contains only safe characters.
 
-    if '..' in filename:
+    The function first rejects any occurrence of ``".."`` to prevent
+    directory traversal. It then matches the entire filename against the
+    regular expression ``^[a-zA-Z0-9\.\-_]+?$`` which allows only letters,
+    numbers, periods, hyphens, and underscores. A match means the filename
+    is free of path separators or other dangerous characters.
+    """
+
+    if ".." in filename:
         return False
 
     if re.findall(r'^[a-zA-Z0-9\.\-_]+?$', filename):

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
 - Application version bumped to `v0.2.4`.
+- Filename validation helper now documents the regex used to reject unsafe names.
 


### PR DESCRIPTION
## Summary
- document filename validation logic in app routes
- note documentation update in docs/README

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the filename validation logic and explicitly describe the rules used to reject unsafe filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->