### PR TITLE
Add stylelint integration

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,6 +28,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+    - name: Install Node dependencies
+      run: npm ci
+    - name: Lint CSS
+      run: npm run lint:css
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard",
+  "rules": {
+    "indentation": 4
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Template edit form now uses `.form-row` containers for aligned inputs.
 - The Add Template form auto-fills the Groups field when a filter is selected.
 - Help page now covers CLI usage, configuration pointers, and links back to the app.
+- CSS files are now linted in CI using **stylelint**.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "glimpser",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "lint:css": "stylelint 'app/static/css/**/*.css'"
+  },
+  "devDependencies": {
+    "stylelint": "^15.10.0",
+    "stylelint-config-standard": "^34.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add stylelint setup in package.json
- configure stylelint rules
- run stylelint in CI workflow
- document CSS linting step

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
- `python -m coverage run -m pytest`
- `npm install` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683ab734e0dc8333ba87643914d6b056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Integrated CSS linting into the continuous integration (CI) workflow to ensure code quality for stylesheets.
	- Added configuration for CSS linting standards and indentation rules.
	- Introduced a package file to manage frontend dependencies and CSS linting scripts.
- **Documentation**
	- Updated documentation to reflect the addition of CSS linting in the CI process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->