### PR TITLE
Add test for LLM response count

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
 - Shutdown helpers and port checks are validated by new tests.
+- LLM response count is now verified by a unit test that patches `random.randint`.
 - Application version bumped to `v0.2.4`.
 - Template and live views now show camera metadata, and PNG streams stop when switching sources.
 - Templates are rescheduled when saved to apply the new settings.

--- a/tests/test_llm_response_count.py
+++ b/tests/test_llm_response_count.py
@@ -1,0 +1,21 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.template_manager import get_llm_response_count
+
+
+class TestLLMResponseCount(unittest.TestCase):
+    @patch("app.utils.template_manager.random.randint", return_value=42)
+    def test_get_llm_response_count(self, mock_randint):
+        """get_llm_response_count should return the patched random value."""
+        result = get_llm_response_count("cam1")
+        self.assertEqual(result, 42)
+        mock_randint.assert_called_once_with(10, 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit test for `get_llm_response_count`
- document the new test in the docs

## Testing
- `flake8`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect new unit test coverage for LLM response count verification.
- **Tests**
  - Added a new unit test to ensure accurate LLM response count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->