### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved screenshot reliability
 - Enhanced camera list UI and video player controls
 - Updated package requirements and cleaned up imports
+- Added CPU builds of JAX 0.6.1 and Flax 0.2.0
+- Bumped scikit-image to 0.25.0
 - Updated default VERSION to 0.2.4 for footer display
 
 ### Fixed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,6 +54,9 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file now includes the CPU builds of **JAX 0.6.1** and
+**Flax 0.2.0**, along with an updated `scikit-image` (0.25.0).
+
 ### 6. (Optional) Configure Environment Variables
 
 Copy `.env.example` to `.env` and adjust values to override defaults:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Pillow==11.2.1
 psutil==6.0.0
 pysqlite3==0.5.4
 pyvirtualdisplay==3.0
-scikit-image==0.21.0
+scikit-image==0.25.0
 selenium==4.23.1
 SQLAlchemy==2.0.41
 #torch==2.4.0
@@ -25,3 +25,5 @@ python-dateutil
 python-dotenv
 nodriver
 pytest
+flax==0.2.0
+jax[cpu]==0.6.1


### PR DESCRIPTION
## Summary
- add JAX 0.6.1 (CPU) and Flax 0.2.0
- bump scikit-image to 0.25.0
- document updated dependencies

## Testing
- `black . --check` *(fails: would reformat 39 files)*
- `flake8` *(fails with many style violations)*
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CPU builds of JAX (v0.6.1) and Flax (v0.2.0) to the Python dependencies.

- **Chores**
  - Upgraded scikit-image to version 0.25.0.
  - Updated documentation to reflect new and updated Python package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->