### PR TITLE
Add testing guide and new restore_config test

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)
 - [Developer Guide](developer_guide.md)
+- [Testing and Coverage](testing.md)
 - [Release Workflow](release_workflow.md)
 - [Docker Build Verification](docker_build.md)
 - [System Monitoring and Logs](system_monitoring.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,18 @@
+# Testing and Coverage
+
+Glimpser includes a comprehensive suite of unit tests. Run them with coverage to ensure your changes do not introduce regressions:
+
+```sh
+python -m coverage run -m pytest
+python -m coverage html
+```
+
+The HTML report will be generated in `htmlcov/index.html`.
+
+Before submitting a patch, lint the code with `flake8`:
+
+```sh
+flake8
+```
+
+Refer to [developer_guide.md](developer_guide.md) for setting up your environment.

--- a/tests/test_config_restore.py
+++ b/tests/test_config_restore.py
@@ -1,0 +1,66 @@
+"""Tests for config.restore_config."""
+
+import os
+import sqlite3
+import importlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class TestRestoreConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        self.backup_path = os.path.join(self.temp_dir.name, "backup.json")
+        env = {
+            "GLIMPSER_DATABASE_PATH": self.db_path,
+            "GLIMPSER_BACKUP_PATH": self.backup_path,
+        }
+        self.env_patch = patch.dict(os.environ, env)
+        self.env_patch.start()
+
+        import app.config as config
+        import app.utils.db as db
+
+        importlib.reload(config)
+        importlib.reload(db)
+        self.config = config
+
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            """CREATE TABLE settings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                value TEXT NOT NULL
+            )"""
+        )
+        conn.commit()
+        conn.close()
+
+    def tearDown(self):
+        self.env_patch.stop()
+        import app.config as config
+        import app.utils.db as db
+
+        importlib.reload(config)
+        importlib.reload(db)
+        self.temp_dir.cleanup()
+
+    def test_restore_config_populates_db(self):
+        data = {"FOO": "bar", "BAZ": "qux"}
+        with open(self.backup_path, "w") as f:
+            import json
+
+            json.dump(data, f)
+
+        self.config.restore_config()
+
+        conn = sqlite3.connect(self.db_path)
+        rows = dict(conn.execute("SELECT name, value FROM settings").fetchall())
+        conn.close()
+        self.assertEqual(rows, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document how to run tests and check coverage
- link new documentation page from the index
- add unit test for `restore_config`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c59c219108333902c3318fc014d08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new "Testing and Coverage" section to the documentation, providing instructions for running unit tests, measuring test coverage, and performing code linting.
- **Tests**
  - Introduced new tests to verify the configuration restore functionality, ensuring settings are correctly populated from backup files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->