### PR TITLE
Add console clearing CLI

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -46,3 +46,8 @@ defaults loaded from environment variables:
 | `--backup-path` | Override the configuration backup file. |
 
 Use `--help` with any script to see these options from the command line.
+
+## glimpser-clear
+
+This helper clears the console screen. It uses the same logic as the main
+application's startup routine and works on Windows, macOS and Linux.

--- a/main.py
+++ b/main.py
@@ -213,7 +213,6 @@ def create_application(args=None):
     return create_app(enable_watchdog=enable_watchdog, schedule=schedule)
 
 
-
 def output_shutdown_stats():
     # Get and display system metrics
     metrics = get_system_metrics()
@@ -272,6 +271,10 @@ def clear_console():
         _ = os.system("clear")
 
 
+def clear_console_cli():
+    """Entry point for the ``glimpser-clear`` command."""
+    clear_console()
+
 
 def is_port_in_use(port):
     # Skip the check if running in Docker
@@ -280,7 +283,6 @@ def is_port_in_use(port):
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0
-
 
 
 def main(argv=None):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points={
         "console_scripts": [
             "glimpser=main:main",
+            "glimpser-clear=main:clear_console_cli",
         ],
     },
 )

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -78,6 +78,11 @@ class TestMainUtilities(unittest.TestCase):
             main.clear_console()
             mock_system.assert_called_once_with("clear")
 
+    @patch("main.clear_console")
+    def test_clear_console_cli_calls_clear(self, mock_clear):
+        main.clear_console_cli()
+        mock_clear.assert_called_once()
+
     @patch("main.socket.socket")
     def test_is_port_in_use(self, mock_socket):
         mock_instance = mock_socket.return_value.__enter__.return_value


### PR DESCRIPTION
## Summary
- add `clear_console_cli` helper and install as `glimpser-clear`
- document new command-line tool
- test console clearing CLI helper

## Testing
- `flake8`
- `pytest tests/test_main_utilities.py::TestMainUtilities::test_clear_console_cli_calls_clear -q`

------
https://chatgpt.com/codex/tasks/task_e_683cfc34acb08333be43027d35601dfa