### PR TITLE
Suppress metadata when viewing groups

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -291,20 +291,23 @@ function changeCamera() {
 
         function updateTemplateDetails() {
             const details = templateDetails[currentCamera];
-            const isConnected = checkCameraConnection(currentCamera);
+            const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
 
-            if (details) {
-                video.title = details.last_caption;
-                templateDetailsContainer.innerHTML = `
-                    <div>
-                        <strong>Last Screenshot:</strong> ${details.last_screenshot_time || 'N/A'}<br/>
-                        <strong>Last Video:</strong> ${details.last_video_time || 'N/A'}<br/>
-                        <strong>Last Caption:</strong> ${details.last_caption || 'N/A'}<br/>
-                        ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ''}
-                    </div>`;
-            } else {
+            if (!details || isGroupView) {
+                templateDetailsContainer.style.display = 'none';
                 templateDetailsContainer.innerHTML = '';
+                return;
             }
+
+            video.title = details.last_caption;
+            templateDetailsContainer.style.display = 'block';
+            templateDetailsContainer.innerHTML = `
+                <div>
+                    <strong>Last Screenshot:</strong> ${details.last_screenshot_time || 'N/A'}<br/>
+                    <strong>Last Video:</strong> ${details.last_video_time || 'N/A'}<br/>
+                    <strong>Last Caption:</strong> ${details.last_caption || 'N/A'}<br/>
+                    ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ''}
+                </div>`;
         }
 
         function updateFeed() {


### PR DESCRIPTION
## Summary
- hide last screenshot, last video, and last caption details when viewing "All" or group cameras

## Testing
- `black --check app/templates/live.html` *(fails: Cannot parse)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b0d9254b88333b2cea5bf6202072c