### PR TITLE
Fix stream endpoint and timestamping

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -936,7 +936,7 @@ def init_routes(app):
 
         if file and allowed_filename(file.filename):
             # Generate a unique timestamped filename
-            timestamp = datetime.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
             filename = f"{template_name}_{timestamp}.png.tmp"
             output_path = os.path.join(SCREENSHOT_DIRECTORY, template_name, filename)
             # if not os.path.normpath(output_path).startswith(SCREENSHOT_DIRECTORY):
@@ -1001,7 +1001,7 @@ def init_routes(app):
         most_recent_time = 0
         most_recent_file = None
         last_file = None
-        for template in sorted_templates:
+        for _, template in sorted_templates:
             name = validate_template_name(template.get("name"))
             if name is None:
                 continue
@@ -1012,6 +1012,8 @@ def init_routes(app):
                 name,
             )
             lfiles = [f for f in glob.glob(path + "/*.png") if os.path.isfile(f)]
+            if not lfiles:
+                continue
             lfiles.sort(key=os.path.getmtime)
             last_file = lfiles[-1]
             if (
@@ -1028,7 +1030,9 @@ def init_routes(app):
 
         if os.path.exists(most_recent_file):
             return send_file(most_recent_file)
-        return send_file(last_file)  # better than nothing
+        if last_file and os.path.exists(last_file):
+            return send_file(last_file)  # better than nothing
+        abort(404)
 
     @app.route(
         "/test.rtsp",

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import shutil
+import unittest
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestStreamPngRoute(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_stream_png"
+        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.tpl_patch = patch("app.routes.template_manager.get_templates")
+        self.login_patch.start()
+        self.sc_patch.start()
+        self.mock_tpl = self.tpl_patch.start()
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        self.tpl_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_empty_directory_returns_404(self):
+        self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
+        resp = self.client.get("/stream.png")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_returns_latest_image(self):
+        self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
+        img_path = os.path.join(self.repo_root, self.sshot_dir, "cam1", "cam1_1.png")
+        Image.new("RGB", (1, 1)).save(img_path)
+        resp = self.client.get("/stream.png")
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_submit_image_route.py
+++ b/tests/test_submit_image_route.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import shutil
+import unittest
+import io
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestSubmitImageRoute(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_submit_image"
+        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.tpl_patch = patch("app.routes.template_manager.get_template")
+        self.update_patch = patch(
+            "app.routes.template_manager.update_last_screenshot_time"
+        )
+        self.ts_patch = patch("app.routes.screenshots.add_timestamp")
+        self.login_patch.start()
+        self.sc_patch.start()
+        self.mock_tpl = self.tpl_patch.start()
+        self.update_patch.start()
+        self.ts_patch.start()
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        self.tpl_patch.stop()
+        self.update_patch.stop()
+        self.ts_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_submit_image_saves_file(self):
+        self.mock_tpl.return_value = {"name": "cam1"}
+        img_bytes = io.BytesIO()
+        Image.new("RGB", (1, 1)).save(img_bytes, format="PNG")
+        img_bytes.seek(0)
+        data = {"file": (img_bytes, "shot.png")}
+        resp = self.client.post(
+            "/submit_image/cam1",
+            data=data,
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(resp.status_code, 200)
+        files = os.listdir(os.path.join(self.repo_root, self.sshot_dir, "cam1"))
+        self.assertTrue(any(f.endswith(".png") for f in files))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct timestamp generation
- handle empty screenshot directories in `/stream.png`
- test submit image route
- test stream endpoint

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b34a5e4f883338ced984af96da419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for image streaming and submission routes, ensuring proper responses when files are missing or invalid.
- **Tests**
	- Added new tests to verify the correct behavior of image streaming and submission endpoints, including handling of empty directories and successful file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->