### PR TITLE
Implement nav fade on inactivity for players

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -308,6 +308,11 @@ header {
     display: flex; /* Flexbox for layout */
     align-items: center; /* Vertically align items */
     justify-content: space-between; /* Space out the title and navigation */
+    transition: opacity 0.5s; /* Smooth fade for inactivity */
+}
+
+header.fade-out {
+    opacity: 0;
 }
 
 header h1 {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -71,6 +71,26 @@ export function initNav() {
         `${now.toLocaleTimeString()}\n${Intl.DateTimeFormat().resolvedOptions().timeZone}\n${now.toDateString()}`;
     }
 
+    function setupNavFade() {
+      const header = document.querySelector('header');
+      const player = document.querySelector('.video-container');
+      if (!header || !player) return;
+
+      let fadeTimeout;
+
+      const showNav = () => {
+        header.classList.remove('fade-out');
+        clearTimeout(fadeTimeout);
+        fadeTimeout = setTimeout(() => header.classList.add('fade-out'), 3000);
+      };
+
+      ['mousemove', 'scroll'].forEach((evt) => {
+        document.addEventListener(evt, showNav);
+      });
+
+      showNav();
+    }
+
     setInterval(checkHealth, 5000);
     checkHealth();
 
@@ -79,5 +99,7 @@ export function initNav() {
 
     setInterval(updateCoolClock, 1000);
     updateCoolClock();
+
+    setupNavFade();
   });
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,3 +38,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Core colors and fonts are defined via CSS variables.
 - Navigation menus use a consistent accent color with smooth hover effects.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
+- Player pages fade the navigation bar when the mouse is idle for a few seconds.


### PR DESCRIPTION
## Summary
- fade the navigation header after inactivity
- hide the nav when the mouse or scroll is idle on player pages
- document the new fading behavior

## Testing
- `flake8`
- `npx stylelint "app/static/css/**/*.css"` *(fails: connect EHOSTUNREACH)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cbe5303dc8333ba6b4b714d51512c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The navigation bar on player pages now smoothly fades out after a few seconds of mouse inactivity, enhancing the user experience.
- **Documentation**
  - Updated documentation to reflect the new navigation fade-out feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->