### PR TITLE
Add direct link to monitored pages

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -233,6 +233,22 @@ select:hover {
     z-index: 5;
 }
 
+.open-url-link {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    border-radius: 4px;
+    padding: 2px 4px;
+    text-decoration: none;
+    z-index: 6;
+}
+
+.open-url-link:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+}
+
 video:hover + .play-icon {
     display: block; /* Show play icon on hover */
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -349,6 +349,7 @@ async function loadTemplates() {
                 <div class="play-icon">&#9658;</div>
               </div>
             </a>
+            <a href='${template.url}' target='_blank' class='open-url-link' title='Open monitored page' aria-label='Open monitored page'>↗</a>
           `;
           templateList.appendChild(templateDiv);
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -364,6 +364,7 @@ function closePromptModal() {
     <button id="instant-screenshot-btn" onclick="takeInstantScreenshot('{{ template_name }}')" title="Take a screenshot of the template immediately">Take Instant Screenshot</button>
     <button id="update-video-btn" onclick="updateVideo('{{ template_name }}')" title="Update the video for this template">Update Video</button>
     <button id="show-camera-details-btn" onclick="showCameraDetails('{{ template_name }}')" title="Show camera details and endpoints">Show Camera Details</button>
+    <button id="open-url-btn" onclick="window.open('{{ template_details.url }}', '_blank')" title="Open the monitored page">Open Page</button>
     <br/>
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The "All" camera PNG stream now refreshes automatically.
 - HTML templates are tested for image `alt` text and required form fields.
 - Prompt optimizer logic is now tested for screenshot handling and prompt restoration.
+- Template and live views now provide links to open the monitored page directly.


### PR DESCRIPTION
## Summary
- add quick external link to each template card
- style the new external link overlay
- provide button in template details to open the monitored page
- document availability of new links

## Testing
- `black --check app/routes.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: 48 errors during collection)*