### PR TITLE
Fix All camera PNG stream refresh

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -534,7 +534,12 @@ function playPNG() {
         pngInterval = setInterval(refreshGroupPNG, 10000 / speed);
     } else if (currentCamera === 'All') {
         // Special handling for the "All" option
-        image.src = '/stream.png';
+        const refreshAllPNG = () => {
+            image.src = '/stream.png?time=' + new Date().getTime();
+        };
+        refreshAllPNG();
+        clearInterval(pngInterval);
+        pngInterval = setInterval(refreshAllPNG, 10000 / speed);
     } else {
         // Original behavior for individual cameras
         refreshPNG();

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The live view page no longer shows a duplicate navigation header.
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
 - Group and All cameras now bypass offline checks when loading feeds.
+- The "All" camera PNG stream now refreshes automatically.


### PR DESCRIPTION
## Summary
- fix the All camera PNG stream so it refreshes periodically
- document the PNG refresh improvement in the docs

## Testing
- `flake8`
- `pytest -q`