### PR TITLE
Improve live feed reliability

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -332,11 +332,13 @@ def generate_video_stream(video_path: str):
 
 
 def generate_live_stream(url: str):
-    """Yield video data directly from a remote URL using ffmpeg.
+    """Yield video data directly from a remote URL using ``ffmpeg``.
 
-    Some camera APIs expose JPEG snapshots rather than a continuous
-    video stream. If the URL resembles a static image endpoint, poll
-    the image directly to keep the live view working.
+    Some camera APIs expose JPEG snapshots rather than a continuous video
+    stream. If the URL resembles a static image endpoint, poll the image
+    directly to keep the live view working. Otherwise continuously invoke
+    ``ffmpeg`` and restart it on failure so the client receives a valid
+    MP4 stream whenever possible.
     """
 
     image_like = (
@@ -386,48 +388,32 @@ def generate_live_stream(url: str):
         ]
     )
 
-    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    frames_produced = False
-
-    try:
-        while True:
-            chunk = process.stdout.read(1024 * 1024)
-            if not chunk:
-                break
-            frames_produced = True
-            yield chunk
-            if process.poll() is not None:
-                break
-    except GeneratorExit:
-        pass
-    finally:
-        process.kill()
-        process.wait(timeout=1)
-
-    if frames_produced and process.returncode == 0:
-        return
-
-    # Fallback to still images if ffmpeg fails
     while True:
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-            tmp_path = tmp.name
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
 
         try:
-            if screenshots.capture_frame_from_stream(url, tmp_path, timeout=10):
-                with open(tmp_path, "rb") as f:
-                    yield f.read()
-            time.sleep(1 / max(config.LIVE_FALLBACK_FPS, 1))
-            if process.poll() is not None:
-                # Avoid zombie process just in case
-                break
+            while True:
+                chunk = process.stdout.read(1024 * 1024)
+                if not chunk:
+                    break
+                yield chunk
+                if process.poll() is not None:
+                    break
         except GeneratorExit:
-            break
+            process.kill()
+            process.wait(timeout=1)
+            return
         finally:
-            try:
-                os.remove(tmp_path)
-            except OSError:
-                pass
+            process.kill()
+            process.wait(timeout=1)
+
+        if process.returncode == 0:
+            return
+
+        logging.error("ffmpeg exited with %s, retrying", process.returncode)
+        time.sleep(2)
 
 
 login_attempts = {}

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -100,9 +100,9 @@ Stream a camera directly from its configured URL in real time. Specify `camera` 
 
 Example: `/live_video?camera=frontdoor`
 
-If the underlying `ffmpeg` process fails to stream, the server
-automatically captures still frames once per second as a fallback so
-clients continue to receive updates.
+If the underlying `ffmpeg` process exits unexpectedly the server now
+restarts it automatically. This ensures the client receives a valid MP4
+stream whenever the camera becomes available again.
 
 ### 5. Additional Streaming Endpoints
 


### PR DESCRIPTION
## Summary
- restart ffmpeg when live feed stops to avoid serving stale images
- document the new restart behavior in `/live_video` endpoint

## Testing
- `black app/routes.py`
- `flake8 app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb03450f08333a85d1c2d86935ded