### PR TITLE
Improve live stream fallback speed

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -201,6 +201,11 @@ PROBE_SIZE_DEFAULT = get_setting("PROBE_SIZE_DEFAULT", "5M")
 PROBE_SIZE_RTSP = get_setting("PROBE_SIZE_RTSP", "10M")
 PROBE_SIZE_OTHER = get_setting("PROBE_SIZE_OTHER", "20M")
 
+# Frame rate used when `generate_live_stream` falls back to
+# still image capture. Increase to get smoother previews if
+# your hardware can handle the extra load.
+LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
+
 # Email settings
 EMAIL_ENABLED = get_setting("EMAIL_ENABLED", "False")
 EMAIL_SENDER = get_setting("EMAIL_SENDER", "your-email@example.com")

--- a/app/routes.py
+++ b/app/routes.py
@@ -339,6 +339,12 @@ def generate_live_stream(url: str):
         command.extend(["-hwaccel", config.FFMPEG_HWACCEL])
     command.extend(
         [
+            "-reconnect",
+            "1",
+            "-reconnect_streamed",
+            "1",
+            "-reconnect_delay_max",
+            "2",
             "-i",
             url,
             "-loglevel",
@@ -376,7 +382,7 @@ def generate_live_stream(url: str):
     if frames_produced and process.returncode == 0:
         return
 
-    # Fallback to 1 fps screenshots if ffmpeg fails
+    # Fallback to still images if ffmpeg fails
     while True:
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
             tmp_path = tmp.name
@@ -385,7 +391,7 @@ def generate_live_stream(url: str):
             if screenshots.capture_frame_from_stream(url, tmp_path, timeout=10):
                 with open(tmp_path, "rb") as f:
                     yield f.read()
-            time.sleep(1)
+            time.sleep(1 / max(config.LIVE_FALLBACK_FPS, 1))
             if process.poll() is not None:
                 # Avoid zombie process just in case
                 break

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -104,6 +104,7 @@ Settings controlling how frames are captured from video sources:
 - `PROBE_SIZE_DEFAULT` – probe size for HTTP/HTTPS streams (default `5M`)
 - `PROBE_SIZE_RTSP` – probe size for RTSP streams (default `10M`)
 - `PROBE_SIZE_OTHER` – probe size for other protocols (default `20M`)
+- `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 
 ## Advanced Options
 


### PR DESCRIPTION
## Summary
- add `LIVE_FALLBACK_FPS` configuration
- improve reconnection handling for `/live_video`
- document new setting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca39f772083338d558ec3bc6e126d