### PR TITLE
Add camera metadata displays and clean up PNG streams

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -279,8 +279,14 @@ function changeCamera() {
             if (details) {
                 video.title = details.last_caption;
                 templateDetailsContainer.innerHTML = `
-			    <a href='/camera/${currentCamera}'></a>
-                `;
+                    <div>
+                        <strong>Last Screenshot:</strong> ${details.last_screenshot_time || 'N/A'}<br/>
+                        <strong>Last Video:</strong> ${details.last_video_time || 'N/A'}<br/>
+                        <strong>Last Caption:</strong> ${details.last_caption || 'N/A'}<br/>
+                        ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ''}
+                    </div>`;
+            } else {
+                templateDetailsContainer.innerHTML = '';
             }
         }
 
@@ -327,10 +333,10 @@ function changeCamera() {
             }
         }
 
-        function playM3U8() {
-            video.style.display = 'block';
-            image.style.display = 'none';
-            clearInterval(pngInterval);
+function playM3U8() {
+    video.style.display = 'block';
+    image.style.display = 'none';
+    stopPNG();
 
             let m3u8Url;
             if (currentCamera.startsWith('group-')) {
@@ -385,7 +391,7 @@ function changeCamera() {
 function playLoop() {
     video.style.display = 'block';
     image.style.display = 'none';
-    clearInterval(pngInterval);
+    stopPNG();
 
     if (currentCamera.startsWith('group-') || currentCamera === 'All') {
         // Handle both groups and the special "All" group
@@ -433,8 +439,8 @@ function refreshPNG() {
 function playMP4() {
     video.style.display = 'block';
     image.style.display = 'none';
-	document.getElementById("seek-bar").style.display = "block";
-    clearInterval(pngInterval);
+        document.getElementById("seek-bar").style.display = "block";
+    stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
         const groupName = currentCamera.split('group-')[1];
@@ -474,7 +480,7 @@ function playLive() {
     video.style.display = 'block';
     image.style.display = 'none';
     document.getElementById("seek-bar").style.display = "block";
-    clearInterval(pngInterval);
+    stopPNG();
 
     if (currentCamera.startsWith('group-') || currentCamera === 'All') {
         // Fallback to MP4 streaming for groups or All
@@ -494,7 +500,7 @@ function playPNG() {
         const speed = Math.pow(2, slider.value);
 	document.getElementById("seek-bar").style.display = "none";
 	console.log( document.getElementById("seek-bar"), speed);
-    clearInterval(pngInterval);
+    stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
         let cameraIndex = 0;
@@ -524,8 +530,8 @@ function playPNG() {
 function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
-	document.getElementById("seek-bar").style.display = "block";
-    clearInterval(pngInterval);
+        document.getElementById("seek-bar").style.display = "block";
+    stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
         const groupName = currentCamera.split('group-')[1];
@@ -542,8 +548,8 @@ function playMJPG() {
 function playMotion() {
     video.style.display = 'none';
     image.style.display = 'block';
-	document.getElementById("seek-bar").style.display = "none";
-    clearInterval(pngInterval);
+        document.getElementById("seek-bar").style.display = "none";
+    stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
         const groupName = currentCamera.split('group-')[1];
@@ -578,7 +584,14 @@ function playMotion() {
 	        speedDisplay.classList.add('highlight-speed');
     setTimeout(() => speedDisplay.classList.remove('highlight-speed'), 500);
     }
-    // todo: stop the old playing png stream
+
+    function stopPNG() {
+        if (pngInterval) {
+            clearInterval(pngInterval);
+            pngInterval = null;
+        }
+        image.src = '';
+    }
 
     function checkCameraConnection(cameraName) {
         const camera = templateDetails[cameraName];

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -2,10 +2,9 @@
 
 {% extends 'base.html' %}
 {% block content %}
-
-
-
-    </script>
+<script>
+    const cameraMeta = {{ template_details|tojson }};
+</script>
 
             <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay style='display: block; height: 90vh; width: 90vw;' width='90%'
 			    {% if template_details.last_caption %}
@@ -105,6 +104,18 @@ function updateVideo(templateName) {
 }
 
 </script>
+
+    <div id="camera-metadata" style="margin: 10px 0; color: #ccc;">
+        <ul>
+            <li><strong>Last Screenshot:</strong> {{ template_details.last_screenshot_time }}</li>
+            <li><strong>Last Video:</strong> {{ template_details.last_video_time }}</li>
+            <li><strong>Last Caption:</strong> {{ template_details.last_caption }}</li>
+            <li><strong>Caption Time:</strong> {{ template_details.last_caption_time }}</li>
+            {% if template_details.offline_since %}
+            <li><strong>Offline Since:</strong> {{ template_details.offline_since }}</li>
+            {% endif %}
+        </ul>
+    </div>
 
 
   <details title="View recent videos for this template"><summary>Recent Videos</summary>
@@ -279,7 +290,7 @@ function confirmDelete(templateName) {
 // todo, add the camera metadata template_details here too
 function showCameraDetails(templateName) {
     const baseUrl = window.location.origin;
-    const details = {
+    const endpoints = {
         'Camera Name': templateName,
         'Last Screenshot URL': `${baseUrl}/last_screenshot/${templateName}`,
         'Last Video URL': `${baseUrl}/last_video/${templateName}`,
@@ -290,11 +301,29 @@ function showCameraDetails(templateName) {
         'Template Details URL': `${baseUrl}/templates/${templateName}`
     };
 
-    let detailsHtml = '<h3>Camera Details</h3><pre>';
-    for (const [key, value] of Object.entries(details)) {
+    const meta = cameraMeta;
+    const metadata = {
+        'Last Screenshot Time': meta.last_screenshot_time,
+        'Last Video Time': meta.last_video_time,
+        'Last Caption': meta.last_caption,
+        'Caption Time': meta.last_caption_time,
+        'Offline Since': meta.offline_since
+    };
+
+    let detailsHtml = '<h3>Camera Endpoints</h3><pre>';
+    for (const [key, value] of Object.entries(endpoints)) {
         detailsHtml += `${key}: ${value}\n`;
     }
     detailsHtml += '</pre>';
+
+    detailsHtml += '<h3>Camera Metadata</h3><pre>';
+    for (const [key, value] of Object.entries(metadata)) {
+        if (value) {
+            detailsHtml += `${key}: ${value}\n`;
+        }
+    }
+    detailsHtml += '</pre>';
+
     detailsHtml += '<button onclick="copyToClipboard()">Copy to Clipboard</button>';
 
     document.getElementById('camera-details-content').innerHTML = detailsHtml;

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,4 +10,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
 - Application version bumped to `v0.2.4`.
+- Template and live views now show camera metadata, and PNG streams stop when switching sources.
 


### PR DESCRIPTION
## Summary
- show camera metadata on template details page
- display last capture info in live view
- stop previous PNG streams when switching sources
- document the UI updates

## Testing
- `flake8`
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Camera metadata (last screenshot time, last video time, last caption, and offline status) is now displayed in both template and live views.
- **Enhancements**
  - Improved handling of PNG streams: streams are now properly stopped when switching video sources, providing a smoother experience.
- **Documentation**
  - Updated changelog to reflect the addition of camera metadata display and improved PNG stream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->