### PR TITLE
Handle invalid screenshots

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -459,6 +459,10 @@ def generate(
                             logging.error(
                                 "Failed to open last shot %s: invalid image", last_shot
                             )
+                            try:
+                                os.remove(last_shot)
+                            except OSError:
+                                pass
                     except Exception as e:
                         logging.error("Failed to open last shot %s: %s", last_shot, e)
                 else:
@@ -533,6 +537,10 @@ def generate(
                                     "Failed to open last shot %s: invalid image",
                                     most_recent_file,
                                 )
+                                try:
+                                    os.remove(most_recent_file)
+                                except OSError:
+                                    pass
                                 frame = None
 
                             if frame is not None:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -165,6 +165,8 @@ Glimpser writes logs to the console and exposes them via the `/status` page. If 
 - Use the **System Monitoring and Logs** guide to access live logs.
 - Increase the `LOG_LEVEL` environment variable to `DEBUG` for more details.
 - Review recent entries for stack traces or connection errors.
+- If logs show "Failed to open last shot ... invalid image", the screenshot file
+  is corrupted. Delete the file so a new capture can replace it.
 
 ## 10. Upgrade Issues
 


### PR DESCRIPTION
## Summary
- remove corrupted screenshots if they fail to open
- clarify troubleshooting steps for invalid images

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c769132908333aa1c463d1cdda90d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid image files by automatically removing corrupted screenshots when detected, reducing potential errors during image processing.

- **Documentation**
  - Added troubleshooting guidance for resolving issues with corrupted screenshot files, including recommended actions when specific error messages appear in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->