### PR TITLE
Require POST for /compile_teaser

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1733,7 +1733,7 @@ def init_routes(app):
 
         abort(404)
 
-    @app.route("/compile_teaser", methods=["GET"])  # todo: should probably be post?
+    @app.route("/compile_teaser", methods=["POST"])
     @login_required
     def take_compile():
         video_archiver.compile_to_teaser()

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -178,8 +178,16 @@ that can be used to improve future captions.
 
 Example response:
 ```json
+
 {"prompt": "Busy roadway — highlight license plates"}
 ```
+
+### 12. Compile Teaser Video
+
+**POST /compile_teaser**
+
+Trigger compilation of recent footage into a teaser video. Requires authentication.
+GET requests to this endpoint return `405 Method Not Allowed`.
 
 ## Error Handling
 

--- a/tests/test_compile_teaser_route.py
+++ b/tests/test_compile_teaser_route.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestCompileTeaserRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.compile_patch = patch("app.routes.video_archiver.compile_to_teaser")
+        self.login_patch.start()
+        self.mock_compile = self.compile_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.compile_patch.stop()
+
+    def test_compile_teaser_post(self):
+        resp = self.client.post("/compile_teaser")
+        self.assertEqual(resp.status_code, 200)
+        self.mock_compile.assert_called()
+
+    def test_compile_teaser_get_not_allowed(self):
+        resp = self.client.get("/compile_teaser")
+        self.assertEqual(resp.status_code, 405)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restrict `/compile_teaser` route to POST
- document new POST-only endpoint
- test compile teaser route

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cdd10116083338bd9961e689605f4