### PR TITLE
fix: dark mode array copy

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1511,7 +1511,9 @@ def capture_frame_from_stream(
 
 
 def apply_dark_mode(img, rng=30, txt_rng=120):
-    arr = np.asarray(img.convert("RGB"))
+    arr = np.asarray(
+        img.convert("RGB")
+    ).copy()  # copy to avoid "assignment destination is read-only" errors
     dark = arr <= rng
     light = arr >= 255 - txt_rng
     mask = dark.any(axis=-1) | light.any(axis=-1)

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -65,7 +65,7 @@ The choice between these methods depends on factors such as:
 After capturing the content, Glimpser applies several post-processing steps:
 
 1. **Background Removal**: Remove unnecessary background from captured images.
-2. **Dark Mode**: Apply dark mode to the captured image if requested.
+2. **Dark Mode**: Apply dark mode to the captured image if requested. The image array is copied before modification to avoid "assignment destination is read-only" errors.
 3. **Timestamp Addition**: Add a timestamp to the captured image for reference.
 4. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
 


### PR DESCRIPTION
## Summary
- copy the RGB array before applying dark mode so pixels are writable
- explain the copy requirement in documentation

## Testing
- `flake8`
- `pytest -q`