### PR TITLE
Fix cache logic for proxy downloads

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -578,7 +578,7 @@ def download_image(
     response = None
 
     cached = get_cached_status_code(url)
-    if cached is not None and cached != 200:
+    if cached is not None and cached != 200 and proxy is None:
         logging.debug(f"Skipping {url} due to cached status {cached}")
         return False
     try:


### PR DESCRIPTION
## Summary
- avoid skipping cached URLs when a proxy is provided

## Testing
- `pytest -q`
- `coverage run -m pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image download reliability by allowing downloads through a proxy even if a previous attempt without a proxy failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->