### PR TITLE
Add HTML template validation tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
 - Group and All cameras now bypass offline checks when loading feeds.
 - The "All" camera PNG stream now refreshes automatically.
+- HTML templates are tested for image `alt` text and required form fields.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -1,0 +1,72 @@
+import os
+import sys
+from pathlib import Path
+from html.parser import HTMLParser
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class TemplateParser(HTMLParser):
+    """Simple HTML parser to capture img tags and form inputs."""
+
+    def __init__(self):
+        super().__init__()
+        self.img_tags = []
+        self.forms = []
+        self._current_form = None
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+        if tag == "img":
+            self.img_tags.append(attrs_dict)
+        elif tag == "form":
+            self._current_form = {"attrs": attrs_dict, "inputs": []}
+            self.forms.append(self._current_form)
+        elif tag in {"input", "textarea", "select"} and self._current_form is not None:
+            self._current_form["inputs"].append(attrs_dict)
+
+    def handle_endtag(self, tag):
+        if tag == "form":
+            self._current_form = None
+
+
+def parse_template(path: Path) -> TemplateParser:
+    parser = TemplateParser()
+    with open(path, encoding="utf-8") as f:
+        parser.feed(f.read())
+    return parser
+
+
+class TestHtmlTemplates(unittest.TestCase):
+    def test_img_tags_have_alt(self):
+        templates_dir = Path("app/templates")
+        for template in templates_dir.glob("*.html"):
+            parser = parse_template(template)
+            for attrs in parser.img_tags:
+                with self.subTest(template=template, attrs=attrs):
+                    self.assertIn("alt", attrs)
+                    self.assertTrue(attrs["alt"].strip())
+
+    def test_login_form_inputs(self):
+        parser = parse_template(Path("app/templates/login.html"))
+        self.assertTrue(parser.forms, "login.html should contain a form")
+        inputs = {i.get("name") for i in parser.forms[0]["inputs"]}
+        self.assertIn("username", inputs)
+        self.assertIn("password", inputs)
+
+    def test_index_add_template_form_inputs(self):
+        parser = parse_template(Path("app/templates/index.html"))
+        add_form = None
+        for form in parser.forms:
+            if form["attrs"].get("id") == "add-template-form":
+                add_form = form
+                break
+        self.assertIsNotNone(add_form, "add-template-form missing")
+        inputs = {i.get("id") or i.get("name") for i in add_form["inputs"]}
+        required = {"name", "url", "frequency", "timeout"}
+        self.assertTrue(required.issubset(inputs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests to parse HTML templates and validate `alt` text
- check required inputs in `login.html` and `index.html`
- document template tests in docs

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to note that HTML templates are now checked for image alt text and required form fields, emphasizing improved accessibility and form validation.
- **Tests**
  - Introduced automated tests to ensure all images in HTML templates include alt text and that key forms contain required input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->