### PR TITLE
Add simple SSO login

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -164,6 +164,8 @@ SECRET_KEY = get_setting("SECRET_KEY", "default_secret_key")
 USER_NAME = get_setting("USER_NAME", "admin")
 USER_PASSWORD_HASH = get_setting("USER_PASSWORD_HASH", "")
 API_KEY = get_setting("API_KEY", "")
+SSO_TOKEN = get_setting("SSO_TOKEN", "")
+SSO_USERNAME = get_setting("SSO_USERNAME", USER_NAME)
 CHATGPT_KEY = get_setting("CHATGPT_KEY", "")  # maybe generalize as LLM_KEY ?
 
 LLM_MODEL_VERSION = get_setting(

--- a/app/routes.py
+++ b/app/routes.py
@@ -841,6 +841,36 @@ def init_routes(app):
                 flash("Invalid username or password", "error")
         return render_template("login.html")
 
+    @app.route("/sso", methods=["GET"])
+    def sso_login():
+        token = request.args.get("token") or request.headers.get("X-SSO-Token")
+        if token != config.SSO_TOKEN or not token:
+            flash("Invalid SSO token", "error")
+            logging.warning("Invalid SSO token from %s", request.remote_addr)
+            return redirect(url_for("login"))
+
+        db_session = SessionLocal()
+        try:
+            user = (
+                db_session.query(User).filter_by(username=config.SSO_USERNAME).first()
+            )
+        finally:
+            db_session.close()
+
+        if not user:
+            flash("Configured SSO user not found", "error")
+            logging.error("SSO user %s not found", config.SSO_USERNAME)
+            return redirect(url_for("login"))
+
+        session["user_id"] = user.id
+        session["expiry"] = (
+            datetime.now() + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        session.permanent = True
+        flash("Logged in via SSO", "success")
+        logging.info("SSO login for %s from %s", user.username, request.remote_addr)
+        return redirect(url_for("index"))
+
     @app.route("/help")
     @login_required
     def help_page():

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -43,6 +43,8 @@ updated with `generate_credentials.py` or through the web interface.
 - `SECRET_KEY` – secret key used for session management (default
   `default_secret_key`)
 - `API_KEY` – key used to access the API (empty by default)
+- `SSO_TOKEN` – token used for the `/sso` login endpoint (empty by default)
+- `SSO_USERNAME` – username associated with SSO logins (defaults to `USER_NAME`)
 - `CHATGPT_KEY` – API key for AI captioning and summarization (empty by
   default)
 - `SESSION_COOKIE_SECURE` – set `True` to send cookies only over HTTPS

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -21,6 +21,7 @@ Before diving into specific integrations, it's important to understand the gener
 3. **Scheduling**: Glimpser's scheduling capabilities (`app/utils/scheduling.py`) can be used to synchronize with external systems.
 
 4. **Authentication**: Ensure that you use proper authentication when making API calls to Glimpser.
+5. **Single Sign-On**: When configured, send your SSO token to the `/sso` endpoint to establish a session.
 
 ## Blue Iris Integration
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -3,9 +3,9 @@
 import unittest
 
 import os
-import sys 
+import sys
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 import datetime
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 from app.config import USER_NAME, API_KEY
 from app.routes import login_required, login_attempts
 from app import create_app
+
 
 class TestAuthentication(unittest.TestCase):
     def setUp(self):
@@ -33,18 +34,22 @@ class TestAuthentication(unittest.TestCase):
         self.app_context.pop()
 
     def test_login_success(self):
-        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.login_attempts", {}), patch("app.routes.check_password_hash", return_value=True):
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.login_attempts", {}
+        ), patch("app.routes.check_password_hash", return_value=True):
             dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
 
             class DummyQuery:
                 def filter_by(self, **kwargs):
                     return self
+
                 def first(self):
                     return dummy_user
 
             class DummySession:
                 def query(self, model):
                     return DummyQuery()
+
                 def close(self):
                     pass
 
@@ -58,22 +63,26 @@ class TestAuthentication(unittest.TestCase):
                 },
             )
             self.assertEqual(response.status_code, 302)
-            # seems sus... 
-            #self.assertIn("/", response.headers["Path"])
+            # seems sus...
+            # self.assertIn("/", response.headers["Path"])
 
     def test_login_failure(self):
-        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.check_password_hash", return_value=False
+        ):
             dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
 
             class DummyQuery:
                 def filter_by(self, **kwargs):
                     return self
+
                 def first(self):
                     return dummy_user
 
             class DummySession:
                 def query(self, model):
                     return DummyQuery()
+
                 def close(self):
                     pass
 
@@ -86,54 +95,81 @@ class TestAuthentication(unittest.TestCase):
 
     def test_login_failure_lockout(self):
         # Simulate multiple failed login attempts to trigger lockout
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         for _ in range(5):  # Assuming lockout occurs after 5 attempts
-            with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
-                dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+            with patch("app.routes.SessionLocal") as mock_session_local, patch(
+                "app.routes.check_password_hash", return_value=False
+            ):
+                dummy_user = SimpleNamespace(
+                    id=1, username=USER_NAME, password_hash="hash"
+                )
+
                 class DummyQuery:
                     def filter_by(self, **kwargs):
                         return self
+
                     def first(self):
                         return dummy_user
+
                 class DummySession:
                     def query(self, model):
                         return DummyQuery()
+
                     def close(self):
                         pass
-                mock_session_local.return_value = DummySession()
-                self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
 
-        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=False):
+                mock_session_local.return_value = DummySession()
+                self.client.post(
+                    "/login", data={"username": USER_NAME, "password": "wrong_password"}
+                )
+
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.check_password_hash", return_value=False
+        ):
             dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
             class DummyQuery:
                 def filter_by(self, **kwargs):
                     return self
+
                 def first(self):
                     return dummy_user
+
             class DummySession:
                 def query(self, model):
                     return DummyQuery()
+
                 def close(self):
                     pass
+
             mock_session_local.return_value = DummySession()
-            response = self.client.post("/login", data={"username": USER_NAME, "password": "wrong_password"})
+            response = self.client.post(
+                "/login", data={"username": USER_NAME, "password": "wrong_password"}
+            )
         self.assertEqual(response.status_code, 429)  # Expecting lockout response
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
 
     def test_logout(self):
-        login_attempts = {} # reset
-        with patch("app.routes.SessionLocal") as mock_session_local, patch("app.routes.check_password_hash", return_value=True):
+        login_attempts = {}  # reset
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.check_password_hash", return_value=True
+        ):
             dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
             class DummyQuery:
                 def filter_by(self, **kwargs):
                     return self
+
                 def first(self):
                     return dummy_user
+
             class DummySession:
                 def query(self, model):
                     return DummyQuery()
+
                 def close(self):
                     pass
+
             mock_session_local.return_value = DummySession()
             self.client.post(
                 "/login", data={"username": USER_NAME, "password": "correct_password"}
@@ -143,73 +179,93 @@ class TestAuthentication(unittest.TestCase):
         self.assertIn("/login", response.headers["Location"])
 
     def test_login_required_without_login(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         response = self.client.get("/protected")
         self.assertEqual(response.status_code, 302)
         self.assertIn("/login", response.headers["Location"])
 
     def test_login_required_with_login(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+
         class DummyQuery:
             def filter_by(self, **kwargs):
                 return self
+
             def first(self):
                 return dummy_user
+
         class DummySession:
             def query(self, model):
                 return DummyQuery()
+
             def close(self):
                 pass
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.SessionLocal", return_value=DummySession()):
+
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.SessionLocal", return_value=DummySession()
+        ):
             response = self.client.get("/protected")
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"Protected Content", response.data)
 
     def test_login_required_with_expired_session(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         # Set an expiry date that is in the past
-        expired_time = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
+        expired_time = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
         dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+
         class DummyQuery:
             def filter_by(self, **kwargs):
                 return self
+
             def first(self):
                 return dummy_user
+
         class DummySession:
             def query(self, model):
                 return DummyQuery()
+
             def close(self):
                 pass
-        with patch("app.routes.session", {"user_id": 1, "expiry": expired_time}), patch("app.routes.SessionLocal", return_value=DummySession()):
+
+        with patch("app.routes.session", {"user_id": 1, "expiry": expired_time}), patch(
+            "app.routes.SessionLocal", return_value=DummySession()
+        ):
             response = self.client.get("/protected")
             self.assertEqual(response.status_code, 302)
             self.assertIn("/login", response.headers["Location"])
 
     def test_login_required_with_api_key(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         mock_api_key = "mock_api_key_for_testing"
         with patch("app.routes.API_KEY", mock_api_key):
-            response = self.client.get("/protected", headers={"X-API-Key": mock_api_key})
+            response = self.client.get(
+                "/protected", headers={"X-API-Key": mock_api_key}
+            )
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"Protected Content", response.data)
 
-            response = self.client.get("/protected", headers={"X-API-Key": "wrong_api_key"})
+            response = self.client.get(
+                "/protected", headers={"X-API-Key": "wrong_api_key"}
+            )
             self.assertEqual(response.status_code, 401)
             self.assertIn(b"Invalid API key", response.data)
 
     def test_login_required_with_no_api_key(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         # Test the behavior when no API key is provided
         response = self.client.get("/protected")
         self.assertEqual(response.status_code, 302)
         self.assertIn("/login", response.headers["Location"])
 
     def test_login_required_with_timed_api_key(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         mock_timed_key = "mock_timed_key_for_testing"
         with patch("app.routes.is_hash_valid", return_value=True):
-            response = self.client.get("/protected?timed_key=" +  mock_timed_key)
+            response = self.client.get("/protected?timed_key=" + mock_timed_key)
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"Protected Content", response.data)
 
@@ -219,50 +275,98 @@ class TestAuthentication(unittest.TestCase):
             self.assertIn(b"Invalid timed key", response.data)
 
     def test_combined_session_and_api_key(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         # Test with both session and API key
         mock_api_key = "mock_api_key_for_testing"
         with patch("app.routes.API_KEY", mock_api_key):
             dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+
             class DummyQuery:
                 def filter_by(self, **kwargs):
                     return self
+
                 def first(self):
                     return dummy_user
+
             class DummySession:
                 def query(self, model):
                     return DummyQuery()
+
                 def close(self):
                     pass
-            with patch("app.routes.session", {"user_id": 1}), patch("app.routes.SessionLocal", return_value=DummySession()):
-                response = self.client.get("/protected", headers={"X-API-Key": mock_api_key})
+
+            with patch("app.routes.session", {"user_id": 1}), patch(
+                "app.routes.SessionLocal", return_value=DummySession()
+            ):
+                response = self.client.get(
+                    "/protected", headers={"X-API-Key": mock_api_key}
+                )
                 self.assertEqual(response.status_code, 200)
                 self.assertIn(b"Protected Content", response.data)
 
     def test_invalid_session_data(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         # Test with invalid session data
         with patch("app.routes.session", {"user_id": "not_a_boolean"}):
             response = self.client.get("/protected")
             # TODO: fix these
-            #self.assertEqual(response.status_code, 302)
-            #self.assertIn("/login", response.headers["Location"])
+            # self.assertEqual(response.status_code, 302)
+            # self.assertIn("/login", response.headers["Location"])
 
     def test_api_key_security(self):
-        login_attempts = {} # reset 
+        login_attempts = {}  # reset
         # Test with a replay attack scenario (using a previously valid API key)
         mock_api_key = "mock_api_key_for_testing"
         with patch("app.routes.API_KEY", mock_api_key):
-            response = self.client.get("/protected", headers={"X-API-Key": mock_api_key})
+            response = self.client.get(
+                "/protected", headers={"X-API-Key": mock_api_key}
+            )
             self.assertEqual(response.status_code, 200)
             self.assertIn(b"Protected Content", response.data)
 
         # Assume API key should now be invalid (e.g., if it was a one-time-use key)
         with patch("app.routes.API_KEY", "another_mock_api_key"):
-            response = self.client.get("/protected", headers={"X-API-Key": mock_api_key})
+            response = self.client.get(
+                "/protected", headers={"X-API-Key": mock_api_key}
+            )
             self.assertEqual(response.status_code, 401)
             self.assertIn(b"Invalid API key", response.data)
 
+    def test_sso_login_success(self):
+        login_attempts = {}  # reset
+        with patch("app.routes.config.SSO_TOKEN", "secret"), patch(
+            "app.routes.config.SSO_USERNAME",
+            USER_NAME,
+        ), patch("app.routes.SessionLocal") as mock_session_local:
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.get("/sso?token=secret")
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/", response.headers["Location"])
+
+    def test_sso_login_invalid(self):
+        login_attempts = {}  # reset
+        with patch("app.routes.config.SSO_TOKEN", "secret"):
+            response = self.client.get("/sso?token=wrong")
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/login", response.headers["Location"])
+
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- introduce `SSO_TOKEN` and `SSO_USERNAME` config values
- create `/sso` route for token-based login
- document new settings and integration steps
- test SSO login scenarios

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b29fea384833391cdf3466986fe47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Single Sign-On (SSO) login via a new `/sso` endpoint, allowing users to authenticate using a pre-shared token.
  - Added configuration options for SSO token and SSO username.

- **Documentation**
  - Updated configuration and integration guides to include SSO setup instructions and usage details.

- **Tests**
  - Added tests to verify successful and unsuccessful SSO login scenarios.
  - Improved formatting and readability of authentication-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->