### PR TITLE
Add --no-crawlers flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ common flags are:
 # Start without the background scheduler
 glimpser --no-scheduler
 
+# Skip scheduling crawler jobs
+glimpser --no-crawlers
+
 # Disable the watchdog thread
 glimpser --no-watchdog
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -44,7 +44,7 @@ class SQLAlchemyHandler(logging.Handler):
 """
 
 
-def create_app(enable_watchdog=True, schedule=True):
+def create_app(enable_watchdog=True, schedule=True, crawlers=True):
     """Create and configure the Flask application.
 
     This function sets up the entire Flask application, including:
@@ -64,6 +64,11 @@ def create_app(enable_watchdog=True, schedule=True):
         configuration using :func:`restore_config` and exits the process so
         an external supervisor can restart it.  Pass ``False`` to disable
         this thread entirely, which is useful when running unit tests.
+
+    crawlers : bool, optional
+        When ``True`` (the default) crawler jobs are scheduled.  Pass
+        ``False`` to skip scheduling crawlers, which is useful during
+        testing or when using the application purely for playback.
 
     Returns
     -------
@@ -122,7 +127,8 @@ def create_app(enable_watchdog=True, schedule=True):
             scheduler.remove_all_jobs()
 
             # Schedule various periodic tasks
-            schedule_crawlers()  # TODO: make this a command line argument
+            if crawlers:
+                schedule_crawlers()
             scheduler.add_job(
                 id="compile_to_teaser",
                 func=compile_to_teaser,

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -17,6 +17,7 @@ The primary application script accepts the following options:
 | `--debug` | Enable debug mode. |
 | `--no-scheduler` | Disable the background scheduler. |
 | `--no-watchdog` | Disable the watchdog thread. |
+| `--no-crawlers` | Skip scheduling crawler jobs. |
 | `--screenshot-dir` | Directory for storing screenshots. |
 | `--video-dir` | Directory for storing video files. |
 | `--summaries-dir` | **Deprecated:** summaries are now stored in the database. |

--- a/main.py
+++ b/main.py
@@ -85,6 +85,12 @@ def parse_arguments(arg_list=None):
         default=False,
     )
     parser.add_argument(
+        "--no-crawlers",
+        action="store_true",
+        help="Skip scheduling crawler jobs",
+        default=False,
+    )
+    parser.add_argument(
         "--screenshot-dir",
         default=config.SCREENSHOT_DIRECTORY,
         help="Directory for storing screenshots",
@@ -209,9 +215,11 @@ def create_application(args=None):
 
     schedule = not getattr(args, "no_scheduler", False)
     enable_watchdog = not getattr(args, "no_watchdog", False)
+    crawlers = not getattr(args, "no_crawlers", False)
 
-    return create_app(enable_watchdog=enable_watchdog, schedule=schedule)
-
+    return create_app(
+        enable_watchdog=enable_watchdog, schedule=schedule, crawlers=crawlers
+    )
 
 
 def output_shutdown_stats():
@@ -272,7 +280,6 @@ def clear_console():
         _ = os.system("clear")
 
 
-
 def is_port_in_use(port):
     # Skip the check if running in Docker
     if os.environ.get("IN_DOCKER"):
@@ -280,7 +287,6 @@ def is_port_in_use(port):
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0
-
 
 
 def main(argv=None):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,8 +139,12 @@ class TestMain(unittest.TestCase):
         args.no_scheduler = True
         args.no_watchdog = True
 
+        args.no_crawlers = True
+
         main.create_application(args)
-        mock_create_app.assert_called_with(enable_watchdog=False, schedule=False)
+        mock_create_app.assert_called_with(
+            enable_watchdog=False, schedule=False, crawlers=False
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--no-crawlers` flag to command line parser
- wire flag through `create_application` and `create_app`
- skip scheduling crawlers when disabled
- document the new option
- test `create_application` with the new flag

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cfc15532483338c5cdf8063a76a5d