### PR TITLE
Fix Play All button

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -73,6 +73,28 @@ document.addEventListener('DOMContentLoaded', () => {
   setupSearch();
   setupStatusPageVideoHover();
   setupVideoControls();
+
+  // Play All / Stop All functionality for index page videos
+  const playAllButton = document.getElementById('play-all-button');
+  let isPlaying = false;
+  if (playAllButton) {
+    playAllButton.addEventListener('click', () => {
+      const videos = document.querySelectorAll('.templateDiv video');
+      if (isPlaying) {
+        videos.forEach((video) => {
+          video.pause();
+          video.currentTime = 0;
+        });
+        playAllButton.textContent = 'Play All';
+      } else {
+        videos.forEach((video) => {
+          video.play().catch((e) => console.error('Error playing video:', e));
+        });
+        playAllButton.textContent = 'Stop All';
+      }
+      isPlaying = !isPlaying;
+    });
+  }
   
   // Update video sources every 30 minutes
   setInterval(updateVideoSources, 60000 * 30);
@@ -482,27 +504,6 @@ if (toggleSchedulerButton && schedulerStatus) {
     });
 }
 
-// Play All / Stop All functionality for index page videos
-const playAllButton = document.getElementById('play-all-button');
-let isPlaying = false;
-if (playAllButton) {
-  playAllButton.addEventListener('click', () => {
-    const videos = document.querySelectorAll('.templateDiv video');
-    if (isPlaying) {
-      videos.forEach(video => {
-        video.pause();
-        video.currentTime = 0;
-      });
-      playAllButton.textContent = 'Play All';
-    } else {
-      videos.forEach(video => {
-        video.play().catch(e => console.error("Error playing video:", e));
-      });
-      playAllButton.textContent = 'Stop All';
-    }
-    isPlaying = !isPlaying;
-  });
-}
 
 // Google Cast API initialization
 function initializeCastApi() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Template and live views now show camera metadata, and PNG streams stop when switching sources.
 - Templates are rescheduled when saved to apply the new settings.
 
+- The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.


### PR DESCRIPTION
## Summary
- initialize Play All button after the DOM loads
- document the fix in docs

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored functionality of the "Play All / Stop All" button on the front page, ensuring it works as intended for controlling all videos.

- **Documentation**
  - Updated documentation to reflect the restoration and proper initialization of the "Play All" button feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->