### PR TITLE
Add jax and flax dependencies

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,6 +19,7 @@ This guide will walk you through the process of setting up Glimpser and running 
    ```
    pip install -r requirements.txt
    ```
+   The list now includes `jax[cpu]` and `flax` for machine learning support.
 
 3. Run the application:
    ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,6 +54,9 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
+This file now includes `jax[cpu]` and `flax` as dependencies. These packages
+provide accelerated array operations and neural network utilities.
+
 ### 6. (Optional) Configure Environment Variables
 
 Copy `.env.example` to `.env` and adjust values to override defaults:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Pillow==11.2.1
 psutil==6.0.0
 pysqlite3==0.5.4
 pyvirtualdisplay==3.0
-scikit-image==0.21.0
+scikit-image==0.25.0
 selenium==4.23.1
 SQLAlchemy==2.0.41
 #torch==2.4.0
@@ -25,3 +25,5 @@ python-dateutil
 python-dotenv
 nodriver
 pytest
+jax[cpu]
+flax


### PR DESCRIPTION
## Summary
- add `jax[cpu]` and `flax` packages
- update `scikit-image` to `0.25.0`
- mention new dependencies in installation docs
- highlight jax/flax in getting started guide

## Testing
- `flake8`
- `pytest -q`