### PR TITLE
Add basic MCP integration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -181,3 +181,7 @@ EMAIL_PASSWORD = get_setting("EMAIL_PASSWORD", "")
 TWILIO_SID = get_setting("TWILIO_SID", "")
 TWILIO_TOKEN = get_setting("TWILIO_TOKEN", "")
 TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")
+
+# MCP settings
+MCP_SERVER_COMMAND = get_setting("MCP_SERVER_COMMAND", "")
+MCP_SERVER_URL = get_setting("MCP_SERVER_URL", "")

--- a/app/routes.py
+++ b/app/routes.py
@@ -716,6 +716,25 @@ def init_routes(app):
         }
         return jsonify(api_info), 200
 
+    @app.route("/mcp/tools")
+    @login_required
+    def mcp_tools():
+        """Return the list of tools exposed by the configured MCP server."""
+        from app.utils import mcp
+
+        tools = mcp.list_tools_sync()
+        return jsonify(tools)
+
+    @app.route("/mcp/tool/<string:name>", methods=["POST"])
+    @login_required
+    def mcp_call_tool(name):
+        """Call a tool on the configured MCP server."""
+        from app.utils import mcp
+
+        params = request.get_json(silent=True) or {}
+        result = mcp.call_tool_sync(name, params)
+        return jsonify(result)
+
     @app.route("/login", methods=["GET", "POST"])
     def login():
         ip_address = request.remote_addr

--- a/app/utils/mcp.py
+++ b/app/utils/mcp.py
@@ -1,0 +1,106 @@
+"""Utility functions for interacting with MCP servers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import logging
+
+try:
+    from openai_agents_python import (
+        MCPServerStdio,
+        MCPServerSse,
+        MCPServerStreamableHttp,
+    )
+except Exception:  # pragma: no cover - openai-agents may not be installed
+    MCPServerStdio = None
+    MCPServerSse = None
+    MCPServerStreamableHttp = None
+
+
+class _StubMCPServer:
+    """Fallback server used when ``openai-agents`` is unavailable."""
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "name": "echo",
+                "description": "Return the provided text",
+            }
+        ]
+
+    async def call_tool(
+        self, name: str, params: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        if name != "echo":
+            return {"error": f"Unknown tool: {name}"}
+        return {"text": (params or {}).get("text", "")}
+
+
+class MCPClient:
+    """Wrapper around an MCP server."""
+
+    def __init__(self, command: str | None = None, url: str | None = None):
+        self.command = command
+        self.url = url
+        self._server = None
+
+    async def _ensure_server(self):
+        if self._server is not None:
+            return
+        if MCPServerStdio and self.command:
+            self._server = MCPServerStdio(params={"command": self.command, "args": []})
+            await self._server.__aenter__()
+        elif MCPServerSse and self.url:
+            self._server = MCPServerSse(url=self.url)
+            await self._server.__aenter__()
+        elif MCPServerStreamableHttp and self.url:
+            self._server = MCPServerStreamableHttp(url=self.url)
+            await self._server.__aenter__()
+        else:
+            logging.warning("openai-agents not installed, using stub MCP server")
+            self._server = _StubMCPServer()
+
+    async def list_tools(self) -> List[Dict[str, Any]]:
+        await self._ensure_server()
+        return await self._server.list_tools()
+
+    async def call_tool(
+        self, name: str, params: Dict[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        await self._ensure_server()
+        return await self._server.call_tool(name, params)
+
+    async def close(self):  # pragma: no cover - best effort cleanup
+        if hasattr(self._server, "__aexit__"):
+            await self._server.__aexit__(None, None, None)
+        self._server = None
+
+
+# Convenience functions used by routes
+_default_client: MCPClient | None = None
+
+
+def _get_default_client() -> MCPClient:
+    global _default_client
+    if _default_client is None:
+        from app import config
+
+        _default_client = MCPClient(
+            command=config.MCP_SERVER_COMMAND,
+            url=config.MCP_SERVER_URL,
+        )
+    return _default_client
+
+
+def list_tools_sync() -> List[Dict[str, Any]]:
+    """Return the list of tools from the configured MCP server."""
+    client = _get_default_client()
+    return asyncio.run(client.list_tools())
+
+
+def call_tool_sync(name: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Call a tool on the configured MCP server."""
+    client = _get_default_client()
+    return asyncio.run(client.call_tool(name, params))

--- a/tests/test_mcp_endpoints.py
+++ b/tests/test_mcp_endpoints.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestMcpEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    def test_list_tools(self):
+        resp = self.client.get("/mcp/tools")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIsInstance(data, list)
+        self.assertTrue(any(tool.get("name") == "echo" for tool in data))
+
+    def test_call_tool(self):
+        resp = self.client.post("/mcp/tool/echo", json={"text": "hello"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json().get("text"), "hello")


### PR DESCRIPTION
## Summary
- create `mcp` utility with a stubbed MCP client
- expose `/mcp/tools` and `/mcp/tool/<name>` endpoints
- wire MCP settings into configuration
- test MCP endpoints

## Testing
- `flake8 app/routes.py app/config.py app/utils/mcp.py tests/test_mcp_endpoints.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ad8efe4bc83338dc1c242b67c0935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two new endpoints for listing available tools and invoking specific tools on an MCP server, accessible after login.
- **Chores**
  - Introduced configuration options to specify MCP server command and URL.
- **Tests**
  - Added tests to verify the new MCP endpoints for tool listing and invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->