### PR TITLE
Add command line docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ glimpser --no-watchdog
 
 Run `glimpser --help` to see all available options.
 
+For a full description of every command-line flag, including the separate credentials utility, see [docs/command_line.md](docs/command_line.md).
+
    You will be prompted to create a secret key to initialize the local sqlite database. Follow the rest of the guided setup and then direct your browser to http://127.0.0.1:8082 to finish the rest of the setup.
 
 ### Docker Quick Start

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,0 +1,37 @@
+# Command Line Reference
+
+This guide describes the available command line arguments for the main `glimpser` application and the `generate_credentials.py` utility.
+
+## glimpser (main.py)
+
+The primary application script accepts the following options:
+
+| Argument | Description |
+| --- | --- |
+| `--db-path` | Path to the SQLite database file. |
+| `--host` | Host for the web server. |
+| `--port` | Port for the web server. |
+| `--log-path` | Path to the log file. |
+| `--log-level` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
+| `--console-log` | Enable logging to the console. |
+| `--debug` | Enable debug mode. |
+| `--no-scheduler` | Disable the background scheduler. |
+| `--no-watchdog` | Disable the watchdog thread. |
+| `--screenshot-dir` | Directory for storing screenshots. |
+| `--video-dir` | Directory for storing video files. |
+| `--summaries-dir` | Directory for storing summaries. |
+
+## generate_credentials.py
+
+This helper script creates or updates the credentials stored in the database.
+
+| Argument | Description |
+| --- | --- |
+| `--db-path` | Path to the SQLite database file. |
+| `--username` | Username for login. |
+| `--password` | Password for login. |
+| `--update-password` | Update only the password without modifying other settings. |
+| `--secret-key` | Custom secret key; a new one is generated if not provided. |
+| `--update-key` | Replace the stored secret key. |
+
+Use `--help` with either script to see these options from the command line.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [API Documentation](api_documentation.md)
 - [Capture Process](capture_process.md)
 - [Configuration Guide](configuration_guide.md)
+- [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)
 - [Developer Guide](developer_guide.md)
 - [Release Workflow](release_workflow.md)


### PR DESCRIPTION
## Summary
- document CLI arguments for `main.py` and `generate_credentials.py`
- link new guide in documentation index
- mention CLI docs in installation section

## Testing
- `flake8 | head -n 5` *(fails: E265 block comment should start with '# ')*
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive command line reference guide detailing all available command-line options for the main application and credentials utility.
  - Updated the main documentation index with a link to the new command line reference.
  - Enhanced the README to direct users to the expanded command-line documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->