### PR TITLE
Fix release automation trigger

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -8,6 +8,8 @@ jobs:
   tag_release:
     permissions:
       contents: write
+      # Allow the push to trigger other workflows (e.g. package release)
+      workflow: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -14,6 +14,9 @@ Tags are normally created automatically when the version in `setup.py` is bumped
 on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.5`
 and pushes it to GitHub, which then triggers the build jobs above.
 
+Since the tag is pushed by a workflow, the job must grant `workflow: write`
+permissions so that the subsequent release workflow is triggered.
+
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh


### PR DESCRIPTION
## Summary
- ensure the tag workflow grants `workflow: write`
- document the permission requirement in release docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b83d2e9b4833388160be6f378448f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release workflow documentation to clarify required permissions for triggering workflows after a tag is pushed.

- **Chores**
  - Adjusted workflow permissions to ensure proper triggering of subsequent workflows after version tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->