### PR TITLE
Add template sorting query

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -43,6 +43,7 @@ from .screenshots import (
 from .template_manager import (
     get_template,
     get_templates,
+    get_templates_sorted_by_last_caption_time,
     save_template,
     update_last_screenshot_time,
     mark_offline,
@@ -658,17 +659,9 @@ def update_summary():
 
     # summarize all of htis together
     lstring = "The following are a list of real time dashboards and cameras, and their recent status updates:\n"
-    templates = get_templates()  # Make sure to fetch the templates within this function
+    templates = get_templates_sorted_by_last_caption_time()
 
-    # Sort templates by last_caption_time, descending order
-    # TODO: this could just be a sql call instead
-    sorted_templates = sorted(
-        templates.items(),
-        key=lambda item: item[1].get("last_caption_time", ""),
-        reverse=True,
-    )
-
-    for id, template in sorted_templates:
+    for id, template in templates:
         name = template.get("name")
         if "private" in template.get("groups", ""):
             continue

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -126,6 +126,33 @@ class TemplateManager:
         finally:
             session.close()
 
+    def get_templates_by_last_caption_time(self):
+        """Return templates ordered by ``last_caption_time`` descending.
+
+        Returns
+        -------
+        list
+            Tuples of template name and attribute dicts sorted newest first.
+        """
+
+        session = self.get_session()
+        try:
+            templates = (
+                session.query(Template)
+                .order_by(Template.last_caption_time.desc())
+                .all()
+            )
+            result = []
+            for template in templates:
+                if template.name is None or template.name == "":
+                    continue
+                data = template.__dict__.copy()
+                data.pop("_sa_instance_state", None)
+                result.append((template.name, data))
+            return result
+        finally:
+            session.close()
+
     def save_template(self, name, details):
         """Create or update a template in the database.
 
@@ -337,6 +364,13 @@ def get_templates():
         details["last_screenshot_time"] = get_latest_screenshot_date(camera_path)
         details["last_video_time"] = get_latest_video_date(video_path)
     return templates
+
+
+def get_templates_sorted_by_last_caption_time():
+    """Return templates sorted by ``last_caption_time`` newest first."""
+
+    manager = TemplateManager()
+    return manager.get_templates_by_last_caption_time()
 
 
 def get_template(name):

--- a/tests/test_fuzz_update_summary.py
+++ b/tests/test_fuzz_update_summary.py
@@ -37,7 +37,8 @@ class TestFuzzUpdateSummary(unittest.TestCase):
                 }
 
                 with patch(
-                    "app.utils.scheduling.get_templates", return_value=templates
+                    "app.utils.scheduling.get_templates_sorted_by_last_caption_time",
+                    return_value=list(templates.items()),
                 ), patch(
                     "app.utils.scheduling.summarize",
                     return_value="".join(

--- a/tests/test_summary_storage.py
+++ b/tests/test_summary_storage.py
@@ -39,7 +39,10 @@ class TestSummaryStorage(unittest.TestCase):
         importlib.reload(models.summary)
         self.temp_dir.cleanup()
 
-    @patch("app.utils.scheduling.get_templates", return_value={})
+    @patch(
+        "app.utils.scheduling.get_templates_sorted_by_last_caption_time",
+        return_value=[],
+    )
     @patch("app.utils.scheduling.summarize", return_value='{"1":"foo"}')
     def test_update_summary_saves_to_db(self, mock_sum, mock_get_templates):
         scheduling.update_summary()

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -48,6 +48,26 @@ class TestTemplateManager(unittest.TestCase):
         self.assertEqual(result["template2"]["frequency"], 120)
 
     @patch("app.utils.template_manager.SessionLocal")
+    def test_get_templates_by_last_caption_time(self, mock_session):
+        mock_session_instance = MagicMock()
+        mock_session.return_value = mock_session_instance
+        mock_query = mock_session_instance.query.return_value
+        mock_order = mock_query.order_by
+        mock_all = mock_order.return_value.all
+
+        t1 = Template(name="t1", last_caption_time="2023-01-01 00:00:00")
+        t2 = Template(name="t2", last_caption_time="2023-01-02 00:00:00")
+        t3 = Template(name="t3", last_caption_time="2023-01-03 00:00:00")
+        mock_all.return_value = [t3, t2, t1]
+
+        result = self.template_manager.get_templates_by_last_caption_time()
+
+        self.assertEqual(result[0][0], "t3")
+        self.assertEqual(result[1][0], "t2")
+        self.assertEqual(result[2][0], "t1")
+        mock_order.assert_called()
+
+    @patch("app.utils.template_manager.SessionLocal")
     def test_save_template(self, mock_session):
         # Mock the session and query
         mock_session_instance = MagicMock()


### PR DESCRIPTION
## Summary
- support retrieving templates ordered by `last_caption_time`
- use the new query in `update_summary`
- adjust template manager tests
- update summary tests for new helper

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cffc18d148333af81c3b35a0ee878