### PR TITLE
Add MCP and proxy validator tests

### DIFF
--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import mcp
+
+
+class TestMCPClient(unittest.TestCase):
+    def tearDown(self):
+        mcp._default_client = None
+
+    def test_stub_operations(self):
+        client = mcp.MCPClient()
+        tools = asyncio.run(client.list_tools())
+        self.assertTrue(any(t["name"] == "echo" for t in tools))
+
+        result = asyncio.run(client.call_tool("echo", {"text": "hi"}))
+        self.assertEqual(result, {"text": "hi"})
+
+        result = asyncio.run(client.call_tool("bad"))
+        self.assertEqual(result, {"error": "Unknown tool: bad"})
+
+    def test_sync_helpers_use_config(self):
+        with (
+            patch("app.config.MCP_SERVER_COMMAND", "cmd"),
+            patch("app.config.MCP_SERVER_URL", "url"),
+            patch("app.utils.mcp.MCPClient") as mock_cls,
+        ):
+            inst = mock_cls.return_value
+            inst.list_tools = AsyncMock(return_value=[{"name": "echo"}])
+            inst.call_tool = AsyncMock(return_value={"text": "hi"})
+            mcp._default_client = None
+            tools1 = mcp.list_tools_sync()
+            result = mcp.call_tool_sync("echo", {"text": "hi"})
+        self.assertEqual(tools1, [{"name": "echo"}])
+        self.assertEqual(result, {"text": "hi"})
+        mock_cls.assert_called_once_with(command="cmd", url="url")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_proxy.py
+++ b/tests/test_validate_proxy.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.validators import validate_proxy
+
+
+class TestValidateProxy(unittest.TestCase):
+    def test_none(self):
+        self.assertIsNone(validate_proxy(None))
+
+    def test_blank(self):
+        self.assertIsNone(validate_proxy("   "))
+
+    def test_invalid_scheme(self):
+        self.assertIsNone(validate_proxy("ftp://example.com"))
+
+    def test_valid_http(self):
+        self.assertEqual(validate_proxy("http://example.com"), "http://example.com")
+
+    def test_valid_https(self):
+        self.assertEqual(validate_proxy("https://example.com"), "https://example.com")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for the MCP client helpers
- add tests for `validate_proxy`

## Testing
- `flake8 tests/test_mcp_client.py tests/test_validate_proxy.py`
- `pytest -q tests/test_mcp_client.py tests/test_validate_proxy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0cd627c48333ad5ca0b2bfddf92d