### PR TITLE
Improve discovery page async updates

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2075,12 +2075,20 @@ def init_routes(app):
             # can display a progress bar.
             q.put({"total": len(camera_discovery.get_discovery_stages())})
 
-            def progress(stage, count):
-                q.put({"stage": stage, "count": count})
+            sent = set()
+
+            def progress(stage, count, new_cams):
+                fresh = []
+                for cam in new_cams:
+                    key = (cam.get("ip"), cam.get("protocol"), cam.get("port"))
+                    if key not in sent:
+                        sent.add(key)
+                        fresh.append(cam)
+                q.put({"stage": stage, "count": count, "cameras": fresh})
 
             def run():
-                cams = camera_discovery.discover_cameras(progress_callback=progress)
-                q.put({"done": True, "cameras": cams})
+                camera_discovery.discover_cameras(progress_callback=progress)
+                q.put({"done": True})
 
             thread = Thread(target=run, daemon=True)
             thread.start()

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -49,6 +49,29 @@
             progress.removeAttribute('value');
             body.innerHTML = '';
             const source = new EventSource('/discover/scan_stream');
+            const known = new Set();
+            const addRow = (cam) => {
+                const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
+                if (known.has(key)) return;
+                known.add(key);
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${cam.ip}</td>
+                    <td>${cam.protocol}</td>
+                    <td>${cam.port}</td>
+                    <td>${JSON.stringify(cam.info)}</td>
+                    <td>
+                        <form action="/discover/add" method="post">
+                            <input type="hidden" name="ip" value="${cam.ip}">
+                            <input type="hidden" name="protocol" value="${cam.protocol}">
+                            <input type="hidden" name="port" value="${cam.port}">
+                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ''}
+                            <input type="hidden" name="name" value="${cam.ip}">
+                            <button type="submit" title="Add this camera">Add</button>
+                        </form>
+                    </td>`;
+                body.appendChild(tr);
+            };
             source.onmessage = (event) => {
                 const data = JSON.parse(event.data);
                 if (data.total) {
@@ -57,31 +80,15 @@
                     return;
                 }
                 if (data.done) {
-                    msg.textContent = `Found ${data.cameras.length} cameras.`;
+                    msg.textContent = `Found ${known.size} cameras.`;
                     progress.style.display = 'none';
-                    data.cameras.forEach(cam => {
-                        const tr = document.createElement('tr');
-                        tr.innerHTML = `
-                            <td>${cam.ip}</td>
-                            <td>${cam.protocol}</td>
-                            <td>${cam.port}</td>
-                            <td>${JSON.stringify(cam.info)}</td>
-                            <td>
-                                <form action="/discover/add" method="post">
-                                    <input type="hidden" name="ip" value="${cam.ip}">
-                                    <input type="hidden" name="protocol" value="${cam.protocol}">
-                                    <input type="hidden" name="port" value="${cam.port}">
-                                    ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ''}
-                                    <input type="hidden" name="name" value="${cam.ip}">
-                                    <button type="submit" title="Add this camera">Add</button>
-                                </form>
-                            </td>`;
-                        body.appendChild(tr);
-                    });
                     source.close();
-                } else {
-                    progress.value += 1;
-                    msg.textContent = `Scanning ${data.stage} (${data.count} found)...`;
+                    return;
+                }
+                progress.value += 1;
+                msg.textContent = `Scanning ${data.stage} (${data.count} found)...`;
+                if (data.cameras) {
+                    data.cameras.forEach(addRow);
                 }
             };
             source.onerror = (e) => {

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -419,7 +419,9 @@ def discover_cameras(progress_callback=None):
     Parameters
     ----------
     progress_callback : callable, optional
-        Called with ``(stage, count)`` each time a discovery step completes.
+        Called with ``(stage, count, new_cameras)`` each time a discovery
+        step completes. ``new_cameras`` is the list of cameras found during
+        that stage.
     """
     cameras: list[dict] = []
 
@@ -449,13 +451,15 @@ def discover_cameras(progress_callback=None):
         }
         for fut in as_completed(future_to_stage):
             stage = future_to_stage[fut]
+            stage_cameras = []
             try:
-                cameras.extend(fut.result())
+                stage_cameras = fut.result()
+                cameras.extend(stage_cameras)
             except Exception as e:  # pragma: no cover - network
                 logging.warning("%s discovery error: %s", stage, e)
             finally:
                 if progress_callback:
-                    progress_callback(stage, len(cameras))
+                    progress_callback(stage, len(cameras), stage_cameras)
 
     # Always include the internal status page so the system can monitor itself
     from app.config import PORT

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -20,7 +20,7 @@ def discover_cameras_scan_stream():
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
 ```
 
-When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message reports the total number of discovery stages so the progress bar can show overall completion. Subsequent messages indicate which stage has finished and how many cameras have been found so far. The final event delivers the list of cameras as JSON which the page inserts into the table.
+When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message reports the total number of discovery stages so the progress bar can show overall completion. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with ``{"done": true}`` simply signals completion.
 
 During the scan you will see messages like `Scanning onvif (3 found)...`. The stage name shows which discovery method just finished, while the number in parentheses reflects how many cameras have been detected so far.
 


### PR DESCRIPTION
## Summary
- stream new cameras to the UI as each stage completes
- handle incremental events in the `discover` page
- clarify discovery streaming docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdcea516c83339bfadd83c0daed0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Camera discovery progress now provides real-time updates with newly found cameras displayed immediately, preventing duplicates in the results table.

- **Bug Fixes**
	- Eliminated duplicate camera entries during the discovery process.

- **Documentation**
	- Updated documentation to clarify the new progress reporting and event stream behavior during camera discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->