### PR TITLE
Fix remote file path exploit

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -931,6 +931,12 @@ def capture_or_download(name: str, template: dict) -> bool:
 
     # Extract parameters from the template
     url = template.get("url")
+
+    # Disallow local file paths to avoid unintended file disclosure
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.scheme not in {"http", "https", "rtsp", "rtmp"}:
+        logging.error("Unsupported URL scheme: %s", parsed.scheme)
+        return False
     if throttle_cache.get(url) and throttle_cache[url].get("timeout", 0) > time.time():
         # just skip things that are obviously broken.  "Backoff"..
         return False

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -30,13 +30,14 @@ The general flow of the capture process is as follows:
 
 1. **Input Validation**: Check if the provided name and template are valid.
 2. **URL Parsing**: Extract the domain and port from the URL.
-3. **Host Reachability Check**: For network URLs, ensure the target host is reachable.
-4. **Output Path Preparation**: Generate a unique output path for the captured content.
-5. **Content Type Determination**: Analyze the URL and perform a HEAD request to determine the content type.
-6. **Capture Method Selection**: Choose the appropriate capture method based on the content type and other parameters.
-7. **Capture Execution**: Execute the selected capture method.
-8. **Post-Processing**: Apply any necessary post-processing steps, such as adding timestamps or applying dark mode.
-9. **Result Handling**: Return the success status of the capture process.
+3. **Scheme Verification**: Reject URLs that use unsupported schemes (e.g. `file://`) to prevent local file access.
+4. **Host Reachability Check**: For network URLs, ensure the target host is reachable.
+5. **Output Path Preparation**: Generate a unique output path for the captured content.
+6. **Content Type Determination**: Analyze the URL and perform a HEAD request to determine the content type.
+7. **Capture Method Selection**: Choose the appropriate capture method based on the content type and other parameters.
+8. **Capture Execution**: Execute the selected capture method.
+9. **Post-Processing**: Apply any necessary post-processing steps, such as adding timestamps or applying dark mode.
+10. **Result Handling**: Return the success status of the capture process.
 
 ## Content-Specific Capture Methods
 

--- a/tests/test_capture_file_url.py
+++ b/tests/test_capture_file_url.py
@@ -19,8 +19,8 @@ class TestCaptureFileURL(unittest.TestCase):
         try:
             url = f"file://{path}"
             result = ss.capture_or_download("test", {"url": url})
-            self.assertTrue(result)
-            mock_download.assert_called_once()
+            self.assertFalse(result)
+            mock_download.assert_not_called()
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Summary
- reject unsupported URL schemes in `capture_or_download`
- update documentation for new scheme verification step
- adjust test for file URLs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b29f06fb883338e14b43d8b916d1c