### PR TITLE
Add security headers

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -594,6 +594,16 @@ def allowed_filename(filename: str) -> bool:
 def init_routes(app):
     # get_active_groups()
 
+    @app.after_request
+    def add_security_headers(response):
+        """Add common security headers to every response."""
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        response.headers["Cache-Control"] = "no-store"
+        return response
+
     @app.context_processor
     def inject_footer_data():
         outdated = False

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -10,6 +10,17 @@ All API requests require an API key. Include your API key in the header of each 
 Authorization: Bearer YOUR_API_KEY
 ```
 
+## Security Headers
+
+All responses now include standard security headers to help prevent
+common attacks. Important headers are:
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `X-XSS-Protection: 1; mode=block`
+- `Referrer-Policy: no-referrer`
+- `Cache-Control: no-store`
+
 ## Endpoints
 
 The current build exposes a limited API focused on template management and

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,28 @@
+import unittest
+import os
+import sys
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes  # noqa: E402
+
+
+class TestSecurityHeaders(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def test_headers_present(self):
+        resp = self.client.get("/api/discover")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("X-Content-Type-Options"), "nosniff")
+        self.assertEqual(resp.headers.get("X-Frame-Options"), "DENY")
+        self.assertEqual(resp.headers.get("X-XSS-Protection"), "1; mode=block")
+        self.assertEqual(resp.headers.get("Referrer-Policy"), "no-referrer")
+        self.assertEqual(resp.headers.get("Cache-Control"), "no-store")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add common security headers in `init_routes`
- document default security headers in API docs
- test that `/api/discover` returns the headers

## Testing
- `black app/routes.py tests/test_security_headers.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c5a970f788333a41ab60379c825e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - All API responses now include enhanced security headers for improved protection.
- **Documentation**
  - Added a section detailing the security headers included in API responses.
- **Tests**
  - Introduced tests to verify the presence of security headers in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->