### PR TITLE
Add hamburger menu for mobile navigation

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -309,6 +309,15 @@ nav {
     gap: 10px; /* Space between navigation items */
 }
 
+.nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 24px;
+    cursor: pointer;
+}
+
 .nav-left,
 .nav-right {
     display: flex;
@@ -377,9 +386,23 @@ nav a:hover, nav a.active {
         font-size: 20px; /* Smaller font size on mobile */
     }
 
+    .nav-toggle {
+        display: block;
+    }
+
     nav {
         flex-direction: column; /* Stack navigation items on mobile */
         align-items: flex-start;
+    }
+
+    nav .nav-links {
+        display: none;
+        flex-direction: column;
+        width: 100%;
+    }
+
+    nav.open .nav-links {
+        display: flex;
     }
 
     nav a {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,0 +1,11 @@
+export function initNavToggle() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggleButton = document.querySelector('.nav-toggle');
+    const nav = document.querySelector('nav');
+    if (toggleButton && nav) {
+      toggleButton.addEventListener('click', () => {
+        nav.classList.toggle('open');
+      });
+    }
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,7 +1,9 @@
 import { initTemplates } from './templates.js';
 import { initVideoControls } from './video.js';
 import { initSchedulerToggle } from './scheduler.js';
+import { initNavToggle } from './nav.js';
 
 initTemplates();
 initVideoControls();
 initSchedulerToggle();
+initNavToggle();

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,6 +1,8 @@
 
                 <h1><a href='/'><img src='{{ url_for('static', filename='img/glimpser_small.png') }}' alt='Glimpser logo' title='Glimpser'></a></h1>
+        <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
         <nav>
+            <div class="nav-links">
             <div class="nav-left">
                 {% for ag in active_groups %}
                 <a href='/group/{{ag}}'>{{ag}}</a>
@@ -125,6 +127,7 @@ checkDanger();
 
                             </tr>
                     </table>
+            </div>
             </div>
         </nav>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation health indicator uses a dedicated CSS class.
 - JavaScript is now split into modules for templates, video controls, and scheduler toggling.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
+- Mobile navigation now collapses into a hamburger menu.


### PR DESCRIPTION
## Summary
- make navigation collapsible on small screens
- include nav toggle script
- document the new hamburger menu

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b28c766a88333ac3ff58af98cc1b5