### PR TITLE
Detect template edits and reschedule jobs

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -153,7 +153,9 @@ class TemplateManager:
             if template is None:
                 template = Template()
                 session.add(template)
-            ldelta = False
+                ldelta = True
+            else:
+                ldelta = False
             if template:
                 for key, value in details.items():
                     try:
@@ -219,6 +221,8 @@ class TemplateManager:
                         ldelta = True
             if ldelta is True:
                 session.commit()
+                # Recreate the scheduler job so the new settings take effect
+                _update_scheduler_job(name, template.frequency)
             return True
         except Exception as e:
             logging.error("Error saving template: %s", str(e))
@@ -648,3 +652,32 @@ def mark_offline(name: str) -> None:
             session.commit()
     finally:
         session.close()
+
+
+def _update_scheduler_job(name: str, frequency: int) -> None:
+    """Reschedule the APScheduler job for ``name`` if it exists.
+
+    The scheduler uses the template's frequency to determine the interval. Any
+    update should remove the old job and create a new one so changes apply
+    immediately.
+    """
+
+    from . import scheduling  # Imported here to avoid circular dependency
+
+    try:
+        scheduling.scheduler.remove_job(name)
+    except Exception:
+        pass
+
+    seconds = 60 * int(frequency)
+    try:
+        scheduling.scheduler.add_job(
+            func=scheduling.update_camera,
+            trigger="interval",
+            seconds=seconds,
+            args=[name, {}],
+            id=name,
+            replace_existing=True,
+        )
+    except Exception as e:
+        logging.error("job schedule error: %s", e)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -64,3 +64,4 @@ When adding new features, include corresponding tests under the `tests/` directo
 - Scheduler helpers are tested in `tests/test_scheduling_more.py`.
 - Template update validation ensures numeric fields remain in range and
   required values are present.
+- `save_template` now reschedules APScheduler jobs when a template is edited.

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -308,5 +308,27 @@ class TestStorageUsage(unittest.TestCase):
                 self.assertEqual(result, "3.0 KB")
 
 
+class TestSchedulerUpdates(unittest.TestCase):
+    @patch("app.utils.scheduling.scheduler")
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_save_template_reschedules_job(self, mock_session, mock_sched):
+        """Updating a template should recreate its scheduled job."""
+
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        template = Template(name="cam1", frequency=1)
+        mock_sess.query.return_value.filter_by.return_value.first.return_value = (
+            template
+        )
+
+        manager = TemplateManager()
+        result = manager.save_template("cam1", {"frequency": 2})
+
+        self.assertTrue(result)
+        mock_sess.commit.assert_called_once()
+        mock_sched.remove_job.assert_called_with("cam1")
+        mock_sched.add_job.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reschedule APScheduler jobs when a template is saved
- document scheduler rescheduling in developer guide
- test that saving a template recreates its job

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cffc743148333b2b3a0fc2d912185