### PR TITLE
Add TOTP authentication

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, Integer, String
 
 from app.utils.db import Base
 
+
 class User(Base):
     __tablename__ = "users"
 
@@ -9,6 +10,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=False)
     password_hash = Column(String, nullable=False)
     role = Column(String, nullable=True)
+    totp_secret = Column(String, nullable=True)
 
     def __repr__(self) -> str:
         return f"<User id={self.id} username={self.username}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -75,6 +75,7 @@ from app.utils.db import SessionLocal, engine
 from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
 from app.utils.profiling import profile_route, get_latency_stats
+from app.utils.totp import verify_totp_code
 
 
 def restart_server():
@@ -923,6 +924,7 @@ def init_routes(app):
         if request.method == "POST":
             username = request.form["username"]
             password = request.form["password"]
+            valid_login = True
 
             db_session = SessionLocal()
             try:
@@ -931,17 +933,27 @@ def init_routes(app):
                 db_session.close()
 
             if user and check_password_hash(user.password_hash, password):
-                session["user_id"] = user.id
-                session["expiry"] = (
-                    now + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
-                ).strftime("%Y-%m-%d %H:%M:%S")
-                session.permanent = True
-                login_attempts.pop(
-                    ip_address, None
-                )  # Reset attempts on successful login
-                logging.info("Successful login for %s from %s", username, ip_address)
-                return redirect(url_for("index"))
+                if user.totp_secret and not verify_totp_code(
+                    user.totp_secret, request.form.get("totp_code")
+                ):
+                    valid_login = False
+                else:
+                    session["user_id"] = user.id
+                    session["expiry"] = (
+                        now + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
+                    ).strftime("%Y-%m-%d %H:%M:%S")
+                    session.permanent = True
+                    login_attempts.pop(
+                        ip_address, None
+                    )  # Reset attempts on successful login
+                    logging.info(
+                        "Successful login for %s from %s", username, ip_address
+                    )
+                    return redirect(url_for("index"))
             else:
+                valid_login = False
+
+            if not valid_login:
                 # Record the failed attempt
                 if ip_address not in login_attempts:
                     login_attempts[ip_address] = {"attempts": 1, "locked_until": now}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,7 +7,9 @@
             Username:<br>
             <input type="text" name="username" required title="Enter your username"><br>
             Password:<br>
-            <input type="password" name="password" required title="Enter your password"><br><br>
+            <input type="password" name="password" required title="Enter your password"><br>
+            TOTP Code:<br>
+            <input type="text" name="totp_code" title="Time-based one-time password"><br><br>
 
             {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}

--- a/app/utils/totp.py
+++ b/app/utils/totp.py
@@ -1,0 +1,17 @@
+import pyotp
+
+
+def generate_totp_secret() -> str:
+    """Return a new random base32 secret for TOTP."""
+    return pyotp.random_base32()
+
+
+def verify_totp_code(secret: str, code: str) -> bool:
+    """Verify a user-provided TOTP code against the secret."""
+    if not secret or not code:
+        return False
+    try:
+        totp = pyotp.TOTP(secret)
+        return totp.verify(code, valid_window=1)
+    except Exception:
+        return False

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,6 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Troubleshooting](troubleshooting.md)
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
+- [Two-Factor Authentication](totp.md)
 - [LLM Cost Tracking](cost_tracking.md)
 

--- a/docs/totp.md
+++ b/docs/totp.md
@@ -1,0 +1,18 @@
+# Enabling Two-Factor Authentication
+
+Glimpser supports time-based one-time passwords (TOTP) for an optional second
+authentication factor.
+
+1. Install the extra dependency:
+   ```sh
+   pip install pyotp
+   ```
+2. Generate a secret for your user in the database. You can use the helper
+   function `generate_totp_secret` from `app.utils.totp` and store the value in
+   the `totp_secret` column.
+3. Add the secret to your authenticator app (such as Google Authenticator).
+4. When logging in, enter the current TOTP code along with your username and
+   password.
+
+If no `totp_secret` is set, the code field may be left blank and login proceeds
+normally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ python-dateutil
 python-dotenv
 nodriver
 pytest
+pyotp
 flax==0.2.0
 jax[cpu]==0.6.1

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -66,6 +66,40 @@ class TestAuthentication(unittest.TestCase):
             # seems sus...
             # self.assertIn("/", response.headers["Path"])
 
+    def test_login_success_with_totp(self):
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.check_password_hash", return_value=True
+        ), patch("app.routes.verify_totp_code", return_value=True):
+            dummy_user = SimpleNamespace(
+                id=1, username=USER_NAME, password_hash="hash", totp_secret="x"
+            )
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.post(
+                "/login",
+                data={
+                    "username": USER_NAME,
+                    "password": "correct_password",
+                    "totp_code": "123456",
+                },
+            )
+            self.assertEqual(response.status_code, 302)
+
     def test_login_failure(self):
         with patch("app.routes.SessionLocal") as mock_session_local, patch(
             "app.routes.check_password_hash", return_value=False
@@ -90,6 +124,40 @@ class TestAuthentication(unittest.TestCase):
 
             response = self.client.post(
                 "/login", data={"username": USER_NAME, "password": "wrong_password"}
+            )
+            self.assertEqual(response.status_code, 200)
+
+    def test_login_failure_bad_totp(self):
+        with patch("app.routes.SessionLocal") as mock_session_local, patch(
+            "app.routes.check_password_hash", return_value=True
+        ), patch("app.routes.verify_totp_code", return_value=False):
+            dummy_user = SimpleNamespace(
+                id=1, username=USER_NAME, password_hash="hash", totp_secret="x"
+            )
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.post(
+                "/login",
+                data={
+                    "username": USER_NAME,
+                    "password": "correct_password",
+                    "totp_code": "000000",
+                },
             )
             self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
## Summary
- add `totp_secret` field to `User`
- provide `generate_totp_secret` and `verify_totp_code`
- update login page and route for TOTP check
- document enabling two-factor auth
- test login success and failure with TOTP

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyotp')*

------
https://chatgpt.com/codex/tasks/task_e_683cf619e3e083339006d4361ef50a02