### PR TITLE
Add configurable CLIP model

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -193,6 +193,12 @@ FFPROBE_PATH = get_setting("FFPROBE_PATH", "ffprobe")
 # Enable GPU acceleration if supported (e.g. "auto", "cuda", etc.)
 FFMPEG_HWACCEL = get_setting("FFMPEG_HWACCEL", "False")
 
+# CLIP model used for object filtering in scheduling
+CLIP_MODEL_NAME = get_setting(
+    "CLIP_MODEL_NAME",
+    "openai/clip-vit-base-patch32",
+)
+
 
 # New settings for capture_frame_from_stream function
 NUM_FRAMES = int(get_setting("NUM_FRAMES", 3))

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -19,7 +19,13 @@ from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw, ImageFont
 from transformers import CLIPProcessor, CLIPModel
 
-from app.config import DEBUG, SCREENSHOT_DIRECTORY, SUMMARIES_DIRECTORY, VIDEO_DIRECTORY
+from app.config import (
+    DEBUG,
+    SCREENSHOT_DIRECTORY,
+    SUMMARIES_DIRECTORY,
+    VIDEO_DIRECTORY,
+    CLIP_MODEL_NAME,
+)
 from app.utils.db import SessionLocal
 from app.models import Summary
 
@@ -426,14 +432,10 @@ def update_camera(name, template, image_file=None):
             global clip_model, clip_processor
 
             if clip_model is None:
-                clip_model = CLIPModel.from_pretrained(
-                    "openai/clip-vit-base-patch32"
-                )  # TODO: make these models configurable
+                clip_model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
 
             if clip_processor is None:
-                clip_processor = CLIPProcessor.from_pretrained(
-                    "openai/clip-vit-base-patch32"
-                )
+                clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
 
             # Load the latest image
             latest_image_path = os.path.join(directory, png_files[-1])

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -116,5 +116,7 @@ Additional variables control AI behaviour and external tools:
 - `FFMPEG_PATH` – path to the `ffmpeg` binary (default `ffmpeg`)
 - `FFPROBE_PATH` – path to the `ffprobe` binary (default `ffprobe`)
 - `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (`False` disables)
+- `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
+  Example: `openai/clip-vit-large-patch14`
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -1,0 +1,96 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.utils.scheduling as scheduling
+
+
+class TestClipModelSetting(unittest.TestCase):
+    def test_custom_clip_model_used(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cam_dir = os.path.join(tmp, "cam1")
+            os.makedirs(cam_dir)
+            Image.new("RGB", (10, 10)).save(
+                os.path.join(cam_dir, "cam1_20240101000000.png")
+            )
+
+            template = {
+                "name": "cam1",
+                "object_filter": "dog",
+                "object_confidence": 0,
+                "last_caption": "",
+                "last_motion_caption": "",
+                "notes": "",
+                "frequency": 30,
+                "motion": 0,
+                "livecaption": "false",
+            }
+
+            class DummyLogits:
+                def softmax(self, dim):
+                    class Prob:
+                        def __getitem__(self, idx):
+                            return 1.0
+
+                    return Prob()
+
+            class DummyOutput:
+                def __init__(self):
+                    self.logits_per_image = DummyLogits()
+
+            class DummyModel:
+                calls = []
+
+                @classmethod
+                def from_pretrained(cls, name):
+                    cls.calls.append(name)
+                    return cls()
+
+                def __call__(self, **inputs):
+                    return DummyOutput()
+
+            class DummyProcessor:
+                calls = []
+
+                @classmethod
+                def from_pretrained(cls, name):
+                    cls.calls.append(name)
+                    return cls()
+
+                def __call__(self, text, images, return_tensors=None, padding=None):
+                    return {}
+
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("app.utils.scheduling.CLIP_MODEL_NAME", "custom-model"),
+                patch("app.utils.scheduling.capture_or_download", return_value=True),
+                patch("app.utils.scheduling.add_timestamp"),
+                patch("app.utils.scheduling.remove_background"),
+                patch("app.utils.scheduling.add_motion_and_caption"),
+                patch("app.utils.scheduling.save_template"),
+                patch("app.utils.scheduling.send_http_callback"),
+                patch("app.utils.scheduling.chatgpt_compare", return_value="caption"),
+                patch("app.utils.scheduling.is_mostly_blank", return_value=False),
+                patch("app.utils.scheduling.get_template", return_value=template),
+                patch("os.symlink"),
+                patch("os.rename"),
+                patch("os.unlink"),
+                patch("app.utils.scheduling.CLIPModel", DummyModel) as mock_model_class,
+                patch(
+                    "app.utils.scheduling.CLIPProcessor", DummyProcessor
+                ) as mock_processor_class,
+            ):
+                scheduling.clip_model = None
+                scheduling.clip_processor = None
+                scheduling.update_camera("cam1", template)
+                self.assertEqual(DummyModel.calls, ["custom-model"])
+                self.assertEqual(DummyProcessor.calls, ["custom-model"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `CLIP_MODEL_NAME` option to config
- use configured CLIP model in scheduler
- document new setting in configuration guide
- test that custom CLIP model name is used

## Testing
- `flake8 tests/test_clip_config.py app/utils/scheduling.py app/config.py`
- `black tests/test_clip_config.py app/utils/scheduling.py app/config.py`
- `pytest -q tests/test_clip_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf61cab74833382db1813fdfc6e3c