### PR TITLE
Release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added CPU builds of JAX 0.6.1 and Flax 0.2.0
 - Bumped scikit-image to 0.25.0
 - Bumped numpy to 1.25.0
-- Updated default VERSION to 0.2.5 for footer display
+- Updated default VERSION to 0.2.6 for footer display
 
 ### Fixed
 - Addressed Python build issues and string concatenation errors
 - Fixed screenshot timeouts and setup script problems
 - Offline cameras now display an overlay and keep the camera selector usable
+
+## [0.2.6] - 2025-06-01
+
+### Changed
+- Bumped package version in setup.py to 0.2.6.
 
 ## [0.2.5] - 2025-05-31
 
@@ -77,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - N/A
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.5...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.6
 [0.2.5]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.5
 [0.2.4]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.4
 [0.2.3]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.3

--- a/app/config.py
+++ b/app/config.py
@@ -131,7 +131,7 @@ TZ = get_setting("TZ", "UTC")
 try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
-    _PKG_VERSION = "0.2.5"
+    _PKG_VERSION = "0.2.6"
 sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -11,7 +11,7 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 PyPI.
 
 Tags are normally created automatically when the version in `setup.py` is bumped
-on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.5`
+on the `main` branch.  The `Tag Release` workflow creates a tag like `v0.2.6`
 and pushes it to GitHub, which then triggers the build jobs above.
 
 Since the tag is pushed by a workflow, the job must grant `workflow: write`
@@ -20,8 +20,8 @@ permissions so that the subsequent release workflow is triggered.
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.5
-git push origin v0.2.5
+git tag v0.2.6
+git push origin v0.2.6
 ```
 
 Alternatively, run `scripts/auto_tag_release.py` to create and push the tag

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="glimpser",
-    version="0.2.5",
+    version="0.2.6",
     author="Kristopher Kubicki",
     author_email="kristopher@glimser.net",
     description="A real-time monitoring application for capturing and analyzing live data from various sources",


### PR DESCRIPTION
## Summary
- bump version to 0.2.6
- document automated tagging example
- add changelog entry for v0.2.6

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9d70d7988333be2159312c335399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated version number to 0.2.6 across documentation, configuration, and package metadata.
  - Refreshed changelog and release workflow documentation to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->