### PR TITLE
Autofill groups when filter selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with Blue Iris, Home Assistant and Hubitat
 - Custom video controls including Play All/Stop All
 - Automatic group loading for cameras
+- Add Template form auto-fills selected group
 - API discovery and paginated log view
 - LLM summary generation with email alerts
 - Capture time tracking for templates

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -4,13 +4,35 @@ document.addEventListener('DOMContentLoaded', () => {
   // Cache DOM elements
   const form = document.querySelector('#template-form form');
   const groupDropdown = document.getElementById('group-dropdown');
+  const groupsInput = document.getElementById('groups');
+  const templateDetails = document
+    .getElementById('template-form')?.closest('details');
   const slider = document.getElementById('grid-width-slider');
   const templateList = document.getElementById('template-list');
   const searchInput = document.getElementById('search-input');
 
   // Setup event listeners
+  function autofillGroup() {
+    if (groupsInput && groupDropdown && groupDropdown.value !== 'all') {
+      groupsInput.value = groupDropdown.value;
+    }
+  }
+
   if (groupDropdown) {
-    groupDropdown.addEventListener('change', loadTemplates);
+    groupDropdown.addEventListener('change', () => {
+      loadTemplates();
+      if (templateDetails && templateDetails.open) {
+        autofillGroup();
+      }
+    });
+  }
+
+  if (templateDetails) {
+    templateDetails.addEventListener('toggle', () => {
+      if (templateDetails.open) {
+        autofillGroup();
+      }
+    });
   }
 
   if (slider && templateList) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The "All" camera PNG stream now refreshes automatically.
 - HTML templates are tested for image `alt` text and required form fields.
 - Prompt optimizer logic is now tested for screenshot handling and prompt restoration.
+- The Add Template form auto-fills the Groups field when a filter is selected.


### PR DESCRIPTION
## Summary
- autofill the groups field when opening Add Template if a group filter is active
- document the change
- note the feature in the changelog

## Testing
- `black . --quiet`
- `flake8` *(fails: E402 module level import not at top of file, F401 etc.)*
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Template form now automatically fills the selected group when creating or editing a template, streamlining the process.

- **Documentation**
  - Updated documentation to reflect the new auto-fill feature in the Add Template form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->