### PR TITLE
Finalize generate_video_stream

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -320,9 +320,12 @@ def update_setting(name: str, value: str) -> bool:
     return True
 
 
-# TODO:
 def generate_video_stream(video_path: str):
-    """Yield video data in chunks, looping continuously."""
+    """Yield video data in chunks and restart when the end is reached."""
+
+    # The video preview on the UI expects an infinite generator. Read the
+    # file in 1MB increments and loop back to the beginning once no more
+    # bytes are available.
 
     chunk_size = 1024 * 1024  # 1 MB
     while True:
@@ -331,13 +334,15 @@ def generate_video_stream(video_path: str):
             break
 
         with open(video_path, "rb") as video:
-            chunk = video.read(chunk_size)
-            while chunk:
-                yield chunk
+            while True:
                 chunk = video.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
 
+        # Immediately loop back and stream again so the client sees a
+        # seamless loop without gaps.
         logging.debug("Restarting video stream")
-        time.sleep(30)  # Wait before streaming again
 
 
 def generate_live_stream(url: str):

--- a/tests/test_routes_utils.py
+++ b/tests/test_routes_utils.py
@@ -8,13 +8,15 @@ import os
 from unittest.mock import patch
 
 # Provide a dummy psutil module if it's not installed
-if 'psutil' not in sys.modules:
-    sys.modules['psutil'] = types.ModuleType('psutil')
+if "psutil" not in sys.modules:
+    sys.modules["psutil"] = types.ModuleType("psutil")
 
-if 'flask' not in sys.modules:
-    flask_mock = types.ModuleType('flask')
+if "flask" not in sys.modules:
+    flask_mock = types.ModuleType("flask")
+
     def _dummy(*args, **kwargs):
         return None
+
     flask_mock.abort = _dummy
     flask_mock.jsonify = lambda *a, **k: {}
     flask_mock.flash = _dummy
@@ -25,75 +27,86 @@ if 'flask' not in sys.modules:
     flask_mock.send_from_directory = _dummy
     flask_mock.session = {}
     flask_mock.url_for = lambda *a, **k: ""
-    flask_mock.Response = type('Response', (), {})
-    flask_mock.Flask = type('Flask', (), {})
-    sys.modules['flask'] = flask_mock
+    flask_mock.Response = type("Response", (), {})
+    flask_mock.Flask = type("Flask", (), {})
+    sys.modules["flask"] = flask_mock
 
-if 'sqlalchemy' not in sys.modules:
-    sqlalchemy_mock = types.ModuleType('sqlalchemy')
+if "sqlalchemy" not in sys.modules:
+    sqlalchemy_mock = types.ModuleType("sqlalchemy")
     sqlalchemy_mock.text = lambda *a, **k: None
-    sys.modules['sqlalchemy'] = sqlalchemy_mock
-    sys.modules['sqlalchemy.orm'] = types.ModuleType('sqlalchemy.orm')
-    sys.modules['sqlalchemy.orm'].sessionmaker = lambda *a, **k: None
+    sys.modules["sqlalchemy"] = sqlalchemy_mock
+    sys.modules["sqlalchemy.orm"] = types.ModuleType("sqlalchemy.orm")
+    sys.modules["sqlalchemy.orm"].sessionmaker = lambda *a, **k: None
 
-if 'werkzeug.security' not in sys.modules:
-    ws_mock = types.ModuleType('werkzeug.security')
+if "werkzeug.security" not in sys.modules:
+    ws_mock = types.ModuleType("werkzeug.security")
     ws_mock.check_password_hash = lambda pw_hash, pw: True
-    sys.modules['werkzeug.security'] = ws_mock
+    sys.modules["werkzeug.security"] = ws_mock
 
-if 'werkzeug.utils' not in sys.modules:
-    wu_mock = types.ModuleType('werkzeug.utils')
+if "werkzeug.utils" not in sys.modules:
+    wu_mock = types.ModuleType("werkzeug.utils")
     wu_mock.secure_filename = lambda x: x
-    sys.modules['werkzeug.utils'] = wu_mock
+    sys.modules["werkzeug.utils"] = wu_mock
 
-if 'PIL' not in sys.modules:
-    pil_mock = types.ModuleType('PIL')
-    pil_mock.Image = type('Image', (), {})
-    sys.modules['PIL'] = pil_mock
+if "PIL" not in sys.modules:
+    pil_mock = types.ModuleType("PIL")
+    pil_mock.Image = type("Image", (), {})
+    sys.modules["PIL"] = pil_mock
 
-if 'app.config' not in sys.modules:
-    config_mock = types.ModuleType('app.config')
-    config_mock.API_KEY = 'dummy'
-    config_mock.SCREENSHOT_DIRECTORY = ''
-    config_mock.USER_NAME = ''
-    config_mock.USER_PASSWORD_HASH = ''
-    config_mock.VIDEO_DIRECTORY = ''
+if "app.config" not in sys.modules:
+    config_mock = types.ModuleType("app.config")
+    config_mock.API_KEY = "dummy"
+    config_mock.SCREENSHOT_DIRECTORY = ""
+    config_mock.USER_NAME = ""
+    config_mock.USER_PASSWORD_HASH = ""
+    config_mock.VIDEO_DIRECTORY = ""
     config_mock.VERSION = 0
-    config_mock.BACKUP_PATH = ''
+    config_mock.BACKUP_PATH = ""
     config_mock.backup_config = lambda: None
     config_mock.restore_config = lambda: None
-    sys.modules['app.config'] = config_mock
+    sys.modules["app.config"] = config_mock
 
 # Stub app.utils and submodules used in app.routes
-if 'app.utils' not in sys.modules:
-    utils_pkg = types.ModuleType('app.utils')
-    sys.modules['app.utils'] = utils_pkg
+if "app.utils" not in sys.modules:
+    utils_pkg = types.ModuleType("app.utils")
+    sys.modules["app.utils"] = utils_pkg
 
-for sub in ['scheduling', 'template_manager', 'video_archiver', 'screenshots', 'db', 'retention_policy', 'email_alerts']:
-    mod_name = f'app.utils.{sub}'
+for sub in [
+    "scheduling",
+    "template_manager",
+    "video_archiver",
+    "screenshots",
+    "db",
+    "retention_policy",
+    "email_alerts",
+]:
+    mod_name = f"app.utils.{sub}"
     if mod_name not in sys.modules:
         mod = types.ModuleType(mod_name)
         sys.modules[mod_name] = mod
-        if sub == 'scheduling':
+        if sub == "scheduling":
             mod.log_cache = []
+
             class DummyLock:
                 def acquire(self):
                     pass
+
                 def release(self):
                     pass
+
             mod.log_cache_lock = DummyLock()
             mod.schedule_crawlers = lambda *a, **k: None
             mod.schedule_summarization = lambda *a, **k: None
             mod.scheduler = None
             mod.start_log_caching = lambda: None
-        if sub == 'db':
+        if sub == "db":
             mod.SessionLocal = lambda: None
-        if sub == 'retention_policy':
+        if sub == "retention_policy":
             mod.retention_cleanup = lambda *a, **k: None
-        if sub == 'video_archiver':
+        if sub == "video_archiver":
             mod.archive_screenshots = lambda *a, **k: None
             mod.compile_to_teaser = lambda *a, **k: None
-        if sub == 'email_alerts':
+        if sub == "email_alerts":
             mod.email_alert = lambda *a, **k: None
 
 from app.routes import generate_timed_hash, is_hash_valid, generate_video_stream
@@ -117,7 +130,9 @@ class TestRoutesUtils(unittest.TestCase):
 
             # Expired timestamp -> invalid
             expired_time = str(int(time.time()) - 1)
-            expired_digest = hashlib.sha256(f"{constant_key}{expired_time}".encode()).hexdigest()
+            expired_digest = hashlib.sha256(
+                f"{constant_key}{expired_time}".encode()
+            ).hexdigest()
             expired_value = f"{expired_digest}.{expired_time}"
             self.assertFalse(is_hash_valid(expired_value))
 
@@ -127,18 +142,27 @@ class TestRoutesUtils(unittest.TestCase):
 
 
 class TestGenerateVideoStream(unittest.TestCase):
-    @patch("app.routes.time.sleep", return_value=None)
-    def test_generate_video_stream(self, _):
+    def test_generate_video_stream(self):
+        """Generator yields chunks and restarts when finished."""
+
         with tempfile.NamedTemporaryFile(delete=False) as temp:
-            temp.write(b"data")
+            chunk1 = b"a" * (1024 * 1024)
+            chunk2 = b"b" * (1024 * 1024)
+            chunk3 = b"c" * (512 * 1024)
+            temp.write(chunk1 + chunk2 + chunk3)
             temp.flush()
             path = temp.name
 
         gen = generate_video_stream(path)
-        chunk = next(gen)
-        self.assertEqual(chunk, b"data")
-        gen.close()
-        os.remove(path)
+        try:
+            self.assertEqual(next(gen), chunk1)
+            self.assertEqual(next(gen), chunk2)
+            self.assertEqual(next(gen), chunk3)
+            # Generator should restart from the beginning
+            self.assertEqual(next(gen), chunk1)
+        finally:
+            gen.close()
+            os.remove(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- finalize video stream generator so playback loops
- test generator chunking and restart behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cffa4fd988333b889b876eca71181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved video preview streaming to loop seamlessly without delays or gaps.

- **Tests**
	- Enhanced test coverage and reliability for video streaming functionality.
	- Improved test setup for better simulation of dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->