### PR TITLE
Fix live view iframe

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -646,7 +646,10 @@ def init_routes(app):
     def add_security_headers(response):
         """Add common security headers to every response."""
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
+        # Allow pages from this site to be embedded in iframes
+        # without opening the application to clickjacking from
+        # other domains.
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["Cache-Control"] = "no-store"

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -16,7 +16,7 @@ All responses now include standard security headers to help prevent
 common attacks. Important headers are:
 
 - `X-Content-Type-Options: nosniff`
-- `X-Frame-Options: DENY`
+- `X-Frame-Options: SAMEORIGIN`
 - `X-XSS-Protection: 1; mode=block`
 - `Referrer-Policy: no-referrer`
 - `Cache-Control: no-store`

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -18,7 +18,7 @@ class TestSecurityHeaders(unittest.TestCase):
         resp = self.client.get("/api/discover")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.headers.get("X-Content-Type-Options"), "nosniff")
-        self.assertEqual(resp.headers.get("X-Frame-Options"), "DENY")
+        self.assertEqual(resp.headers.get("X-Frame-Options"), "SAMEORIGIN")
         self.assertEqual(resp.headers.get("X-XSS-Protection"), "1; mode=block")
         self.assertEqual(resp.headers.get("Referrer-Policy"), "no-referrer")
         self.assertEqual(resp.headers.get("Cache-Control"), "no-store")


### PR DESCRIPTION
## Summary
- allow same-origin iframe embedding
- document `SAMEORIGIN` header
- update security header test

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683caad61d0c8333a0ee5cc5b67aa199