### PR TITLE
Fix settings route auth

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1814,6 +1814,7 @@ def init_routes(app):
         return send_from_directory(path, filename)
 
     @app.route("/settings", methods=["GET", "POST"])
+    @login_required
     def settings():
         if request.method == "POST":
             email_settings = [

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -69,15 +69,14 @@ setInterval(checkHealth, 5000);
 checkHealth();
 
         </script>
-        {% endif %}
-                                    </td>
                                     <td>
                                             <a href='/discover' class="settings-icon" title='Discover Cameras'>&#128269;</a>
                                     </td>
 
                                     <td>
                                             <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
-				    </td><td>
+                                    </td>
+                                    <td>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Live">
                         <div id="dateDisplay" class="clock-face">
@@ -89,13 +88,15 @@ checkHealth();
                         </div>
                     </div>
                 </a>
-				    </td><td>
+                                    </td>
+                                    <td>
                 <a href='/settings' class="settings-icon" title="Update settings">&#9881;</a>
-				    </td>
+                                    </td>
+        {% endif %}
 
 
-			    </tr>
-		    </table>
+                            </tr>
+                    </table>
             </div>
         </nav>
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -65,11 +65,12 @@ Example response:
 
 **GET /settings**
 
-Return the settings page in HTML format.
+Requires authentication via session or API key.
+Returns the settings page in HTML format.
 
 **POST /settings**
 
-Submit form data to modify configuration values. A successful update redirects back to the settings page.
+Requires authentication. Submit form data to modify configuration values. A successful update redirects back to the settings page.
 
 ### 3. Stream MP4 Video
 


### PR DESCRIPTION
## Summary
- require login for /settings route
- hide nav icons when not logged in
- document authentication requirement for settings

## Testing
- `flake8` *(fails: module level import not at top of file, etc.)*
- `pytest -q` *(fails: OperationalError no such table: users in settings route tests)*

------
https://chatgpt.com/codex/tasks/task_e_683af40b73b8833395db436c97ba3c49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted access to the settings page, ensuring only authenticated users can view or modify settings.

- **Documentation**
  - Updated API documentation to clarify that authentication is required for accessing and modifying settings.

- **Style**
  - Improved navigation menu formatting and ensured certain navigation links are only visible to logged-in users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->