### PR TITLE
Add CLI overrides for config paths

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@
 import os
 import json
 import logging
+import argparse
 from importlib.metadata import PackageNotFoundError, version
 
 from dotenv import load_dotenv, find_dotenv
@@ -13,10 +14,35 @@ load_dotenv(find_dotenv())
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-# TODO: also consider argparse...
-DATABASE_PATH = os.getenv("GLIMPSER_DATABASE_PATH", "data/glimpser.db")
-LOGGING_PATH = os.getenv("GLIMPSER_LOGGING_PATH", "logs/glimpser.log")
-BACKUP_PATH = os.getenv("GLIMPSER_BACKUP_PATH", "data/config_backup.json")
+
+# Parse command line arguments when executed directly
+def _parse_cli_args():
+    parser = argparse.ArgumentParser(description="Glimpser configuration")
+    parser.add_argument("--db-path", help="Path to the SQLite database file")
+    parser.add_argument("--log-path", help="Path to the log file")
+    parser.add_argument(
+        "--backup-path", help="Path to the configuration backup JSON file"
+    )
+    return parser.parse_args()
+
+
+_cli_args = _parse_cli_args() if __name__ == "__main__" else None
+
+DATABASE_PATH = (
+    _cli_args.db_path
+    if _cli_args and _cli_args.db_path
+    else os.getenv("GLIMPSER_DATABASE_PATH", "data/glimpser.db")
+)
+LOGGING_PATH = (
+    _cli_args.log_path
+    if _cli_args and _cli_args.log_path
+    else os.getenv("GLIMPSER_LOGGING_PATH", "logs/glimpser.log")
+)
+BACKUP_PATH = (
+    _cli_args.backup_path
+    if _cli_args and _cli_args.backup_path
+    else os.getenv("GLIMPSER_BACKUP_PATH", "data/config_backup.json")
+)
 
 # todo.. make sure this is not duplicate loading...
 engine = create_engine(f"sqlite:///{DATABASE_PATH}")

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,6 +1,6 @@
 # Command Line Reference
 
-This guide describes the available command line arguments for the main `glimpser` application and the `generate_credentials.py` utility.
+This guide describes the available command line arguments for the main `glimpser` application, `generate_credentials.py`, and `app/config.py` when run as a script.
 
 ## glimpser (main.py)
 
@@ -34,4 +34,15 @@ This helper script creates or updates the credentials stored in the database.
 | `--secret-key` | Custom secret key; a new one is generated if not provided. |
 | `--update-key` | Replace the stored secret key. |
 
-Use `--help` with either script to see these options from the command line.
+## config.py
+
+When invoked directly, `app/config.py` accepts a few path options to override the
+defaults loaded from environment variables:
+
+| Argument | Description |
+| --- | --- |
+| `--db-path` | Override the SQLite database location. |
+| `--log-path` | Override the main log file path. |
+| `--backup-path` | Override the configuration backup file. |
+
+Use `--help` with any script to see these options from the command line.


### PR DESCRIPTION
## Summary
- parse command line args in `app/config.py` when run directly
- document `config.py` CLI options

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cf63f5738833389ae47d398c53e2b