### PR TITLE
Remove deprecated center tags

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -309,6 +309,20 @@ nav {
     gap: 10px; /* Space between navigation items */
 }
 
+.nav-left,
+.nav-right {
+    display: flex;
+    align-items: center;
+}
+
+.nav-center {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+
 nav a {
     color: #fff; /* White text */
     text-decoration: none; /* No underline */
@@ -677,6 +691,11 @@ footer {
 }
 
 /* Login Page Styles */
+.login-wrapper {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
 .login-container {
     background-color: white;
     padding: 20px;

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
-    <center>
+    <div class="login-wrapper">
     <div class="login-container" title="Login form">
         <h2>Login Required</h2>
         <form method="post" title="Enter your credentials to log in">
@@ -15,6 +15,6 @@
             <input type="submit" value="Login" title="Click to log in">
         </form>
     </div>
-        </center>
+    </div>
 {% endblock %}
 

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -8,11 +8,11 @@
                 <!-- Discover icon moved to nav-right for consistency -->
             </div>
 
-	    <div class="nav-center" style='text-align:center;'>
+            <div class="nav-center">
 {% if template_name %}
-<center><h1><a href='/templates/{{template_name}}'>{{template_name}}</a></h1></center>
-    {% endif %} 
-	    </div>
+                <h1><a href='/templates/{{template_name}}'>{{template_name}}</a></h1>
+    {% endif %}
+            </div>
 
             <div class="nav-right">
 		    <table>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -8,3 +8,4 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The navigation Settings link has a single descriptive `title` attribute.
 - The Discover page icon also uses a descriptive `title` attribute.
 - When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.
+- Deprecated `<center>` tags were removed from templates and replaced with CSS-based centering.


### PR DESCRIPTION
## Summary
- remove `<center>` usage from login and nav templates
- center elements with flexbox in CSS
- document UI change in `accessibility.md`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad25406e88333a0eb99185e05239d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved navigation and login page layouts with new CSS flexbox classes for better alignment and centering.
	- Replaced deprecated <center> tags with modern CSS-based centering in navigation and login templates.

- **Documentation**
	- Updated accessibility documentation to reflect the shift from deprecated HTML tags to CSS-based centering for improved markup and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->