### PR TITLE
Expose JS functions for tests

### DIFF
--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -57,3 +57,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Start the initial event stream
     startEventStream();
 });
+
+if (typeof module !== 'undefined') {
+    module.exports = { updateTable };
+}

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -51,3 +51,7 @@ setInterval(updatePerformanceMetrics, 5000);
 
 // Initial update
 updatePerformanceMetrics();
+
+if (typeof module !== 'undefined') {
+    module.exports = { updatePerformanceMetrics, updateCPUSparkline };
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -563,3 +563,7 @@ function startCasting() {
   }
 }
 
+if (typeof module !== 'undefined') {
+  module.exports = { loadTemplates, updateGridLayout, timeAgo };
+}
+

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -53,6 +53,9 @@ For more details, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 - New routes can be added in `app/routes.py`.
 - Utility functions live in `app/utils/`.
 - Configuration defaults are defined in `app/config.py`.
+- JavaScript utilities in `app/static/js/` expose functions via `module.exports`
+  when running under Node, allowing the test suite to import them without
+  impacting browser usage.
 
 When adding new features, include corresponding tests under the `tests/` directory.
 - Utilities for network testing now have dedicated tests in `tests/test_network_testing_utils.py`.


### PR DESCRIPTION
## Summary
- export key helpers conditionally for Node
- document the exports in the developer guide

## Testing
- `black --check app`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ab7217a948333bc7ce37739c1448d