### PR TITLE
Fix Node dependency install step

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         node-version: '18'
     - name: Install Node dependencies
-      run: npm ci
+      run: npm install
     - name: Lint CSS
       run: npm run lint:css
     - name: Lint with flake8

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -27,6 +27,10 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    cp .env.example .env
    # edit .env before running the app
    ```
+5. Install the Node.js dependencies used for CSS linting:
+   ```sh
+   npm install
+   ```
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- use `npm install` instead of `npm ci`
- mention Node install step without lock file in developer guide

## Testing
- `flake8` *(fails: many style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aca18db008333a26d0f8a9ce5428c