### PR TITLE
Persist HTTP status cache

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -89,6 +89,41 @@ etag_cache = {}
 status_code_cache = {}
 status_code_cache_time = {}
 STATUS_CACHE_TTL = 60 * 60  # 1 hour
+STATUS_CACHE_PATH = "data/status_cache.json"
+
+
+def _load_status_cache() -> None:
+    """Load cached status codes from ``STATUS_CACHE_PATH``."""
+    if not os.path.exists(STATUS_CACHE_PATH):
+        return
+    try:
+        with open(STATUS_CACHE_PATH, "r") as f:
+            data = json.load(f)
+    except Exception:
+        return
+
+    status_code_cache.clear()
+    status_code_cache_time.clear()
+    for url, info in data.items():
+        status_code_cache[url] = info.get("code")
+        status_code_cache_time[url] = info.get("time", 0)
+
+
+def _persist_status_cache() -> None:
+    """Write ``status_code_cache`` to ``STATUS_CACHE_PATH``."""
+    os.makedirs(os.path.dirname(STATUS_CACHE_PATH), exist_ok=True)
+    data = {
+        url: {"code": code, "time": status_code_cache_time.get(url, 0)}
+        for url, code in status_code_cache.items()
+    }
+    try:
+        with open(STATUS_CACHE_PATH, "w") as f:
+            json.dump(data, f)
+    except Exception:
+        logging.exception("Failed to persist status cache")
+
+
+_load_status_cache()
 
 
 FONT_CANDIDATES = [
@@ -184,10 +219,11 @@ def get_cached_status_code(url):
     ts = status_code_cache_time.get(url, 0)
     if code is not None and time.time() - ts < STATUS_CACHE_TTL:
         return code
-    elif code is not None:
-        # entry expired
+    if code is not None:
+        # Entry expired, remove and persist cleanup
         status_code_cache.pop(url, None)
         status_code_cache_time.pop(url, None)
+        _persist_status_cache()
     return None
 
 
@@ -195,6 +231,7 @@ def set_cached_status_code(url, code):
     """Store status code for URL with current timestamp."""
     status_code_cache[url] = code
     status_code_cache_time[url] = time.time()
+    _persist_status_cache()
 
 
 # Callback functions to update activity state

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -82,6 +82,12 @@ After capturing the content, Glimpser applies several post-processing steps:
 5. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
 6. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
 
+## Status Code Caching
+
+Glimpser stores the last HTTP status code for each URL in `data/status_cache.json`.
+If a previous attempt returned a non‐200 status, further requests are skipped for
+one hour. This prevents repeated network calls to unreachable resources.
+
 ## Capture Timeout
 
 `CAPTURE_TIMEOUT` controls how long Glimpser waits while grabbing a screenshot or pulling a

--- a/tests/test_screenshots_additional.py
+++ b/tests/test_screenshots_additional.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 import tempfile
+import shutil
 from unittest.mock import patch
 from PIL import Image
 
@@ -11,6 +12,21 @@ import app.utils.screenshots as ss
 
 
 class TestScreenshotsExtras(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.patcher = patch(
+            "app.utils.screenshots.STATUS_CACHE_PATH",
+            os.path.join(self.tmpdir, "cache.json"),
+        )
+        self.patcher.start()
+        ss.status_code_cache.clear()
+        ss.status_code_cache_time.clear()
+        ss._persist_status_cache()
+
+    def tearDown(self):
+        self.patcher.stop()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
     def test_is_valid_png(self):
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
             Image.new("RGB", (1, 1)).save(tmp, format="PNG")

--- a/tests/test_status_cache.py
+++ b/tests/test_status_cache.py
@@ -1,44 +1,60 @@
 import os
 import sys
 import unittest
+import tempfile
+import shutil
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.utils.screenshots import (
-    set_cached_status_code,
-    get_cached_status_code,
-    status_code_cache,
-    status_code_cache_time,
-    STATUS_CACHE_TTL,
-)
+from app.utils import screenshots as ss
 
 
 class TestStatusCodeCache(unittest.TestCase):
     def setUp(self):
-        status_code_cache.clear()
-        status_code_cache_time.clear()
+        self.tmpdir = tempfile.mkdtemp()
+        self.patcher = patch(
+            "app.utils.screenshots.STATUS_CACHE_PATH",
+            os.path.join(self.tmpdir, "cache.json"),
+        )
+        self.patcher.start()
+        ss.status_code_cache.clear()
+        ss.status_code_cache_time.clear()
+        ss._persist_status_cache()
+
+    def tearDown(self):
+        self.patcher.stop()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def test_cache_expiry_and_cleanup(self):
         with patch("time.time") as mock_time:
             # Store code at deterministic timestamp
             mock_time.return_value = 100
-            set_cached_status_code("u", 200)
+            ss.set_cached_status_code("u", 200)
 
-            self.assertEqual(status_code_cache["u"], 200)
-            self.assertEqual(status_code_cache_time["u"], 100)
+            self.assertEqual(ss.status_code_cache["u"], 200)
+            self.assertEqual(ss.status_code_cache_time["u"], 100)
 
             # Retrieve before expiration
-            mock_time.return_value = 100 + STATUS_CACHE_TTL - 1
-            self.assertEqual(get_cached_status_code("u"), 200)
-            self.assertIn("u", status_code_cache)
-            self.assertIn("u", status_code_cache_time)
+            mock_time.return_value = 100 + ss.STATUS_CACHE_TTL - 1
+            self.assertEqual(ss.get_cached_status_code("u"), 200)
+            self.assertIn("u", ss.status_code_cache)
+            self.assertIn("u", ss.status_code_cache_time)
 
             # Advance time past TTL and verify cleanup
-            mock_time.return_value = 100 + STATUS_CACHE_TTL + 1
-            self.assertIsNone(get_cached_status_code("u"))
-            self.assertEqual(status_code_cache, {})
-            self.assertEqual(status_code_cache_time, {})
+            mock_time.return_value = 100 + ss.STATUS_CACHE_TTL + 1
+            self.assertIsNone(ss.get_cached_status_code("u"))
+            self.assertEqual(ss.status_code_cache, {})
+            self.assertEqual(ss.status_code_cache_time, {})
+
+    def test_cache_persistence(self):
+        ss.set_cached_status_code("u", 500)
+        self.assertTrue(os.path.exists(ss.STATUS_CACHE_PATH))
+        # Clear memory and reload
+        ss.status_code_cache.clear()
+        ss.status_code_cache_time.clear()
+        ss._load_status_cache()
+        self.assertEqual(ss.get_cached_status_code("u"), 500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- persist failed request status codes in `data/status_cache.json`
- reload/persist the cache across runs
- skip failing requests using the persisted cache
- update docs with status code caching info
- test caching persistence logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf6230698833398da0b40619583a6