### PR TITLE
Fix live header duplication

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -4,9 +4,6 @@
         // Track the last time the health endpoint failed
         window.lastHealthFailed = false;
     </script>
-    <header>
-        {% include 'nav.html' %}
-    </header>
 
     <style>
         .video-container {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Templates are rescheduled when saved to apply the new settings.
 
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.
+- The live view page no longer shows a duplicate navigation header.


### PR DESCRIPTION
## Summary
- remove redundant nav header from live view
- note fix in documentation

## Testing
- `flake8`
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed duplicate navigation header from the live view page for a cleaner user interface.

- **Documentation**
  - Updated documentation to reflect the removal of the duplicate navigation header on the live view page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->