### PR TITLE
Add SSDP and HTTP discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
   [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
-- **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF, RTSP, and RTMP cameras.
+- **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices.
 - **Local Cameras**: `/discover` also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -126,6 +126,45 @@ def _probe_mdns(timeout=2):
     return cameras
 
 
+def _probe_ssdp(timeout=2):
+    """Probe for devices announcing themselves via SSDP/UPnP."""
+    cameras = []
+    request = (
+        "M-SEARCH * HTTP/1.1\r\n"
+        "HOST:239.255.255.250:1900\r\n"
+        'MAN:"ssdp:discover"\r\n'
+        "MX:1\r\n"
+        "ST:ssdp:all\r\n\r\n"
+    )
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sock.settimeout(timeout)
+    try:
+        sock.sendto(request.encode(), ("239.255.255.250", 1900))
+        while True:
+            try:
+                resp, addr = sock.recvfrom(1024)
+            except socket.timeout:
+                break
+            ip = addr[0]
+            port = 80
+            headers = resp.decode(errors="ignore").split("\r\n")
+            for line in headers:
+                if line.lower().startswith("location:"):
+                    try:
+                        url = urlparse(line.split(":", 1)[1].strip())
+                        ip = url.hostname or ip
+                        port = url.port or port
+                    except Exception:
+                        pass
+                    break
+            cameras.append({"ip": ip, "protocol": "ssdp", "port": port, "info": {}})
+    except Exception as e:
+        logging.debug("SSDP probe error: %s", e)
+    finally:
+        sock.close()
+    return cameras
+
+
 def _fetch_sdp(ip, port, timeout=2):
     """Attempt to retrieve an SDP description from an RTSP endpoint."""
     request = (
@@ -152,6 +191,19 @@ def _fetch_sdp(ip, port, timeout=2):
     except Exception as e:  # pragma: no cover - network
         logging.debug("SDP fetch error for %s:%s: %s", ip, port, e)
         return None
+
+
+def _check_http_endpoint(ip: str, port: int, path: str, timeout: int = 2) -> bool:
+    """Return True if an HTTP GET returns status 200."""
+    request = f"GET {path} HTTP/1.1\r\nHost: {ip}\r\nConnection: close\r\n\r\n"
+    try:
+        with socket.create_connection((ip, port), timeout=timeout) as sock:
+            sock.sendall(request.encode())
+            resp = sock.recv(64)
+            return resp.startswith(b"HTTP/1") and b"200" in resp.split(b"\r\n")[0]
+    except Exception as e:  # pragma: no cover - network
+        logging.debug("HTTP check error for %s:%s%s: %s", ip, port, path, e)
+        return False
 
 
 def _scan_rtsp_ports(subnets):
@@ -187,6 +239,62 @@ def _scan_rtmp_ports(subnets):
             checked.add(ip)
             if is_port_open(ip, 1935, timeout=1):
                 found.append({"ip": ip, "protocol": "rtmp", "port": 1935, "info": {}})
+    return found
+
+
+def _scan_http_endpoints(subnets):
+    """Scan HTTP ports for MJPEG/snapshot URLs."""
+    paths = ["/snapshot.jpg", "/video.mjpg"]
+    found = []
+    checked: set[str] = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            for port in (80, 8080, 443):
+                if not is_port_open(ip, port, timeout=1):
+                    continue
+                for path in paths:
+                    if _check_http_endpoint(ip, port, path, timeout=1):
+                        found.append(
+                            {
+                                "ip": ip,
+                                "protocol": "http",
+                                "port": port,
+                                "info": {"path": path},
+                            }
+                        )
+                        break
+    return found
+
+
+def _scan_hls_streams(subnets):
+    """Scan HTTP ports for HLS playlists."""
+    playlists = ["/index.m3u8", "/live.m3u8"]
+    found = []
+    checked: set[str] = set()
+    for net in subnets:
+        for host in net.hosts():
+            ip = str(host)
+            if ip in checked:
+                continue
+            checked.add(ip)
+            for port in (80, 8080, 443):
+                if not is_port_open(ip, port, timeout=1):
+                    continue
+                for path in playlists:
+                    if _check_http_endpoint(ip, port, path, timeout=1):
+                        found.append(
+                            {
+                                "ip": ip,
+                                "protocol": "hls",
+                                "port": port,
+                                "info": {"path": path},
+                            }
+                        )
+                        break
     return found
 
 
@@ -286,6 +394,10 @@ def discover_cameras():
     cameras = []
     cameras.extend(_probe_onvif())
     try:
+        cameras.extend(_probe_ssdp())
+    except Exception as e:
+        logging.debug("SSDP discovery error: %s", e)
+    try:
         cameras.extend(_probe_mdns())
     except Exception as e:
         logging.debug("mDNS discovery error: %s", e)
@@ -296,6 +408,8 @@ def discover_cameras():
         cameras.extend(_scan_sip_ports(subnets))
         cameras.extend(_scan_webrtc_ports(subnets))
         cameras.extend(_scan_snmp_ports(subnets))
+        cameras.extend(_scan_http_endpoints(subnets))
+        cameras.extend(_scan_hls_streams(subnets))
     except Exception as e:
         logging.warning("RTSP scan error: %s", e)
     try:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -32,7 +32,10 @@ The discovery code combines multiple approaches:
 5. **WebRTC/STUN scan** – `_scan_webrtc_ports()` detects WebRTC servers by checking ports `3478` and `5349`.
 6. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
 7. **SNMP scan** – `_scan_snmp_ports()` checks port `161` for SNMP agents and reads the device name if possible.
-8. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+8. **SSDP/UPnP probe** – `_probe_ssdp()` sends an M-SEARCH request to detect cameras announcing via SSDP.
+9. **HTTP endpoint scan** – `_scan_http_endpoints()` checks ports `80`, `8080`, and `443` for `/snapshot.jpg` or `/video.mjpg` streams.
+10. **HLS detection** – `_scan_hls_streams()` looks for playlist files like `/index.m3u8`.
+11. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
 
 All discovered entries are merged and returned. The key parts of the implementation are shown below:
 
@@ -95,6 +98,26 @@ def _scan_snmp_ports(subnets):
                 found.append({"ip": ip, "protocol": "snmp", "port": 161, "info": info})
 
 
+def _scan_http_endpoints(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            for port in (80, 8080, 443):
+                if is_port_open(ip, port, timeout=1):
+                    if _check_http_endpoint(ip, port, "/snapshot.jpg", timeout=1):
+                        found.append({"ip": ip, "protocol": "http", "port": port, "info": {"path": "/snapshot.jpg"}})
+
+
+def _scan_hls_streams(subnets):
+    for net in subnets:
+        for host in net.hosts():
+            ...
+            for port in (80, 8080, 443):
+                if is_port_open(ip, port, timeout=1):
+                    if _check_http_endpoint(ip, port, "/index.m3u8", timeout=1):
+                        found.append({"ip": ip, "protocol": "hls", "port": port, "info": {"path": "/index.m3u8"}})
+
+
 def _local_video_devices(base_path="/dev"):
     for path in glob.glob(os.path.join(base_path, "video*")):
         found.append({"ip": path, "protocol": "local", "port": 0, "info": {}})
@@ -112,7 +135,7 @@ metrics page.
 
 ## Common cameras to try
 
-Any IP camera that supports **ONVIF**, **RTSP**, or **RTMP** streams should show
+Any IP camera that supports **ONVIF**, **RTSP**, **RTMP**, **HTTP/MJPEG**, or **HLS** streams should show
 up in the discovery list. The following brands are frequently used and respond
 well to the existing discovery methods:
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -42,6 +42,8 @@ class TestCameraDiscovery(unittest.TestCase):
             ("192.168.1.6", 5060),
             ("10.0.0.6", 5349),
             ("192.168.1.6", 161),
+            ("192.168.1.6", 80),
+            ("10.0.0.6", 8080),
         }
 
     @patch("app.utils.camera_discovery.glob.glob")
@@ -149,9 +151,11 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery._probe_ssdp")
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery.is_port_open")
+    @patch("app.utils.camera_discovery._check_http_endpoint")
     @patch("app.utils.camera_discovery._fetch_snmp_sysname")
     @patch("app.utils.camera_discovery._fetch_sdp")
     @patch("app.utils.camera_discovery.psutil.net_if_addrs")
@@ -160,14 +164,23 @@ class TestCameraDiscovery(unittest.TestCase):
         mock_addrs,
         mock_fetch_sdp,
         mock_fetch_snmp,
+        mock_check_http,
         mock_port_open,
         mock_onvif,
         mock_mdns,
+        mock_ssdp,
     ):
         mock_addrs.return_value = self._mock_interfaces()
         mock_port_open.side_effect = self._port_open_side_effect
         mock_fetch_sdp.return_value = "v=0"
         mock_fetch_snmp.return_value = "cam1"
+        mock_check_http.side_effect = lambda ip, port, path, timeout=1: (
+            (ip, port, path)
+            in {
+                ("192.168.1.6", 80, "/snapshot.jpg"),
+                ("10.0.0.6", 8080, "/index.m3u8"),
+            }
+        )
         mock_onvif.return_value = [
             {"ip": "192.168.1.6", "protocol": "onvif", "port": 80, "info": {}},
             {
@@ -179,6 +192,9 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         mock_mdns.return_value = [
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}}
+        ]
+        mock_ssdp.return_value = [
+            {"ip": "192.168.1.8", "protocol": "ssdp", "port": 80, "info": {}}
         ]
         result = camera_discovery.discover_cameras()
         expected = [
@@ -200,11 +216,24 @@ class TestCameraDiscovery(unittest.TestCase):
             {"ip": "10.0.0.6", "protocol": "webrtc", "port": 5349, "info": {}},
             {
                 "ip": "192.168.1.6",
+                "protocol": "http",
+                "port": 80,
+                "info": {"path": "/snapshot.jpg"},
+            },
+            {
+                "ip": "10.0.0.6",
+                "protocol": "hls",
+                "port": 8080,
+                "info": {"path": "/index.m3u8"},
+            },
+            {
+                "ip": "192.168.1.6",
                 "protocol": "snmp",
                 "port": 161,
                 "info": {"name": "cam1"},
             },
             {"ip": "192.168.1.7", "protocol": "mdns", "port": 8080, "info": {}},
+            {"ip": "192.168.1.8", "protocol": "ssdp", "port": 80, "info": {}},
             {
                 "ip": "127.0.0.1",
                 "protocol": "http",


### PR DESCRIPTION
## Summary
- discover cameras via SSDP probe and HTTP-based endpoints
- support MJPEG and HLS in discovery
- document the new discovery features
- test new discovery paths

## Testing
- `flake8`
- `pytest -q`