### PR TITLE
Add prompt suggestion endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,6 +58,7 @@ from app.utils import (
     video_archiver,
     screenshots,
     camera_discovery,
+    prompt_optimizer,
 )
 from app.utils.db import SessionLocal
 
@@ -1664,6 +1665,18 @@ def init_routes(app):
 
         lscreens = template_manager.get_screenshots_for_template(template_name)
         return jsonify({"screenshots": lscreens})
+
+    @app.route("/generate_prompt/<string:template_name>", methods=["POST"])
+    @login_required
+    def generate_prompt_route(template_name: TemplateName):
+        """Return a suggested caption prompt for ``template_name``."""
+
+        template_name = validate_template_name(template_name)
+        if template_name is None:
+            abort(404)
+
+        prompt = prompt_optimizer.generate_prompt(template_name)
+        return jsonify({"prompt": prompt})
 
     @app.route("/screenshots/<string:name>/<string:filename>")
     @login_required

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -157,6 +157,7 @@ function updateVideo(templateName) {
 
                 <label for="notes" style="color: #fff;" title="Additional notes">Notes:</label>
                 <textarea id="notes" name="notes" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter any additional notes or comments">{{ template_details.notes }}</textarea>
+                <button type="button" onclick="suggestPrompt('{{ template_name }}')" style="margin-top:5px;">Suggest Prompt</button>
 
                 <label for="object_filter" style="color: #fff;" title="Filter for specific objects">Object Filter:</label>
                 <input type="text" id="object_filter" name="object_filter" value="{{ template_details.object_filter }}" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter object types to filter (e.g., 'person,car')">
@@ -342,6 +343,19 @@ function copyToClipboard() {
 function closeModal() {
     document.getElementById('camera-details-modal').style.display = 'none';
 }
+
+function suggestPrompt(name) {
+    fetch(`/generate_prompt/${name}`, {method: 'POST'})
+        .then(resp => resp.json())
+        .then(data => {
+            document.getElementById('prompt-text').value = data.prompt || '';
+            document.getElementById('prompt-modal').style.display = 'block';
+        });
+}
+
+function closePromptModal() {
+    document.getElementById('prompt-modal').style.display = 'none';
+}
 </script>
 
 
@@ -358,6 +372,13 @@ function closeModal() {
     <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
       <span onclick="closeModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
       <div id="camera-details-content"></div>
+    </div>
+  </div>
+
+  <div id="prompt-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
+    <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
+      <span onclick="closePromptModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
+      <textarea id="prompt-text" style="width: 100%; height: 100px;"></textarea>
     </div>
   </div>
 {% endblock %}

--- a/app/utils/prompt_optimizer.py
+++ b/app/utils/prompt_optimizer.py
@@ -1,0 +1,41 @@
+"""Utility for generating optimized caption prompts."""
+
+import os
+
+from app.config import SCREENSHOT_DIRECTORY
+from .template_manager import get_screenshots_for_template
+from .image_processing import ChatGPTImageComparison
+import app.utils.image_processing as img_proc
+
+
+def generate_prompt(template_name: str, num_images: int = 3) -> str:
+    """Return a suggested caption prompt for ``template_name``."""
+
+    screenshots = get_screenshots_for_template(template_name)[:num_images]
+    if not screenshots:
+        return ""
+
+    base = os.path.join(
+        os.path.dirname(os.path.join(__file__)),
+        "..",
+        SCREENSHOT_DIRECTORY,
+        template_name,
+    )
+    image_paths = [
+        os.path.join(base, shot)
+        for shot in screenshots
+        if os.path.exists(os.path.join(base, shot))
+    ]
+    if not image_paths:
+        return ""
+
+    new_prompt = "Review the images and provide a short caption prompt to improve future captions."
+    original_prompt = img_proc.LLM_CAPTION_PROMPT
+    img_proc.LLM_CAPTION_PROMPT = new_prompt
+    try:
+        comparer = ChatGPTImageComparison()
+        result, _ = comparer.compare_images("", image_paths, tokens=32)
+    finally:
+        img_proc.LLM_CAPTION_PROMPT = original_prompt
+
+    return result or ""

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -153,6 +153,18 @@ Example response:
 {"screenshots": ["cam1_20240101.png", "cam1_20240102.png"]}
 ```
 
+### 11. Suggest Caption Prompt
+
+**POST /generate_prompt/<template_name>**
+
+Analyze the latest screenshots for the template and return a short text prompt
+that can be used to improve future captions.
+
+Example response:
+```json
+{"prompt": "Busy roadway — highlight license plates"}
+```
+
 ## Error Handling
 
 All endpoints may return the following error responses:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,6 +44,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 6. Go to the "Monitoring" section to view your live data feed.
 
 7. Explore the auto-generated captions and summaries.
+8. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
 
 ## Next Steps
 

--- a/tests/test_generate_prompt_route.py
+++ b/tests/test_generate_prompt_route.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestGeneratePromptRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.prompt_optimizer.generate_prompt")
+    def test_generate_prompt_success(self, mock_gen):
+        mock_gen.return_value = "Test caption"
+        resp = self.client.post("/generate_prompt/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"prompt": "Test caption"})
+        mock_gen.assert_called_with("cam1")
+
+    @patch("app.routes.prompt_optimizer.generate_prompt", return_value="")
+    def test_generate_prompt_no_images(self, mock_gen):
+        resp = self.client.post("/generate_prompt/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"prompt": ""})
+        mock_gen.assert_called_with("cam1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement prompt suggestion helper using ChatGPTImageComparison
- expose `/generate_prompt/<template_name>` POST route
- show Suggest Prompt button and modal in template details
- document new API and button behaviour
- test prompt generation route

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Suggest Prompt" button on the template detail page, allowing users to generate improved caption prompts for image templates via a modal dialog.
  - Introduced a new API endpoint to suggest caption prompts based on recent template screenshots.

- **Documentation**
  - Updated API documentation to include the new prompt suggestion endpoint.
  - Added instructions to the getting started guide for using the "Suggest Prompt" feature.

- **Tests**
  - Added tests to verify the new prompt suggestion API endpoint's functionality and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->