### PR TITLE
Add request profiling support

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -74,6 +74,7 @@ from app.utils.db import SessionLocal, engine
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
+from app.utils.profiling import profile_route, get_latency_stats
 
 
 def restart_server():
@@ -696,6 +697,7 @@ def init_routes(app):
     # Add a new route for the extended health check
     @app.route("/health")
     @login_required
+    @profile_route("/health")
     def health_check():
 
         scheduler_status = "failed"
@@ -785,6 +787,7 @@ def init_routes(app):
 
     @app.route("/danger_status")
     @login_required
+    @profile_route("/danger_status")
     def danger_status():
         """Return whether Danger mode can be used."""
         port_open = is_chrome_debug_port_open("127.0.0.1", 9222)
@@ -794,6 +797,7 @@ def init_routes(app):
         )
 
     @app.route("/api/discover")
+    @profile_route("/api/discover")
     def api_discover():
         api_info = {
             "version": "1.0",
@@ -2246,6 +2250,7 @@ def init_routes(app):
 
     @app.route("/toggle_scheduler", methods=["POST"])
     @login_required
+    @profile_route("/toggle_scheduler")
     def toggle_scheduler():
         try:
             if scheduling.scheduler.running:
@@ -2263,7 +2268,13 @@ def init_routes(app):
 
     @app.route("/scheduler_status")
     @login_required
+    @profile_route("/scheduler_status")
     def get_scheduler_status():
         return jsonify(
             {"status": "running" if scheduling.scheduler.running else "stopped"}
         )
+
+    @app.route("/profiling")
+    @login_required
+    def profiling_data():
+        return jsonify(get_latency_stats())

--- a/app/utils/profiling.py
+++ b/app/utils/profiling.py
@@ -1,0 +1,70 @@
+import json
+import os
+import time
+from functools import wraps
+from threading import Lock
+
+LOG_PATH = "data/latency_log.json"
+_lock = Lock()
+
+
+def _load_log():
+    if os.path.exists(LOG_PATH):
+        try:
+            with open(LOG_PATH, "r") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def _save_log(entries):
+    os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+    with open(LOG_PATH, "w") as f:
+        json.dump(entries, f)
+
+
+def profile_route(name=None):
+    """Decorator for measuring route execution time."""
+
+    def decorator(func):
+        route_name = name or func.__name__
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start = time.time()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                elapsed = (time.time() - start) * 1000.0
+                with _lock:
+                    data = _load_log()
+                    data.append(
+                        {
+                            "route": route_name,
+                            "elapsed_ms": elapsed,
+                            "timestamp": time.time(),
+                        }
+                    )
+                    _save_log(data)
+
+        return wrapper
+
+    return decorator
+
+
+def get_latency_stats():
+    """Return aggregated latency statistics."""
+    with _lock:
+        data = _load_log()
+    stats = {}
+    for entry in data:
+        route = entry.get("route")
+        stats.setdefault(route, {"count": 0, "total": 0.0})
+        stats[route]["count"] += 1
+        stats[route]["total"] += entry.get("elapsed_ms", 0.0)
+    for route, info in stats.items():
+        count = info["count"]
+        info["average_ms"] = info["total"] / count if count else 0.0
+        del info["total"]
+    return stats

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -45,3 +45,14 @@ metrics.
 ## Danger Mode Indicator
 
 When Chrome's remote debugging port is open and no user input has been detected for a short time, Danger mode becomes available. An orange dot in the navigation bar shows this state. Hovering over the dot explains why Danger mode may be unavailable. See [Danger Mode](danger_mode.md) for setup instructions.
+
+## Profiling
+
+Each profiled API request writes its execution time to `data/latency_log.json`.
+Query aggregated averages and counts using the `/profiling` endpoint:
+
+```bash
+curl /profiling
+```
+
+Use this information to identify slow endpoints and monitor performance.

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,42 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from flask import Flask
+from app.routes import init_routes
+
+
+class TestProfiling(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        # disable authentication
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        # use temporary file for log
+        self.temp_log = tempfile.NamedTemporaryFile(delete=False)
+        self.log_patch = patch("app.utils.profiling.LOG_PATH", self.temp_log.name)
+        self.log_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.log_patch.stop()
+        self.temp_log.close()
+        os.unlink(self.temp_log.name)
+
+    def test_latency_recorded(self):
+        resp = self.client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        with open(self.temp_log.name) as f:
+            data = json.load(f)
+        self.assertTrue(any(d["route"] == "/health" for d in data))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add lightweight profiling decorator to log route latency
- profile several API endpoints and add `/profiling` route
- document profiling output location and usage
- test that profiling records latency data

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cafb88e608333a99ce68184f55a5f