### PR TITLE
Add retry/headers to HTTP callbacks

### DIFF
--- a/app/utils/http_callbacks.py
+++ b/app/utils/http_callbacks.py
@@ -1,15 +1,53 @@
 import logging
+import time
 import requests
 
 
-def send_http_callback(url, event_type, payload):
-    """Send an HTTP POST callback if a URL is provided."""
+def send_http_callback(
+    url,
+    event_type,
+    payload,
+    *,
+    timeout=5,
+    headers=None,
+    retries=0,
+):
+    """Send an HTTP POST callback if a URL is provided.
+
+    Parameters
+    ----------
+    url : str
+        Destination URL for the callback.
+    event_type : str
+        Type of event being reported.
+    payload : dict
+        Data payload to include in the POST body.
+    timeout : int, optional
+        Request timeout in seconds. Defaults to ``5``.
+    headers : dict, optional
+        Additional HTTP headers to include.
+    retries : int, optional
+        Number of retry attempts on failure.
+
+    Failures are logged. Retries use exponential backoff to avoid
+    hammering the remote service.
+    """
     if not url:
         return
-    try:
-        data = {"event": event_type, "payload": payload}
-        requests.post(url, json=data, timeout=5)
-        logging.info("HTTP callback sent to %s", url)
-    except Exception as e:
-        logging.error("HTTP callback error: %s", e)
 
+    data = {"event": event_type, "payload": payload}
+    headers = headers or {}
+    attempt = 0
+    while True:
+        try:
+            requests.post(url, json=data, timeout=timeout, headers=headers)
+            logging.info("HTTP callback sent to %s", url)
+            break
+        except Exception as exc:
+            logging.error("HTTP callback error: %s", exc)
+            attempt += 1
+            if attempt > retries:
+                break
+            # Exponential backoff capped at 30 seconds prevents a rapid
+            # retry loop when the remote service is unavailable.
+            time.sleep(min(2**attempt, 30))

--- a/docs/http_callbacks.md
+++ b/docs/http_callbacks.md
@@ -16,7 +16,15 @@ The relevant code is shown below:
 
 ```python
 # app/utils/http_callbacks.py
-send_http_callback(url, event_type, payload)
+send_http_callback(
+    url,
+    event_type,
+    payload,
+    *,
+    timeout=5,
+    headers=None,
+    retries=0,
+)
 ```
 
 Scheduling tasks assemble the payload and call this function whenever an
@@ -32,6 +40,19 @@ payload = {
     "motion": bool(lsum),
 }
 send_http_callback(template.get("callback_url"), event, payload)
+```
+
+You can override the timeout, provide headers, and enable retries:
+
+```python
+send_http_callback(
+    template.get("callback_url"),
+    event,
+    payload,
+    timeout=10,
+    headers={"Authorization": "Bearer TOKEN"},
+    retries=2,
+)
 ```
 
 ## Configuring a Callback URL

--- a/tests/test_http_callbacks.py
+++ b/tests/test_http_callbacks.py
@@ -6,16 +6,43 @@ from app.utils.http_callbacks import send_http_callback
 
 class TestHttpCallbacks(unittest.TestCase):
     def test_send_http_callback_no_url(self):
-        with patch('requests.post') as mock_post:
-            send_http_callback('', 'event', {})
+        with patch("requests.post") as mock_post:
+            send_http_callback("", "event", {})
             mock_post.assert_not_called()
 
     def test_send_http_callback_posts(self):
-        with patch('requests.post') as mock_post:
+        with patch("requests.post") as mock_post:
             mock_post.return_value.status_code = 200
-            send_http_callback('http://example.com', 'event', {'a': 1})
-            mock_post.assert_called_once_with('http://example.com', json={'event': 'event', 'payload': {'a': 1}}, timeout=5)
+            send_http_callback("http://example.com", "event", {"a": 1})
+            mock_post.assert_called_once_with(
+                "http://example.com",
+                json={"event": "event", "payload": {"a": 1}},
+                timeout=5,
+                headers={},
+            )
+
+    def test_send_http_callback_custom_headers(self):
+        with patch("requests.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            send_http_callback(
+                "http://example.com",
+                "event",
+                {"a": 1},
+                timeout=10,
+                headers={"X-Test": "1"},
+            )
+            mock_post.assert_called_once_with(
+                "http://example.com",
+                json={"event": "event", "payload": {"a": 1}},
+                timeout=10,
+                headers={"X-Test": "1"},
+            )
+
+    def test_send_http_callback_retries(self):
+        with patch("requests.post", side_effect=[Exception("fail"), None]) as mock_post:
+            send_http_callback("http://example.com", "event", {"a": 1}, retries=1)
+            self.assertEqual(mock_post.call_count, 2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add timeout, header and retry parameters to `send_http_callback`
- document new callback options
- extend tests for HTTP callback utility

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf4dd6d708333a73ff188d0529c90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTTP callback functionality with support for configurable timeout, custom headers, and automatic retries with exponential backoff for failed requests.

- **Documentation**
	- Updated usage instructions and examples to cover new timeout, headers, and retries options for HTTP callbacks.

- **Tests**
	- Added and improved test cases to verify new callback features and ensure correct handling of headers, timeouts, and retry logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->