### PR TITLE
Remove summaries-dir option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,6 @@ GLIMPSER_BACKUP_PATH=data/config_backup.json
 # File locations
 SCREENSHOT_DIRECTORY=data/screenshots/
 VIDEO_DIRECTORY=data/video/
-SUMMARIES_DIRECTORY=data/summaries/
 
 # Email settings
 EMAIL_ENABLED=False

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV FLASK_APP=main.py \
     PYTHONUNBUFFERED=1
 
 # Create necessary directories
-RUN mkdir -p /app/db /app/logs /app/screenshots /app/videos /app/summaries
+RUN mkdir -p /app/db /app/logs /app/screenshots /app/videos
 
 # Expose port
 EXPOSE 8082

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -74,7 +74,6 @@ def create_app(watchdog=True, schedule=True):
         SECRET_KEY,
         MAX_WORKERS,
         SCREENSHOT_DIRECTORY,
-        SUMMARIES_DIRECTORY,
         VIDEO_DIRECTORY,
         SESSION_COOKIE_SECURE,
         SESSION_COOKIE_HTTPONLY,
@@ -94,7 +93,6 @@ def create_app(watchdog=True, schedule=True):
     # Ensure required directories exist
     os.makedirs(SCREENSHOT_DIRECTORY, exist_ok=True)
     os.makedirs(VIDEO_DIRECTORY, exist_ok=True)
-    os.makedirs(SUMMARIES_DIRECTORY, exist_ok=True)
 
     from app.routes import init_routes
 

--- a/app/config.py
+++ b/app/config.py
@@ -119,7 +119,6 @@ SCHEDULER_API_ENABLED = True
 # be careful when mounting network devices
 SCREENSHOT_DIRECTORY = "data/screenshots/"
 VIDEO_DIRECTORY = "data/video/"
-SUMMARIES_DIRECTORY = "data/summaries/"
 
 # Load settings from the database
 UA = get_setting(

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -19,7 +19,7 @@ from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw, ImageFont
 from transformers import CLIPProcessor, CLIPModel
 
-from app.config import DEBUG, SCREENSHOT_DIRECTORY, SUMMARIES_DIRECTORY, VIDEO_DIRECTORY
+from app.config import DEBUG, SCREENSHOT_DIRECTORY, VIDEO_DIRECTORY
 from app.utils.db import SessionLocal
 from app.models import Summary
 
@@ -711,9 +711,6 @@ def update_summary():
                 + str(gnotes)
                 + "\n"
             )
-
-    output_path = os.path.join(SUMMARIES_DIRECTORY)
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     history = None
     session = SessionLocal()

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,7 +4,6 @@ set -e
 # Create necessary directories
 mkdir -p /opt/glimpser/data/screenshots
 mkdir -p /opt/glimpser/data/video
-mkdir -p /opt/glimpser/data/summaries
 mkdir -p /opt/glimpser/logs
 
 # Install Python dependencies

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -19,7 +19,6 @@ The primary application script accepts the following options:
 | `--no-watchdog` | Disable the watchdog thread. |
 | `--screenshot-dir` | Directory for storing screenshots. |
 | `--video-dir` | Directory for storing video files. |
-| `--summaries-dir` | **Deprecated:** summaries are now stored in the database. |
 
 ## generate_credentials.py
 

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -62,9 +62,6 @@ user table in sync.
 
 - `SCREENSHOT_DIRECTORY` – directory for raw screenshots (default `data/screenshots/`)
 - `VIDEO_DIRECTORY` – directory for recorded videos (default `data/video/`)
-- `SUMMARIES_DIRECTORY` – **deprecated**; summaries are now stored in the database.
-
-  Older deployments may still reference this path but it is no longer used.
 
 You can change these paths via the settings table or by editing `app/config.py` if you maintain a custom build.
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!./env/bin/python3            
+#!./env/bin/python3
 #  main.py
 
 import logging
@@ -23,6 +23,7 @@ banner = """
                               |_|
 """
 
+
 def parse_arguments(arg_list=None):
     """
     Parse command-line arguments for the Glimpser application.
@@ -35,17 +36,42 @@ def parse_arguments(arg_list=None):
         argparse.Namespace: An object containing the parsed arguments.
     """
     parser = argparse.ArgumentParser(description="Glimpser %s" % config.VERSION)
-    parser.add_argument("--db-path", default=config.DATABASE_PATH,
-            help="Path to the database file (default: %s)" % config.DATABASE_PATH)
-    parser.add_argument("--host", default=config.HOST, help="Host for the web server (default: %s)" % config.HOST)
-    parser.add_argument("--port", type=int, default=config.PORT, help="Port for the web server (default: %s)" % config.PORT)
-    parser.add_argument("--log-path", default=config.LOGGING_PATH,
-            help="Path to the log file (default: %s)" % config.LOGGING_PATH)
-    parser.add_argument("--log-level", default=config.LOG_LEVEL, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                        help="Logging level")
-    parser.add_argument("--console-log", action="store_true", help="Enable logging to the console", default=False)
-    parser.add_argument("--debug", action="store_true", default=config.DEBUG,
-                        help="Enable debug mode")
+    parser.add_argument(
+        "--db-path",
+        default=config.DATABASE_PATH,
+        help="Path to the database file (default: %s)" % config.DATABASE_PATH,
+    )
+    parser.add_argument(
+        "--host",
+        default=config.HOST,
+        help="Host for the web server (default: %s)" % config.HOST,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=config.PORT,
+        help="Port for the web server (default: %s)" % config.PORT,
+    )
+    parser.add_argument(
+        "--log-path",
+        default=config.LOGGING_PATH,
+        help="Path to the log file (default: %s)" % config.LOGGING_PATH,
+    )
+    parser.add_argument(
+        "--log-level",
+        default=config.LOG_LEVEL,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--console-log",
+        action="store_true",
+        help="Enable logging to the console",
+        default=False,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=config.DEBUG, help="Enable debug mode"
+    )
     parser.add_argument(
         "--no-scheduler",
         action="store_true",
@@ -58,13 +84,18 @@ def parse_arguments(arg_list=None):
         help="Disable the watchdog thread",
         default=False,
     )
-    parser.add_argument("--screenshot-dir", default=config.SCREENSHOT_DIRECTORY,
-                        help="Directory for storing screenshots")
-    parser.add_argument("--video-dir", default=config.VIDEO_DIRECTORY,
-                        help="Directory for storing video files")
-    parser.add_argument("--summaries-dir", default=config.SUMMARIES_DIRECTORY,
-                        help="Directory for storing summaries")
+    parser.add_argument(
+        "--screenshot-dir",
+        default=config.SCREENSHOT_DIRECTORY,
+        help="Directory for storing screenshots",
+    )
+    parser.add_argument(
+        "--video-dir",
+        default=config.VIDEO_DIRECTORY,
+        help="Directory for storing video files",
+    )
     return parser.parse_args(arg_list)
+
 
 def setup_config(args=None):
     """
@@ -87,7 +118,7 @@ def setup_config(args=None):
     config.DEBUG_MODE = args.debug
     config.SCREENSHOT_DIRECTORY = args.screenshot_dir
     config.VIDEO_DIRECTORY = args.video_dir
-    config.SUMMARIES_DIRECTORY = args.summaries_dir
+
 
 def setup_logging(args=None):
     """
@@ -116,17 +147,18 @@ def setup_logging(args=None):
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
+
 def ensure_directories():
     """
     Create necessary directories for the application if they don't exist.
 
-    This function creates directories for the database, logs, screenshots, videos, and summaries.
+    This function creates directories for the database, logs, screenshots, and videos.
     """
     os.makedirs(os.path.dirname(config.DATABASE_PATH), exist_ok=True)
     os.makedirs(os.path.dirname(config.LOGGING_PATH), exist_ok=True)
     os.makedirs(config.SCREENSHOT_DIRECTORY, exist_ok=True)
     os.makedirs(config.VIDEO_DIRECTORY, exist_ok=True)
-    os.makedirs(config.SUMMARIES_DIRECTORY, exist_ok=True)
+
 
 def generate_credentials_if_needed():
     """
@@ -137,7 +169,9 @@ def generate_credentials_if_needed():
     """
     if not os.path.exists(config.DATABASE_PATH):
         from generate_credentials import generate_credentials
+
         generate_credentials(args=None)
+
 
 def create_application(args=None):
     """
@@ -171,19 +205,23 @@ def create_application(args=None):
 
     return create_app(watchdog=watchdog, schedule=schedule)
 
+
 def output_shutdown_stats():
     # Get and display system metrics
     metrics = get_system_metrics()
     logging.info("System Metrics at Shutdown:")
-    logging.info("CPU Usage: %s%%", metrics['cpu_usage'])
-    logging.info("Memory Usage: %s%%", metrics['memory_usage'])
-    logging.info("Disk Usage: %s%%", metrics['disk_usage'])
-    logging.info("Open Files: %s", metrics['open_files'])
-    logging.info("Thread Count: %s", metrics['thread_count'])
-    logging.info("Uptime: %s", metrics['uptime'])
+    logging.info("CPU Usage: %s%%", metrics["cpu_usage"])
+    logging.info("Memory Usage: %s%%", metrics["memory_usage"])
+    logging.info("Disk Usage: %s%%", metrics["disk_usage"])
+    logging.info("Open Files: %s", metrics["open_files"])
+    logging.info("Thread Count: %s", metrics["thread_count"])
+    logging.info("Uptime: %s", metrics["uptime"])
     logging.info("Thank you for running Glimpser. Goodbye!")
 
+
 display_note = True
+
+
 def cleanup_resources():
     # Shutdown the scheduler
     try:
@@ -201,37 +239,39 @@ def cleanup_resources():
                 # concurrent.futures.Future.cancel()
                 thread.join(timeout=0.01)
                 if thread.is_alive():
-                    logging.warning(
-                        "Thread %s is still alive after join", thread.name
-                    )
+                    logging.warning("Thread %s is still alive after join", thread.name)
             except Exception as e:
                 logging.error("Error terminating thread %s: %s", thread.name, e)
 
-    #global banner
+    # global banner
     # Add any other cleanup tasks here (e.g., closing database connections)
     output_shutdown_stats()
 
+
 def graceful_shutdown(signum, frame):
-    #time.sleep(random.randint(0,10) * 0.1)
-    #time.sleep(10)
+    # time.sleep(random.randint(0,10) * 0.1)
+    # time.sleep(10)
     time.sleep(0.01)
     sys.exit(0)
 
+
 def clear_console():
     # For Windows
-    if os.name == 'nt':
-        _ = os.system('cls')
+    if os.name == "nt":
+        _ = os.system("cls")
     # For macOS and Linux
     else:
-        _ = os.system('clear')
+        _ = os.system("clear")
+
 
 def is_port_in_use(port):
     # Skip the check if running in Docker
-    if os.environ.get('IN_DOCKER'):
+    if os.environ.get("IN_DOCKER"):
         return False
-    
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
+        return s.connect_ex(("localhost", port)) == 0
+
 
 def main(argv=None):
     """Entry point for the ``glimpser`` command."""
@@ -257,7 +297,9 @@ def main(argv=None):
 
     try:
         logging.info("Starting web...")
-        app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True)
+        app.run(
+            host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
+        )
     except KeyboardInterrupt:
         logging.info("KeyboardInterrupt received. Exiting...")
     except Exception as e:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,7 +13,7 @@ from app import create_app
 
 class TestCreateApp(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(watchdog=False, schedule=False) # maybe? 
+        self.app = create_app(watchdog=False, schedule=False)  # maybe?
         self.client = self.app.test_client()
 
     def test_app_creation(self):
@@ -24,12 +24,10 @@ class TestCreateApp(unittest.TestCase):
         from app.config import (
             SCREENSHOT_DIRECTORY,
             VIDEO_DIRECTORY,
-            SUMMARIES_DIRECTORY,
         )
 
         self.assertTrue(os.path.exists(SCREENSHOT_DIRECTORY))
         self.assertTrue(os.path.exists(VIDEO_DIRECTORY))
-        self.assertTrue(os.path.exists(SUMMARIES_DIRECTORY))
 
     def test_routes_initialization(self):
         # Test if some expected routes are present
@@ -38,7 +36,7 @@ class TestCreateApp(unittest.TestCase):
             self.assertIn("login", self.app.view_functions)
             self.assertIn("logout", self.app.view_functions)
 
-    '''
+    """
     # wont work because schedule=False above
     def test_scheduler_initialization(self):
         scheduler = self.app.extensions.get("scheduler")
@@ -52,7 +50,7 @@ class TestCreateApp(unittest.TestCase):
         self.assertIn("compile_to_teaser", job_ids)
         self.assertIn("archive_screenshots", job_ids)
         self.assertIn("retention_cleanup", job_ids)
-    '''
+    """
 
 
 if __name__ == "__main__":

--- a/tests/test_installation_and_first_use.py
+++ b/tests/test_installation_and_first_use.py
@@ -21,12 +21,10 @@ class TestInstallationAndFirstUse(unittest.TestCase):
         self.original_db_path = config.DATABASE_PATH
         self.original_screenshot_dir = config.SCREENSHOT_DIRECTORY
         self.original_video_dir = config.VIDEO_DIRECTORY
-        self.original_summaries_dir = config.SUMMARIES_DIRECTORY
 
         config.DATABASE_PATH = os.path.join(self.temp_dir, "test_glimpser.db")
         config.SCREENSHOT_DIRECTORY = os.path.join(self.temp_dir, "screenshots")
         config.VIDEO_DIRECTORY = os.path.join(self.temp_dir, "video")
-        config.SUMMARIES_DIRECTORY = os.path.join(self.temp_dir, "summaries")
 
         # Create the Flask test client
         self.app = create_app(watchdog=False, schedule=False)
@@ -37,7 +35,6 @@ class TestInstallationAndFirstUse(unittest.TestCase):
         config.DATABASE_PATH = self.original_db_path
         config.SCREENSHOT_DIRECTORY = self.original_screenshot_dir
         config.VIDEO_DIRECTORY = self.original_video_dir
-        config.SUMMARIES_DIRECTORY = self.original_summaries_dir
 
         # Remove the temporary directory and its contents
         shutil.rmtree(self.temp_dir)
@@ -51,18 +48,19 @@ class TestInstallationAndFirstUse(unittest.TestCase):
         """Test that required directories are created"""
         self.assertTrue(os.path.exists(config.SCREENSHOT_DIRECTORY))
         self.assertTrue(os.path.exists(config.VIDEO_DIRECTORY))
-        self.assertTrue(os.path.exists(config.SUMMARIES_DIRECTORY))
 
     def test_database_initialization(self):
         """Test that the database file is created"""
-        # TODO: i think this needs a join... 
-        #self.assertTrue(os.path.exists(config.DATABASE_PATH))
+        # TODO: i think this needs a join...
+        # self.assertTrue(os.path.exists(config.DATABASE_PATH))
 
     def test_root_route(self):
         """Test the root route of the application"""
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 302) # will be a redirect because of no auth
-        self.assertTrue('/login' in response.text)
+        self.assertEqual(
+            response.status_code, 302
+        )  # will be a redirect because of no auth
+        self.assertTrue("/login" in response.text)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,14 @@ class TestMain(unittest.TestCase):
 
     def test_parse_arguments(self):
         with patch(
-            "sys.argv", ["main.py", "--db-path", os.path.join(self.temp_dir, "db.sqlite"), "--port", "8080"]
+            "sys.argv",
+            [
+                "main.py",
+                "--db-path",
+                os.path.join(self.temp_dir, "db.sqlite"),
+                "--port",
+                "8080",
+            ],
         ):
             args = main.parse_arguments()
             self.assertEqual(args.db_path, os.path.join(self.temp_dir, "db.sqlite"))
@@ -45,7 +52,6 @@ class TestMain(unittest.TestCase):
         args.debug = True
         args.screenshot_dir = os.path.join(self.temp_dir, "screenshots")
         args.video_dir = os.path.join(self.temp_dir, "videos")
-        args.summaries_dir = os.path.join(self.temp_dir, "summaries")
 
         main.setup_config(args)
 
@@ -54,11 +60,12 @@ class TestMain(unittest.TestCase):
         self.assertEqual(config.PORT, 8080)
         self.assertEqual(config.LOGGING_PATH, os.path.join(self.temp_dir, "log.txt"))
         self.assertTrue(config.DEBUG_MODE)
-        self.assertEqual(config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots"))
+        self.assertEqual(
+            config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots")
+        )
         self.assertEqual(config.VIDEO_DIRECTORY, os.path.join(self.temp_dir, "videos"))
-        self.assertEqual(config.SUMMARIES_DIRECTORY, os.path.join(self.temp_dir, "summaries"))
 
-    @patch.object(logging, 'getLogger')
+    @patch.object(logging, "getLogger")
     def test_setup_logging(self, mock_get_logger):
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
@@ -70,9 +77,9 @@ class TestMain(unittest.TestCase):
         main.setup_logging(args)
 
         mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
-        #mock_logger.addHandler.assert_any_call(mock.ANY)  # Check that any handler was added
- 
-    '''
+        # mock_logger.addHandler.assert_any_call(mock.ANY)  # Check that any handler was added
+
+    """
     @patch("logging.FileHandler")
     @patch("logging.StreamHandler")
     def test_setup_logging(self, mock_stream_handler, mock_file_handler):
@@ -84,12 +91,12 @@ class TestMain(unittest.TestCase):
 
         mock_file_handler.assert_called_once()
         mock_stream_handler.assert_called_once()
-    '''
+    """
 
     @patch("os.makedirs")
     def test_ensure_directories(self, mock_makedirs):
         main.ensure_directories()
-        self.assertEqual(mock_makedirs.call_count, 5)
+        self.assertEqual(mock_makedirs.call_count, 4)
 
     @patch("generate_credentials.generate_credentials")
     @patch("os.path.exists")
@@ -124,7 +131,6 @@ class TestMain(unittest.TestCase):
         args.debug = False
         args.screenshot_dir = config.SCREENSHOT_DIRECTORY
         args.video_dir = config.VIDEO_DIRECTORY
-        args.summaries_dir = config.SUMMARIES_DIRECTORY
         args.no_scheduler = True
         args.no_watchdog = True
 


### PR DESCRIPTION
## Summary
- drop `--summaries-dir` CLI option
- clean up unused summaries directory logic and docs
- update tests for new configuration

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9e4703e08333ad2dc5dd3b7a9e46