### PR TITLE
Fix Chrome user data dir conflict

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import subprocess
 import time
+import tempfile
 from urllib.parse import urlparse
 import glob
 import base64
@@ -2299,10 +2300,9 @@ def capture_screenshot_and_har(
     user_data_dir = None
     driver = None
     try:
-        # Create ephemeral profile dir in /tmp
-        tmp_profile = f"/tmp/glimpser_{name}"
-        os.makedirs(tmp_profile, exist_ok=True)
-        user_data_dir = tmp_profile  # just to keep track
+        # Create a unique ephemeral profile dir in /tmp
+        tmp_profile = tempfile.mkdtemp(prefix=f"glimpser_{name}_")
+        user_data_dir = tmp_profile  # keep track so we can clean up
 
         # Using undetected_chromedriver for stealth:
         # driver_options = uc.ChromeOptions()


### PR DESCRIPTION
## Summary
- avoid Chrome profile reuse by generating a unique tmp directory

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cbddb1ec08333bd92fab2f71c3d14