### PR TITLE
Fix screenshot archiver crash

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -409,11 +409,18 @@ def compile_to_video(camera_path, video_path) -> bool:
     # print("OK", glob.glob(camera_path + "/*.png"))
 
     # Filter the list of image files to include only those that are newer than the video
-    new_files = [
-        f
-        for f in glob.glob(camera_path + "/*.png")
-        if os.path.getctime(f) > video_mod_time and not f.endswith("_blank.png")
-    ]
+    # Files may disappear between the glob and metadata lookup so catch
+    # FileNotFoundError and skip missing entries.
+    new_files = []
+    for f in glob.glob(os.path.join(camera_path, "*.png")):
+        if f.endswith("_blank.png"):
+            continue
+        try:
+            if os.path.getctime(f) > video_mod_time:
+                new_files.append(f)
+        except FileNotFoundError:
+            # Screenshot was removed concurrently; ignore it
+            continue
 
     # Drop nearly blank images
     filtered_files = []

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -11,3 +11,7 @@ failures can be diagnosed easily.
 Blank screenshots (identified by the `_blank.png` suffix or when the image is
 mostly empty) are discarded before any compilation step. This keeps videos free
 of placeholder frames.
+
+If a screenshot vanishes between discovery and metadata lookup (for example, if
+another process cleans the directory), the archiver simply skips that file. This
+prevents crashes due to `FileNotFoundError` when gathering timestamps.


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError when screenshots disappear
- note resilient file handling in docs

## Testing
- `flake8 app/utils/video_archiver.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683adffaa2a483338c376e39703f2d08