### PR TITLE
Fix filename validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1782,14 +1782,16 @@ def init_routes(app):
     @login_required
     def uploaded_file(name: TemplateName, filename: str):
         template_name = validate_template_name(name)
-        if template_name is None:
+        if template_name is None or not allowed_filename(filename):
             abort(404)
+
         path = os.path.join(
             os.path.dirname(os.path.join(__file__)),
             "..",
             SCREENSHOT_DIRECTORY,
             template_name,
         )
+
         if not os.path.exists(path):
             abort(404)
 
@@ -1827,14 +1829,16 @@ def init_routes(app):
     @login_required
     def view_video(name: TemplateName, filename: str):
         template_name = validate_template_name(name)
-        if template_name is None:
+        if template_name is None or not allowed_filename(filename):
             abort(404)
+
         path = os.path.join(
             os.path.dirname(os.path.join(__file__)),
             "..",
             VIDEO_DIRECTORY,
             template_name,
         )
+
         if not os.path.exists(path):
             abort(404)
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -134,7 +134,7 @@ Streams log records via Server-Sent Events. Optional query parameters `level`, `
 
 **GET /videos/<template_name>**
 
-Return a JSON array of archived MP4 filenames for the specified template. Combine with `/videos/<template_name>/<filename>` to download a particular file.
+Return a JSON array of archived MP4 filenames for the specified template. Combine with `/videos/<template_name>/<filename>` to download a particular file. Filenames are validated and requests with illegal characters return `404`.
 
 Example response:
 ```json
@@ -145,7 +145,7 @@ Example response:
 
 **GET /screenshots/<template_name>**
 
-Return a JSON array of screenshot filenames for the specified template. Individual files can be downloaded via `/screenshots/<template_name>/<filename>`.
+Return a JSON array of screenshot filenames for the specified template. Individual files can be downloaded via `/screenshots/<template_name>/<filename>`. Invalid filenames also return `404`.
 
 Placeholder images created when no real screenshot is available end with `_blank.png`. The endpoint includes these names in the sorted list.
 


### PR DESCRIPTION
## Summary
- validate filenames in screenshot and video routes
- document validation in API docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b246eb8dc83339103c9079829e0b2