### PR TITLE
Fix video archiver logging

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -552,6 +552,5 @@ def archive_screenshots():
 
         try:
             compile_to_video(camera_path, video_path)
-        except Exception:
-            # TODO: log something bad happening
-            pass
+        except Exception as e:
+            logging.exception("Failed to compile video for camera %s", camera_name)

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -5,6 +5,9 @@ files are rotated when they grow too large or when their creation date exceeds
 `MAX_COMPRESSED_VIDEO_AGE` days. FFmpeg stdout and stderr are logged to aid
 troubleshooting.
 
+Errors encountered during compilation are logged with the camera name so that
+failures can be diagnosed easily.
+
 Blank screenshots (identified by the `_blank.png` suffix or when the image is
 mostly empty) are discarded before any compilation step. This keeps videos free
 of placeholder frames.

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -263,6 +263,16 @@ class TestVideoArchiver(unittest.TestCase):
             archive_screenshots()
         self.assertEqual(mock_compile_to_video.call_count, 2)
 
+    @patch("app.utils.video_archiver.logging.exception")
+    @patch("app.utils.video_archiver.compile_to_video", side_effect=Exception("fail"))
+    def test_archive_screenshots_logs_error(self, mock_compile_to_video, mock_log):
+        with (
+            patch("os.listdir", return_value=["camera1"]),
+            patch("os.path.isdir", return_value=True),
+        ):
+            archive_screenshots()
+        mock_log.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- log failures during screenshot compilation
- document new logging behaviour
- test archive_screenshots error handling

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_683ad6c76d708333acf1071ba6f921c8