### PR TITLE
Improve thumbnail slider usability

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -647,3 +647,12 @@ input[type=submit] {
 input[type=submit]:hover {
     background-color: #45a049;
 }
+#grid-width-slider {
+    width: clamp(200px, 50vw, 600px);
+}
+
+@media (max-width: 767px) {
+    #grid-width-slider {
+        width: 100%;
+    }
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,6 +23,9 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
+### Why is the thumbnail size slider so narrow?
+The width slider on the index page now scales with the browser window. If it appears cramped, try widening the window or adjust the CSS in `style.css` to suit your layout.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- widen the thumbnail size slider so it's easier to adjust
- document how to tweak the slider

## Testing
- `black . --check`
- `python -m flake8` *(fails: No module named flake8)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*