### PR TITLE
Fix CSS lint issue

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -105,7 +105,7 @@ html {
 }
 
 body {
-    font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     margin: 0;
     padding: 0;
     /* Background for contrast */


### PR DESCRIPTION
## Summary
- remove quotes around Inter font to satisfy stylelint

## Testing
- `flake8`
- `pytest -q`
- `npm install` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ae511c76c8333b31b4c8d174ce83c