### PR TITLE
Add motion query for manual screenshot

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1812,8 +1812,14 @@ def init_routes(app):
         if templates.get(template_name) is None:
             abort(404)
 
-        # TODO: consider adding motion control
-        scheduling.update_camera(template_name, templates.get(template_name))
+        motion_flag = request.args.get("motion", "false").lower() in [
+            "1",
+            "true",
+            "yes",
+        ]
+        scheduling.update_camera(
+            template_name, templates.get(template_name), motion=motion_flag
+        )
         return jsonify(
             {"status": "success", "message": f"Screenshot for {template_name} taken"}
         )

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -206,7 +206,7 @@ def add_motion_and_caption(image_path, caption=None, motion=False):
             logging.error(f"Error updating image {image_path} : {e}")
 
 
-def update_camera(name, template, image_file=None):
+def update_camera(name, template, image_file=None, motion=False):
 
     # just ignore the old
     template = get_template(name)
@@ -309,12 +309,13 @@ def update_camera(name, template, image_file=None):
 
         motion_config = template.get("motion", 1)
         if (
-            motion_config in [1, None]
+            not motion
+            and motion_config in [1, None]
             and (template.get("last_caption", "") or "") != ""
         ):
             return
 
-        lsum = False
+        lsum = motion
         percentage_difference = 0
 
         latest_image_path = os.path.join(directory, png_files[-1])
@@ -343,12 +344,12 @@ def update_camera(name, template, image_file=None):
         prev_motion = os.path.join(directory, "last_motion.png")
         # print(" detected motion", lsum, name, template.get('last_caption'))
 
-        allow = False
+        allow = motion
 
         #  Work through, Motion detection, then object detection, then live caption, then online captioning
         #
         last_caption_time, _last_motion_caption = None, None
-        last_caption_trigger, last_motion_trigger = False, False
+        last_caption_trigger, last_motion_trigger = motion, motion
 
         if (template.get("last_caption", "") or "") == "":
             allow = True

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -128,6 +128,8 @@ Several other routes provide streaming functionality:
 
 Manually capture a screenshot for the specified template.
 
+Appending `?motion=true` forces motion analysis for the resulting frame.
+
 Example response:
 ```json
 {"status": "success", "message": "Screenshot for camera1 taken"}

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -41,8 +41,13 @@ Blue Iris is a popular video surveillance software. Here's how to integrate it w
    - Set up an alert that triggers on motion or other events you're interested in.
    - In the alert action, add a webhook that calls Glimpser's screenshot capture endpoint:
      ```
-     http://<glimpser_ip>:<port>/take_screenshot/<template_name>
-     ```
+    http://<glimpser_ip>:<port>/take_screenshot/<template_name>
+    ```
+
+    Add `?motion=true` to force motion analysis:
+    ```
+    http://<glimpser_ip>:<port>/take_screenshot/<template_name>?motion=true
+    ```
 
 4. **Glimpser Analysis Results**:
    - Set up a scheduled task in Blue Iris that periodically checks Glimpser's API for analysis results.
@@ -103,6 +108,10 @@ webhook endpoint, but you can still connect the two systems using webhooks:
      ```
      http://<glimpser_ip>:<port>/take_screenshot/<template_name>
      ```
+    Add `?motion=true` to force motion analysis:
+    ```
+    http://<glimpser_ip>:<port>/take_screenshot/<template_name>?motion=true
+    ```
 
 ## IFTTT Integration
 

--- a/tests/test_take_screenshot_route.py
+++ b/tests/test_take_screenshot_route.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import shutil
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestTakeScreenshotRoute(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_take_screenshot"
+        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.tpl_patch = patch("app.routes.template_manager.get_templates")
+        self.update_patch = patch("app.routes.scheduling.update_camera")
+        self.login_patch.start()
+        self.sc_patch.start()
+        self.mock_templates = self.tpl_patch.start()
+        self.mock_update = self.update_patch.start()
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        self.tpl_patch.stop()
+        self.update_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_motion_query_passed(self):
+        self.mock_templates.return_value = {"cam1": {"name": "cam1"}}
+        resp = self.client.get("/take_screenshot/cam1?motion=true")
+        self.assertEqual(resp.status_code, 200)
+        self.mock_update.assert_called_with("cam1", {"name": "cam1"}, motion=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow /take_screenshot to accept `?motion=true`
- propagate the flag to `scheduling.update_camera`
- document the new option in API and integration guide
- test that the motion flag is forwarded

## Testing
- `flake8`
- `pytest -q tests/test_take_screenshot_route.py`

------
https://chatgpt.com/codex/tasks/task_e_683cf6253aa883339e34cb6eb13f3f14