### PR TITLE
Add progress bar and faster discover

### DIFF
--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -2,6 +2,7 @@
 {% block content %}
     <h2>Discovered Cameras</h2>
     <button id="discover-btn">Discover</button>
+    <progress id="discover-progress" style="display:none;"></progress>
     <div id="discover-message"></div>
     <table>
         <thead>
@@ -39,10 +40,12 @@
     <script>
     const button = document.getElementById('discover-btn');
     const msg = document.getElementById('discover-message');
+    const progress = document.getElementById('discover-progress');
     const body = document.getElementById('discover-body');
     if (button) {
         button.addEventListener('click', async () => {
             msg.textContent = 'Searching...';
+            progress.style.display = 'inline';
             body.innerHTML = '';
             try {
                 const response = await fetch('/discover/scan', {method: 'POST'});
@@ -70,6 +73,8 @@
             } catch (e) {
                 console.error('Discovery error', e);
                 msg.textContent = 'Error discovering cameras';
+            } finally {
+                progress.style.display = 'none';
             }
         });
     }

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -16,18 +16,29 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     Zeroconf = None
 
 
-def _local_subnets():
+def _local_subnets(max_prefixlen: int = 24):
+    """Return local IPv4 subnets limited to ``max_prefixlen``.
+
+    Some interfaces report very large networks (e.g. ``10.0.0.0/8``) which makes
+    discovery scans effectively unbounded.  To keep discovery responsive we cap
+    the size of each subnet to at most ``max_prefixlen``.
+    """
+
     subnets = []
-    for iface, addrs in psutil.net_if_addrs().items():
+    for _iface, addrs in psutil.net_if_addrs().items():
         for addr in addrs:
             if addr.family == socket.AF_INET:
                 ip = addr.address
                 netmask = addr.netmask
-                if ip and netmask:
-                    try:
-                        subnets.append(ip_network(f"{ip}/{netmask}", strict=False))
-                    except Exception:
-                        pass
+                if not ip or not netmask:
+                    continue
+                try:
+                    net = ip_network(f"{ip}/{netmask}", strict=False)
+                    if net.prefixlen < max_prefixlen:
+                        net = ip_network(f"{ip}/{max_prefixlen}", strict=False)
+                    subnets.append(net)
+                except Exception:
+                    pass
     return subnets
 
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -1,6 +1,6 @@
 # Camera Discovery
 
-Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. When triggered, the logic in `app/utils/camera_discovery.py` runs and any responding cameras are listed.
+Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A small progress bar appears while the scan runs. When triggered, the logic in `app/utils/camera_discovery.py` runs and any responding cameras are listed. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
 
 ## How the `/discover` route works
 


### PR DESCRIPTION
## Summary
- avoid huge network scans by limiting to `/24`
- show a progress indicator while cameras are being discovered
- document the new progress bar and network limit

## Testing
- `flake8 app/utils/camera_discovery.py`
- `pytest -q`