### PR TITLE
Extend teaser route for groups

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1319,22 +1319,25 @@ def init_routes(app):
 
         abort(404)
 
-    # TODO: extend this for groups
     @app.route("/last_teaser")
     @login_required
     def serve_teaser():
-        """
-        Serve the group teaser video
-        """
-        # Placeholder logic to serve the screenshot
-        path = os.path.join(
+        """Serve the teaser video for a specific group."""
+
+        group = request.args.get("group")
+        if group and not re.match(r"^[a-zA-Z0-9_]+$", group):
+            abort(400, "Invalid group name. Group name must be alphanumeric.")
+
+        lgroup = secure_filename(group) if group else "all"
+        base_path = os.path.join(
             os.path.dirname(os.path.join(__file__)), "..", VIDEO_DIRECTORY
         )
-        if not os.path.exists(path):
+        if not os.path.exists(base_path):
             abort(404)
 
-        if os.path.exists(path + "/all_in_process.mp4"):
-            return send_file(path + "/all_in_process.mp4")
+        video_path = os.path.join(base_path, f"{lgroup}_in_process.mp4")
+        if os.path.exists(video_path):
+            return send_file(video_path)
 
         abort(404)
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -98,7 +98,7 @@ Several other routes provide streaming functionality:
 - **GET /stream.m3u8** – HLS playlist referencing the latest videos from all cameras.
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
-- **GET /last_teaser** – Returns the teaser video compiled from recent footage.
+- **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`.
 
 ### 6. Trigger Screenshot Capture

--- a/tests/test_last_teaser_route.py
+++ b/tests/test_last_teaser_route.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.routes as routes
+from app.routes import init_routes
+import app.config as config
+
+
+class TestLastTeaserRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.send_file")
+    @patch("os.path.exists", return_value=True)
+    def test_last_teaser_group(self, mock_exists, mock_send):
+        resp = self.client.get("/last_teaser?group=mygroup")
+        self.assertEqual(resp.status_code, 200)
+        expected = os.path.join(
+            os.path.dirname(routes.__file__),
+            "..",
+            config.VIDEO_DIRECTORY,
+            "mygroup_in_process.mp4",
+        )
+        mock_send.assert_called_with(expected)
+
+    @patch("os.path.exists", return_value=True)
+    def test_last_teaser_invalid_group(self, mock_exists):
+        resp = self.client.get("/last_teaser?group=bad/name")
+        self.assertEqual(resp.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support group selection in `/last_teaser`
- document new query parameter
- test teaser route

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`
