### PR TITLE
Improve footer layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -648,7 +648,28 @@ footer {
     background-color: #000;
     color: #fff;
     padding: 10px;
-    }
+    border-top: 2px solid #444;
+    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.footer-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.footer-copy {
+    margin-right: 10px;
+    font-size: 0.9em;
+}
 
 .tsv-buttons {
     display: flex;

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -2,16 +2,14 @@
 <footer>
     <div class="footer-content">
         <div class="footer-logo">
-		<!--
+            <!--
             <a href="/">
                 <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" alt="Glimpser" title="Glimpser">
             </a>
-		-->
+            -->
         </div>
-    <div class="footer-copyright">
-        <p>&copy; <span id="current-year"></span> Glimpser. All rights reserved.</p>
-    </div>
         <nav class="footer-nav">
+            <span class="footer-copy">&copy; <span id="current-year"></span> Glimpser. All rights reserved.</span>
             <a href='https://github.com/KristopherKubicki/glimpser/releases'>v{{VERSION}}{% if VERSION_OUTDATED %}<span title="Update available">&#9888;</span>{% endif %}</a>
             <a href="/help" title="View help documentation">Help</a>
             <a href="https://glimpser.net" target="_blank">About</a>


### PR DESCRIPTION
## Summary
- restyle footer for a sleeker look
- put copyright line on same line as version text

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae3c69ab48333af2ca8b75d92f11c