### PR TITLE
Fix URL parsing edge case

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -892,19 +892,33 @@ def is_address_reachable(address, port=80, timeout=5):
 
 
 def parse_url(url):
-    parsed_url = urlparse(url)
+    """Return the domain and port extracted from *url*.
+
+    ``urllib.parse.urlparse`` treats strings without a scheme oddly.  For
+    example ``"example.com:8080/path"`` is parsed with ``"example.com"`` as the
+    *scheme* rather than the hostname.  To handle such URLs we prefix ``"//"`` so
+    they are interpreted as network locations.
+    """
+
+    # Handle URLs missing a scheme like ``example.com:8080/path`` by prefixing
+    # ``//`` which causes ``urlparse`` to parse the hostname and port correctly.
+    if "://" not in url:
+        parsed_url = urlparse("//" + url)
+    else:
+        parsed_url = urlparse(url)
+
     domain = parsed_url.hostname
-    if parsed_url and parsed_url.scheme == "" and domain is None:
+    if parsed_url.scheme == "" and domain is None:
         domain = re.sub(r"\/.+?$", "", parsed_url.path)
 
     port = parsed_url.port
-    # If the port is None and the scheme is specified, infer the default port
+    # If the port is None and the scheme is specified, infer the default port.
     if port is None:
         if parsed_url.scheme == "http":
             port = 80
         elif parsed_url.scheme == "https":
             port = 443
-        # Add more schemes and their default ports if necessary
+        # Add more schemes and their default ports if necessary.
 
     return domain, port
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -4,9 +4,10 @@ import sys
 import os
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.utils.screenshots import parse_url, is_address_reachable, get_arp_output
+
 
 class TestURLParsing(unittest.TestCase):
 
@@ -28,42 +29,52 @@ class TestURLParsing(unittest.TestCase):
         self.assertEqual(domain, "example.com")
         self.assertIsNone(port)
 
+    def test_parse_url_no_scheme_with_port(self):
+        url = "example.com:8080/some/path"
+        domain, port = parse_url(url)
+        self.assertEqual(domain, "example.com")
+        self.assertEqual(port, 8080)
+
+
 class TestARPTable(unittest.TestCase):
 
-    @patch('subprocess.check_output')
+    @patch("subprocess.check_output")
     def test_get_arp_output_linux(self, mock_check_output):
-        mock_check_output.return_value = b'192.168.0.1 dev eth0 lladdr 00:11:22:33:44:55 REACHABLE'
+        mock_check_output.return_value = (
+            b"192.168.0.1 dev eth0 lladdr 00:11:22:33:44:55 REACHABLE"
+        )
         ip_address = "192.168.0.1"
         result = get_arp_output(ip_address, timeout=5)
-        self.assertIn(b'REACHABLE', result)
+        self.assertIn(b"REACHABLE", result)
 
-    @patch('subprocess.check_output')
+    @patch("subprocess.check_output")
     def test_get_arp_output_windows(self, mock_check_output):
-        mock_check_output.return_value = b'Internet Address      Physical Address      Type\n192.168.0.1          00-11-22-33-44-55     dynamic'
+        mock_check_output.return_value = b"Internet Address      Physical Address      Type\n192.168.0.1          00-11-22-33-44-55     dynamic"
         ip_address = "192.168.0.1"
         result = get_arp_output(ip_address, timeout=5)
-        self.assertIn(b'dynamic', result)
+        self.assertIn(b"dynamic", result)
+
 
 class TestIPAddressValidation(unittest.TestCase):
 
-    @patch('socket.gethostbyname')
+    @patch("socket.gethostbyname")
     def test_is_address_reachable_success(self, mock_gethostbyname):
         mock_gethostbyname.return_value = "93.184.216.34"  # example.com IP
-        with patch('socket.socket') as mock_socket:
+        with patch("socket.socket") as mock_socket:
             mock_instance = mock_socket.return_value
             mock_instance.connect_ex.return_value = 0  # Simulate successful connection
             result = is_address_reachable("example.com", port=80)
             self.assertTrue(result)
 
-    @patch('socket.gethostbyname')
+    @patch("socket.gethostbyname")
     def test_is_address_reachable_fail(self, mock_gethostbyname):
         mock_gethostbyname.return_value = "93.184.216.34"
-        with patch('socket.socket') as mock_socket:
+        with patch("socket.socket") as mock_socket:
             mock_instance = mock_socket.return_value
             mock_instance.connect_ex.return_value = 1  # Simulate failed connection
             result = is_address_reachable("example.com", port=80)
             self.assertFalse(result)
 
-if __name__ == '__main__':
-    unittest.main()
 
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle scheme-less URLs with a port in `parse_url`
- test for port parsing without a scheme

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b90dd6018833387594d27f95d1011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL parsing to correctly handle URLs without a scheme, especially those with ports (e.g., example.com:8080/path).
- **Tests**
  - Added a new test to verify correct parsing of URLs without schemes but with ports.
  - Minor formatting improvements for consistency in test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->