### PR TITLE
Skip blank frames in screenshot and video archiver

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1608,7 +1608,8 @@ def capture_screenshot_and_har_light(
                 logging.warning(
                     f"Captured image is mostly blank—skipping. {url} {name}"
                 )
-                # return False
+                os.unlink(tmp_path)
+                return False
 
             image = remove_background(image)
             if dark:
@@ -2372,9 +2373,10 @@ def _finalize_screenshot(tmp_path, final_path, name, invert, dark):
         with Image.open(tmp_path) as img:
             img = img.convert("RGB")
 
-            # If the image is mostly blank, log a warning but continue
             if is_mostly_blank(img):
                 logging.warning(f"[{name}] The captured screenshot looks mostly blank.")
+                os.remove(tmp_path)
+                return False
 
             # Optional background removal
             img = remove_background(img)

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -8,6 +8,9 @@ import subprocess
 import tempfile
 import time
 import logging
+from PIL import Image
+
+from app.utils.screenshots import is_mostly_blank
 from enum import Enum, auto
 
 from .validators import validate_template_name
@@ -409,9 +412,20 @@ def compile_to_video(camera_path, video_path) -> bool:
     new_files = [
         f
         for f in glob.glob(camera_path + "/*.png")
-        if os.path.getctime(f) > video_mod_time
+        if os.path.getctime(f) > video_mod_time and not f.endswith("_blank.png")
     ]
-    new_files = sorted(new_files)
+
+    # Drop nearly blank images
+    filtered_files = []
+    for file in new_files:
+        try:
+            with Image.open(file) as img:
+                if not is_mostly_blank(img):
+                    filtered_files.append(file)
+        except Exception:
+            continue
+
+    new_files = sorted(filtered_files)
 
     # print("compile", time.time(), video_mod_time, len(new_files))
 

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -4,3 +4,7 @@ The video archiver compiles screenshots into MP4 segments using FFmpeg. Output
 files are rotated when they grow too large or when their creation date exceeds
 `MAX_COMPRESSED_VIDEO_AGE` days. FFmpeg stdout and stderr are logged to aid
 troubleshooting.
+
+Blank screenshots (identified by the `_blank.png` suffix or when the image is
+mostly empty) are discarded before any compilation step. This keeps videos free
+of placeholder frames.

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -71,28 +71,34 @@ class TestScreenshotCapture(unittest.TestCase):
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
         # Assertions
-        # self.assertFalse(result)
-        # self.assertFalse(os.path.exists(self.output_path))
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(self.output_path))
 
-    @patch("app.utils.screenshots.webdriver.Chrome")
-    @patch("app.utils.screenshots.is_mostly_blank")
-    def test_capture_screenshot_blank_image(self, mock_is_mostly_blank, mock_chrome):
-        # Mock the Chrome driver and its methods
+    @patch("app.utils.screenshots.launch_headless_chrome")
+    @patch("app.utils.screenshots.get_chrome_version", return_value=120)
+    @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.is_mostly_blank", return_value=True)
+    def test_capture_screenshot_blank_image(
+        self, mock_blank, mock_get_path, mock_get_version, mock_launch
+    ):
         mock_driver = MagicMock()
-        mock_chrome.return_value = mock_driver
+        mock_launch.return_value = mock_driver
         mock_driver.get.return_value = None
-        mock_driver.save_screenshot.return_value = True
 
-        # Mock is_mostly_blank to return True
-        mock_is_mostly_blank.return_value = True
+        partial = self.output_path + ".tmp.png"
 
-        # Call the function, might have to mock this better
+        def fake_save(path):
+            Image.new("RGB", (1, 1)).save(partial)
+            return True
+
+        mock_driver.save_screenshot.side_effect = fake_save
+
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
-        # Assertions
-        # self.assertFalse(result) # i think this is going to be True, not false...
-        # self.assertFalse(os.path.exists(self.output_path))
-        # mock_is_mostly_blank.assert_called_once()
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(self.output_path))
+        self.assertFalse(os.path.exists(partial))
+        mock_blank.assert_called()
 
     @patch("app.utils.screenshots.webdriver.Chrome")
     def test_capture_screenshot_with_dark_mode(self, mock_chrome):

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import sys
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -65,8 +65,9 @@ class TestVideoArchiver(unittest.TestCase):
         }
         mock_get_video_duration.return_value = 10
 
-        with patch("os.path.exists", return_value=True), patch(
-            "glob.glob", return_value=["/path/to/video.mp4"]
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("glob.glob", return_value=["/path/to/video.mp4"]),
         ):
             compile_to_teaser()
 
@@ -92,13 +93,13 @@ class TestVideoArchiver(unittest.TestCase):
     def test_get_video_duration(self, mock_exists, mock_subprocess_run):
         # Mock the file check to return True
         mock_exists.return_value = True
-        
+
         # Mock the subprocess run to return the desired duration
         mock_subprocess_run.return_value.stdout = "10.5"
-        
+
         # Call the function
         duration = get_video_duration("dummy.mp4")
-        
+
         # Assert the result
         self.assertEqual(duration, 10.5)
 
@@ -120,11 +121,19 @@ class TestVideoArchiver(unittest.TestCase):
 
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("subprocess.run")
-    def test_concatenate_videos_retry(self, mock_subprocess_run, mock_get_video_duration):
+    def test_concatenate_videos_retry(
+        self, mock_subprocess_run, mock_get_video_duration
+    ):
         mock_get_video_duration.return_value = 10
-        mock_subprocess_run.side_effect = [RuntimeError("Resource temporarily unavailable"), None]
+        mock_subprocess_run.side_effect = [
+            RuntimeError("Resource temporarily unavailable"),
+            None,
+        ]
         with (
-            patch("app.utils.video_archiver.handle_concat_error", return_value=ConcatStatus.RETRY) as mock_handle,
+            patch(
+                "app.utils.video_archiver.handle_concat_error",
+                return_value=ConcatStatus.RETRY,
+            ) as mock_handle,
             patch("os.path.exists", return_value=True),
             patch("os.path.getsize", return_value=1),
             patch("os.rename"),
@@ -134,27 +143,32 @@ class TestVideoArchiver(unittest.TestCase):
         self.assertEqual(mock_subprocess_run.call_count, 2)
 
     def test_handle_concat_error(self):
-        with patch("os.path.getsize", return_value=100), patch(
-            "os.rename"
-        ) as mock_rename:
+        with (
+            patch("os.path.getsize", return_value=100),
+            patch("os.rename") as mock_rename,
+        ):
             status = handle_concat_error(
                 Exception("Invalid data found"), "temp.mp4", "in_process.mp4"
             )
             mock_rename.assert_called_once_with("temp.mp4", "in_process.mp4")
             self.assertEqual(status, ConcatStatus.RECOVERED)
 
-        with patch("os.path.getsize", return_value=100), patch(
-            "os.rename"
-        ) as mock_rename:
+        with (
+            patch("os.path.getsize", return_value=100),
+            patch("os.rename") as mock_rename,
+        ):
             status = handle_concat_error(
-                Exception("Resource temporarily unavailable"), "temp.mp4", "in_process.mp4"
+                Exception("Resource temporarily unavailable"),
+                "temp.mp4",
+                "in_process.mp4",
             )
             mock_rename.assert_not_called()
             self.assertEqual(status, ConcatStatus.RETRY)
 
-        with patch("os.path.getsize", return_value=100), patch(
-            "os.rename"
-        ) as mock_rename:
+        with (
+            patch("os.path.getsize", return_value=100),
+            patch("os.rename") as mock_rename,
+        ):
             status = handle_concat_error(
                 Exception("Some fatal error"), "temp.mp4", "in_process.mp4"
             )
@@ -163,9 +177,16 @@ class TestVideoArchiver(unittest.TestCase):
 
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("app.utils.video_archiver.concatenate_videos")
+    @patch("app.utils.video_archiver.Image.open")
+    @patch("app.utils.video_archiver.is_mostly_blank", return_value=False)
     @patch("glob.glob")
     def test_compile_to_video(
-        self, mock_glob, mock_concatenate_videos, mock_get_video_duration
+        self,
+        mock_glob,
+        mock_blank,
+        mock_open,
+        mock_concatenate_videos,
+        mock_get_video_duration,
     ):
         mock_glob.return_value = ["frame_2.png", "frame_2.png"]
         mock_get_video_duration.return_value = 5
@@ -175,21 +196,69 @@ class TestVideoArchiver(unittest.TestCase):
             patch("os.path.exists", return_value=True),
             patch("os.path.isfile", return_value=False),
             patch("os.path.getmtime", return_value=1724516114),
-            patch("os.path.getctime", return_value=1724516114),
+            patch("os.path.getctime", return_value=1724516115),
             patch("os.path.getsize", return_value=1000),
             patch("os.rename"),
             patch("subprocess.run") as mock_subprocess_run,
         ):
+            mock_open.return_value.__enter__.return_value = MagicMock()
+            mock_open.return_value.__exit__.return_value = None
             mock_subprocess_run.return_value.returncode = 0
             result = compile_to_video(self.temp_dir, self.temp_dir)
 
         self.assertIsNone(result)
         self.assertTrue(mock_subprocess_run.called)
 
+    @patch("app.utils.video_archiver.run_ffmpeg")
+    @patch("app.utils.video_archiver.Image.open")
+    @patch("glob.glob")
+    def test_compile_to_video_ignores_blank_frames(
+        self, mock_glob, mock_open, mock_run_ffmpeg
+    ):
+        mock_glob.return_value = ["shot_blank.png", "shot_2.png"]
+
+        captured_lines = []
+
+        def fake_run(cmd):
+            if isinstance(cmd, list) and "-i" in cmd:
+                idx = cmd.index("-i") + 1
+                with open(cmd[idx]) as f:
+                    captured_lines.extend(f.read().splitlines())
+
+            class R:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return R()
+
+        mock_run_ffmpeg.side_effect = fake_run
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=False),
+            patch("os.path.getmtime", return_value=1724516114),
+            patch("os.path.getctime", return_value=1724516115),
+            patch("os.path.getsize", return_value=1000),
+            patch("os.rename"),
+            patch(
+                "app.utils.video_archiver.is_mostly_blank",
+                side_effect=[True, False],
+            ),
+            patch("subprocess.run") as mock_subprocess_run,
+        ):
+            mock_open.return_value.__enter__.return_value = MagicMock()
+            mock_open.return_value.__exit__.return_value = None
+            mock_subprocess_run.return_value.returncode = 0
+            compile_to_video(self.temp_dir, self.temp_dir)
+
+        mock_open.assert_called_once_with("shot_2.png")
+
     @patch("app.utils.video_archiver.compile_to_video")
     def test_archive_screenshots(self, mock_compile_to_video):
-        with patch("os.listdir", return_value=["camera1", "camera2"]), patch(
-            "os.path.isdir", return_value=True
+        with (
+            patch("os.listdir", return_value=["camera1", "camera2"]),
+            patch("os.path.isdir", return_value=True),
         ):
             archive_screenshots()
         self.assertEqual(mock_compile_to_video.call_count, 2)


### PR DESCRIPTION
## Summary
- skip saving blank screenshots in light capture and finalization
- ignore `_blank.png` frames and nearly empty images when building videos
- document blank frame filtering
- test skipping of blank images and ignoring of placeholder frames

## Testing
- `flake8`
- `pytest -q`