### PR TITLE
Fix login-required session checks

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -154,6 +154,14 @@ def login_required(f):
 
         # Check for valid session
         elif session.get("user_id"):
+            # Ensure the stored user_id is an integer. Any malformed session
+            # data should trigger a logout redirect rather than allowing the
+            # request through.
+            if not isinstance(session.get("user_id"), int):
+                session.pop("user_id", None)
+                flash("Session expired. Please log in again.")
+                return redirect(url_for("login", next=request.url))
+
             expiry = session.get("expiry")
             if expiry and datetime.now() > datetime.strptime(
                 expiry, "%Y-%m-%d %H:%M:%S"

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -309,9 +309,8 @@ class TestAuthentication(unittest.TestCase):
         # Test with invalid session data
         with patch("app.routes.session", {"user_id": "not_a_boolean"}):
             response = self.client.get("/protected")
-            # TODO: fix these
-            # self.assertEqual(response.status_code, 302)
-            # self.assertIn("/login", response.headers["Location"])
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/login", response.headers["Location"])
 
     def test_api_key_security(self):
         login_attempts = {}  # reset


### PR DESCRIPTION
## Summary
- validate `user_id` in `login_required`
- assert redirect for invalid session data

## Testing
- `flake8`
- `pytest tests/test_authentication.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cf631976c8333a8659edee7fa1f0f