### PR TITLE
Fix motion live view filtering

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -66,7 +66,6 @@ from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
 
 
-
 def restart_server():
     logging.info("Restarting server...")
 
@@ -394,7 +393,9 @@ def resize_and_pad(img, size, color=(0, 0, 0)):
 lock = Lock()
 
 
-def generate(group=None, filename="latest_camera.png", rtsp=False, session_id=None):
+def generate(
+    group=None, camera=None, filename="latest_camera.png", rtsp=False, session_id=None
+):
     # pretty hacky but it works ok
     global last_time, last_shot
     boundary = b"frame"
@@ -420,6 +421,7 @@ def generate(group=None, filename="latest_camera.png", rtsp=False, session_id=No
             with lock:
                 if (
                     group is None
+                    and camera is None
                     and last_time
                     and time.time() - last_time < 1
                     and last_shot
@@ -451,6 +453,9 @@ def generate(group=None, filename="latest_camera.png", rtsp=False, session_id=No
                             template_details.get("name")
                         )
                         if template_name is None:
+                            continue
+
+                        if camera and template_name != camera:
                             continue
 
                         template_groups = []
@@ -1021,34 +1026,38 @@ def init_routes(app):
     @app.route("/stream.mjpg", methods=["GET"])
     def stream_mjpg():
         group = request.args.get("group")
+        camera = request.args.get("camera")
         return Response(
-            generate(group=group, filename="latest_camera.png"),
+            generate(group=group, camera=camera, filename="latest_camera.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 
     @app.route("/motion.mjpg", methods=["GET"])
     def motion_mjpg():
         group = request.args.get("group")
+        camera = request.args.get("camera")
         return Response(
-            generate(group=group, filename="last_motion.png"),
+            generate(group=group, camera=camera, filename="last_motion.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 
     @app.route("/caption.mjpg", methods=["GET"])
     def caption_mjpg():
         group = request.args.get("group")
+        camera = request.args.get("camera")
         logging.debug("last caption")
         return Response(
-            generate(group=group, filename="last_caption.png"),
+            generate(group=group, camera=camera, filename="last_caption.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 
     @app.route("/motion_caption.mjpg", methods=["GET"])
     def motion_caption_mjpg():
         group = request.args.get("group")
+        camera = request.args.get("camera")
         logging.debug("last motion caption")
         return Response(
-            generate(group=group, filename="last_motion_caption.png"),
+            generate(group=group, camera=camera, filename="last_motion_caption.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -92,9 +92,9 @@ Example: `/live_video?camera=frontdoor`
 
 Several other routes provide streaming functionality:
 
-- **GET /stream.mjpg** – Continuous MJPEG stream of the latest camera image. Optional `group` query parameter limits the feed to a group.
+- **GET /stream.mjpg** – Continuous MJPEG stream of the latest camera image. Optional `camera` or `group` query parameters limit the feed.
 - **GET /stream.png** – Returns the most recent screenshot across all cameras.
-- **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `group` as a query parameter.
+- **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `camera` or `group` as query parameters.
 - **GET /caption.mjpg** – MJPEG stream of the last caption frame for a group.
 - **GET /motion_caption.mjpg** – Combines motion and caption frames in a single MJPEG stream.
 - **GET /stream.m3u8** – HLS playlist referencing the latest videos from all cameras.

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+
+
+class TestMotionMjpg(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(watchdog=False, schedule=False)
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    def _check_call(self, url, expected_camera, expected_group):
+        with patch("app.routes.generate") as mock_gen:
+            mock_gen.return_value = iter([b"TEST"])
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 200)
+            mock_gen.assert_called_with(
+                group=expected_group,
+                camera=expected_camera,
+                filename="last_motion.png",
+            )
+            next(resp.response)
+
+    def test_camera_query(self):
+        self._check_call("/motion.mjpg?camera=cam1", "cam1", None)
+
+    def test_group_query(self):
+        self._check_call("/motion.mjpg?group=front", None, "front")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `camera` query param for MJPEG generators
- document camera options for streaming endpoints
- add regression tests for `/motion.mjpg`

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering MJPEG streaming endpoints by camera name in addition to group.
- **Documentation**
  - Updated streaming endpoint documentation to reflect support for camera-based filtering.
- **Tests**
  - Introduced new tests to verify camera and group query parameter handling for the motion stream endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->