### PR TITLE
Add role-based access checks

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -2,13 +2,17 @@ from sqlalchemy import Column, Integer, String
 
 from app.utils.db import Base
 
+
 class User(Base):
     __tablename__ = "users"
+
+    ROLE_ADMIN = "admin"
+    ROLE_USER = "user"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    role = Column(String, nullable=True)
+    role = Column(String, nullable=False, default=ROLE_USER)
 
     def __repr__(self) -> str:
         return f"<User id={self.id} username={self.username}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -131,7 +131,22 @@ def is_hash_valid(timed_hash: str) -> bool:
         return False
 
 
-def login_required(f):
+def _has_required_role(user, roles):
+    """Return True if no role restrictions or the user's role is allowed."""
+
+    if not roles:
+        return True
+    if isinstance(user, dict):
+        user_role = user.get("role")
+    else:
+        user_role = getattr(user, "role", None)
+    return user_role in roles
+
+
+def login_required(f=None, *, roles=None):
+    if f is None:
+        return lambda fn: login_required(fn, roles=roles)
+
     @wraps(f)
     def decorated_function(*args, **kwargs):
         # Check for API key in headers, GET parameters, or POST form data
@@ -179,7 +194,8 @@ def login_required(f):
                 flash("Session expired. Please log in again.")
                 return redirect(url_for("login", next=request.url))
 
-            # Optional role checks could be added here
+            if not _has_required_role(user, roles):
+                abort(403)
             return f(*args, **kwargs)
 
         # Handle missing or invalid authentication
@@ -2025,7 +2041,7 @@ def init_routes(app):
         return send_from_directory(path, filename)
 
     @app.route("/settings", methods=["GET", "POST"])
-    @login_required
+    @login_required(roles=[User.ROLE_ADMIN])
     def settings():
         if request.method == "POST":
             email_settings = [

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,4 +38,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Core colors and fonts are defined via CSS variables.
 - Navigation menus use a consistent accent color with smooth hover effects.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
+- Routes can restrict access by user role using a helper on the login decorator.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 from types import SimpleNamespace
 from app.config import USER_NAME, API_KEY
 from app.routes import login_required, login_attempts
+from app.models.user import User
 from app import create_app
 
 
@@ -366,6 +367,77 @@ class TestAuthentication(unittest.TestCase):
             response = self.client.get("/sso?token=wrong")
             self.assertEqual(response.status_code, 302)
             self.assertIn("/login", response.headers["Location"])
+
+    def test_role_based_access_allowed(self):
+        login_attempts = {}
+
+        @self.app.route("/admin")
+        @login_required(roles=[User.ROLE_ADMIN])
+        def admin_route():
+            return "admin"
+
+        dummy_user = SimpleNamespace(id=1, username=USER_NAME, role=User.ROLE_ADMIN)
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+
+            def close(self):
+                pass
+
+        class DummyInspector:
+            def get_table_names(self):
+                return ["users"]
+
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.SessionLocal",
+            return_value=DummySession(),
+        ), patch("app.routes.sa_inspect", return_value=DummyInspector()):
+            response = self.client.get("/admin")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b"admin", response.data)
+
+    def test_role_based_access_denied(self):
+        login_attempts = {}
+
+        @self.app.route("/admin2")
+        @login_required(roles=[User.ROLE_ADMIN])
+        def admin2_route():
+            return "admin2"
+
+        dummy_user = SimpleNamespace(id=1, username=USER_NAME, role=User.ROLE_USER)
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+
+            def close(self):
+                pass
+
+        class DummyInspector:
+            def get_table_names(self):
+                return ["users"]
+
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.SessionLocal",
+            return_value=DummySession(),
+        ), patch("app.routes.sa_inspect", return_value=DummyInspector()):
+            response = self.client.get("/admin2")
+            self.assertEqual(response.status_code, 403)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend user model with role constants and defaults
- support role checks in `login_required`
- restrict settings route to admin users
- test authentication roles
- document role-based permissions

## Testing
- `flake8`
- `pytest -q tests/test_authentication.py`

------
https://chatgpt.com/codex/tasks/task_e_683cf614ef7c833397fd3ec33d3581b3