### PR TITLE
Add MAC manufacturer info to discovery page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Read a high-level [Architecture Overview](docs/architecture_overview.md) to unde
   [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
-- **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices.
+ - **Camera Discovery**: Use the `/discover` page to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address and manufacturer when available.
 - **Camera Fix Suggestions**: Validate a template and discover alternative URLs with `/suggest_fix/<template>`. See [Camera Fix Suggestions](docs/camera_fix.md).
 - **Local Cameras**: `/discover` also lists any available `/dev/video*` devices for easy webcam integration.
 

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -10,6 +10,8 @@
                 <th title="Camera IP address">IP</th>
                 <th title="Protocol type">Protocol</th>
                 <th title="Port number">Port</th>
+                <th title="MAC address">MAC</th>
+                <th title="Device manufacturer">Manufacturer</th>
                 <th title="Additional information">Info</th>
                 <th title="Add camera"></th>
             </tr>
@@ -20,6 +22,8 @@
                 <td>{{ cam.ip }}</td>
                 <td>{{ cam.protocol }}</td>
                 <td>{{ cam.port }}</td>
+                <td>{{ cam.info.mac }}</td>
+                <td>{{ cam.info.manufacturer }}</td>
                 <td>{{ cam.info }}</td>
                 <td>
                     <form action="/discover/add" method="post">
@@ -59,6 +63,8 @@
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
                     <td>${cam.port}</td>
+                    <td>${cam.info.mac || ''}</td>
+                    <td>${cam.info.manufacturer || ''}</td>
                     <td>${JSON.stringify(cam.info)}</td>
                     <td>
                         <form action="/discover/add" method="post">

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -11,6 +11,15 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from .screenshots import is_port_open
 
+# Minimal OUI mapping for MAC manufacturer lookup.  This avoids pulling in
+# extra dependencies while still providing useful vendor hints.  Only a few
+# common prefixes are included.
+OUI_MAP = {
+    "000c29": "VMware",
+    "525400": "QEMU",
+    "080027": "VirtualBox",
+}
+
 # Discovery steps executed by :func:`discover_cameras`.  The list order
 # defines both the execution order and the number of progress updates.
 DISCOVERY_STAGES = [
@@ -38,6 +47,30 @@ try:  # optional Zeroconf support
     from zeroconf import ServiceBrowser, Zeroconf
 except Exception:  # pragma: no cover - optional dependency may be missing
     Zeroconf = None
+
+
+def _mac_for_ip(ip: str) -> str | None:
+    """Return the MAC address for ``ip`` from the ARP table if available."""
+
+    try:
+        with open("/proc/net/arp") as fh:
+            next(fh)
+            for line in fh:
+                parts = line.split()
+                if parts and parts[0] == ip:
+                    return parts[3].lower()
+    except Exception:
+        pass
+    return None
+
+
+def _mac_manufacturer(mac: str | None) -> str | None:
+    """Return the vendor name for ``mac`` using :data:`OUI_MAP`."""
+
+    if not mac:
+        return None
+    prefix = mac.replace(":", "").lower()[:6]
+    return OUI_MAP.get(prefix)
 
 
 def _local_subnets(max_prefixlen: int = 24):
@@ -479,4 +512,15 @@ def discover_cameras(progress_callback=None):
         key = (cam["ip"], cam["protocol"], cam["port"])
         if key not in unique:
             unique[key] = cam
-    return list(unique.values())
+
+    result = list(unique.values())
+    for cam in result:
+        if cam["protocol"] != "local":
+            mac = _mac_for_ip(cam["ip"])
+            if mac:
+                cam.setdefault("info", {})["mac"] = mac
+                vendor = _mac_manufacturer(mac)
+                if vendor:
+                    cam["info"]["manufacturer"] = vendor
+
+    return result

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -128,6 +128,11 @@ def _local_video_devices(base_path="/dev"):
 
 After scanning, `discover_cameras()` removes duplicates and returns the final list of cameras.
 
+Each entry is also augmented with the device's MAC address and, when known,
+the manufacturer derived from its OUI prefix.  These details appear as separate
+columns in the discovery table so you can quickly identify where each camera
+originates.
+
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.
 


### PR DESCRIPTION
## Summary
- show manufacturer details based on MAC prefix
- display MAC and manufacturer columns on discovery page
- document MAC vendor detection in discovery docs
- mention new discovery details in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9f9daae88333bba5628da83cf6fc