### PR TITLE
Enforce image time threshold

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -101,7 +101,11 @@ def run_with_timeout(func, args=(), timeout=300):
         logging.warning("Process terminated due to timeout")
 
 
-def find_closest_image(directory, last_caption_time):
+MAX_IMAGE_TIME_DIFF = datetime.timedelta(minutes=5)
+
+
+def find_closest_image(directory, last_caption_time, max_time_diff=MAX_IMAGE_TIME_DIFF):
+    """Return the closest motion image not older than ``max_time_diff``."""
     closest_image = None
     min_time_diff = None
 
@@ -115,9 +119,12 @@ def find_closest_image(directory, last_caption_time):
             timestamp_str = filename.split("_")[0]
             try:
                 timestamp = datetime.datetime.strptime(timestamp_str, "%Y%m%d%H%M%S")
-                time_diff = abs(
-                    last_caption_time - timestamp
-                )  # todo.. can't go over...
+                time_diff = abs(last_caption_time - timestamp)
+
+                # Ignore images outside the allowed time window
+                if time_diff > max_time_diff:
+                    continue
+
                 if min_time_diff is None or time_diff < min_time_diff:
                     closest_image = filename
                     min_time_diff = time_diff

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -5,10 +5,19 @@ from unittest.mock import patch, MagicMock
 import sys
 import os
 import logging
+import tempfile
+from datetime import datetime, timedelta
+from PIL import Image
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from app.utils.scheduling import scheduler, schedule_crawlers, start_log_caching
+from app.utils.scheduling import (
+    scheduler,
+    schedule_crawlers,
+    start_log_caching,
+    find_closest_image,
+)
+
 
 class TestScheduler(unittest.TestCase):
 
@@ -25,10 +34,10 @@ class TestScheduler(unittest.TestCase):
 
         # Simulate the running of the scheduler (normally done in a separate thread)
         job_func = scheduler.get_job('test_job').func
-        job_func() # hopefully takes less than 5 seconds
+        job_func()  # hopefully takes less than 5 seconds
 
-        job.assert_called_once() 
-        scheduler.remove_job('test_job') 
+        job.assert_called_once()
+        scheduler.remove_job('test_job')
 
     @patch('time.sleep', return_value=None)  # Corrected patch target
     def test_run_scheduled_jobs(self, mock_sleep):
@@ -81,7 +90,7 @@ class TestScheduler(unittest.TestCase):
         # Ensure job2 still runs
         job_func2 = scheduler.get_job('test_job2').func
         job_func2()
-        #job2.assert_called_once() # TODO: fix this ...
+        # job2.assert_called_once() # TODO: fix this ...
         scheduler.remove_job('test_job2')
 
     @patch('time.sleep', return_value=None)
@@ -115,6 +124,22 @@ class TestScheduler(unittest.TestCase):
         mock_thread.return_value.start.assert_called_once()
         mock_add_job.assert_not_called()
 
+    def test_find_closest_image_none_when_outside_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            times = [
+                datetime(2023, 1, 1, 0, 0, 0),
+                datetime(2023, 1, 1, 0, 5, 0),
+            ]
+            for t in times:
+                filename = t.strftime('%Y%m%d%H%M%S') + '_motion.png'
+                Image.new('RGB', (1, 1)).save(os.path.join(tmp, filename))
+
+            last_caption_time = datetime(2023, 1, 1, 0, 10, 0)
+            result = find_closest_image(
+                tmp, last_caption_time, max_time_diff=timedelta(seconds=60)
+            )
+            self.assertIsNone(result)
+
     '''
     @patch('app.utils.scheduling.scheduler.add_job')
     @patch('app.utils.scheduling.get_templates', return_value={
@@ -134,6 +159,6 @@ class TestScheduler(unittest.TestCase):
             mock_add_job.assert_not_called()
     '''
 
+
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
## Summary
- cap how far back `find_closest_image` will search
- test that images outside the threshold are ignored

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cfc18c85c83338753552b52a7ac7d