### PR TITLE
Add UI tooltips

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -7,6 +7,6 @@
     </div>
     <p class="error-message">Oops! Looks like this glimpse is out of focus.</p>
     <p class="error-description">The page you're looking for seems to have vanished into thin air. Maybe it's hiding behind the lens?</p>
-    <a href="{{ url_for('index') }}" class="btn btn-primary">Return to Home</a>
+    <a href="{{ url_for('index') }}" class="btn btn-primary" title="Go back to the home page">Return to Home</a>
 </div>
 {% endblock %}

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -1,9 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
     <h2>Discovered Cameras</h2>
-    <button id="discover-btn">Discover</button>
-    <progress id="discover-progress" style="display:none;"></progress>
-    <div id="discover-message"></div>
+    <button id="discover-btn" title="Scan the network for cameras">Discover</button>
+    <progress id="discover-progress" style="display:none;" title="Discovery progress"></progress>
+    <div id="discover-message" title="Status messages"></div>
     <table>
         <thead>
             <tr>

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -8,6 +8,6 @@
     <p class="error-message">Error {{ error.code }}: {{ error.name }}</p>
     <p class="error-description">{{ error.description }}</p>
     <p class="error-tip">Don't worry, our team of expert photographers is on the case!</p>
-    <a href="{{ url_for('index') }}" class="btn btn-primary">Return to Home</a>
+    <a href="{{ url_for('index') }}" class="btn btn-primary" title="Go back to the home page">Return to Home</a>
 </div>
 {% endblock %}

--- a/app/templates/player.html
+++ b/app/templates/player.html
@@ -4,9 +4,9 @@
     <h2>Live Feed
     </h2>
 
-    <div class="video-container">
-	    <div id="camera-name" class="camera-name"></div>
-        <video id="live-video" controls autoplay muted></video>
+    <div class="video-container" title="Looping video feed from all cameras">
+            <div id="camera-name" class="camera-name" title="Currently playing camera"></div>
+        <video id="live-video" controls autoplay muted title="Video player"></video>
     </div>
 
     <script>

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -4,10 +4,10 @@
 {% block content %}
 
 <div class="scheduler-controls">
-    <button id="toggle-scheduler" class="btn btn-primary">
+    <button id="toggle-scheduler" class="btn btn-primary" title="Start or stop the scheduler">
         Loading...
     </button>
-    <span id="scheduler-status">Checking status...</span>
+    <span id="scheduler-status" title="Current scheduler status">Checking status...</span>
 </div>
 
 <h1>System Status</h1>
@@ -15,12 +15,12 @@
 <!-- Display system metrics -->
 <h2>System Metrics</h2>
 <ul>
-    <li>CPU Usage: {{ metrics.cpu_usage }}%</li>
-    <li>Memory Usage: {{ metrics.memory_usage }}%</li>
-    <li>Disk Usage: {{ metrics.disk_usage }}%</li>
-    <li>Open Files: {{ metrics.open_files }}</li>
-    <li>Thread Count: {{ metrics.thread_count }}</li>
-    <li>Uptime: {{ metrics.uptime }}</li>
+    <li title="Current CPU utilization">CPU Usage: {{ metrics.cpu_usage }}%</li>
+    <li title="Current memory utilization">Memory Usage: {{ metrics.memory_usage }}%</li>
+    <li title="Disk space used">Disk Usage: {{ metrics.disk_usage }}%</li>
+    <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
+    <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
+    <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
 </ul>
 
 

--- a/app/templates/stream.html
+++ b/app/templates/stream.html
@@ -2,9 +2,9 @@
 {% block content %}
     <h2>Live Camera Feed</h2>
 
-    <div class="video-container">
-        <div id="camera-name" class="camera-name"></div>
-        <video id="live-video" controls autoplay muted></video>
+    <div class="video-container" title="Live HLS stream">
+        <div id="camera-name" class="camera-name" title="Current camera"></div>
+        <video id="live-video" controls autoplay muted title="HLS video player"></video>
     </div>
 
         <script>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -9,3 +9,4 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The Discover page icon also uses a descriptive `title` attribute.
 - When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.
 - Deprecated `<center>` tags were removed from templates and replaced with CSS-based centering.
+- Error pages, the status dashboard, and video players now include tooltips on buttons and metrics.


### PR DESCRIPTION
## Summary
- add tooltips to error pages, discovery page, player, stream, and system status
- document new tooltips in the accessibility guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c3ac38e8083338c97850b7d06ff77