### PR TITLE
Enhance m3u8 playlist filtering

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1133,6 +1133,9 @@ def init_routes(app):
         if not os.path.exists(path):
             abort(404)
 
+        camera = request.args.get("camera")
+        group = request.args.get("group")
+
         # Generate playlist content
         playlist_content = "#EXTM3U\n"
         playlist_content += "#EXT-X-VERSION:3\n"
@@ -1142,18 +1145,38 @@ def init_routes(app):
         playlist_content += "#EXT-X-MEDIA-SEQUENCE:0\n"
 
         templates = template_manager.get_templates()
+
+        filtered_templates = []
+        if camera:
+            camera = validate_template_name(camera)
+            if camera is None:
+                abort(400, "Invalid camera name")
+            details = templates.get(camera)
+            if details:
+                filtered_templates.append((camera, details))
+        elif group:
+            if not re.match(r"^[a-zA-Z0-9_]+$", group):
+                abort(400, "Invalid group name. Group name must be alphanumeric.")
+            for name, details in templates.items():
+                groups = [g.strip() for g in details.get("groups", "").split(",")]
+                if group in groups:
+                    valid = validate_template_name(name)
+                    if valid:
+                        filtered_templates.append((valid, details))
+        else:
+            for name, details in templates.items():
+                valid = validate_template_name(name)
+                if valid:
+                    filtered_templates.append((valid, details))
+
         # Sort templates by 'last_video_time' descending
         sorted_templates = sorted(
-            templates.items(),
+            filtered_templates,
             key=lambda x: (x[1].get("last_video_time", 0) or 0),
             reverse=True,
         )
 
-        for camera_id, template in sorted_templates:
-            camera_name = validate_template_name(template.get("name"))
-            if camera_name is None:
-                continue
-            # Assuming the MP4 file is the segment
+        for camera_name, _ in sorted_templates:
             lkey = generate_timed_hash()
             video_path = f"{request.url_root}last_video/{camera_name}?timed_key={lkey}"
             playlist_content += f"#EXTINF:10.0,{camera_name}\n{video_path}\n"

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -97,7 +97,9 @@ Several other routes provide streaming functionality:
 - **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `camera` or `group` as query parameters.
 - **GET /caption.mjpg** – MJPEG stream of the last caption frame for a group.
 - **GET /motion_caption.mjpg** – Combines motion and caption frames in a single MJPEG stream.
-- **GET /stream.m3u8** – HLS playlist referencing the latest videos from all cameras.
+- **GET /stream.m3u8** – HLS playlist referencing the latest videos.
+  Optional `camera` or `group` query parameters filter the playlist to a
+  single camera or group of cameras.
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.


### PR DESCRIPTION
## Summary
- allow `/stream.m3u8` to filter by `camera` or `group`
- document new query parameters

## Testing
- `black app/routes.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering the video playlist by camera or group using query parameters on the streaming endpoint.

- **Documentation**
  - Updated API documentation to describe new filtering options for the streaming playlist endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->