### PR TITLE
Implement RTSP keepalive

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1212,6 +1212,7 @@ def init_routes(app):
                     "seq": random.randint(0, 65535),
                     "timestamp": random.randint(0, 0xFFFFFFFF),
                     "ssrc": random.randint(0, 0xFFFFFFFF),
+                    "last_keepalive": time.time(),
                 }
 
             transport = request.headers.get("Transport", "")
@@ -1259,7 +1260,10 @@ def init_routes(app):
             return Response(headers={"CSeq": cseq, "Session": session_id})
 
         elif request.method == "GET_PARAMETER":
-            return "Method Not Allowed", 405
+            if session_id not in rtsp_sessions:
+                abort(454)
+            rtsp_sessions[session_id]["last_keepalive"] = time.time()
+            return Response(headers={"CSeq": cseq, "Session": session_id})
 
         elif request.method == "TEARDOWN":
             if session_id in rtsp_sessions:

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -119,7 +119,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`.
+- **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 
 ### 6. Trigger Screenshot Capture
 

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -53,13 +53,14 @@ class TestRTSP(unittest.TestCase):
         self.assertEqual(resp.headers.get("Session"), session_id)
         self.assertEqual(routes.rtsp_sessions[session_id]["state"], "PLAYING")
 
-        # GET_PARAMETER not implemented
+        # GET_PARAMETER keepalive
         resp = self.client.open(
             "/test.rtsp",
             method="GET_PARAMETER",
             headers={"CSeq": "5", "Session": session_id},
         )
-        self.assertEqual(resp.status_code, 405)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("Session"), session_id)
 
         # rtsp_stream should return RTP packets when PLAYING
         fake_frame = b"JPEGDATA"


### PR DESCRIPTION
## Summary
- handle `GET_PARAMETER` to keep RTSP sessions alive
- document RTSP keepalive in API docs
- update RTSP tests for new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cfa7c50288333a46a2cf83bda9b09