### PR TITLE
Fix blocked settings and update health endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -215,3 +215,11 @@ TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")
 # MCP settings
 MCP_SERVER_COMMAND = get_setting("MCP_SERVER_COMMAND", "")
 MCP_SERVER_URL = get_setting("MCP_SERVER_URL", "")
+
+# Settings that should never be displayed in the UI
+SENSITIVE_SETTINGS = [
+    "SECRET_KEY",
+    "USER_PASSWORD_HASH",
+    "DATABASE_URL",
+    "VERSION",
+]

--- a/app/routes.py
+++ b/app/routes.py
@@ -51,6 +51,7 @@ from app.config import (
     BACKUP_PATH,
     backup_config,
     restore_config,
+    SENSITIVE_SETTINGS,
 )
 from app.models import User
 from app.utils import (
@@ -237,11 +238,13 @@ def get_all_settings():
             {"name": name, "value": value} for name, value in settings.items()
         ]
 
-        # TODO: blocklist some settings - set this somewhere
+        # Remove sensitive items before showing them in the settings page
         lsettings_list = []
-        blocks = ["SECRET_KEY", "USER_PASSWORD_HASH", "DATABASE_URL", "VERSION"]
         for sl in settings_list:
-            if re.findall(r"^[A-Z_]+?$", sl["name"]) and sl["name"] not in blocks:
+            if (
+                re.findall(r"^[A-Z_]+?$", sl["name"])
+                and sl["name"] not in SENSITIVE_SETTINGS
+            ):
                 lsettings_list.append({"name": sl["name"], "value": sl["value"]})
 
         return lsettings_list

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -2,7 +2,7 @@ let cpuData = [];
 const maxDataPoints = 60;
 
 function updatePerformanceMetrics() {
-    fetch('/system_metrics')
+    fetch('/health')
         .then(response => response.json())
         .then(data => {
             document.getElementById('cpu-value').textContent = `${data.cpu_usage}%`;

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details.
+The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint.
 
 ### Metrics
 

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -38,7 +38,7 @@ describe('performance.js', () => {
 
     await updatePerformanceMetrics();
 
-    expect(fetch).toHaveBeenCalledWith('/system_metrics');
+    expect(fetch).toHaveBeenCalledWith('/health');
     expect(document.getElementById('cpu-value').textContent).toBe('50%');
     expect(document.getElementById('memory-value').textContent).toBe('40%');
     expect(document.getElementById('uptime-value').textContent).toBe('1h');


### PR DESCRIPTION
## Summary
- hide sensitive settings from the settings page
- change performance.js to query `/health`
- update related test and docs

## Testing
- `flake8 app/routes.py app/config.py | head`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae2853f7c8333a020fc256fe160c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the settings page to dynamically hide sensitive configuration values based on a centralized list, improving security and consistency.

- **New Features**
  - Added documentation about the new `/health` endpoint for programmatically retrieving raw system metric data.

- **Chores**
  - Changed the performance metrics fetch endpoint from `/system_metrics` to `/health` for improved clarity and consistency.
  - Updated related tests to reflect the new endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->