### PR TITLE
Ensure footer uses package version

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@
 import os
 import json
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
 from dotenv import load_dotenv, find_dotenv
 
@@ -98,7 +99,12 @@ UA = get_setting(
 )
 LANG = get_setting("LANG", "en-US")
 TZ = get_setting("TZ", "UTC")
-VERSION = get_setting("VERSION", "0.2.4")
+try:
+    _PKG_VERSION = version("glimpser")
+except PackageNotFoundError:
+    _PKG_VERSION = "0.2.4"
+# Default to the package version if not overridden in the database
+VERSION = get_setting("VERSION", _PKG_VERSION)
 NAME = get_setting("NAME", "glimpser")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Screenshot utility functions now have dedicated unit tests.
 - Shutdown helpers and port checks are validated by new tests.
 - LLM response count is now verified by a unit test that patches `random.randint`.
-- Application version bumped to `v0.2.4`.
+- Footer now displays the package version from installed metadata.
 - Template and live views now show camera metadata, and PNG streams stop when switching sources.
 - Templates are rescheduled when saved to apply the new settings.
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -22,7 +22,7 @@ Below are key settings loaded from the database with their default values. You
 can modify them in the application interface or directly in the database.
 
 - `NAME` – application name (default `glimpser`)
-- `VERSION` – configuration version number (default `0.2.4`)
+- `VERSION` – application version (defaults to the installed package version)
 - `LANG` – default language (default `en-US`)
 - `TZ` – timezone used for logs (default `UTC`)
 - `HOST` – address to bind the server (default `0.0.0.0`)


### PR DESCRIPTION
## Summary
- use importlib.metadata to get package version in configuration
- mention dynamic version sourcing in docs

## Testing
- `flake8 app/config.py`
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The application now dynamically displays the installed package version in the footer, rather than a static version number.
- **Documentation**
	- Updated documentation to clarify that the application version now defaults to the installed package version instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->