### PR TITLE
Sync VERSION with package

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -85,6 +85,35 @@ def restore_config():
             session.close()
 
 
+def sync_version(pkg_version: str) -> None:
+    """Update the VERSION row when it doesn't match ``pkg_version``."""
+    if os.getenv("VERSION"):
+        return
+
+    session = SessionLocal()
+    try:
+        existing = session.execute(
+            text("SELECT value FROM settings WHERE name = :name"),
+            {"name": "VERSION"},
+        ).fetchone()
+        if existing is None or existing[0] != pkg_version:
+            session.execute(
+                text(
+                    "INSERT INTO settings (name, value) VALUES (:name, :value) "
+                    "ON CONFLICT(name) DO UPDATE SET value = :value"
+                ),
+                {"name": "VERSION", "value": pkg_version},
+            )
+            session.commit()
+    except Exception as e:
+        if "no such table" in str(e):
+            logging.warning("table does not exist")
+        else:
+            logging.warning("initialization error %s", e)
+    finally:
+        session.close()
+
+
 SCHEDULER_API_ENABLED = True
 
 # be careful when mounting network devices
@@ -103,6 +132,7 @@ try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
     _PKG_VERSION = "0.2.4"
+sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)
 NAME = get_setting("NAME", "glimpser")

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - LLM response count is now verified by a unit test that patches `random.randint`.
 - Footer now displays the package version from installed metadata.
 - Footer version link shows a warning icon when a newer release is available.
+- The VERSION setting now syncs with the installed package version on startup.
 - Template and live views now show camera metadata, and PNG streams stop when switching sources.
 - Templates are rescheduled when saved to apply the new settings.
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -22,7 +22,8 @@ Below are key settings loaded from the database with their default values. You
 can modify them in the application interface or directly in the database.
 
 - `NAME` – application name (default `glimpser`)
-- `VERSION` – application version (defaults to the installed package version)
+- `VERSION` – application version (defaults to the installed package version and
+  is updated automatically when it changes)
 - `LANG` – default language (default `en-US`)
 - `TZ` – timezone used for logs (default `UTC`)
 - `HOST` – address to bind the server (default `0.0.0.0`)

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,67 @@
+import os
+import sqlite3
+import importlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class TestVersionSync(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmp_dir.name, "test.db")
+        self.env_patch = patch.dict(
+            os.environ,
+            {
+                "GLIMPSER_DATABASE_PATH": self.db_path,
+                "GLIMPSER_BACKUP_PATH": os.path.join(self.tmp_dir.name, "backup.json"),
+            },
+        )
+        self.env_patch.start()
+
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "CREATE TABLE settings (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO settings (name, value) VALUES (?, ?)", ("VERSION", "0.1")
+        )
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        self.env_patch.stop()
+        self.tmp_dir.cleanup()
+
+    def _get_version(self):
+        conn = sqlite3.connect(self.db_path)
+        val = conn.execute(
+            "SELECT value FROM settings WHERE name='VERSION'"
+        ).fetchone()[0]
+        conn.close()
+        return val
+
+    def test_version_autoupdates(self):
+        from importlib.metadata import version as real_version
+
+        def fake_version(pkg):
+            if pkg == "glimpser":
+                return "2.0.0"
+            return real_version(pkg)
+
+        with patch("importlib.metadata.version", side_effect=fake_version):
+            import app.config as config
+            import app.utils.db as db
+
+            importlib.reload(config)
+            importlib.reload(db)
+        self.assertEqual(config.VERSION, "2.0.0")
+        self.assertEqual(self._get_version(), "2.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sync version with package metadata on startup
- update docs about new auto-update behaviour
- describe version sync in release notes
- test version auto-update logic

## Testing
- `flake8`
- `pytest tests/test_version_sync.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ade61721483339caccff5f3e1e133