### PR TITLE
Improve group live view

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -463,6 +463,11 @@ button, a {
   margin: 0 auto; /* Center the dial */
 }
 
+/* Speed slider and label container */
+#speed-container {
+    display: none;
+}
+
 /* Cool Clock Styles */
 .cool-clock {
     width: 25px;

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -89,12 +89,13 @@
         </video>
         <div class="video-controls">
             <input type="range" id="seek-bar" value="0">
-            <div class="control-row">
-                <button id="play-pause"><i class="fa-play-pause"></i> Test
-		</button>
 
-	<input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()">
-        <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
+            <div class="control-row">
+                <button id="play-pause"><i class="fa-play-pause"></i> Test</button>
+                <div id="speed-container">
+                    <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()">
+                    <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
+                </div>
 
 	<!-- <button id="cast-button">Cast</button> -->
                 <button id="full-screen" title='fullscreen'><i class="fas fa-expand"></i></button>
@@ -159,6 +160,9 @@
         const templateDetails = {{ template_details|tojson }};
         let currentCamera = 'All'; // Set the default camera to "All"
         let pngInterval;
+        let liveSwitchInterval;
+        let liveSwitchFunction;
+        const speedContainer = document.getElementById('speed-container');
         const videoOverlay = document.getElementById('video-overlay');
         const loadingIndicator = document.getElementById('loading-indicator');
         const playPauseIndicator = document.getElementById('play-pause-indicator');
@@ -287,6 +291,7 @@ function changeCamera() {
         hideOfflineIndicator();
         updateTemplateDetails();
         updateFeed(); // Make sure to update the video feed after changing the camera or group
+        updateSpeedContainer();
     }
 }
 
@@ -314,6 +319,7 @@ function changeCamera() {
         function updateFeed() {
             const source = document.getElementById('video-source').value;
             const isConnected = checkCameraConnection(currentCamera);
+            updateSpeedContainer();
 
             if (!isConnected) {
                 showOfflineIndicator(currentCamera);
@@ -356,6 +362,7 @@ function changeCamera() {
 function playM3U8() {
     video.style.display = 'block';
     image.style.display = 'none';
+    stopLiveSwitch();
     stopPNG();
 
             let m3u8Url;
@@ -411,6 +418,7 @@ function playM3U8() {
 function playLoop() {
     video.style.display = 'block';
     image.style.display = 'none';
+    stopLiveSwitch();
     stopPNG();
 
     if (currentCamera.startsWith('group-') || currentCamera === 'All') {
@@ -460,6 +468,7 @@ function playMP4() {
     video.style.display = 'block';
     image.style.display = 'none';
         document.getElementById("seek-bar").style.display = "block";
+    stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
@@ -501,21 +510,44 @@ function playLive() {
     image.style.display = 'none';
     document.getElementById("seek-bar").style.display = "block";
     stopPNG();
+    stopLiveSwitch();
 
     if (currentCamera.startsWith('group-') || currentCamera === 'All') {
-        // Fallback to MP4 streaming for groups or All
-        playMP4();
-        return;
-    }
+        let groupCameras;
+        if (currentCamera === 'All') {
+            groupCameras = Object.keys(templateDetails).filter(key => key !== 'All');
+        } else {
+            const groupName = currentCamera.split('group-')[1];
+            groupCameras = templateDetails['group-' + groupName].groupCameras;
+        }
 
-    video.src = '/live_video?camera=' + encodeURIComponent(currentCamera);
-    video.load();
-    video.play();
+        let cameraIndex = 0;
+        liveSwitchFunction = () => {
+            if (cameraIndex >= groupCameras.length) {
+                cameraIndex = 0;
+            }
+            const cameraName = groupCameras[cameraIndex];
+            video.src = '/live_video?camera=' + encodeURIComponent(cameraName);
+            video.load();
+            video.play();
+            cameraIndex++;
+        };
+
+        const slider = document.getElementById('speed-slider');
+        const speed = Math.pow(2, slider.value);
+        liveSwitchFunction();
+        liveSwitchInterval = setInterval(liveSwitchFunction, 10000 / speed);
+    } else {
+        video.src = '/live_video?camera=' + encodeURIComponent(currentCamera);
+        video.load();
+        video.play();
+    }
 }
 
 function playPNG() {
     video.style.display = 'none';
     image.style.display = 'block';
+    stopLiveSwitch();
         const slider = document.getElementById('speed-slider');
         const speed = Math.pow(2, slider.value);
 	document.getElementById("seek-bar").style.display = "none";
@@ -556,6 +588,7 @@ function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
         document.getElementById("seek-bar").style.display = "block";
+    stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
@@ -574,6 +607,7 @@ function playMotion() {
     video.style.display = 'none';
     image.style.display = 'block';
         document.getElementById("seek-bar").style.display = "none";
+    stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
@@ -600,13 +634,19 @@ function playMotion() {
         video.playbackRate = parseFloat(speed.toFixed(2)); // Ensure the speed is a float with two decimal places
         speedDisplay.textContent = speed.toFixed(2) + 'x'; // Update the text to show two decimal places
 
-            // Adjust the refresh rate for the PNG stream based on the playback speed
-            if (pngInterval) {
-                clearInterval(pngInterval);
-                pngInterval = setInterval(refreshPNG, 10000 / speed);
-            }
+        // Adjust the refresh rate for the PNG stream based on the playback speed
+        if (pngInterval) {
+            clearInterval(pngInterval);
+            pngInterval = setInterval(refreshPNG, 10000 / speed);
+        }
 
-	        speedDisplay.classList.add('highlight-speed');
+        // Adjust the live group switch interval if active
+        if (liveSwitchInterval && liveSwitchFunction) {
+            clearInterval(liveSwitchInterval);
+            liveSwitchInterval = setInterval(liveSwitchFunction, 10000 / speed);
+        }
+
+        speedDisplay.classList.add('highlight-speed');
     setTimeout(() => speedDisplay.classList.remove('highlight-speed'), 500);
     }
 
@@ -616,6 +656,20 @@ function playMotion() {
             pngInterval = null;
         }
         image.src = '';
+    }
+
+    function stopLiveSwitch() {
+        if (liveSwitchInterval) {
+            clearInterval(liveSwitchInterval);
+            liveSwitchInterval = null;
+            liveSwitchFunction = null;
+        }
+    }
+
+    function updateSpeedContainer() {
+        if (!speedContainer) return;
+        const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
+        speedContainer.style.display = isGroupView ? 'block' : 'none';
     }
 
     function checkCameraConnection(cameraName) {
@@ -642,6 +696,7 @@ function playMotion() {
 
         // Initially update template details and play the MP4 stream
         updateTemplateDetails();
+        updateSpeedContainer();
         playMP4();
     </script>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The live view page no longer shows a duplicate navigation header.
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
 - Group and All cameras now bypass offline checks when loading feeds.
+- Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.
 - HTML templates are tested for image `alt` text and required form fields.
 - Template storage usage is now verified by unit tests.


### PR DESCRIPTION
## Summary
- support switching between cameras when Live video option is used for groups
- control group switch speed via the existing speed slider
- hide the speed slider for single camera views
- document live view improvements

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca203a12483338fa9a9fd9e5311c0