### PR TITLE
Skip invalid proxy strings

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -68,6 +68,7 @@ from app.config import (
     PROBE_SIZE_OTHER,
     TZ,
 )
+from app.utils.validators import validate_proxy
 
 last_camera_test = {}
 last_camera_test_time = {}
@@ -570,6 +571,8 @@ def download_image(
         stealth (bool): Use stealth user agent.
         proxy (str, optional): Proxy to use for the HTTP request.
     """
+
+    proxy = validate_proxy(proxy)
 
     # ideally the timeout should be pretty high, its an image, and it could be real big
     if timeout < 10:
@@ -1534,6 +1537,7 @@ def capture_screenshot_and_har_light(
     """
     Capture a screenshot of a URL using wkhtmltoimage (WebKit).
     """
+    proxy = validate_proxy(proxy)
     # Check if wkhtmltoimage is available
     if shutil.which("wkhtmltoimage") is None:
         logging.warning("wkhtmltoimage is not installed or not in the system path.")
@@ -2133,6 +2137,8 @@ def capture_screenshot_and_har(
 
     Returns True on success, False otherwise.
     """
+
+    proxy = validate_proxy(proxy)
 
     # Quick sanity check
     if not re.match(r"^https?://", url, flags=re.IGNORECASE):

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -1,6 +1,28 @@
 # app/utils/validators.py
 
 from werkzeug.utils import secure_filename
+import re
+
+
+def validate_proxy(proxy: str | None) -> str | None:
+    """Return the proxy string if valid, otherwise ``None``.
+
+    A valid proxy must start with ``http://`` or ``https://``. Whitespace-only
+    values are ignored.
+    """
+
+    if proxy is None:
+        return None
+
+    proxy = str(proxy).strip()
+
+    if not proxy:
+        return None
+
+    if not re.match(r"^https?://", proxy, flags=re.IGNORECASE):
+        return None
+
+    return proxy
 
 
 def validate_template_name(template_name: str):
@@ -106,6 +128,8 @@ def validate_update_data(data: dict) -> dict:
         "object_filter",
     ]:
         value = data.get(key)
+        if key == "proxy":
+            value = validate_proxy(value)
         if value not in [None, ""]:
             sanitized[key] = value
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,6 +30,12 @@ This guide addresses common issues that users might encounter while using Glimps
 - Regenerate your API key in the Glimpser web interface
 - Ensure you're using the correct API key format in your requests
 
+### Problem: Invalid proxy values
+
+**Solution:**
+- Ensure the proxy string begins with `http://` or `https://`.
+- Blank or malformed proxy values are ignored by Glimpser.
+
 ## 3. Performance Issues
 
 ### Problem: High CPU usage

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -9,9 +9,10 @@ import logging
 import io
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.utils.screenshots import capture_screenshot_and_har, download_image
+
 
 class TestScreenshotCapture(unittest.TestCase):
     def setUp(self):
@@ -35,11 +36,11 @@ class TestScreenshotCapture(unittest.TestCase):
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
         # Assertions
-        #self.assertTrue(result)  # assuming network connetion... 
-        # TODO: cleant his up 
-        #self.assertTrue(os.path.exists(self.output_path))
-        #mock_driver.get.assert_called_once_with("http://example.com")
-        #mock_driver.save_screenshot.assert_called_once_with(self.output_path)
+        # self.assertTrue(result)  # assuming network connetion...
+        # TODO: cleant his up
+        # self.assertTrue(os.path.exists(self.output_path))
+        # mock_driver.get.assert_called_once_with("http://example.com")
+        # mock_driver.save_screenshot.assert_called_once_with(self.output_path)
 
     @patch("app.utils.screenshots.webdriver.Chrome")
     def test_capture_screenshot_with_popup(self, mock_chrome):
@@ -56,10 +57,10 @@ class TestScreenshotCapture(unittest.TestCase):
         )
 
         # Assertions
-        #self.assertTrue(result)
-        #self.assertTrue(os.path.exists(self.output_path))
-        #mock_driver.find_elements.assert_called_once()
-        #mock_driver.execute_script.assert_called_once()
+        # self.assertTrue(result)
+        # self.assertTrue(os.path.exists(self.output_path))
+        # mock_driver.find_elements.assert_called_once()
+        # mock_driver.execute_script.assert_called_once()
 
     @patch("app.utils.screenshots.webdriver.Chrome")
     def test_capture_screenshot_failure(self, mock_chrome):
@@ -70,8 +71,8 @@ class TestScreenshotCapture(unittest.TestCase):
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
         # Assertions
-        #self.assertFalse(result)
-        #self.assertFalse(os.path.exists(self.output_path))
+        # self.assertFalse(result)
+        # self.assertFalse(os.path.exists(self.output_path))
 
     @patch("app.utils.screenshots.webdriver.Chrome")
     @patch("app.utils.screenshots.is_mostly_blank")
@@ -89,9 +90,9 @@ class TestScreenshotCapture(unittest.TestCase):
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
         # Assertions
-        #self.assertFalse(result) # i think this is going to be True, not false... 
-        #self.assertFalse(os.path.exists(self.output_path))
-        #mock_is_mostly_blank.assert_called_once()
+        # self.assertFalse(result) # i think this is going to be True, not false...
+        # self.assertFalse(os.path.exists(self.output_path))
+        # mock_is_mostly_blank.assert_called_once()
 
     @patch("app.utils.screenshots.webdriver.Chrome")
     def test_capture_screenshot_with_dark_mode(self, mock_chrome):
@@ -107,11 +108,11 @@ class TestScreenshotCapture(unittest.TestCase):
         )
 
         # Assertions
-        #self.assertTrue(result)
-        #self.assertTrue(os.path.exists(self.output_path))
-        #mock_driver.execute_cdp_cmd.assert_called_with(
+        # self.assertTrue(result)
+        # self.assertTrue(os.path.exists(self.output_path))
+        # mock_driver.execute_cdp_cmd.assert_called_with(
         #    "Emulation.setAutoDarkModeOverride", {"enabled": True}
-        #)
+        # )
 
     @patch("app.utils.screenshots.http_session")
     def test_download_image_uses_proxy(self, mock_session_factory):
@@ -138,6 +139,27 @@ class TestScreenshotCapture(unittest.TestCase):
             {"http": "http://proxy:8080", "https": "http://proxy:8080"},
         )
 
+    @patch("app.utils.screenshots.http_session")
+    def test_download_image_skips_invalid_proxy(self, mock_session_factory):
+        mock_session = MagicMock()
+        mock_response = MagicMock()
+        img_bytes = io.BytesIO()
+        Image.new("RGB", (1, 1)).save(img_bytes, format="PNG")
+        mock_response.status_code = 200
+        mock_response.content = img_bytes.getvalue()
+        mock_session.get.return_value = mock_response
+        mock_session_factory.return_value = mock_session
+
+        with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+            download_image(
+                "http://example.com/test.png",
+                tmp.name,
+                proxy=" ",
+            )
+
+        kwargs = mock_session.get.call_args.kwargs
+        self.assertNotIn("proxies", kwargs)
+
+
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_update_validation.py
+++ b/tests/test_update_validation.py
@@ -28,6 +28,16 @@ class TestValidateUpdateData(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_update_data({})
 
+    def test_invalid_proxy_removed(self):
+        data = {"url": "http://example", "proxy": "   "}
+        result = validate_update_data(data)
+        self.assertNotIn("proxy", result)
+
+    def test_valid_proxy_preserved(self):
+        data = {"url": "http://example", "proxy": "http://localhost:8080"}
+        result = validate_update_data(data)
+        self.assertEqual(result["proxy"], "http://localhost:8080")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate proxy inputs in `validators`
- skip malformed proxy strings in screenshot functions
- document how invalid proxies are handled
- add tests for proxy validation

## Testing
- `black app/utils/validators.py app/utils/screenshots.py tests/test_update_validation.py tests/test_screenshot_capture.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved validation of proxy settings to ensure only properly formatted proxy URLs are used.
- **Documentation**
	- Added troubleshooting guidance for handling invalid proxy values in the configuration.
- **Tests**
	- Introduced new tests to verify correct handling and validation of proxy values, including behavior when invalid proxies are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->