### PR TITLE
Add style for structured XPath inputs

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -647,3 +647,16 @@ input[type=submit] {
 input[type=submit]:hover {
     background-color: #45a049;
 }
+/* Structured XPath input layout */
+.structured-xpath-input {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 5px;
+}
+
+.structured-xpath-input select,
+.structured-xpath-input input,
+.structured-xpath-input button {
+    flex: 1;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The "All" camera PNG stream now refreshes automatically.
 - HTML templates are tested for image `alt` text and required form fields.
 - Prompt optimizer logic is now tested for screenshot handling and prompt restoration.
+- Structured XPath input fields now share uniform widths via the new `.structured-xpath-input` class.


### PR DESCRIPTION
## Summary
- style `.structured-xpath-input` container for consistent flex layout
- document new styling

## Testing
- `flake8`
- `pytest -q`