### PR TITLE
Rename watchdog flag

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -44,7 +44,7 @@ class SQLAlchemyHandler(logging.Handler):
 """
 
 
-def create_app(watchdog=True, schedule=True):
+def create_app(enable_watchdog=True, schedule=True):
     """Create and configure the Flask application.
 
     This function sets up the entire Flask application, including:
@@ -57,7 +57,7 @@ def create_app(watchdog=True, schedule=True):
 
     Parameters
     ----------
-    watchdog : bool, optional
+    enable_watchdog : bool, optional
         When ``True`` (the default) a background thread periodically
         polls the ``/health`` endpoint and checks the number of open file
         handles.  If either check fails it restores the last known good
@@ -147,7 +147,7 @@ def create_app(watchdog=True, schedule=True):
     backup_config()
 
     # Set up a watchdog thread to monitor the application
-    def watchdog():
+    def _watchdog_thread():
         """Background health monitor.
 
         The thread issues requests to ``/health`` and inspects the number of
@@ -196,8 +196,8 @@ def create_app(watchdog=True, schedule=True):
                         logging.warning("Restart cooldown in effect. Skipping restart.")
 
     # Start the watchdog thread
-    if watchdog is True:
-        watchdog_thread = threading.Thread(target=watchdog)
+    if enable_watchdog:
+        watchdog_thread = threading.Thread(target=_watchdog_thread)
         watchdog_thread.daemon = True
         watchdog_thread.start()
         app.watchdog_thread = watchdog_thread

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!./env/bin/python3            
+#!./env/bin/python3
 #  main.py
 
 import logging
@@ -23,6 +23,7 @@ banner = """
                               |_|
 """
 
+
 def parse_arguments(arg_list=None):
     """
     Parse command-line arguments for the Glimpser application.
@@ -35,17 +36,42 @@ def parse_arguments(arg_list=None):
         argparse.Namespace: An object containing the parsed arguments.
     """
     parser = argparse.ArgumentParser(description="Glimpser %s" % config.VERSION)
-    parser.add_argument("--db-path", default=config.DATABASE_PATH,
-            help="Path to the database file (default: %s)" % config.DATABASE_PATH)
-    parser.add_argument("--host", default=config.HOST, help="Host for the web server (default: %s)" % config.HOST)
-    parser.add_argument("--port", type=int, default=config.PORT, help="Port for the web server (default: %s)" % config.PORT)
-    parser.add_argument("--log-path", default=config.LOGGING_PATH,
-            help="Path to the log file (default: %s)" % config.LOGGING_PATH)
-    parser.add_argument("--log-level", default=config.LOG_LEVEL, choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                        help="Logging level")
-    parser.add_argument("--console-log", action="store_true", help="Enable logging to the console", default=False)
-    parser.add_argument("--debug", action="store_true", default=config.DEBUG,
-                        help="Enable debug mode")
+    parser.add_argument(
+        "--db-path",
+        default=config.DATABASE_PATH,
+        help="Path to the database file (default: %s)" % config.DATABASE_PATH,
+    )
+    parser.add_argument(
+        "--host",
+        default=config.HOST,
+        help="Host for the web server (default: %s)" % config.HOST,
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=config.PORT,
+        help="Port for the web server (default: %s)" % config.PORT,
+    )
+    parser.add_argument(
+        "--log-path",
+        default=config.LOGGING_PATH,
+        help="Path to the log file (default: %s)" % config.LOGGING_PATH,
+    )
+    parser.add_argument(
+        "--log-level",
+        default=config.LOG_LEVEL,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--console-log",
+        action="store_true",
+        help="Enable logging to the console",
+        default=False,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=config.DEBUG, help="Enable debug mode"
+    )
     parser.add_argument(
         "--no-scheduler",
         action="store_true",
@@ -58,13 +84,23 @@ def parse_arguments(arg_list=None):
         help="Disable the watchdog thread",
         default=False,
     )
-    parser.add_argument("--screenshot-dir", default=config.SCREENSHOT_DIRECTORY,
-                        help="Directory for storing screenshots")
-    parser.add_argument("--video-dir", default=config.VIDEO_DIRECTORY,
-                        help="Directory for storing video files")
-    parser.add_argument("--summaries-dir", default=config.SUMMARIES_DIRECTORY,
-                        help="Directory for storing summaries")
+    parser.add_argument(
+        "--screenshot-dir",
+        default=config.SCREENSHOT_DIRECTORY,
+        help="Directory for storing screenshots",
+    )
+    parser.add_argument(
+        "--video-dir",
+        default=config.VIDEO_DIRECTORY,
+        help="Directory for storing video files",
+    )
+    parser.add_argument(
+        "--summaries-dir",
+        default=config.SUMMARIES_DIRECTORY,
+        help="Directory for storing summaries",
+    )
     return parser.parse_args(arg_list)
+
 
 def setup_config(args=None):
     """
@@ -88,6 +124,7 @@ def setup_config(args=None):
     config.SCREENSHOT_DIRECTORY = args.screenshot_dir
     config.VIDEO_DIRECTORY = args.video_dir
     config.SUMMARIES_DIRECTORY = args.summaries_dir
+
 
 def setup_logging(args=None):
     """
@@ -116,6 +153,7 @@ def setup_logging(args=None):
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
+
 def ensure_directories():
     """
     Create necessary directories for the application if they don't exist.
@@ -128,6 +166,7 @@ def ensure_directories():
     os.makedirs(config.VIDEO_DIRECTORY, exist_ok=True)
     os.makedirs(config.SUMMARIES_DIRECTORY, exist_ok=True)
 
+
 def generate_credentials_if_needed():
     """
     Generate credentials if the database file doesn't exist.
@@ -137,7 +176,9 @@ def generate_credentials_if_needed():
     """
     if not os.path.exists(config.DATABASE_PATH):
         from generate_credentials import generate_credentials
+
         generate_credentials(args=None)
+
 
 def create_application(args=None):
     """
@@ -167,23 +208,27 @@ def create_application(args=None):
     generate_credentials_if_needed()
 
     schedule = not getattr(args, "no_scheduler", False)
-    watchdog = not getattr(args, "no_watchdog", False)
+    enable_watchdog = not getattr(args, "no_watchdog", False)
 
-    return create_app(watchdog=watchdog, schedule=schedule)
+    return create_app(enable_watchdog=enable_watchdog, schedule=schedule)
+
 
 def output_shutdown_stats():
     # Get and display system metrics
     metrics = get_system_metrics()
     logging.info("System Metrics at Shutdown:")
-    logging.info("CPU Usage: %s%%", metrics['cpu_usage'])
-    logging.info("Memory Usage: %s%%", metrics['memory_usage'])
-    logging.info("Disk Usage: %s%%", metrics['disk_usage'])
-    logging.info("Open Files: %s", metrics['open_files'])
-    logging.info("Thread Count: %s", metrics['thread_count'])
-    logging.info("Uptime: %s", metrics['uptime'])
+    logging.info("CPU Usage: %s%%", metrics["cpu_usage"])
+    logging.info("Memory Usage: %s%%", metrics["memory_usage"])
+    logging.info("Disk Usage: %s%%", metrics["disk_usage"])
+    logging.info("Open Files: %s", metrics["open_files"])
+    logging.info("Thread Count: %s", metrics["thread_count"])
+    logging.info("Uptime: %s", metrics["uptime"])
     logging.info("Thank you for running Glimpser. Goodbye!")
 
+
 display_note = True
+
+
 def cleanup_resources():
     # Shutdown the scheduler
     try:
@@ -201,37 +246,39 @@ def cleanup_resources():
                 # concurrent.futures.Future.cancel()
                 thread.join(timeout=0.01)
                 if thread.is_alive():
-                    logging.warning(
-                        "Thread %s is still alive after join", thread.name
-                    )
+                    logging.warning("Thread %s is still alive after join", thread.name)
             except Exception as e:
                 logging.error("Error terminating thread %s: %s", thread.name, e)
 
-    #global banner
+    # global banner
     # Add any other cleanup tasks here (e.g., closing database connections)
     output_shutdown_stats()
 
+
 def graceful_shutdown(signum, frame):
-    #time.sleep(random.randint(0,10) * 0.1)
-    #time.sleep(10)
+    # time.sleep(random.randint(0,10) * 0.1)
+    # time.sleep(10)
     time.sleep(0.01)
     sys.exit(0)
 
+
 def clear_console():
     # For Windows
-    if os.name == 'nt':
-        _ = os.system('cls')
+    if os.name == "nt":
+        _ = os.system("cls")
     # For macOS and Linux
     else:
-        _ = os.system('clear')
+        _ = os.system("clear")
+
 
 def is_port_in_use(port):
     # Skip the check if running in Docker
-    if os.environ.get('IN_DOCKER'):
+    if os.environ.get("IN_DOCKER"):
         return False
-    
+
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
+        return s.connect_ex(("localhost", port)) == 0
+
 
 def main(argv=None):
     """Entry point for the ``glimpser`` command."""
@@ -257,7 +304,9 @@ def main(argv=None):
 
     try:
         logging.info("Starting web...")
-        app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True)
+        app.run(
+            host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
+        )
     except KeyboardInterrupt:
         logging.info("KeyboardInterrupt received. Exiting...")
     except Exception as e:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -19,7 +19,7 @@ from app import create_app
 
 class TestAuthentication(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,7 +13,7 @@ from app import create_app
 
 class TestCreateApp(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(watchdog=False, schedule=False) # maybe? 
+        self.app = create_app(enable_watchdog=False, schedule=False)  # maybe?
         self.client = self.app.test_client()
 
     def test_app_creation(self):
@@ -38,7 +38,7 @@ class TestCreateApp(unittest.TestCase):
             self.assertIn("login", self.app.view_functions)
             self.assertIn("logout", self.app.view_functions)
 
-    '''
+    """
     # wont work because schedule=False above
     def test_scheduler_initialization(self):
         scheduler = self.app.extensions.get("scheduler")
@@ -52,7 +52,7 @@ class TestCreateApp(unittest.TestCase):
         self.assertIn("compile_to_teaser", job_ids)
         self.assertIn("archive_screenshots", job_ids)
         self.assertIn("retention_cleanup", job_ids)
-    '''
+    """
 
 
 if __name__ == "__main__":

--- a/tests/test_installation_and_first_use.py
+++ b/tests/test_installation_and_first_use.py
@@ -29,7 +29,7 @@ class TestInstallationAndFirstUse(unittest.TestCase):
         config.SUMMARIES_DIRECTORY = os.path.join(self.temp_dir, "summaries")
 
         # Create the Flask test client
-        self.app = create_app(watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
 
     def tearDown(self):
@@ -55,14 +55,16 @@ class TestInstallationAndFirstUse(unittest.TestCase):
 
     def test_database_initialization(self):
         """Test that the database file is created"""
-        # TODO: i think this needs a join... 
-        #self.assertTrue(os.path.exists(config.DATABASE_PATH))
+        # TODO: i think this needs a join...
+        # self.assertTrue(os.path.exists(config.DATABASE_PATH))
 
     def test_root_route(self):
         """Test the root route of the application"""
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 302) # will be a redirect because of no auth
-        self.assertTrue('/login' in response.text)
+        self.assertEqual(
+            response.status_code, 302
+        )  # will be a redirect because of no auth
+        self.assertTrue("/login" in response.text)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,14 @@ class TestMain(unittest.TestCase):
 
     def test_parse_arguments(self):
         with patch(
-            "sys.argv", ["main.py", "--db-path", os.path.join(self.temp_dir, "db.sqlite"), "--port", "8080"]
+            "sys.argv",
+            [
+                "main.py",
+                "--db-path",
+                os.path.join(self.temp_dir, "db.sqlite"),
+                "--port",
+                "8080",
+            ],
         ):
             args = main.parse_arguments()
             self.assertEqual(args.db_path, os.path.join(self.temp_dir, "db.sqlite"))
@@ -54,11 +61,15 @@ class TestMain(unittest.TestCase):
         self.assertEqual(config.PORT, 8080)
         self.assertEqual(config.LOGGING_PATH, os.path.join(self.temp_dir, "log.txt"))
         self.assertTrue(config.DEBUG_MODE)
-        self.assertEqual(config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots"))
+        self.assertEqual(
+            config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots")
+        )
         self.assertEqual(config.VIDEO_DIRECTORY, os.path.join(self.temp_dir, "videos"))
-        self.assertEqual(config.SUMMARIES_DIRECTORY, os.path.join(self.temp_dir, "summaries"))
+        self.assertEqual(
+            config.SUMMARIES_DIRECTORY, os.path.join(self.temp_dir, "summaries")
+        )
 
-    @patch.object(logging, 'getLogger')
+    @patch.object(logging, "getLogger")
     def test_setup_logging(self, mock_get_logger):
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
@@ -70,9 +81,9 @@ class TestMain(unittest.TestCase):
         main.setup_logging(args)
 
         mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
-        #mock_logger.addHandler.assert_any_call(mock.ANY)  # Check that any handler was added
- 
-    '''
+        # mock_logger.addHandler.assert_any_call(mock.ANY)  # Check that any handler was added
+
+    """
     @patch("logging.FileHandler")
     @patch("logging.StreamHandler")
     def test_setup_logging(self, mock_stream_handler, mock_file_handler):
@@ -84,7 +95,7 @@ class TestMain(unittest.TestCase):
 
         mock_file_handler.assert_called_once()
         mock_stream_handler.assert_called_once()
-    '''
+    """
 
     @patch("os.makedirs")
     def test_ensure_directories(self, mock_makedirs):
@@ -129,7 +140,7 @@ class TestMain(unittest.TestCase):
         args.no_watchdog = True
 
         main.create_application(args)
-        mock_create_app.assert_called_with(watchdog=False, schedule=False)
+        mock_create_app.assert_called_with(enable_watchdog=False, schedule=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -10,7 +10,7 @@ from app import create_app
 
 class TestMotionMjpg(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -1,4 +1,5 @@
 import os, sys
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 from unittest.mock import patch
@@ -9,7 +10,7 @@ import app.routes as routes
 
 class TestRTSP(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False)
         self.app.testing = True
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
@@ -64,12 +65,15 @@ class TestRTSP(unittest.TestCase):
         fake_frame = b"JPEGDATA"
         rtp_header = b"\x80\x60\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01"
 
-        def fake_generate(group=None, filename="latest_camera.png", rtsp=False, session_id=None):
+        def fake_generate(
+            group=None, filename="latest_camera.png", rtsp=False, session_id=None
+        ):
             def gen():
                 if rtsp:
                     yield rtp_header + fake_frame
                 else:
                     yield fake_frame
+
             return gen()
 
         with patch("app.routes.generate", side_effect=fake_generate):

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+
 class TestSettingsRoute(unittest.TestCase):
     def setUp(self):
         # Create temporary directory and database path
@@ -30,6 +31,7 @@ class TestSettingsRoute(unittest.TestCase):
         import app.config as config
         import app.utils.db as db
         import app.routes as routes
+
         importlib.reload(config)
         importlib.reload(db)
         importlib.reload(routes)
@@ -43,7 +45,7 @@ class TestSettingsRoute(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        self.app = app.create_app(watchdog=False, schedule=False)
+        self.app = app.create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()
@@ -62,6 +64,7 @@ class TestSettingsRoute(unittest.TestCase):
         import app.config as config
         import app.utils.db as db
         import app.routes as routes
+
         importlib.reload(config)
         importlib.reload(db)
         importlib.reload(routes)
@@ -77,7 +80,9 @@ class TestSettingsRoute(unittest.TestCase):
         return row[0] if row else None
 
     def test_add_and_delete_setting(self):
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
             response = self.client.post(
                 "/settings",
                 data={"action": "add", "new_name": "TEST", "new_value": "1"},
@@ -86,7 +91,9 @@ class TestSettingsRoute(unittest.TestCase):
         self.assertIn("/settings", response.headers["Location"])
         self.assertEqual(self._get_value("TEST"), "1")
 
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
             response = self.client.post(
                 "/settings", data={"action": "delete", "name_to_delete": "TEST"}
             )
@@ -105,7 +112,9 @@ class TestSettingsRoute(unittest.TestCase):
             "EMAIL_USERNAME": "user",
             "EMAIL_PASSWORD": "pass",
         }
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
             response = self.client.post("/settings", data=payload)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self._get_value("EMAIL_SENDER"), "user@example.com")
@@ -118,7 +127,9 @@ class TestSettingsRoute(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
             response = self.client.post("/settings", data={"action": "backup"})
         self.assertEqual(response.status_code, 302)
         self.assertTrue(os.path.exists(self.backup_path))
@@ -127,13 +138,16 @@ class TestSettingsRoute(unittest.TestCase):
         with open(self.backup_path, "r") as f:
             data = f.read()
         import json
+
         config = json.loads(data)
         config["A"] = "2"
         upload_path = os.path.join(self.temp_dir.name, "upload.json")
         with open(upload_path, "w") as f:
             json.dump(config, f)
 
-        with patch("app.routes.session", {"user_id": 1}), patch("app.routes.login_required", lambda x: x):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
             with open(upload_path, "rb") as file_data:
                 response = self.client.post(
                     "/settings",
@@ -142,6 +156,7 @@ class TestSettingsRoute(unittest.TestCase):
                 )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self._get_value("A"), "2")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename the `watchdog` flag in `create_app` to `enable_watchdog`
- update watchdog thread setup accordingly
- adjust main helper and tests for new parameter

## Testing
- `black app/__init__.py main.py tests/test_rtsp.py tests/test_motion_endpoint.py tests/test_settings_route.py tests/test_authentication.py tests/test_installation_and_first_use.py tests/test_init.py tests/test_main.py`
- `flake8 app/__init__.py main.py tests/test_rtsp.py tests/test_motion_endpoint.py tests/test_settings_route.py tests/test_authentication.py tests/test_installation_and_first_use.py tests/test_init.py tests/test_main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683caa570c2c8333bb982eea196c3a13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated parameter names from `watchdog` to `enable_watchdog` throughout the application and tests for improved clarity and consistency.
  - Improved code formatting and readability in several files, including multi-line argument formatting and consistent use of double quotes.

- **Tests**
  - Updated test setup calls to use the new `enable_watchdog` parameter name.
  - Reformatted test code for enhanced readability without altering test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->