### PR TITLE
Automate tagging releases

### DIFF
--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -20,3 +20,6 @@ You can still trigger a release manually by creating and pushing a tag:
 git tag v0.2.4
 git push origin v0.2.4
 ```
+
+Alternatively, run `scripts/auto_tag_release.py` to create and push the tag
+for the current version automatically.

--- a/scripts/auto_tag_release.py
+++ b/scripts/auto_tag_release.py
@@ -1,0 +1,36 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+VERSION_FILE = Path("setup.py")
+
+
+def get_version():
+    for line in VERSION_FILE.read_text().splitlines():
+        if "version=" in line:
+            return line.split('"')[1]
+    raise RuntimeError("Version not found in setup.py")
+
+
+def tag_exists(tag):
+    result = subprocess.run(["git", "tag", "-l", tag], capture_output=True, text=True)
+    return tag in result.stdout.split()
+
+
+def create_tag(tag):
+    subprocess.check_call(["git", "tag", tag])
+    subprocess.check_call(["git", "push", "origin", tag])
+
+
+def main():
+    version = get_version()
+    tag = f"v{version}"
+    if tag_exists(tag):
+        print(f"Tag {tag} already exists")
+        return
+    create_tag(tag)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `auto_tag_release.py` helper to create/push release tags
- mention the helper script in the release workflow docs

## Testing
- `flake8 scripts/auto_tag_release.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ae59697c88333b00293087d3584bc