### PR TITLE
Fix internal watchdog health check

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -79,6 +79,7 @@ def create_app(enable_watchdog=True, schedule=True):
         SESSION_COOKIE_SECURE,
         SESSION_COOKIE_HTTPONLY,
         SESSION_TIMEOUT_MINUTES,
+        API_KEY,
     )
 
     app = Flask(__name__)
@@ -168,7 +169,7 @@ def create_app(enable_watchdog=True, schedule=True):
                 try:
                     # Check app responsiveness
                     with app.test_client() as client:
-                        response = client.get("/health")
+                        response = client.get("/health", headers={"X-API-Key": API_KEY})
                         if response.status_code != 200:
                             raise Exception("Application is not responding correctly")
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -9,6 +9,8 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Starts the background scheduler and optional watchdog thread.
   The watchdog performs health checks and only triggers a restart after
   three consecutive failures to avoid unnecessary restarts during startup.
+  Requests to `/health` include the configured API key so the check
+  succeeds even when login is required.
 
 ## Configuration Handling (`app/config.py`)
 - Loads environment variables and values stored in the database.


### PR DESCRIPTION
## Summary
- ensure the watchdog authenticates when polling `/health`
- mention API key usage in architecture overview

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_683cb1f84cc883339d6f53a197313b84