### PR TITLE
Refactor CSS and remove inline styles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -479,7 +479,15 @@ button, a {
 }
 
 /* Template Form Styles */
-#template-form, #edit-template {
+#template-form {
+    background-color: #222;
+    padding: 20px;
+    border-radius: 10px;
+    max-width: 1000px;
+    margin: 20px auto;
+}
+
+#edit-template {
     background-color: #222;
     padding: 20px;
     border-radius: 10px;
@@ -510,6 +518,8 @@ button, a {
 #edit-template input[type="number"],
 #edit-template textarea {
     padding: 5px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
 }
 
 .form-row {
@@ -613,12 +623,173 @@ button, a {
     height: 60px;
     margin-top: 5px;
     resize: vertical;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
 }
 
 .update-button {
+    align-self: flex-end;
+    margin-top: 10px;
+    border: none;
+    background-color: #4CAF50;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+/* Captions table */
+.caption-table {
     width: 100%;
-    padding: 5px;
-    margin-top: 5px;
+    border-collapse: collapse;
+}
+
+.caption-table th {
+    padding: 8px;
+    background-color: #f4f4f4;
+}
+
+#camera-table {
+    min-width: 90%;
+    max-width: 90%;
+}
+
+.templateDiv-sm {
+    max-width: 10vh;
+    max-height: 1em;
+}
+
+.notes-form {
+    display: flex;
+    flex-direction: column;
+}
+
+.chat-box {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 10px;
+    background-color: #f9f9f9;
+}
+
+.chat-prompt {
+    margin-bottom: 8px;
+}
+
+.chat-response {
+    margin-top: 8px;
+}
+
+.label-bold {
+    display: block;
+    font-weight: bold;
+}
+
+.last-caption {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 8px;
+    background-color: #fff;
+}
+
+.modal-overlay {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+}
+
+.modal-close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.camera-metadata {
+    margin: 10px 0;
+    color: #ccc;
+}
+
+.progress-hidden {
+    display: none;
+}
+
+#video-overlay {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: none;
+}
+
+#live-video {
+    display: none;
+}
+
+.video-overlay-icon {
+    font-size: 48px;
+}
+
+.health-status {
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background-color: grey;
+}
+
+#discover-progress {
+    display: none;
+}
+
+.offline-indicator {
+    text-align: center;
+    color: white;
+}
+
+.primary-button {
+    width: auto;
+    padding: 10px 20px;
+    background-color: #4CAF50;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.spacer-40vw {
+    width: 40vw;
+}
+
+.text-center {
+    text-align: center;
+}
+
+.video-large {
+    display: block;
+    height: 90vh;
+    width: 90vw;
+}
+
+.prompt-text {
+    width: 100%;
+    height: 100px;
 }
 
 /* Footer Styles */

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -63,10 +63,10 @@
 {% endwith %}
 
     <details><summary>Captions</summary>
-        <table border="1" style="width: 100%; border-collapse: collapse;">
+        <table border="1" class="caption-table">
             <tr>
-                <th style="padding: 8px; background-color: #f4f4f4;">Timestamp</th>
-                <th style="padding: 8px; background-color: #f4f4f4;">Caption</th>
+                <th>Timestamp</th>
+                <th>Caption</th>
             </tr>
             {% for caption in lcaptions %}
             {% for lc in caption %}
@@ -81,7 +81,7 @@
     </details>
 
 <h2>Camera Notes</h2>
-<table id="camera-table" class="camera-table" style="min-width:90%; max-width: 90%;">
+<table id="camera-table" class="camera-table">
     <thead>
         <tr>
             <th>Camera</th>
@@ -92,7 +92,7 @@
         {% for camera in template_details %}
         <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}">
             <td>
-                <div class="templateDiv" style="max-width: 10vh; max-height:1em;">
+                <div class="templateDiv templateDiv-sm">
                     <div class="video-container">
 			    <div class="camera-name"><a href='/templates/{{camera}}'>{{camera}}</a></div>
                         <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}">
@@ -105,7 +105,7 @@
                     </div>
                 </div>
             </td>
-            <td style="align: top left;">
+            <td>
 
 		    dark: {{ template_details[camera]['dark'] }}
 		    browser: {{ template_details[camera]['browser'] }}
@@ -126,20 +126,20 @@
                 </table>
                 <details>
                     <summary>Caption</summary>
-                    <form id="form-{{ camera }}" class="notes-form" style="display: flex; flex-direction: column;">
-                        <div class="chat-box" style="display: flex; flex-direction: column; border: 1px solid #ccc; border-radius: 8px; padding: 10px; background-color: #f9f9f9;">
-                            <div class="chat-prompt" style="margin-bottom: 8px;">
-                                <label for="notes-{{ camera }}" style="display: block; font-weight: bold;">Prompt:</label>
-                                <textarea id="notes-{{ camera }}" class="notes-textarea" style="width: 100%; border-radius: 4px; padding: 8px; border: 1px solid #ddd;">{{ template_details[camera]['notes'] }}</textarea>
+                    <form id="form-{{ camera }}" class="notes-form">
+                        <div class="chat-box">
+                            <div class="chat-prompt">
+                                <label for="notes-{{ camera }}" class="label-bold">Prompt:</label>
+                                <textarea id="notes-{{ camera }}" class="notes-textarea">{{ template_details[camera]['notes'] }}</textarea>
                             </div>
-                            <div class="chat-response" style="margin-top: 8px;">
-                                <label style="display: block; font-weight: bold;">Response:</label>
-                                <div class="last-caption" style="border: 1px solid #ddd; border-radius: 4px; padding: 8px; background-color: #fff;">
+                            <div class="chat-response">
+                                <label class="label-bold">Response:</label>
+                                <div class="last-caption">
                                     {{ template_details[camera]['last_caption'] }}
                                 </div>
                             </div>
                         </div>
-                        <button class="update-button" data-template="{{ camera }}" style="align-self: flex-end; margin-top: 10px; border: none; background-color: #4CAF50; color: white; padding: 8px 16px; border-radius: 4px; cursor: pointer;">
+                        <button class="update-button" data-template="{{ camera }}">
                             Send
                         </button>
                     </form>

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -2,7 +2,7 @@
 {% block content %}
     <h2>Discovered Cameras</h2>
     <button id="discover-btn">Discover</button>
-    <progress id="discover-progress" style="display:none;"></progress>
+    <progress id="discover-progress" class="progress-hidden"></progress>
     <div id="discover-message"></div>
     <table>
         <thead>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,77 +5,77 @@
 
 <details title="Expand to add a new template">
     <summary>Add Template</summary>
-    <div id="template-form" style="background-color: #222; padding: 20px; border-radius: 10px; max-width: 1000px; margin: 20px auto;" title="Form to add a new template">
-        <h3 style="color: #fff; text-align: center; margin-bottom: 20px;">Add Template</h3>
+    <div id="template-form" title="Form to add a new template">
+        <h3>Add Template</h3>
         <form id="add-template-form" action="/templates" method="post" onsubmit="return validateForm()" title="Enter details for the new template">
-		<div>
-                <label for="name" style="color: #fff;" title="Name of the template">Template Name:</label>
-                <input type="text" id="name" name="name" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" required title="Enter a unique name for this template">
+                <div>
+                <label for="name" title="Name of the template">Template Name:</label>
+                <input type="text" id="name" name="name" required title="Enter a unique name for this template">
 
-                <label for="url" style="color: #fff;" title="URL to monitor">URL:</label>
-                <input type="url" id="url" name="url" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" required title="Enter the URL to monitor">
+                <label for="url" title="URL to monitor">URL:</label>
+                <input type="url" id="url" name="url" required title="Enter the URL to monitor">
 
-                <label for="frequency" style="color: #fff;" title="How often to check the URL">Frequency (minutes):</label>
-                <input type="number" id="frequency" name="frequency" value="30" min="1" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" required title="Enter how often to check the URL (in minutes)">
+                <label for="frequency" title="How often to check the URL">Frequency (minutes):</label>
+                <input type="number" id="frequency" name="frequency" value="30" min="1" required title="Enter how often to check the URL (in minutes)">
 
-                <label for="timeout" style="color: #fff;" title="Maximum time to wait for a response">Timeout (seconds):</label>
-                <input type="number" id="timeout" name="timeout" value="10" min="1" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" required title="Enter the maximum time to wait for a response (in seconds)">
+                <label for="timeout" title="Maximum time to wait for a response">Timeout (seconds):</label>
+                <input type="number" id="timeout" name="timeout" value="10" min="1" required title="Enter the maximum time to wait for a response (in seconds)">
 
-                <label for="notes" style="color: #fff;" title="Additional notes">Notes:</label>
-                <textarea id="notes" name="notes" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter any additional notes or comments"></textarea>
+                <label for="notes" title="Additional notes">Notes:</label>
+                <textarea id="notes" name="notes" title="Enter any additional notes or comments"></textarea>
 
-                <label for="object_filter" style="color: #fff;" title="Filter for specific objects">Object Filter:</label>
-                <input type="text" id="object_filter" name="object_filter" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter object types to filter (e.g., 'person,car')">
+                <label for="object_filter" title="Filter for specific objects">Object Filter:</label>
+                <input type="text" id="object_filter" name="object_filter" title="Enter object types to filter (e.g., 'person,car')">
 
-                <label for="object_confidence" style="color: #fff;" title="Minimum confidence for object detection">Object Confidence:</label>
-                <input type="number" id="object_confidence" name="object_confidence" min="0" max="1" step="0.01" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter the minimum confidence level for object detection (0-1)">
+                <label for="object_confidence" title="Minimum confidence for object detection">Object Confidence:</label>
+                <input type="number" id="object_confidence" name="object_confidence" min="0" max="1" step="0.01" title="Enter the minimum confidence level for object detection (0-1)">
 
 
-                <label for="popup_xpath" style="color: #fff;">Popup XPath:</label>
+                <label for="popup_xpath">Popup XPath:</label>
                 <div class="xpath-input-container">
-                    <input type="text" id="popup_xpath" name="popup_xpath" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc; width: 70%;">
-                    <button type="button" onclick="showStructuredInput('popup_xpath')" style="padding: 5px; border-radius: 5px; background-color: #4CAF50; color: #fff; border: none; cursor: pointer;">Structured</button>
+                    <input type="text" id="popup_xpath" name="popup_xpath">
+                    <button type="button" onclick="showStructuredInput('popup_xpath')">Structured</button>
                 </div>
 
-                <label for="dedicated_xpath" style="color: #fff;">Dedicated XPath:</label>
+                <label for="dedicated_xpath">Dedicated XPath:</label>
                 <div class="xpath-input-container">
-                    <input type="text" id="dedicated_xpath" name="dedicated_xpath" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc; width: 70%;">
-                    <button type="button" onclick="showStructuredInput('dedicated_xpath')" style="padding: 5px; border-radius: 5px; background-color: #4CAF50; color: #fff; border: none; cursor: pointer;">Structured</button>
+                    <input type="text" id="dedicated_xpath" name="dedicated_xpath">
+                    <button type="button" onclick="showStructuredInput('dedicated_xpath')">Structured</button>
                 </div>
 
 
-                <label for="callback_url" style="color: #fff;" title="URL for notifications">Callback URL:</label>
-                <input type="url" id="callback_url" name="callback_url" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter URL to receive notifications">
+                <label for="callback_url" title="URL for notifications">Callback URL:</label>
+                <input type="url" id="callback_url" name="callback_url" title="Enter URL to receive notifications">
 
-                <label for="proxy" style="color: #fff;" title="Proxy server address">Proxy:</label>
-                <input type="text" id="proxy" name="proxy" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter proxy server address (optional)">
+                <label for="proxy" title="Proxy server address">Proxy:</label>
+                <input type="text" id="proxy" name="proxy" title="Enter proxy server address (optional)">
 
-                <label for="groups" style="color: #fff;" title="Groups for the template, comma separated ">Groups:</label>
-                <input type="text" id="groups" name="groups" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter comma-separated group names">
+                <label for="groups" title="Groups for the template, comma separated ">Groups:</label>
+                <input type="text" id="groups" name="groups" title="Enter comma-separated group names">
 
-                <label for="rollback_frames" style="color: #fff;" title="Number of frames to rollback">Rollback Frames:</label>
-                <input type="number" id="rollback_frames" name="rollback_frames" value="0" min="0" style="padding: 5px; border-radius: 5px; border: 1px solid #ccc;" title="Enter number of frames to rollback">
+                <label for="rollback_frames" title="Number of frames to rollback">Rollback Frames:</label>
+                <input type="number" id="rollback_frames" name="rollback_frames" value="0" min="0" title="Enter number of frames to rollback">
             </div>
 	    <br/>
 
-            <div style="display: flex; justify-content: space-between; flex-wrap: wrap;">
-                <label for="invert" style="color: #fff;" title="Invert image colors">
+            <div class="checkbox-row">
+                <label for="invert" title="Invert image colors">
                     <input type="checkbox" id="invert" name="invert" title="Invert colors of the captured image"> Invert
                 </label>
-                <label for="dark" style="color: #fff;" title="Use dark mode">
+                <label for="dark" title="Use dark mode">
                     <input type="checkbox" id="dark" name="dark" checked title="Enable dark mode for the captured page"> Dark Mode
                 </label>
-                <label for="headless" style="color: #fff;" title="Run in headless mode">
+                <label for="headless" title="Run in headless mode">
                     <input type="checkbox" id="headless" name="headless" checked title="Run browser in headless mode"> Headless
                 </label>
-                <label for="stealth" style="color: #fff;" title="Use stealth mode">
+                <label for="stealth" title="Use stealth mode">
                     <input type="checkbox" id="stealth" name="stealth" title="Use stealth mode to avoid detection"> Stealth
                 </label>
             </div>
 	    <br/>
 
-            <div style="text-align: center; margin-top: 20px;">
-                <input type="submit" value="Submit" style="padding: 10px 20px; background-color: #4CAF50; color: #fff; border: none; border-radius: 5px; cursor: pointer;" title="Submit the template">
+            <div class="form-actions">
+                <input type="submit" value="Submit" class="primary-button" title="Submit the template">
             </div>
         </form>
     </div>

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -81,7 +81,7 @@
 
     <div class="video-container">
         <img id="live-image" alt="Live feed frame" title="Current frame from the live feed">
-        <video id="live-video" style="display: none;" autoplay muted>
+        <video id="live-video" autoplay muted>
             <source src="" type="video/mp4">
             Your browser does not support the video tag.
         </video>
@@ -128,18 +128,18 @@
         {% endfor %}
     </select>
 
-     <div style='width:40vw;'> &nbsp;</div>
+     <div class="spacer-40vw"> &nbsp;</div>
 
 
             </div>
 
 
         </div>
-        <div id="video-overlay" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); display: none;">
-            <div id="loading-indicator" style="display: none;">Loading...</div>
-            <div id="play-pause-indicator" style="display: none; font-size: 48px;">▶</div>
-            <div id="offline-indicator" style="display: none; text-align: center; color: white;">
-                <i class="fas fa-video-slash" style="font-size:48px;"></i>
+        <div id="video-overlay">
+            <div id="loading-indicator" class="progress-hidden">Loading...</div>
+            <div id="play-pause-indicator" class="progress-hidden video-overlay-icon">▶</div>
+            <div id="offline-indicator" class="progress-hidden offline-indicator">
+                <i class="fas fa-video-slash video-overlay-icon"></i>
                 <p id="offline-message"></p>
             </div>
         </div>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -8,7 +8,7 @@
                 <!-- Discover icon moved to nav-right for consistency -->
             </div>
 
-	    <div class="nav-center" style='text-align:center;'>
+            <div class="nav-center text-center">
 {% if template_name %}
 <center><h1><a href='/templates/{{template_name}}'>{{template_name}}</a></h1></center>
     {% endif %} 
@@ -19,7 +19,7 @@
 			    <tr>
 
 				    <td>
-					    <div id="health-status" style="width: 15px; height: 15px; border-radius: 50%; background-color: grey;" title="System Performance"><a href='/status'></a></div>
+                                            <div id="health-status" class="health-status" title="System Performance"><a href='/status'></a></div>
 				    </td>
 	<script>
                 if (typeof window.lastHealthFailed === 'undefined') {

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -6,7 +6,7 @@
     const cameraMeta = {{ template_details|tojson }};
 </script>
 
-            <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay style='display: block; height: 90vh; width: 90vw;' width='90%'
+            <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay class="video-large" width='90%'
 			    {% if template_details.last_caption %}
 			    title='{{template_details.last_caption}}'
 			    {% else %}
@@ -105,7 +105,7 @@ function updateVideo(templateName) {
 
 </script>
 
-    <div id="camera-metadata" style="margin: 10px 0; color: #ccc;">
+    <div id="camera-metadata" class="camera-metadata">
         <ul>
             <li><strong>Last Screenshot:</strong> {{ template_details.last_screenshot_time }}</li>
             <li><strong>Last Video:</strong> {{ template_details.last_video_time }}</li>
@@ -402,17 +402,17 @@ function closePromptModal() {
 
 
 
-  <div id="camera-details-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
-    <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
-      <span onclick="closeModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
+  <div id="camera-details-modal" class="modal-overlay">
+    <div class="modal-content">
+      <span onclick="closeModal()" class="modal-close">&times;</span>
       <div id="camera-details-content"></div>
     </div>
   </div>
 
-  <div id="prompt-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
-    <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
-      <span onclick="closePromptModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
-      <textarea id="prompt-text" style="width: 100%; height: 100px;"></textarea>
+  <div id="prompt-modal" class="modal-overlay">
+    <div class="modal-content">
+      <span onclick="closePromptModal()" class="modal-close">&times;</span>
+      <textarea id="prompt-text" class="prompt-text"></textarea>
     </div>
   </div>
 {% endblock %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The Add Template form auto-fills the Groups field when a filter is selected.
 - Help page now covers CLI usage, configuration pointers, and links back to the app.
 - CSS files are now linted in CI using **stylelint**.
+- Inline `style` attributes have been replaced by reusable CSS classes in `style.css`.


### PR DESCRIPTION
## Summary
- move inline CSS into app/static/css/style.css
- replace inline style attributes in HTML templates with CSS classes
- document CSS cleanup in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad253364c83338e7a5b6f419d8a5a