### PR TITLE
Improve first-run UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -798,3 +798,10 @@ input[type=submit]:hover {
     text-align: center;
     color: white;
 }
+
+.no-templates {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-color);
+}
+

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -285,11 +285,13 @@ export async function loadTemplates() {
       });
     }, { threshold: 0.5 });
 
+    let hasTemplates = false;
     Object.entries(templates).forEach(([name, template], index) => {
       if (
         templateBelongsToGroup(template, selectedGroup) &&
         templateMatchesSearch(template, searchQuery)
       ) {
+        hasTemplates = true;
         const lastScreenshotTime = template.last_screenshot_time;
         const humanizedTimestamp = timeAgo(lastScreenshotTime);
         const nextCaptureTime = timeAgo(template.next_screenshot_time);
@@ -354,6 +356,18 @@ export async function loadTemplates() {
         }
       }
     });
+
+    if (!hasTemplates) {
+      const msg = document.createElement('div');
+      msg.className = 'no-templates';
+      msg.textContent = 'No templates found. Use "Add Template" above to create one.';
+      if (isIndexPage) {
+        templateList.appendChild(msg);
+      } else if (isCaptionsPage) {
+        templateContainer.appendChild(msg);
+      }
+      if (templateDetails) templateDetails.open = true;
+    }
 
     if (isIndexPage) {
       window.addEventListener('resize', updateGridLayout);

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,7 +33,8 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 1. Log in to the Glimpser web interface.
 
-2. Navigate to the "Add Source" section.
+2. When no templates exist, the **Add Template** form opens automatically with a notice on the home page.
+   Otherwise, navigate to the "Add Source" section.
 
 3. Choose a data source type (e.g., camera, dashboard, or video stream).
 


### PR DESCRIPTION
## Summary
- show a notice when no templates exist and auto-expand the Add Template form
- style the empty state message
- document the new behaviour in the getting started guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c39e8584c8333934924f81f854abc