### PR TITLE
Add screenshot validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1395,9 +1395,13 @@ def init_routes(app):
             abort(404)
 
         lfiles = [f for f in glob.glob(path + "/*.png") if os.path.isfile(f)]
-        lfiles.sort(key=os.path.getmtime)
-        if len(lfiles) > 0:
-            return send_file(lfiles[-1])
+        lfiles.sort(key=os.path.getmtime, reverse=True)
+        for shot in lfiles:
+            try:
+                if os.path.getsize(shot) > 0 and screenshots._is_valid_png(shot):
+                    return send_file(shot)
+            except OSError:
+                continue
 
         abort(404)
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -97,7 +97,7 @@ Several other routes provide streaming functionality:
 - **GET /motion_caption.mjpg** – Combines motion and caption frames in a single MJPEG stream.
 - **GET /stream.m3u8** – HLS playlist referencing the latest videos from all cameras.
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template.
-- **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
+- **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template. Returns `404` if no valid screenshot is found.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`.
 

--- a/tests/test_serve_screenshot.py
+++ b/tests/test_serve_screenshot.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import shutil
+import unittest
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestServeScreenshot(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_screenshots"
+        self.full_base = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        os.makedirs(self.full_base, exist_ok=True)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch.start()
+        self.login_patch.start()
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_empty_screenshot_returns_404(self):
+        path = os.path.join(self.full_base, "cam1_20200101.png")
+        open(path, "wb").close()
+        resp = self.client.get("/last_screenshot/cam1")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_valid_screenshot_served(self):
+        path = os.path.join(self.full_base, "cam1_20200102.png")
+        Image.new("RGB", (1, 1)).save(path)
+        resp = self.client.get("/last_screenshot/cam1")
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- verify screenshot exists and is valid before serving
- document 404 behavior for `/last_screenshot`
- test the new screenshot validation logic

## Testing
- `flake8`
- `pytest -q`