### PR TITLE
Fix symlink handling in archiver

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -96,7 +96,11 @@ def find_closest_image(directory, last_caption_time):
     min_time_diff = None
 
     for filename in os.listdir(directory):
-        if filename.endswith(".png") and "motion" in filename:
+        if (
+            filename.endswith(".png")
+            and "motion" in filename
+            and not os.path.islink(os.path.join(directory, filename))
+        ):
             # Extract timestamp from filename
             timestamp_str = filename.split("_")[0]
             try:
@@ -239,7 +243,9 @@ def update_camera(name, template, image_file=None):
         png_files = [
             f
             for f in os.listdir(directory)
-            if f.endswith(".png") and os.path.isfile(os.path.join(directory, f))
+            if f.endswith(".png")
+            and os.path.isfile(os.path.join(directory, f))
+            and not os.path.islink(os.path.join(directory, f))
         ]
         if not png_files:
             return None  # camera is out

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -413,6 +413,8 @@ def compile_to_video(camera_path, video_path) -> bool:
     # FileNotFoundError and skip missing entries.
     new_files = []
     for f in glob.glob(os.path.join(camera_path, "*.png")):
+        if os.path.islink(f):
+            continue
         if f.endswith("_blank.png"):
             continue
         try:


### PR DESCRIPTION
## Summary
- ignore symlinks when scanning screenshots
- prevent infinite symlink loops from latest image links

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae1807dd88333b5e693bdb854cb0f