### PR TITLE
Add danger mode UI indicator

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -64,6 +64,7 @@ from app.utils import (
     prompt_optimizer,
     camera_fix,
 )
+from app.utils.screenshots import is_chrome_debug_port_open, check_user_activity
 from app.utils.db import SessionLocal, engine
 
 # from app.models.log import Log
@@ -695,6 +696,16 @@ def init_routes(app):
             200,
         )  # always return 200, but might be degraded.
 
+    @app.route("/danger_status")
+    @login_required
+    def danger_status():
+        """Return whether Danger mode can be used."""
+        port_open = is_chrome_debug_port_open("127.0.0.1", 9222)
+        idle = not check_user_activity(timeout=1)
+        return jsonify(
+            {"port_open": port_open, "idle": idle, "ready": port_open and idle}
+        )
+
     @app.route("/api/discover")
     def api_discover():
         api_info = {
@@ -704,6 +715,12 @@ def init_routes(app):
                     "path": "/health",
                     "method": "GET",
                     "description": "Check the health status of the API",
+                    "authentication_required": False,
+                },
+                {
+                    "path": "/danger_status",
+                    "method": "GET",
+                    "description": "Check if Danger mode is ready",
                     "authentication_required": False,
                 },
                 {

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -21,6 +21,9 @@
                                     <td>
                                             <div id="health-status" class="status-indicator" title="System Performance"><a href='/status'></a></div>
                                     </td>
+                                    <td>
+                                            <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
+                                    </td>
         {% if session.get('user_id') %}
         <script>
                 if (typeof window.lastHealthFailed === 'undefined') {
@@ -67,6 +70,31 @@ setInterval(checkHealth, 5000);
 
 // Initial health check
 checkHealth();
+
+function checkDanger() {
+    fetch('/danger_status')
+        .then(response => response.json())
+        .then(data => {
+            const dangerStatus = document.getElementById('danger-status');
+            if (data.ready) {
+                dangerStatus.style.backgroundColor = 'orange';
+                dangerStatus.title = 'Danger Mode Ready';
+            } else {
+                dangerStatus.style.backgroundColor = 'grey';
+                let reason = [];
+                if (!data.port_open) reason.push('Debug port closed');
+                if (!data.idle) reason.push('User active');
+                dangerStatus.title = 'Danger Mode Off';
+                if (reason.length) dangerStatus.title += '\n' + reason.join(', ');
+            }
+        })
+        .catch(error => {
+            console.error('Error fetching danger status:', error);
+        });
+}
+
+setInterval(checkDanger, 5000);
+checkDanger();
 
         </script>
                                     <td>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -41,3 +41,7 @@ The log viewer reads log lines from memory, ensuring minimal disk overhead.
 The `/status` page also appears on the `/discover` screen as a **System Status**
 camera. Adding it lets Glimpser capture periodic screenshots of its own health
 metrics.
+
+## Danger Mode Indicator
+
+When Chrome's remote debugging port is open and no user input has been detected for a short time, Danger mode becomes available. An orange dot in the navigation bar shows this state. Hovering over the dot explains why Danger mode may be unavailable.

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestDangerStatusEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.is_chrome_debug_port_open", return_value=True)
+    @patch("app.routes.check_user_activity", return_value=False)
+    def test_danger_ready(self, mock_idle, mock_port):
+        resp = self.client.get("/danger_status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.get_json(), {"port_open": True, "idle": True, "ready": True}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- show danger mode status via `/danger_status`
- display a new orange indicator in the navigation bar when danger mode is ready
- document the indicator in system monitoring guide
- test the new `/danger_status` endpoint

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0d48f3348333a26b6a8e5840e42d