### PR TITLE
Add live viewer to template details

### DIFF
--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -6,6 +6,10 @@
     const cameraMeta = {{ template_details|tojson }};
 </script>
 
+<div id="live-embed" style="margin-bottom: 20px;">
+    <iframe src="{{ url_for('live') }}" width="100%" height="500" title="Embedded Live View" style="border:none;"></iframe>
+</div>
+
             <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay style='display: block; height: 90vh; width: 90vw;' width='90%'
 			    {% if template_details.last_caption %}
 			    title='{{template_details.last_caption}}'


### PR DESCRIPTION
## Summary
- embed live view page inside template detail page

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca624075083338eb7b608d3f19eba