### PR TITLE
Handle blank screenshot filenames

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -1,7 +1,6 @@
 # app/utils/template_manager.py
 
 import os
-import re
 import shutil
 import random
 import logging
@@ -204,7 +203,7 @@ class TemplateManager:
                                 value = True
                             elif value == "off":
                                 value = False
-                            elif type(value) == bool:
+                            elif isinstance(value, bool):
                                 pass
                             else:
                                 logging.debug("MISSSSED %s", value)
@@ -453,7 +452,9 @@ def get_screenshots_for_template(name: str) -> list:
     try:
         sorted_screenshots = sorted(
             screenshots,
-            key=lambda x: datetime.strptime(x[len(name) + 1 : -4], "%Y%m%d%H%M%S"),
+            key=lambda x: datetime.strptime(
+                x[len(name) + 1 : -4].replace("_blank", ""), "%Y%m%d%H%M%S"
+            ),
             reverse=True,
         )
     except Exception as e:

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -144,6 +144,8 @@ Example response:
 
 Return a JSON array of screenshot filenames for the specified template. Individual files can be downloaded via `/screenshots/<template_name>/<filename>`.
 
+Placeholder images created when no real screenshot is available end with `_blank.png`. The endpoint includes these names in the sorted list.
+
 Example response:
 ```json
 {"screenshots": ["cam1_20240101.png", "cam1_20240102.png"]}

--- a/tests/test_get_screenshots_for_template.py
+++ b/tests/test_get_screenshots_for_template.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.template_manager import get_screenshots_for_template  # noqa: E402
+
+
+class TestGetScreenshotsForTemplate(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = "test_sort_shots"
+        self.base = os.path.join(self.test_dir, "cam1")
+        os.makedirs(self.base, exist_ok=True)
+        self.patch = patch(
+            "app.utils.template_manager.SCREENSHOT_DIRECTORY", self.test_dir
+        )
+        self.patch.start()
+
+        open(os.path.join(self.base, "cam1_20240101000000.png"), "wb").close()
+        open(os.path.join(self.base, "cam1_20240102000000_blank.png"), "wb").close()
+        open(os.path.join(self.base, "cam1_20240103000000.png"), "wb").close()
+
+    def tearDown(self):
+        self.patch.stop()
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_blank_suffix_sorted(self):
+        shots = get_screenshots_for_template("cam1")
+        self.assertEqual(
+            shots,
+            [
+                "cam1_20240103000000.png",
+                "cam1_20240102000000_blank.png",
+                "cam1_20240101000000.png",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ignore `_blank` suffix when sorting screenshots
- document blank screenshot filenames
- test the screenshot sorting logic

## Testing
- `flake8 app/utils/template_manager.py tests/test_get_screenshots_for_template.py`
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that placeholder images with filenames ending in `_blank.png` are included in the list of screenshots for the relevant API endpoint.

- **Bug Fixes**
  - Improved the sorting of screenshot filenames to correctly handle files with the `_blank` suffix.

- **Tests**
  - Added unit tests to verify the correct sorting of screenshot filenames, including those with the `_blank` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->