### PR TITLE
Add fast MJPEG streaming endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -632,6 +632,53 @@ def generate(
         time.sleep(1 - (time.time() - ltime))
 
 
+def generate_fast_mjpg(camera: str):
+    """Yield MJPEG frames by repeatedly capturing screenshots.
+
+    The function calls ``scheduling.update_camera`` directly to grab a fresh
+    frame as quickly as possible. If capturing fails, the previously captured
+    frame is re-used and the delay between attempts increases to avoid
+    overwhelming the camera endpoint.
+    """
+
+    template = template_manager.get_template(camera)
+    if not template:
+        return
+
+    boundary = b"frame"
+    last_frame = None
+    failures = 0
+
+    path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        SCREENSHOT_DIRECTORY,
+        camera,
+        "latest_camera.png",
+    )
+
+    while True:
+        start = time.time()
+        try:
+            scheduling.update_camera(camera, template)
+            if os.path.exists(path):
+                with open(path, "rb") as f:
+                    last_frame = f.read()
+            failures = 0
+        except Exception as e:  # pragma: no cover - unexpected errors
+            logging.error("fast mjpg capture failed for %s: %s", camera, e)
+            failures += 1
+
+        if last_frame:
+            yield b"--" + boundary + b"\r\n"
+            yield b"Content-Type: image/png\r\n\r\n" + last_frame + b"\r\n"
+
+        delay = min(0.1 * (2**failures), 5)
+        elapsed = time.time() - start
+        if elapsed < delay:
+            time.sleep(delay - elapsed)
+
+
 def allowed_filename(filename: str) -> bool:
     r"""Return ``True`` when ``filename`` contains only safe characters.
 
@@ -1253,6 +1300,19 @@ def init_routes(app):
         logging.debug("last motion caption")
         return Response(
             generate(group=group, camera=camera, filename="last_motion_caption.png"),
+            mimetype="multipart/x-mixed-replace; boundary=frame",
+        )
+
+    @app.route("/fast_stream.mjpg", methods=["GET"])
+    @login_required
+    def fast_stream_mjpg():
+        camera = request.args.get("camera")
+        if not camera:
+            abort(400, "camera parameter required")
+        if not template_manager.get_template(camera):
+            abort(404)
+        return Response(
+            generate_fast_mjpg(camera),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 

--- a/tests/test_fast_mjpg_route.py
+++ b/tests/test_fast_mjpg_route.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import shutil
+import unittest
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestFastMjpgRoute(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_fast_mjpg"
+        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.tpl_patch = patch("app.routes.template_manager.get_template")
+        self.update_patch = patch("app.routes.scheduling.update_camera")
+        self.login_patch.start()
+        self.sc_patch.start()
+        self.mock_tpl = self.tpl_patch.start()
+        self.mock_update = self.update_patch.start()
+
+        def create_frame(name, template):
+            img_path = os.path.join(
+                self.repo_root, self.sshot_dir, name, "latest_camera.png"
+            )
+            Image.new("RGB", (1, 1)).save(img_path)
+
+        self.mock_update.side_effect = create_frame
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        self.tpl_patch.stop()
+        self.update_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_route_returns_200(self):
+        self.mock_tpl.return_value = {"name": "cam1", "url": "http://example.com"}
+        resp = self.client.get("/fast_stream.mjpg?camera=cam1")
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `generate_fast_mjpg` to capture frames repeatedly using the existing scheduler
- expose `/fast_stream.mjpg` that streams frames using the new generator
- test the new route

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cb382d858833384ad205d21a98d46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new streaming endpoint for MJPEG video, allowing users to view live camera feeds with faster frame updates.

- **Tests**
  - Added automated tests to ensure the new MJPEG streaming endpoint responds correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->