### PR TITLE
Improve live video stability

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -64,7 +64,11 @@ from app.utils import (
     prompt_optimizer,
     camera_fix,
 )
-from app.utils.screenshots import is_chrome_debug_port_open, check_user_activity
+from app.utils.screenshots import (
+    is_chrome_debug_port_open,
+    check_user_activity,
+    capture_frame_from_stream,
+)
 from app.utils.db import SessionLocal, engine
 
 # from app.models.log import Log
@@ -350,18 +354,48 @@ def generate_live_stream(url: str):
         ]
     )
 
-    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    frames_produced = False
 
     try:
         while True:
             chunk = process.stdout.read(1024 * 1024)
             if not chunk:
                 break
+            frames_produced = True
             yield chunk
+            if process.poll() is not None:
+                break
     except GeneratorExit:
         pass
     finally:
         process.kill()
+        process.wait(timeout=1)
+
+    if frames_produced and process.returncode == 0:
+        return
+
+    # Fallback to 1 fps screenshots if ffmpeg fails
+    while True:
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            if screenshots.capture_frame_from_stream(url, tmp_path, timeout=10):
+                with open(tmp_path, "rb") as f:
+                    yield f.read()
+            time.sleep(1)
+            if process.poll() is not None:
+                # Avoid zombie process just in case
+                break
+        except GeneratorExit:
+            break
+        finally:
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
 
 
 login_attempts = {}

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -100,6 +100,10 @@ Stream a camera directly from its configured URL in real time. Specify `camera` 
 
 Example: `/live_video?camera=frontdoor`
 
+If the underlying `ffmpeg` process fails to stream, the server
+automatically captures still frames once per second as a fallback so
+clients continue to receive updates.
+
 ### 5. Additional Streaming Endpoints
 
 Several other routes provide streaming functionality:


### PR DESCRIPTION
## Summary
- monitor ffmpeg subprocess during live stream
- when ffmpeg fails switch to 1fps screenshot fallback
- document fallback in API docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca13747488333a9b0dc9bbe6f3d7c