### PR TITLE
Fix quoting in wkhtml capture

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -14,7 +14,6 @@ import subprocess
 import time
 from urllib.parse import urlparse
 import glob
-import shlex
 import base64
 import nodriver
 import psutil
@@ -1573,8 +1572,8 @@ def capture_screenshot_and_har_light(
         "User-Agent",
         lua,
         "--custom-header-propagation",
-        shlex.quote(url),
-        shlex.quote(tmp_path),
+        url,
+        tmp_path,
     ]
 
     try:

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -51,7 +51,7 @@ Glimpser uses different methods to capture various types of content:
 
 For web pages, Glimpser uses two main approaches:
 
-1. **Lightweight Browser Capture**: Uses `wkhtmltoimage` for simple web pages without complex JavaScript or popup handling requirements.
+1. **Lightweight Browser Capture**: Uses `wkhtmltoimage` for simple web pages without complex JavaScript or popup handling requirements. The URL and output path are passed directly to `wkhtmltoimage` without shell quoting.
 2. **Full Browser Capture**: Uses Selenium with Chrome/Chromium for more complex web pages, supporting JavaScript execution, popup handling, and custom selectors.
 
 The choice between these methods depends on factors such as:

--- a/tests/test_screenshot_light.py
+++ b/tests/test_screenshot_light.py
@@ -1,0 +1,54 @@
+import unittest
+import tempfile
+import os
+from unittest.mock import patch, MagicMock
+
+from app.utils.screenshots import capture_screenshot_and_har_light
+
+
+class TestScreenshotLight(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_path = os.path.join(self.temp_dir, "test screenshot.png")
+
+    def tearDown(self):
+        if os.path.exists(self.output_path):
+            os.remove(self.output_path)
+        os.rmdir(self.temp_dir)
+
+    def test_subprocess_run_receives_unquoted_args(self):
+        url = "http://example.com/test path"
+        tmp_path = self.output_path.replace(".png", ".tmp.png")
+        mock_image = MagicMock()
+        mock_image.convert.return_value = mock_image
+        with patch(
+            "app.utils.screenshots.shutil.which", return_value="/usr/bin/wkhtmltoimage"
+        ), patch("app.utils.screenshots.subprocess.run") as mock_run, patch(
+            "app.utils.screenshots.os.path.exists", return_value=True
+        ), patch(
+            "app.utils.screenshots._is_valid_png", return_value=True
+        ), patch(
+            "app.utils.screenshots.Image.open"
+        ) as mock_open, patch(
+            "app.utils.screenshots.is_mostly_blank", return_value=False
+        ), patch(
+            "app.utils.screenshots.remove_background", return_value=mock_image
+        ), patch(
+            "app.utils.screenshots.apply_dark_mode", return_value=mock_image
+        ), patch(
+            "app.utils.screenshots.add_timestamp"
+        ), patch(
+            "app.utils.screenshots.os.rename"
+        ):
+            mock_open.return_value.__enter__.return_value = mock_image
+            mock_open.return_value.__exit__.return_value = None
+            mock_run.return_value.returncode = 0
+            capture_screenshot_and_har_light(url, self.output_path)
+
+        command = mock_run.call_args.args[0]
+        self.assertEqual(command[-2], url)
+        self.assertEqual(command[-1], tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid quoting url and temp path when using `wkhtmltoimage`
- test that `capture_screenshot_and_har_light` passes raw parameters
- document direct parameter usage in capture docs

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify how URL and output path arguments are handled in the lightweight browser capture method.

- **Tests**
  - Added new tests to verify that screenshot capture receives unquoted URL and output path arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->