### PR TITLE
Fix offline camera overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Addressed Python build issues and string concatenation errors
 - Fixed screenshot timeouts and setup script problems
+- Offline cameras now display an overlay and keep the camera selector usable
 
 ## [0.2.4] - 2025-05-28
 

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -141,6 +141,10 @@
         <div id="video-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); display: none;">
             <div id="loading-indicator" style="display: none;">Loading...</div>
             <div id="play-pause-indicator" style="display: none; font-size: 48px;">▶</div>
+            <div id="offline-indicator" style="display: none; text-align: center; color: white;">
+                <i class="fas fa-video-slash" style="font-size:48px;"></i>
+                <p id="offline-message"></p>
+            </div>
         </div>
         <div id="error-message"></div>
     </div>
@@ -162,6 +166,8 @@
         const playPauseIndicator = document.getElementById('play-pause-indicator');
         const errorMessage = document.getElementById('error-message');
         const playButton = document.getElementById('play-pause');
+        const offlineIndicator = document.getElementById('offline-indicator');
+        const offlineMessage = document.getElementById('offline-message');
 
         function showLoadingIndicator() {
             videoOverlay.style.display = 'block';
@@ -198,6 +204,22 @@
             setTimeout(() => {
                 errorMessage.style.display = 'none';
             }, 5000);
+        }
+
+        function showOfflineIndicator(cameraName) {
+            videoOverlay.style.display = 'block';
+            offlineIndicator.style.display = 'block';
+            offlineMessage.textContent = `Camera ${cameraName} is currently offline`;
+            loadingIndicator.style.display = 'none';
+            playPauseIndicator.style.display = 'none';
+        }
+
+        function hideOfflineIndicator() {
+            offlineIndicator.style.display = 'none';
+            offlineMessage.textContent = '';
+            if (loadingIndicator.style.display === 'none' && playPauseIndicator.style.display === 'none') {
+                videoOverlay.style.display = 'none';
+            }
         }
 
         video.addEventListener('waiting', showLoadingIndicator);
@@ -258,15 +280,13 @@ function changeCamera() {
     }
 
     if (!isConnected) {
-        const videoContainer = document.querySelector('.video-container');
-        videoContainer.innerHTML = `
-            <div class="placeholder">
-                <img src="/static/img/camera_offline.png" alt="Camera Offline">
-                <p>Camera ${currentCamera} is currently offline</p>
-            </div>
-        `;
+        showOfflineIndicator(currentCamera);
         hideLoadingIndicator();
+        video.pause();
+        video.src = '';
+        image.src = '';
     } else {
+        hideOfflineIndicator();
         updateTemplateDetails();
         updateFeed(); // Make sure to update the video feed after changing the camera or group
     }
@@ -295,15 +315,14 @@ function changeCamera() {
             const isConnected = checkCameraConnection(currentCamera);
 
             if (!isConnected) {
-                const videoContainer = document.querySelector('.video-container');
-                videoContainer.innerHTML = `
-                    <div class="placeholder">
-                        <img src="/static/img/camera_offline.png" alt="Camera Offline">
-                        <p>Camera ${currentCamera} is currently offline</p>
-                    </div>
-                `;
+                showOfflineIndicator(currentCamera);
                 hideLoadingIndicator();
+                video.pause();
+                video.src = '';
+                image.src = '';
                 return;
+            } else {
+                hideOfflineIndicator();
             }
 
             switch (source) {

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -6,3 +6,4 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The live feed image has both `alt` text and a tooltip.
 - The footer Help link displays a tooltip describing its purpose.
 - The navigation Settings link has a single descriptive `title` attribute.
+- When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.


### PR DESCRIPTION
## Summary
- keep camera selector visible when a camera is offline
- document the overlay UI improvement
- note the fix in the changelog

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an offline indicator overlay in the video player to clearly show when a camera is offline, improving user awareness without removing camera selector usability.

- **Bug Fixes**
  - Offline cameras now display an overlay instead of disabling controls, ensuring continued access to camera selection.

- **Documentation**
  - Updated accessibility documentation to reflect the new offline overlay and improved user experience for offline cameras.
  - Updated changelog to include this fix and other recent improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->