### PR TITLE
Increase default frequency/timeout for stealth templates

### DIFF
--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -64,15 +64,35 @@ def validate_update_data(data: dict) -> dict:
 
     sanitized = {}
 
+    stealth_flag = str(data.get("stealth", False)).lower() in {
+        "true",
+        "1",
+        "t",
+        "y",
+        "yes",
+        "on",
+    }
+    browser_flag = str(data.get("browser", False)).lower() in {
+        "true",
+        "1",
+        "t",
+        "y",
+        "yes",
+        "on",
+    }
+
+    default_frequency = 60 if stealth_flag or browser_flag else 30
+    default_timeout = 30 if stealth_flag or browser_flag else 10
+
     url = (data.get("url") or "").strip()
     if not url:
         raise ValueError("url is required")
     sanitized["url"] = url
 
     try:
-        frequency = int(data.get("frequency", 30) or 30)
+        frequency = int(data.get("frequency", default_frequency) or default_frequency)
     except (TypeError, ValueError):
-        frequency = 30
+        frequency = default_frequency
     if frequency < 1:
         frequency = 1
     if frequency > 525600:
@@ -80,9 +100,9 @@ def validate_update_data(data: dict) -> dict:
     sanitized["frequency"] = frequency
 
     try:
-        timeout = int(data.get("timeout", 10) or 10)
+        timeout = int(data.get("timeout", default_timeout) or default_timeout)
     except (TypeError, ValueError):
-        timeout = 10
+        timeout = default_timeout
     if timeout < 1:
         timeout = 1
     max_timeout = frequency * 60

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -106,6 +106,13 @@ Settings controlling how frames are captured from video sources:
 - `PROBE_SIZE_OTHER` – probe size for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 
+### Stealth Browser Defaults
+
+Templates that enable `stealth` or `browser` mode require heavier page loads. If
+`frequency` or `timeout` are omitted for such templates, Glimpser defaults to a
+`frequency` of **60 minutes** and a `timeout` of **30 seconds** to reduce the
+load on target sites and allow extra time for rendering.
+
 ## Advanced Options
 
 Additional variables control AI behaviour and external tools:

--- a/tests/test_update_validation.py
+++ b/tests/test_update_validation.py
@@ -38,6 +38,18 @@ class TestValidateUpdateData(unittest.TestCase):
         result = validate_update_data(data)
         self.assertEqual(result["proxy"], "http://localhost:8080")
 
+    def test_stealth_defaults(self):
+        data = {"url": "http://example", "stealth": True}
+        result = validate_update_data(data)
+        self.assertEqual(result["frequency"], 60)
+        self.assertEqual(result["timeout"], 30)
+
+    def test_browser_defaults(self):
+        data = {"url": "http://example", "browser": True}
+        result = validate_update_data(data)
+        self.assertEqual(result["frequency"], 60)
+        self.assertEqual(result["timeout"], 30)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- bump defaults in `validate_update_data` when stealth or browser mode is used
- document stealth browser defaults
- verify defaults with new tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cffceb17c8333859be13413b88cbd