### PR TITLE
Add caching test for get_driver

### DIFF
--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch, sentinel
+
+import app.utils.screenshots as ss
+
+
+class TestGetDriver(unittest.TestCase):
+    def setUp(self):
+        ss._DRIVER = None
+
+    def tearDown(self):
+        ss._DRIVER = None
+
+    def test_driver_cached(self):
+        with patch(
+            "app.utils.screenshots.ChromeDriverManager.install",
+            return_value=sentinel.binary,
+        ) as mock_install, patch(
+            "app.utils.screenshots.webdriver.Chrome",
+            return_value=sentinel.driver,
+        ) as mock_chrome:
+            driver1 = ss.get_driver(sentinel.options)
+            driver2 = ss.get_driver(sentinel.options)
+            self.assertIs(driver1, sentinel.driver)
+            self.assertIs(driver1, driver2)
+            mock_install.assert_called_once()
+            mock_chrome.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test caching behavior of `get_driver`

## Testing
- `black tests/test_screenshots_misc.py app/utils/screenshots.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d0040e870833397b3126f36d1784d