### PR TITLE
Move nav scripts to JS

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -117,12 +117,90 @@ document.addEventListener('DOMContentLoaded', () => {
       isPlaying = !isPlaying;
     });
   }
-  
+
+  // Health check and live clock initialization
+  if (typeof window.lastHealthFailed === 'undefined') {
+    window.lastHealthFailed = false;
+  }
+  if (document.getElementById('health-status')) {
+    setInterval(checkHealth, 5000);
+    checkHealth();
+  }
+  if (document.getElementById('coolClock')) {
+    setInterval(updateCoolClock, 1000);
+    updateCoolClock();
+  }
+
   // Update video sources every 30 minutes
   setInterval(updateVideoSources, 60000 * 30);
 });
 
 // Helper functions
+
+function checkHealth() {
+  fetch('/health')
+    .then((response) => response.json())
+    .then((data) => {
+      const healthStatus = document.getElementById('health-status');
+      if (!healthStatus) return;
+      if (data.status === 'healthy') {
+        healthStatus.style.backgroundColor = 'green';
+        healthStatus.title = 'System Status: Healthy\n\n';
+      } else {
+        healthStatus.style.backgroundColor = 'red';
+        healthStatus.title = 'System Status: Degraded\n\n';
+      }
+      healthStatus.title +=
+        `CPU: ${data.metrics.cpu_usage}%\n` +
+        `Memory: ${data.metrics.memory_usage}%\n` +
+        `Disk: ${data.metrics.disk_usage}%\n` +
+        `Open Files: ${data.metrics.open_files}\n` +
+        `Threads: ${data.metrics.thread_count}\n` +
+        `Uptime: ${data.metrics.uptime}\n`;
+
+      if (data.error_messages && data.error_messages.length > 0) {
+        healthStatus.title += '\nErrors:\n' + data.error_messages.join('\n');
+      }
+
+      if (window.lastHealthFailed) {
+        if (typeof updateFeed === 'function') {
+          updateFeed();
+        } else {
+          window.location.reload();
+        }
+        window.lastHealthFailed = false;
+      }
+    })
+    .catch((error) => {
+      console.error('Error fetching health status:', error);
+      const healthStatus = document.getElementById('health-status');
+      if (healthStatus) {
+        healthStatus.style.backgroundColor = 'red';
+        healthStatus.title = 'Error: Unable to fetch health status';
+      }
+      window.lastHealthFailed = true;
+    });
+}
+
+function updateCoolClock() {
+  const clock = document.getElementById('coolClock');
+  if (!clock) return;
+  const now = new Date();
+  const secondsDegrees = (now.getSeconds() / 60) * 360;
+  const minutesDegrees = (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6;
+  const hoursDegrees = (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30;
+
+  document.querySelector('.second-hand').style.transform = `rotate(${secondsDegrees}deg)`;
+  document.querySelector('.minute-hand').style.transform = `rotate(${minutesDegrees}deg)`;
+  document.querySelector('.hour-hand').style.transform = `rotate(${hoursDegrees}deg)`;
+
+  document.getElementById('digitalTime').title =
+    now.toLocaleTimeString() +
+    '\n' +
+    Intl.DateTimeFormat().resolvedOptions().timeZone +
+    '\n' +
+    now.toDateString();
+}
 
 async function loadGroups() {
   const groupDropdown = document.getElementById('group-dropdown');

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -18,56 +18,8 @@
 		    <table>
 			    <tr>
 
-				    <td>
-					    <div id="health-status" style="width: 15px; height: 15px; border-radius: 50%; background-color: grey;" title="System Performance"><a href='/status'></a></div>
-				    </td>
-	<script>
-                if (typeof window.lastHealthFailed === 'undefined') {
-                    window.lastHealthFailed = false;
-                }
-                function checkHealth() {
-    fetch('/health')
-        .then(response => response.json())
-        .then(data => {
-            const healthStatus = document.getElementById('health-status');
-            if (data.status === 'healthy') {
-                healthStatus.style.backgroundColor = 'green';
-                healthStatus.title = 'System Status: Healthy\n\n';
-            } else {
-                healthStatus.style.backgroundColor = 'red';
-                healthStatus.title = 'System Status: Degraded\n\n';
-            }
-            healthStatus.title += `CPU: ${data.metrics.cpu_usage}%\nMemory: ${data.metrics.memory_usage}%\nDisk: ${data.metrics.disk_usage}%\nOpen Files: ${data.metrics.open_files}\nThreads: ${data.metrics.thread_count}\nUptime: ${data.metrics.uptime}\n`;
-
-            if (data.error_messages && data.error_messages.length > 0) {
-                healthStatus.title += '\nErrors:\n' + data.error_messages.join('\n');
-            }
-
-            if (window.lastHealthFailed) {
-                if (typeof updateFeed === 'function') {
-                    updateFeed();
-                } else {
-                    window.location.reload();
-                }
-                window.lastHealthFailed = false;
-            }
-        })
-        .catch(error => {
-            console.error('Error fetching health status:', error);
-            const healthStatus = document.getElementById('health-status');
-            healthStatus.style.backgroundColor = 'red';
-            healthStatus.title = 'Error: Unable to fetch health status';
-            window.lastHealthFailed = true;
-        });
-}
-
-// Check health status every 5 seconds
-setInterval(checkHealth, 5000);
-
-// Initial health check
-checkHealth();
-
-	</script>
+                                    <td>
+                                            <div id="health-status" style="width: 15px; height: 15px; border-radius: 50%; background-color: grey;" title="System Performance"><a href='/status'></a></div>
                                     </td>
                                     <td>
                                             <a href='/discover' class="settings-icon" title='Discover Cameras'>&#128269;</a>
@@ -75,7 +27,8 @@ checkHealth();
 
                                     <td>
                                             <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
-				    </td><td>
+                                    </td>
+                                    <td>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Live">
                         <div id="dateDisplay" class="clock-face">
@@ -87,9 +40,10 @@ checkHealth();
                         </div>
                     </div>
                 </a>
-				    </td><td>
+                                    </td>
+                                    <td>
                 <a href='/settings' class="settings-icon" title="Update settings">&#9881;</a>
-				    </td>
+                                    </td>
 
 
 			    </tr>
@@ -97,21 +51,4 @@ checkHealth();
             </div>
         </nav>
 
-<script>
-    function updateCoolClock() {
-        const now = new Date();
-        const secondsDegrees = (now.getSeconds() / 60) * 360 + 0;
-        const minutesDegrees = (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6 + 0;
-        const hoursDegrees = (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30 + 0;
-
-        document.querySelector('.second-hand').style.transform = `rotate(${secondsDegrees}deg)`;
-        document.querySelector('.minute-hand').style.transform = `rotate(${minutesDegrees}deg)`;
-        document.querySelector('.hour-hand').style.transform = `rotate(${hoursDegrees}deg)`;
-
-        document.getElementById('digitalTime').title = now.toLocaleTimeString() + '\n' + Intl.DateTimeFormat().resolvedOptions().timeZone + '\n' + now.toDateString() ;
-    }
-
-    setInterval(updateCoolClock, 1000);
-    updateCoolClock(); // initial call to display the clock immediately
-</script>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,3 +28,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The Add Template form auto-fills the Groups field when a filter is selected.
 - Help page now covers CLI usage, configuration pointers, and links back to the app.
 - CSS files are now linted in CI using **stylelint**.
+- The navigation health indicator and live clock are now initialized from `script.js`.


### PR DESCRIPTION
## Summary
- relocate health check and clock logic into script.js
- document nav script change

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ad25542188333a37db10a44fcccda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed dynamic health status indicator and live clock updates from the navigation bar. The health status and clock elements are now static and no longer update in real time.

- **Documentation**
  - Updated the README to clarify that health indicator and live clock initialization now occur via a separate script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->