### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved screenshot reliability
 - Enhanced camera list UI and video player controls
 - Updated package requirements and cleaned up imports
+- Added CPU builds of JAX 0.6.1 and Flax 0.2.0
+- Bumped scikit-image to 0.25.0
+- Bumped numpy to 1.25.0
 - Updated default VERSION to 0.2.4 for footer display
 
 ### Fixed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,6 +54,10 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
+The `requirements.txt` file now includes the CPU builds of **JAX 0.6.1** and
+**Flax 0.2.0**, along with updated `scikit-image` (0.25.0) and
+`numpy` (1.25.0).
+
 ### 6. (Optional) Configure Environment Variables
 
 Copy `.env.example` to `.env` and adjust values to override defaults:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ Flask==3.1.1
 Flask-APScheduler==1.13.1
 Flask-Login==0.6.3
 Jinja2==3.1.6
-numpy==1.24.4
+numpy==1.25.0
 pdf2image==1.17.0
 Pillow==11.2.1
 psutil==6.0.0
 pysqlite3==0.5.4
 pyvirtualdisplay==3.0
-scikit-image==0.21.0
+scikit-image==0.25.0
 selenium==4.23.1
 SQLAlchemy==2.0.41
 #torch==2.4.0
@@ -25,3 +25,5 @@ python-dateutil
 python-dotenv
 nodriver
 pytest
+flax==0.2.0
+jax[cpu]==0.6.1


### PR DESCRIPTION
## Summary
- add JAX 0.6.1 (CPU) and Flax 0.2.0
- bump scikit-image to 0.25.0
- bump numpy to 1.25.0
- document updated dependencies

## Testing
- `black . --check` *(fails: would reformat 39 files)*
- `flake8` *(fails with many style violations)*
- `pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies: Upgraded numpy to 1.25.0 and scikit-image to 0.25.0.
	- Added CPU builds for JAX (0.6.1) and Flax (0.2.0) to the requirements.
- **Documentation**
	- Updated installation instructions and changelog to reflect new and updated dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->