### PR TITLE
Clean up timeout docs

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1289,8 +1289,6 @@ def capture_frame_with_ytdlp(url, output_path, name="unknown", invert=False):
         logging.debug("skipping %s %s", lurl_cache[url], url)
         return False
 
-    # TODO: consider timeouts?
-
     lsuccess = False
     try:
         lurl_cache_time[url] = time.time()

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -83,7 +83,7 @@ Configure these values to enable Twilio SMS alerts:
 Settings controlling how frames are captured from video sources:
 
 - `NUM_FRAMES` – number of frames to grab from each stream (default `3`)
-- `CAPTURE_TIMEOUT` – maximum seconds to wait for a frame (default `30`)
+- `CAPTURE_TIMEOUT` – maximum seconds to wait for a frame; also used as the timeout for download and ffmpeg operations (default `30`)
 - `PROBE_SIZE_DEFAULT` – probe size for HTTP/HTTPS streams (default `5M`)
 - `PROBE_SIZE_RTSP` – probe size for RTSP streams (default `10M`)
 - `PROBE_SIZE_OTHER` – probe size for other protocols (default `20M`)


### PR DESCRIPTION
## Summary
- remove stray TODO in `screenshots.py`
- clarify `CAPTURE_TIMEOUT` usage

## Testing
- `flake8`
- `pytest -q`