### PR TITLE
Add CAP alert connector

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -217,6 +217,10 @@ TWILIO_SID = get_setting("TWILIO_SID", "")
 TWILIO_TOKEN = get_setting("TWILIO_TOKEN", "")
 TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")
 
+# Common Alerting Protocol settings
+CAP_ENDPOINT = get_setting("CAP_ENDPOINT", "")
+CAP_SENDER = get_setting("CAP_SENDER", "glimpser@example.com")
+
 # MCP settings
 MCP_SERVER_COMMAND = get_setting("MCP_SERVER_COMMAND", "")
 MCP_SERVER_URL = get_setting("MCP_SERVER_URL", "")

--- a/app/utils/cap_alerts.py
+++ b/app/utils/cap_alerts.py
@@ -1,0 +1,56 @@
+"""Utilities for sending Common Alerting Protocol (CAP) messages."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+import xml.etree.ElementTree as ET
+
+import requests
+
+from app.config import CAP_ENDPOINT, CAP_SENDER
+
+
+def build_cap_message(event_type: str, description: str) -> bytes:
+    """Return a minimal CAP XML message."""
+    alert = ET.Element("alert")
+    ET.SubElement(alert, "identifier").text = str(int(datetime.utcnow().timestamp()))
+    ET.SubElement(alert, "sender").text = CAP_SENDER
+    ET.SubElement(alert, "sent").text = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    ET.SubElement(alert, "status").text = "Actual"
+    ET.SubElement(alert, "msgType").text = "Alert"
+    ET.SubElement(alert, "scope").text = "Public"
+
+    info = ET.SubElement(alert, "info")
+    ET.SubElement(info, "category").text = "Safety"
+    ET.SubElement(info, "event").text = event_type
+    ET.SubElement(info, "urgency").text = "Immediate"
+    ET.SubElement(info, "severity").text = "Minor"
+    ET.SubElement(info, "certainty").text = "Observed"
+    ET.SubElement(info, "description").text = description
+
+    return ET.tostring(alert, encoding="utf-8")
+
+
+def send_cap_alert(event_type: str, description: str) -> None:
+    """Send a CAP alert to the configured endpoint."""
+    if not CAP_ENDPOINT or not CAP_SENDER:
+        logging.info("CAP alerts are disabled.")
+        return
+
+    xml_data = build_cap_message(event_type, description)
+    try:
+        requests.post(
+            CAP_ENDPOINT,
+            data=xml_data,
+            headers={"Content-Type": "application/xml"},
+            timeout=5,
+        )
+        logging.info("CAP alert sent successfully")
+    except Exception as exc:  # requests.RequestException or others
+        logging.error("Error sending CAP alert: %s", exc)
+
+
+def cap_alert(event_type: str, details: str) -> None:
+    """Wrapper that builds a description from event info."""
+    send_cap_alert(event_type, details)

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -20,7 +20,7 @@ This guide provides a high-level look at Glimpser's core components and how they
   - `screenshots.py` – capturing or downloading images and videos.
   - `template_manager.py` – provides `TemplateManager` for validating,
     saving and deleting templates stored in the database.
-  - `email_alerts.py` and `sms_alerts.py` – sending notifications.
+  - `email_alerts.py`, `sms_alerts.py` and `cap_alerts.py` – sending notifications.
 
 ## Scheduler Jobs (`app/utils/scheduling.py`)
 - Uses APScheduler to run periodic tasks.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -87,6 +87,13 @@ Configure these values to enable Twilio SMS alerts:
 - `TWILIO_TOKEN` – your Twilio auth token
 - `TWILIO_NUMBER` – phone number that receives alerts
 
+## CAP Settings
+
+Set these variables to enable Common Alerting Protocol alerts:
+
+- `CAP_ENDPOINT` – URL that accepts CAP XML alerts
+- `CAP_SENDER` – identifier used in the CAP `sender` field
+
 ## Capture Parameters
 
 Settings controlling how frames are captured from video sources:

--- a/tests/test_cap_alerts.py
+++ b/tests/test_cap_alerts.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.cap_alerts import send_cap_alert, cap_alert
+
+
+class TestCAPAlerts(unittest.TestCase):
+    def test_send_cap_alert_disabled(self):
+        with patch("app.utils.cap_alerts.CAP_ENDPOINT", ""), patch(
+            "app.utils.cap_alerts.CAP_SENDER", ""
+        ), patch("requests.post") as mock_post:
+            send_cap_alert("event", "details")
+            mock_post.assert_not_called()
+
+    def test_send_cap_alert_enabled(self):
+        with patch("app.utils.cap_alerts.CAP_ENDPOINT", "http://example.com"), patch(
+            "app.utils.cap_alerts.CAP_SENDER", "sender"
+        ), patch("requests.post") as mock_post:
+            send_cap_alert("event", "details")
+            mock_post.assert_called_once()
+            args, kwargs = mock_post.call_args
+            self.assertEqual(kwargs["headers"]["Content-Type"], "application/xml")
+            self.assertIn(b"<event>event</event>", kwargs["data"])
+
+    def test_cap_alert_wrapper(self):
+        with patch("app.utils.cap_alerts.send_cap_alert") as mock_send:
+            cap_alert("Test", "Details")
+            mock_send.assert_called_once_with("Test", "Details")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new CAP alert utility
- expose `CAP_ENDPOINT` and `CAP_SENDER` settings
- document CAP settings and update architecture overview
- test CAP alert behaviour

## Testing
- `flake8 app/utils/cap_alerts.py tests/test_cap_alerts.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0b0b32248333af721199eac2c5df