### PR TITLE
Validate timestamp when concatenating videos

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -246,6 +246,8 @@ def get_video_duration(video_path):
 
 def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> bool:
     """Concatenate the temporary video with the existing in-process video."""
+    file_updated = False
+
     if (
         os.path.exists(in_process_video)
         and os.path.exists(temp_video)
@@ -295,6 +297,7 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
             try:
                 run_ffmpeg(concat_command)
                 os.rename(concat_video, in_process_video)
+                file_updated = True
                 output_video = os.path.join(VIDEO_DIRECTORY, "latest_camera.mp4")
                 if os.path.exists(output_video + ".tmp"):
                     os.unlink(output_video + ".tmp")
@@ -321,11 +324,20 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
                     return False
         elif os.path.exists(temp_video) and os.path.getsize(temp_video) > 0:
             os.rename(temp_video, in_process_video)
+            file_updated = True
     elif os.path.exists(temp_video) and os.path.getsize(temp_video) > 0:
         os.rename(temp_video, in_process_video)
+        file_updated = True
 
-    # TODO: check timestamp, should be current...
+    # Verify the modification time is recent when a file was updated
     if os.path.exists(in_process_video):
+        if file_updated:
+            mod_time = os.path.getmtime(in_process_video)
+            if abs(time.time() - mod_time) > 10:
+                logging.warning(
+                    "in_process video timestamp stale: %s", in_process_video
+                )
+                return False
         return True
     return False
 

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -15,3 +15,7 @@ of placeholder frames.
 If a screenshot vanishes between discovery and metadata lookup (for example, if
 another process cleans the directory), the archiver simply skips that file. This
 prevents crashes due to `FileNotFoundError` when gathering timestamps.
+
+When segments are concatenated, the resulting `in_process.mp4` is checked to
+ensure its modification time is recent. A stale timestamp triggers a warning
+and the operation is aborted so corrupted videos do not linger.

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -115,6 +115,8 @@ class TestVideoArchiver(unittest.TestCase):
             patch("os.rename"),
             patch("os.symlink"),
             patch("os.unlink"),
+            patch("os.path.getmtime", return_value=100),
+            patch("time.time", return_value=105),
         ):
             result = concatenate_videos("in_process.mp4", "temp.mp4", self.temp_dir)
         self.assertTrue(result)
@@ -138,9 +140,34 @@ class TestVideoArchiver(unittest.TestCase):
             patch("os.path.getsize", return_value=1),
             patch("os.rename"),
             patch("os.symlink"),
+            patch("os.path.getmtime", return_value=100),
+            patch("time.time", return_value=105),
         ):
             result = concatenate_videos("in.mp4", "tmp.mp4", self.temp_dir)
         self.assertEqual(mock_subprocess_run.call_count, 2)
+
+    @patch("app.utils.video_archiver.logging.warning")
+    @patch("app.utils.video_archiver.get_video_duration")
+    @patch("subprocess.run")
+    def test_concatenate_videos_stale_timestamp(
+        self, mock_subprocess_run, mock_get_video_duration, mock_warning
+    ):
+        mock_get_video_duration.return_value = 10
+        mock_subprocess_run.return_value.returncode = 0
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.getsize", return_value=1),
+            patch("os.path.isdir", return_value=True),
+            patch("os.rename"),
+            patch("os.symlink"),
+            patch("os.unlink"),
+            patch("os.path.getmtime", return_value=0),
+            patch("time.time", return_value=100),
+        ):
+            result = concatenate_videos("in.mp4", "tmp.mp4", self.temp_dir)
+
+        self.assertFalse(result)
+        mock_warning.assert_called_once()
 
     def test_handle_concat_error(self):
         with (


### PR DESCRIPTION
## Summary
- ensure `concatenate_videos` rejects stale outputs
- document timestamp validation in video archiver docs
- test timestamp freshness check

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdd0d9b9c8333a82a8f936c61622f