### PR TITLE
Implement manual discovery workflow

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -66,7 +66,6 @@ from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
 
 
-
 def restart_server():
     logging.info("Restarting server...")
 
@@ -1862,8 +1861,13 @@ def init_routes(app):
     @app.route("/discover", methods=["GET"])
     @login_required
     def discover_cameras_route():
+        return render_template("discover.html", cameras=[])
+
+    @app.route("/discover/scan", methods=["POST"])
+    @login_required
+    def discover_cameras_scan():
         cameras = camera_discovery.discover_cameras()
-        return render_template("discover.html", cameras=cameras)
+        return jsonify(cameras)
 
     @app.route("/discover/add", methods=["POST"])
     @login_required

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
     <h2>Discovered Cameras</h2>
+    <button id="discover-btn">Discover</button>
+    <div id="discover-message"></div>
     <table>
         <thead>
             <tr>
@@ -11,7 +13,7 @@
                 <th title="Add camera"></th>
             </tr>
         </thead>
-        <tbody>
+        <tbody id="discover-body">
         {% for cam in cameras %}
             <tr>
                 <td>{{ cam.ip }}</td>
@@ -34,4 +36,42 @@
         {% endfor %}
         </tbody>
     </table>
+    <script>
+    const button = document.getElementById('discover-btn');
+    const msg = document.getElementById('discover-message');
+    const body = document.getElementById('discover-body');
+    if (button) {
+        button.addEventListener('click', async () => {
+            msg.textContent = 'Searching...';
+            body.innerHTML = '';
+            try {
+                const response = await fetch('/discover/scan', {method: 'POST'});
+                const cams = await response.json();
+                msg.textContent = '';
+                cams.forEach(cam => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `
+                        <td>${cam.ip}</td>
+                        <td>${cam.protocol}</td>
+                        <td>${cam.port}</td>
+                        <td>${JSON.stringify(cam.info)}</td>
+                        <td>
+                            <form action="/discover/add" method="post">
+                                <input type="hidden" name="ip" value="${cam.ip}">
+                                <input type="hidden" name="protocol" value="${cam.protocol}">
+                                <input type="hidden" name="port" value="${cam.port}">
+                                ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ''}
+                                <input type="hidden" name="name" value="${cam.ip}">
+                                <button type="submit" title="Add this camera">Add</button>
+                            </form>
+                        </td>`;
+                    body.appendChild(tr);
+                });
+            } catch (e) {
+                console.error('Discovery error', e);
+                msg.textContent = 'Error discovering cameras';
+            }
+        });
+    }
+    </script>
 {% endblock %}

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -1,6 +1,6 @@
 # Camera Discovery
 
-Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page in the web interface runs the logic in `app/utils/camera_discovery.py` and lists any cameras that respond.
+Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. When triggered, the logic in `app/utils/camera_discovery.py` runs and any responding cameras are listed.
 
 ## How the `/discover` route works
 
@@ -10,11 +10,16 @@ The route is defined in `app/routes.py`:
 @app.route('/discover', methods=['GET'])
 @login_required
 def discover_cameras_route():
+    return render_template('discover.html', cameras=[])
+
+@app.route('/discover/scan', methods=['POST'])
+@login_required
+def discover_cameras_scan():
     cameras = camera_discovery.discover_cameras()
-    return render_template('discover.html', cameras=cameras)
+    return jsonify(cameras)
 ```
 
-When you visit `/discover`, Glimpser calls `discover_cameras()` to scan the network and then renders `discover.html` with the results.
+When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button issues a POST to `/discover/scan`. This endpoint runs `discover_cameras()` and returns the results as JSON which are then inserted into the table.
 
 ## Camera scanning logic
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -325,9 +325,39 @@ class TestRoutes(unittest.TestCase):
             sess["user_id"] = 1
         response = self.client.get("/discover")
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with(
-            "discover.html", cameras=mock_discover.return_value
-        )
+        mock_discover.assert_not_called()
+        mock_render_template.assert_called_with("discover.html", cameras=[])
+
+    @patch("app.routes.SessionLocal")
+    @patch("app.routes.camera_discovery.discover_cameras")
+    def test_discover_scan(self, mock_discover, mock_session_local):
+        mock_discover.return_value = [
+            {"ip": "1.2.3.4", "protocol": "rtsp", "port": 554, "info": {}}
+        ]
+        dummy_user = SimpleNamespace(id=1)
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+
+            def close(self):
+                pass
+
+        mock_session_local.return_value = DummySession()
+
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = 1
+        response = self.client.post("/discover/scan")
+        self.assertEqual(response.status_code, 200)
+        mock_discover.assert_called_once()
+        self.assertEqual(response.get_json(), mock_discover.return_value)
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.template_manager.save_template")


### PR DESCRIPTION
## Summary
- make camera discovery start only when clicking the discover button
- add `/discover/scan` route for async scanning
- document new workflow
- test new route behaviour

## Testing
- `flake8 app/routes.py tests/test_routes.py`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Discover" button for on-demand camera discovery, allowing users to scan for cameras without reloading the page.
  - Camera results are now displayed dynamically after scanning, improving user experience with real-time updates.

- **Bug Fixes**
  - The camera list no longer appears automatically on page load, preventing unnecessary scans.

- **Documentation**
  - Updated documentation to reflect the new camera discovery workflow.

- **Tests**
  - Enhanced tests to cover the new discovery process and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->