### PR TITLE
Add guard for group video feeds

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -610,6 +610,9 @@ function playMotion() {
     }
 
     function checkCameraConnection(cameraName) {
+        if (cameraName === 'All' || cameraName.startsWith('group-')) {
+            return true;
+        }
         const camera = templateDetails[cameraName];
         if (!camera) {
             return false;

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,3 +17,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.
 - The live view page no longer shows a duplicate navigation header.
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
+- Group and All cameras now bypass offline checks when loading feeds.


### PR DESCRIPTION
## Summary
- skip offline check for 'All' and group camera names
- document the change

## Testing
- `flake8` *(fails: E265, E302, etc.)*
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - "Group" and "All" cameras now bypass offline status checks when loading feeds, allowing for immediate access to their views.

- **Documentation**
  - Updated the changelog to reflect changes in camera feed loading behavior for "Group" and "All" cameras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->