### PR TITLE
Add offline help note

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -52,4 +52,8 @@ This guide will walk you through the process of setting up Glimpser and running 
 - Check out the [Configuration Guide](configuration_guide.md) to customize Glimpser for your needs.
 - Join our [community forum](#) to connect with other Glimpser users and get support.
 
+## Offline Help
+
+After you visit the `/help` route while online, the help page is stored locally. You can then access `/help` anytime for instructions on adding templates, managing captures, and troubleshooting, even without an internet connection.
+
 Happy monitoring!


### PR DESCRIPTION
## Summary
- document offline /help route in Getting Started guide

## Testing
- `black .`
- `flake8` *(fails: E402, F401, W291, etc.)*
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an "Offline Help" section to the Getting Started guide, explaining how the help page can be accessed offline after an initial visit.
  - Updated the placement of the closing message for improved flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->