### PR TITLE
docs: expand help page

### DIFF
--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -78,6 +78,15 @@
         </section>
 
         <section class="help-section">
+            <h3 class="section-title">Advanced Features</h3>
+            <ul>
+                <li>Schedule automatic archiving with the <a href="../docs/video_archiver.md" target="_blank">video archiver</a>.</li>
+                <li>Track language model usage and cost in the <a href="../docs/cost_tracking.md" target="_blank">cost tracking</a> dashboard.</li>
+                <li>Automatically discover network cameras using the <a href="../docs/camera_discovery.md" target="_blank">discovery tool</a>.</li>
+            </ul>
+        </section>
+
+        <section class="help-section">
             <h3 class="section-title">Configuration Files</h3>
             <p>Settings are stored in <code>app/config.py</code> and the database. Most values can be overridden with environment variables like <code>GLIMPSER_DATABASE_PATH</code>.</p>
         </section>
@@ -88,8 +97,18 @@
         </section>
 
         <section class="help-section">
+            <h3 class="section-title">Troubleshooting</h3>
+            <p>If you run into problems, check the <a href="../docs/troubleshooting.md" target="_blank">troubleshooting guide</a> for common solutions. The <a href="../docs/faq.md" target="_blank">FAQ</a> covers additional tips.</p>
+        </section>
+
+        <section class="help-section">
+            <h3 class="section-title">Contributing &amp; Feedback</h3>
+            <p>Glimpser is an open source project. You can view the source code or open issues on <a href="https://github.com/KristopherKubicki/glimpser" target="_blank">GitHub</a>. Contributions are welcome!</p>
+        </section>
+
+        <section class="help-section">
             <h3 class="section-title">Need More Help?</h3>
-            <p>If you need further assistance, please visit <a href="https://glimpser.net" target="_blank">glimpser.net</a> for more information and support.</p>
+            <p>If you need further assistance, please visit <a href="https://glimpser.net" target="_blank">glimpser.net</a> or the <a href="https://github.com/KristopherKubicki/glimpser" target="_blank">GitHub repository</a> for updates and to report issues.</p>
         </section>
         <p><a href="{{ url_for('index') }}">Back to Glimpser</a></p>
     </main>

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -1,0 +1,21 @@
+# Glimpser Help Page
+
+The built-in help page is accessible at the `/help` route once you log in.
+It provides step-by-step instructions for adding templates, managing
+captures, and using the command line interface. The help page is cached
+locally after you view it online so you can reference it offline.
+
+Key topics covered include:
+
+- Adding a template with detailed field descriptions.
+- Viewing recent screenshots, video captures, and live streams.
+- Managing templates, including editing and deletion.
+- Advanced features like camera discovery, video archiving, and cost tracking.
+- Configuration file locations and environment overrides.
+- Links to the rest of the documentation under `docs/`.
+- Troubleshooting tips and frequently asked questions.
+- A link to the project on [GitHub](https://github.com/KristopherKubicki/glimpser) where you can
+  report issues or contribute.
+
+Navigate back to the main interface using the **Back to Glimpser** link at the
+bottom of the help page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Installation Guide](installation.md)
 - [Integration Guide](integration_guide.md)
 - [Camera Discovery](camera_discovery.md)
+- [Help Page Overview](help_page.md)
 - [Camera Fix Suggestions](camera_fix.md)
 - [HTTP Callback Guide](http_callbacks.md)
 - [Recommendations](recommendations.md)


### PR DESCRIPTION
## Summary
- expand `/help` with advanced features, troubleshooting, and GitHub links
- document the help page in `docs/help_page.md`
- reference the new documentation from `docs/index.md`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683bdcffe43483338e5d8552410985ea