### PR TITLE
Implement TODOs in routes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -856,8 +856,9 @@ def init_routes(app):
     @app.route("/")
     @login_required
     def index():
-        # TODO: maybe include the template details
-        return render_template("index.html")
+        """Render the index page with available templates."""
+        template_details = template_manager.get_templates()
+        return render_template("index.html", template_details=template_details)
 
     def get_active_templates():
         templates = template_manager.get_templates()
@@ -1594,20 +1595,31 @@ def init_routes(app):
                 400,
             )
 
-        logging.debug("TODO: rewrite")
+        logging.debug("Uploading screenshot for %s", template_name)
         templates = template_manager.get_templates()
         if templates.get(template_name) is None:
             abort(404)
 
-        # TODO: add more handling around this
-        # Save the uploaded file to a temporary file
+        if not allowed_filename(
+            image_file.filename
+        ) or not image_file.filename.lower().endswith(".png"):
+            return (
+                jsonify({"status": "error", "message": "Invalid file name"}),
+                400,
+            )
+
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
             image_file.save(temp_file.name)
-            # Call the update_camera function with the temporary file path
+            if not screenshots._is_valid_png(temp_file.name):
+                os.unlink(temp_file.name)
+                return (
+                    jsonify({"status": "error", "message": "Invalid image file"}),
+                    400,
+                )
+
             scheduling.update_camera(
                 template_name, templates.get(template_name), image_file=temp_file.name
             )
-            # potentially trigger motion too...
 
         # Clean up the temporary file
         if temp_file and os.path.exists(temp_file.name):
@@ -1913,10 +1925,10 @@ def init_routes(app):
         settings = get_all_settings()
         return render_template("settings.html", settings=settings)
 
-    # TODO: this has been refactored to health instead.. please update
+    # Retained for backwards compatibility; redirect to the health endpoint.
     @app.route("/system_metrics")
     def system_metrics():
-        return jsonify(scheduling.get_system_metrics())
+        return redirect(url_for("health_check"))
 
     def allowed_file(filename):
         return "." in filename and filename.rsplit(".", 1)[1].lower() == "json"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -115,7 +115,8 @@ class TestRoutes(unittest.TestCase):
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
     @patch("app.routes.render_template")
-    def test_index(self, mock_render_template, mock_session_local):
+    @patch("app.routes.template_manager.get_templates")
+    def test_index(self, mock_get_templates, mock_render_template, mock_session_local):
         dummy_user = SimpleNamespace(id=1)
 
         class DummyQuery:
@@ -133,9 +134,12 @@ class TestRoutes(unittest.TestCase):
                 pass
 
         mock_session_local.return_value = DummySession()
+        mock_get_templates.return_value = {"camera": {}}
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("index.html")
+        mock_render_template.assert_called_with(
+            "index.html", template_details={"camera": {}}
+        )
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})


### PR DESCRIPTION
## Summary
- include template details on index route
- validate uploaded screenshots and log action
- redirect old system metrics endpoint
- update route tests for new arguments

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b2a8a90748333bc29d0d51f1d562a