### PR TITLE
Improve watchdog tolerance

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -159,6 +159,8 @@ def create_app(enable_watchdog=True, schedule=True):
         last_restart_time = 0
         restart_cooldown = 900  # 15 minutes in seconds
         max_file_handles = 1000  # Adjust this value based on your system's limits
+        failure_count = 0
+        failure_threshold = 3
 
         while True:
             time.sleep(10)  # Check every 10 seconds
@@ -180,20 +182,36 @@ def create_app(enable_watchdog=True, schedule=True):
 
                 except Exception as e:
                     logging.error("Application error detected: %s", e)
+                    failure_count += 1
                     current_time = time.time()
-                    if current_time - last_restart_time > restart_cooldown:
-                        logging.info("Attempting to restore previous configuration...")
-                        try:
-                            restore_config()
-                        except Exception as config_error:
-                            logging.error(
-                                "Failed to restore configuration: %s", config_error
+                    if failure_count >= failure_threshold:
+                        if current_time - last_restart_time > restart_cooldown:
+                            logging.info(
+                                "Attempting to restore previous configuration..."
                             )
-                        logging.info("Forcing application restart...")
-                        last_restart_time = current_time
-                        os._exit(1)  # Force restart the application
+                            try:
+                                restore_config()
+                            except Exception as config_error:
+                                logging.error(
+                                    "Failed to restore configuration: %s", config_error
+                                )
+                            logging.info("Forcing application restart...")
+                            last_restart_time = current_time
+                            failure_count = 0
+                            os._exit(1)  # Force restart the application
+                        else:
+                            logging.warning(
+                                "Restart cooldown in effect. Skipping restart."
+                            )
                     else:
-                        logging.warning("Restart cooldown in effect. Skipping restart.")
+                        logging.warning(
+                            "Health check failed (%s/%s)",
+                            failure_count,
+                            failure_threshold,
+                        )
+                else:
+                    # Reset failure count on successful check
+                    failure_count = 0
 
     # Start the watchdog thread
     if enable_watchdog:

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -7,6 +7,8 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Loads configuration values and sets up logging.
 - Initializes routes from `app/routes.py`.
 - Starts the background scheduler and optional watchdog thread.
+  The watchdog performs health checks and only triggers a restart after
+  three consecutive failures to avoid unnecessary restarts during startup.
 
 ## Configuration Handling (`app/config.py`)
 - Loads environment variables and values stored in the database.


### PR DESCRIPTION
## Summary
- prevent the watchdog from restarting after a single health check failure
- document the new watchdog behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cae5a0f64833395becf8322728c90