### PR TITLE
Fix screenshot validation

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1612,7 +1612,9 @@ def capture_screenshot_and_har_light(
             image.save(tmp_path, "PNG")
 
         # Rename from .tmp.png to final .png
-        if os.path.exists(tmp_path) and _is_valid_png(output_path):
+        # Validate the temporary file before renaming so we don't
+        # replace the output with an incomplete image.
+        if os.path.exists(tmp_path) and _is_valid_png(tmp_path):
             add_timestamp(tmp_path, name, invert=invert)
             os.rename(tmp_path, output_path)
             lsuccess = True

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -68,6 +68,7 @@ After capturing the content, Glimpser applies several post-processing steps:
 2. **Dark Mode**: Apply dark mode to the captured image if requested. The image array is copied before modification to avoid "assignment destination is read-only" errors.
 3. **Timestamp Addition**: Add a timestamp to the captured image for reference.
 4. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
+5. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
 
 ## Capture Timeout
 

--- a/tests/test_screenshot_light.py
+++ b/tests/test_screenshot_light.py
@@ -21,24 +21,20 @@ class TestScreenshotLight(unittest.TestCase):
         tmp_path = self.output_path.replace(".png", ".tmp.png")
         mock_image = MagicMock()
         mock_image.convert.return_value = mock_image
-        with patch(
-            "app.utils.screenshots.shutil.which", return_value="/usr/bin/wkhtmltoimage"
-        ), patch("app.utils.screenshots.subprocess.run") as mock_run, patch(
-            "app.utils.screenshots.os.path.exists", return_value=True
-        ), patch(
-            "app.utils.screenshots._is_valid_png", return_value=True
-        ), patch(
-            "app.utils.screenshots.Image.open"
-        ) as mock_open, patch(
-            "app.utils.screenshots.is_mostly_blank", return_value=False
-        ), patch(
-            "app.utils.screenshots.remove_background", return_value=mock_image
-        ), patch(
-            "app.utils.screenshots.apply_dark_mode", return_value=mock_image
-        ), patch(
-            "app.utils.screenshots.add_timestamp"
-        ), patch(
-            "app.utils.screenshots.os.rename"
+        with (
+            patch(
+                "app.utils.screenshots.shutil.which",
+                return_value="/usr/bin/wkhtmltoimage",
+            ),
+            patch("app.utils.screenshots.subprocess.run") as mock_run,
+            patch("app.utils.screenshots.os.path.exists", return_value=True),
+            patch("app.utils.screenshots._is_valid_png", return_value=True),
+            patch("app.utils.screenshots.Image.open") as mock_open,
+            patch("app.utils.screenshots.is_mostly_blank", return_value=False),
+            patch("app.utils.screenshots.remove_background", return_value=mock_image),
+            patch("app.utils.screenshots.apply_dark_mode", return_value=mock_image),
+            patch("app.utils.screenshots.add_timestamp"),
+            patch("app.utils.screenshots.os.rename"),
         ):
             mock_open.return_value.__enter__.return_value = mock_image
             mock_open.return_value.__exit__.return_value = None
@@ -48,6 +44,37 @@ class TestScreenshotLight(unittest.TestCase):
         command = mock_run.call_args.args[0]
         self.assertEqual(command[-2], url)
         self.assertEqual(command[-1], tmp_path)
+
+    def test_valid_tmp_png_saved(self):
+        url = "http://example.com"
+        tmp_path = self.output_path.replace(".png", ".tmp.png")
+        mock_image = MagicMock()
+        mock_image.convert.return_value = mock_image
+        with (
+            patch(
+                "app.utils.screenshots.shutil.which",
+                return_value="/usr/bin/wkhtmltoimage",
+            ),
+            patch("app.utils.screenshots.subprocess.run") as mock_run,
+            patch("app.utils.screenshots.os.path.exists", return_value=True),
+            patch(
+                "app.utils.screenshots._is_valid_png", return_value=True
+            ) as mock_valid,
+            patch("app.utils.screenshots.Image.open") as mock_open,
+            patch("app.utils.screenshots.is_mostly_blank", return_value=False),
+            patch("app.utils.screenshots.remove_background", return_value=mock_image),
+            patch("app.utils.screenshots.apply_dark_mode", return_value=mock_image),
+            patch("app.utils.screenshots.add_timestamp"),
+            patch("app.utils.screenshots.os.rename") as mock_rename,
+        ):
+            mock_open.return_value.__enter__.return_value = mock_image
+            mock_open.return_value.__exit__.return_value = None
+            mock_run.return_value.returncode = 0
+            result = capture_screenshot_and_har_light(url, self.output_path)
+
+        mock_valid.assert_called_once_with(tmp_path)
+        mock_rename.assert_called_once_with(tmp_path, self.output_path)
+        self.assertTrue(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate temporary PNG before renaming in capture helper
- check rename is called when temp screenshot is valid
- mention PNG validation in docs

## Testing
- `flake8`
- `pytest -q`