### PR TITLE
Add http_session singleton tests

### DIFF
--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+from requests.structures import CaseInsensitiveDict
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.utils.screenshots as ss
+
+
+class TestHttpSession(unittest.TestCase):
+    @patch("app.utils.screenshots.requests.Session")
+    def test_http_session_singleton_and_headers(self, mock_session_cls):
+        session_instance = MagicMock()
+        session_instance.headers = CaseInsensitiveDict()
+        mock_session_cls.return_value = session_instance
+
+        ss._session = None
+
+        sess1 = ss.http_session()
+        sess2 = ss.http_session()
+
+        self.assertIs(sess1, sess2)
+        mock_session_cls.assert_called_once()
+        self.assertIn("User-Agent", sess1.headers)
+        self.assertIn("Accept", sess1.headers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test `http_session` to verify singleton behavior and headers

## Testing
- `black tests/test_screenshots_misc.py`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d003b0278833391414c861998d1d4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify correct initialization and singleton behavior of the HTTP session, including required headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->