### PR TITLE
fix: use env shebang for scripts

### DIFF
--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -1,4 +1,4 @@
-#!env/bin/python3
+#!/usr/bin/env python3
 # generate_credentials.py
 
 import secrets
@@ -88,13 +88,15 @@ def generate_credentials(args):
             username = args.username
         else:
             if sys.stdin.isatty():
-                username = input(f"Enter the username for login [{app.config.get_setting('USER_NAME', 'admin')}]: ") or app.config.get_setting("USER_NAME", "admin")
+                username = input(
+                    f"Enter the username for login [{app.config.get_setting('USER_NAME', 'admin')}]: "
+                ) or app.config.get_setting("USER_NAME", "admin")
             else:
                 username = app.config.get_setting("USER_NAME", "admin")
         upsert_setting("USER_NAME", username.strip(), conn)
-    
+
     if args is None or args.password or args.update_password:
-        password = "" # maybe populate with garbage
+        password = ""  # maybe populate with garbage
         if args:
             password = args.password
         else:
@@ -102,7 +104,7 @@ def generate_credentials(args):
                 password = getpass.getpass("Enter the password for login: ")
             else:
                 password = secrets.token_hex(16)
-                # your password is here.  This is the only time youll be able to see it again 
+                # your password is here.  This is the only time youll be able to see it again
 
         password_hash = generate_password_hash(password.strip())
         upsert_setting("USER_PASSWORD_HASH", password_hash, conn)
@@ -112,7 +114,7 @@ def generate_credentials(args):
     if args is None or args.update_key or not args.update_password:
         secret_key = app.config.get_setting("SECRET_KEY", secrets.token_hex(16))
         if args and args.secret_key:
-             secret_key = args.secret_key
+            secret_key = args.secret_key
         upsert_setting("SECRET_KEY", secret_key, conn)
 
     # Mirror settings into the users table
@@ -124,38 +126,25 @@ def generate_credentials(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate or update credentials and settings.")
-    parser.add_argument(
-        "--db-path",
-        type=str,
-        help="Path to the SQLite database file."
+    parser = argparse.ArgumentParser(
+        description="Generate or update credentials and settings."
     )
-    parser.add_argument(
-        "--username",
-        type=str,
-        help="Username for login."
-    )
-    parser.add_argument(
-        "--password",
-        type=str,
-        help="Password for login."
-    )
+    parser.add_argument("--db-path", type=str, help="Path to the SQLite database file.")
+    parser.add_argument("--username", type=str, help="Username for login.")
+    parser.add_argument("--password", type=str, help="Password for login.")
     parser.add_argument(
         "--update-password",
         action="store_true",
-        help="Update the password only, without creating a new database or changing other settings."
+        help="Update the password only, without creating a new database or changing other settings.",
     )
     parser.add_argument(
         "--secret-key",
         type=str,
-        help="Custom secret key. Generates a new one if not provided."
+        help="Custom secret key. Generates a new one if not provided.",
     )
     parser.add_argument(
-        "--update-key",
-        action="store_true",
-        help="Update the secret key."
+        "--update-key", action="store_true", help="Update the secret key."
     )
     args = parser.parse_args()
 
     generate_credentials(args)
-

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!./env/bin/python3            
+#!/usr/bin/env python3
 #  main.py
 
 import logging
@@ -23,6 +23,7 @@ banner = """
                               |_|
 """
 
+
 def parse_arguments(arg_list=None):
     """
     Parse command-line arguments for the Glimpser application.
@@ -35,17 +36,42 @@ def parse_arguments(arg_list=None):
         argparse.Namespace: An object containing the parsed arguments.
     """
     parser = argparse.ArgumentParser(description="Glimpser %s" % config.VERSION)
-    parser.add_argument("--db-path", default=config.DATABASE_PATH,
-            help="Path to the database file (default: %s)" % config.DATABASE_PATH)
-    parser.add_argument("--host", default=config.HOST, help="Host for the web server (default: %s)" % config.HOST)
-    parser.add_argument("--port", type=int, default=config.PORT, help="Port for the web server (default: %s)" % config.PORT)
-    parser.add_argument("--log-path", default=config.LOGGING_PATH,
-            help="Path to the log file (default: %s)" % config.LOGGING_PATH)
-    parser.add_argument("--log-level", default=config.LOG_LEVEL, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                        help="Logging level")
-    parser.add_argument("--console-log", action="store_true", help="Enable logging to the console", default=False)
-    parser.add_argument("--debug", action="store_true", default=config.DEBUG,
-                        help="Enable debug mode")
+    parser.add_argument(
+        "--db-path",
+        default=config.DATABASE_PATH,
+        help="Path to the database file (default: %s)" % config.DATABASE_PATH,
+    )
+    parser.add_argument(
+        "--host",
+        default=config.HOST,
+        help="Host for the web server (default: %s)" % config.HOST,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=config.PORT,
+        help="Port for the web server (default: %s)" % config.PORT,
+    )
+    parser.add_argument(
+        "--log-path",
+        default=config.LOGGING_PATH,
+        help="Path to the log file (default: %s)" % config.LOGGING_PATH,
+    )
+    parser.add_argument(
+        "--log-level",
+        default=config.LOG_LEVEL,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--console-log",
+        action="store_true",
+        help="Enable logging to the console",
+        default=False,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=config.DEBUG, help="Enable debug mode"
+    )
     parser.add_argument(
         "--no-scheduler",
         action="store_true",
@@ -58,13 +84,23 @@ def parse_arguments(arg_list=None):
         help="Disable the watchdog thread",
         default=False,
     )
-    parser.add_argument("--screenshot-dir", default=config.SCREENSHOT_DIRECTORY,
-                        help="Directory for storing screenshots")
-    parser.add_argument("--video-dir", default=config.VIDEO_DIRECTORY,
-                        help="Directory for storing video files")
-    parser.add_argument("--summaries-dir", default=config.SUMMARIES_DIRECTORY,
-                        help="Directory for storing summaries")
+    parser.add_argument(
+        "--screenshot-dir",
+        default=config.SCREENSHOT_DIRECTORY,
+        help="Directory for storing screenshots",
+    )
+    parser.add_argument(
+        "--video-dir",
+        default=config.VIDEO_DIRECTORY,
+        help="Directory for storing video files",
+    )
+    parser.add_argument(
+        "--summaries-dir",
+        default=config.SUMMARIES_DIRECTORY,
+        help="Directory for storing summaries",
+    )
     return parser.parse_args(arg_list)
+
 
 def setup_config(args=None):
     """
@@ -88,6 +124,7 @@ def setup_config(args=None):
     config.SCREENSHOT_DIRECTORY = args.screenshot_dir
     config.VIDEO_DIRECTORY = args.video_dir
     config.SUMMARIES_DIRECTORY = args.summaries_dir
+
 
 def setup_logging(args=None):
     """
@@ -116,6 +153,7 @@ def setup_logging(args=None):
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
+
 def ensure_directories():
     """
     Create necessary directories for the application if they don't exist.
@@ -128,6 +166,7 @@ def ensure_directories():
     os.makedirs(config.VIDEO_DIRECTORY, exist_ok=True)
     os.makedirs(config.SUMMARIES_DIRECTORY, exist_ok=True)
 
+
 def generate_credentials_if_needed():
     """
     Generate credentials if the database file doesn't exist.
@@ -137,7 +176,9 @@ def generate_credentials_if_needed():
     """
     if not os.path.exists(config.DATABASE_PATH):
         from generate_credentials import generate_credentials
+
         generate_credentials(args=None)
+
 
 def create_application(args=None):
     """
@@ -171,6 +212,7 @@ def create_application(args=None):
 
     return create_app(watchdog=watchdog, schedule=schedule)
 
+
 def output_shutdown_stats():
     # Get and display system metrics
     metrics = get_system_metrics()
@@ -183,7 +225,10 @@ def output_shutdown_stats():
     logging.info("Uptime: %s", metrics['uptime'])
     logging.info("Thank you for running Glimpser. Goodbye!")
 
+
 display_note = True
+
+
 def cleanup_resources():
     # Shutdown the scheduler
     try:
@@ -201,21 +246,21 @@ def cleanup_resources():
                 # concurrent.futures.Future.cancel()
                 thread.join(timeout=0.01)
                 if thread.is_alive():
-                    logging.warning(
-                        "Thread %s is still alive after join", thread.name
-                    )
+                    logging.warning("Thread %s is still alive after join", thread.name)
             except Exception as e:
                 logging.error("Error terminating thread %s: %s", thread.name, e)
 
-    #global banner
+    # global banner
     # Add any other cleanup tasks here (e.g., closing database connections)
     output_shutdown_stats()
 
+
 def graceful_shutdown(signum, frame):
-    #time.sleep(random.randint(0,10) * 0.1)
-    #time.sleep(10)
+    # time.sleep(random.randint(0,10) * 0.1)
+    # time.sleep(10)
     time.sleep(0.01)
     sys.exit(0)
+
 
 def clear_console():
     # For Windows
@@ -225,13 +270,15 @@ def clear_console():
     else:
         _ = os.system('clear')
 
+
 def is_port_in_use(port):
     # Skip the check if running in Docker
     if os.environ.get('IN_DOCKER'):
         return False
-    
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(('localhost', port)) == 0
+
 
 def main(argv=None):
     """Entry point for the ``glimpser`` command."""
@@ -257,7 +304,9 @@ def main(argv=None):
 
     try:
         logging.info("Starting web...")
-        app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True)
+        app.run(
+            host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
+        )
     except KeyboardInterrupt:
         logging.info("KeyboardInterrupt received. Exiting...")
     except Exception as e:


### PR DESCRIPTION
## Summary
- update shebangs to use `/usr/bin/env python3`
- apply black formatting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9e417db88333b72dd56db1207384