### PR TITLE
Add persistent log storage

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,14 +20,14 @@ from app.utils.video_archiver import archive_screenshots, compile_to_teaser
 from app.config import backup_config, restore_config
 from app.utils.email_alerts import email_alert
 from app.utils.sms_alerts import sms_alert
-
-# from app.utils.db import SessionLocal
-# from app.models.log import Log
+from app.utils.db import SessionLocal
+from app.models.log import Log
+from sqlalchemy.orm import scoped_session
 
 # needed for the llava compare
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-"""
+
 class SQLAlchemyHandler(logging.Handler):
     def __init__(self):
         super().__init__()
@@ -35,13 +35,13 @@ class SQLAlchemyHandler(logging.Handler):
 
     def emit(self, record):
         log_entry = Log(
+            timestamp=int(record.created),
             level=record.levelname,
             message=record.getMessage(),
-            source=record.name
+            source=record.name,
         )
         self.session.add(log_entry)
         self.session.commit()
-"""
 
 
 def create_app(enable_watchdog=True, schedule=True):
@@ -91,6 +91,7 @@ def create_app(enable_watchdog=True, schedule=True):
     )
     # Set up logging
     app.logger.setLevel(logging.WARN)  # todo: read from config....
+    logging.getLogger().addHandler(SQLAlchemyHandler())
 
     # Ensure required directories exist
     os.makedirs(SCREENSHOT_DIRECTORY, exist_ok=True)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .user import User
 from .summary import Summary
+from .log import Log
 
-__all__ = ["User", "Summary"]
+__all__ = ["User", "Summary", "Log"]

--- a/app/models/log.py
+++ b/app/models/log.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Text
+
+from app.utils.db import Base
+
+
+class Log(Base):
+    """Persistent log entry."""
+
+    __tablename__ = "logs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(Integer, nullable=False)
+    level = Column(String, nullable=False)
+    source = Column(String, nullable=False)
+    message = Column(Text, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<Log id={self.id} level={self.level}>"

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -38,6 +38,18 @@ To filter logs by level and message text, you could request:
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 
+## Persistent Log Storage
+
+All log entries are also written to the `logs` table in the SQLite database. You
+can inspect them directly:
+
+```bash
+sqlite3 data/glimpser.db "SELECT level, source, message FROM logs ORDER BY id DE
+SC LIMIT 10;"
+```
+
+This table is created automatically when the application starts.
+
 The `/status` page also appears on the `/discover` screen as a **System Status**
 camera. Adding it lets Glimpser capture periodic screenshots of its own health
 metrics.

--- a/tests/test_log_storage.py
+++ b/tests/test_log_storage.py
@@ -1,0 +1,84 @@
+import importlib
+import logging
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import app.config as config
+import app.utils.db as db
+import app.utils.scheduling as scheduling
+import app as app_module
+from app.models import Log
+
+
+class TestLogStorage(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        self.env_patch = patch.dict(
+            os.environ, {"GLIMPSER_DATABASE_PATH": self.db_path}
+        )
+        self.env_patch.start()
+
+        importlib.reload(config)
+        importlib.reload(db)
+        importlib.reload(scheduling)
+        import app.models as models
+
+        importlib.reload(models)
+        importlib.reload(models.log)
+        db.init_db()
+        importlib.reload(app_module)
+        self.create_app = app_module.create_app
+
+        self.patcher_cache = patch("app.start_log_caching", lambda: None)
+        self.patcher_metrics = patch(
+            "app.start_metrics_collection",
+            lambda: None,
+            create=True,
+        )
+        self.patcher_email = patch("app.email_alert", lambda *a, **k: None)
+        self.patcher_sms = patch("app.sms_alert", lambda *a, **k: None)
+        for p in (
+            self.patcher_cache,
+            self.patcher_metrics,
+            self.patcher_email,
+            self.patcher_sms,
+        ):
+            p.start()
+
+        self.app = self.create_app(enable_watchdog=False, schedule=False)
+
+    def tearDown(self):
+        for p in (
+            self.patcher_cache,
+            self.patcher_metrics,
+            self.patcher_email,
+            self.patcher_sms,
+        ):
+            p.stop()
+
+        self.env_patch.stop()
+        importlib.reload(config)
+        importlib.reload(db)
+        importlib.reload(scheduling)
+        import app.models as models
+
+        importlib.reload(models)
+        importlib.reload(models.log)
+        self.temp_dir.cleanup()
+
+    def test_log_records_saved(self):
+        logging.getLogger().setLevel(logging.INFO)
+        logging.getLogger().info("stored via db")
+        session = db.SessionLocal()
+        try:
+            messages = [row.message for row in session.query(Log).all()]
+            self.assertIn("stored via db", messages)
+        finally:
+            session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `Log` SQLAlchemy model
- expose model in package
- write log records to database using `SQLAlchemyHandler`
- test log persistence
- document new logging table

## Testing
- `python -m pytest tests/test_log_storage.py -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_683cf510c26c83339b608d67e62cb3f5