### PR TITLE
Improve live page layout

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -8,12 +8,10 @@
     <style>
         .video-container {
             max-width: 100vw;
-            max-height: 96vh; /* 80% of the viewport height */
-	    width: 100%;
-	    min-height: 85vh;
-	    height: 100%;
+            width: 100%;
+            max-height: 92vh; /* allow room for controls on small screens */
             position: relative;
-            overflow: hidden; /* Prevents scrolling */
+            overflow: auto; /* enable scrolling if needed */
         }
         #live-video, #live-image {
             position: absolute;
@@ -77,6 +75,9 @@
             border-radius: 5px;
             display: none;
         }
+        #template-details {
+            margin-top: 10px;
+        }
     </style>
 
     <div class="video-container">
@@ -128,7 +129,6 @@
         {% endfor %}
     </select>
 
-     <div style='width:40vw;'> &nbsp;</div>
 
 
             </div>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,6 +26,9 @@ Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When
 ### Why is the thumbnail size slider so narrow?
 The width slider on the index page now scales with the browser window. If it appears cramped, try widening the window or adjust the CSS in `style.css` to suit your layout.
 
+### Why is the live feed slightly cropped on small screens?
+Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- prevent cropping and allow scrolling on the live feed
- remove extra spacing after the controls
- keep template details from overlapping the feed
- document the fix in the FAQ

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b108aaef883339dd145ae168b79f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved video container styling for better visibility and scrolling on small screens.
  - Added spacing above template details for enhanced layout.

- **Documentation**
  - Added a FAQ entry explaining video cropping and recent improvements to the live feed display on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->