### PR TITLE
Add Discover page icon

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -5,7 +5,7 @@
                 {% for ag in active_groups %}
                 <a href='/group/{{ag}}'>{{ag}}</a>
                 {% endfor %}
-                <a href='/discover'>Discover Cameras</a>
+                <!-- Discover icon moved to nav-right for consistency -->
             </div>
 
 	    <div class="nav-center" style='text-align:center;'>
@@ -68,11 +68,13 @@ setInterval(checkHealth, 5000);
 checkHealth();
 
 	</script>
-				    </td>
+                                    </td>
+                                    <td>
+                                            <a href='/discover' class="settings-icon" title='Discover Cameras'>&#128269;</a>
+                                    </td>
 
-
-				    <td>
-					    <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
+                                    <td>
+                                            <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
 				    </td><td>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Live">

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.
 - The live view page no longer shows a duplicate navigation header.
+- The Discover page link now appears as a magnifying glass icon for consistent navigation.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -6,4 +6,5 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The live feed image has both `alt` text and a tooltip.
 - The footer Help link displays a tooltip describing its purpose.
 - The navigation Settings link has a single descriptive `title` attribute.
+- The Discover page icon also uses a descriptive `title` attribute.
 - When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.


### PR DESCRIPTION
## Summary
- add magnifying glass icon to navigation bar for the Discover page
- document Discover icon in README and accessibility guide

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `pytest -q`