### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CPU builds of JAX 0.6.1 and Flax 0.2.0
 - Bumped scikit-image to 0.25.0
 - Bumped numpy to 1.25.0
-- Updated default VERSION to 0.2.4 for footer display
+- Updated default VERSION to 0.2.5 for footer display
 
 ### Fixed
 - Addressed Python build issues and string concatenation errors
 - Fixed screenshot timeouts and setup script problems
 - Offline cameras now display an overlay and keep the camera selector usable
+
+## [0.2.5] - 2025-05-31
+
+### Changed
+- Bumped package version in setup.py to 0.2.5.
 
 ## [0.2.4] - 2025-05-28
 
@@ -72,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.5
 [0.2.4]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.4
 [0.2.3]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.3
 [0.2.2]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.2

--- a/app/config.py
+++ b/app/config.py
@@ -131,7 +131,7 @@ TZ = get_setting("TZ", "UTC")
 try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
-    _PKG_VERSION = "0.2.4"
+    _PKG_VERSION = "0.2.5"
 sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -11,14 +11,14 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 PyPI.
 
 Tags are normally created automatically when the version in `setup.py` is bumped
-on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.4`
+on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.5`
 and pushes it to GitHub, which then triggers the build jobs above.
 
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.4
-git push origin v0.2.4
+git tag v0.2.5
+git push origin v0.2.5
 ```
 
 Alternatively, run `scripts/auto_tag_release.py` to create and push the tag

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="glimpser",
-    version="0.2.4",
+    version="0.2.5",
     author="Kristopher Kubicki",
     author_email="kristopher@glimser.net",
     description="A real-time monitoring application for capturing and analyzing live data from various sources",


### PR DESCRIPTION
## Summary
- bump package version constants to 0.2.5
- document release process for v0.2.5
- note version bump in changelog

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b2e93ea508333acc3ede1bc4ed279