### PR TITLE
Handle snapshot URLs in live view

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -332,7 +332,33 @@ def generate_video_stream(video_path: str):
 
 
 def generate_live_stream(url: str):
-    """Yield video data directly from a remote URL using ffmpeg."""
+    """Yield video data directly from a remote URL using ffmpeg.
+
+    Some camera APIs expose JPEG snapshots rather than a continuous
+    video stream. If the URL resembles a static image endpoint, poll
+    the image directly to keep the live view working.
+    """
+
+    image_like = (
+        url.lower().endswith((".jpg", ".jpeg", ".png")) or "/picture" in url.lower()
+    )
+    if image_like:
+        session = screenshots.http_session()
+        while True:
+            try:
+                resp = session.get(url, timeout=5, stream=True)
+                if resp.status_code == 200:
+                    yield resp.content
+                else:
+                    logging.error(
+                        "Failed to fetch image from %s (HTTP %s)", url, resp.status_code
+                    )
+            except GeneratorExit:
+                break
+            except Exception as e:
+                logging.error("Error fetching image from %s: %s", url, e)
+            time.sleep(1 / max(config.LIVE_FALLBACK_FPS, 1))
+        return
 
     command = [config.FFMPEG_PATH]
     if config.FFMPEG_HWACCEL and config.FFMPEG_HWACCEL.lower() != "false":

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -182,3 +182,16 @@ Glimpser writes logs to the console and exposes them via the `/status` page. If 
 **Solution:**
 - Ensure you are running the latest Glimpser version.
 - Refresh the page to load the updated JavaScript.
+
+## 11. Live View Problems
+
+### Problem: Live page never loads a frame
+
+If the logs repeat messages like `No frames captured from stream` or
+`Error capturing frame with ffmpeg`, the camera URL may point to a
+snapshot image rather than a true video stream.
+
+**Solution:**
+- Use the camera's RTSP or HTTP video stream URL when available.
+- Snapshot-only URLs now work automatically, but they refresh slowly
+  since a new JPEG must be fetched for each frame.


### PR DESCRIPTION
## Summary
- support snapshot-only camera endpoints in `generate_live_stream`
- document solution for live view failing to load in troubleshooting guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cab624b7c8333956cb9f4dfdbe834