### PR TITLE
Improve summarization frame selection

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -103,6 +103,38 @@ def run_with_timeout(func, args=(), timeout=300):
 
 MAX_IMAGE_TIME_DIFF = datetime.timedelta(minutes=5)
 
+# Separator used when building LLM prompts that contain multiple segments.
+# This helps the model understand logical breaks in the text.
+PROMPT_SEPARATOR = "\n---\n"
+
+
+def select_comparison_frames(directory, latest):
+    """Return a list of comparison frames in priority order.
+
+    The function looks for a reference frame and the previous motion frame
+    before appending the provided latest frame. Only existing files are
+    returned to avoid sending invalid paths to the LLM.
+    """
+
+    frames = []
+
+    reference = os.path.join(directory, "reference.png")
+    if os.path.exists(reference):
+        frames.append(reference)
+
+    prev_motion = os.path.join(directory, "prev_motion.png")
+    if os.path.exists(prev_motion):
+        frames.append(prev_motion)
+    else:
+        last_motion = os.path.join(directory, "last_motion.png")
+        if os.path.exists(last_motion):
+            frames.append(last_motion)
+
+    if latest:
+        frames.append(latest)
+
+    return frames
+
 
 def find_closest_image(directory, last_caption_time, max_time_diff=MAX_IMAGE_TIME_DIFF):
     """Return the closest motion image not older than ``max_time_diff``."""
@@ -473,31 +505,9 @@ def update_camera(name, template, image_file=None, motion=False):
             # allow this to run one time if we have no detection
             #  generate the symlink. if there is a data/screenshots/<camera>/last_motion.png, please rename the move the symlink to prev_motion.png
             #    then, create the symlink for last_motion.png to point to the new png_files[-1]
-            image_paths = []
-            # add reference image if exists
-            if os.path.exists(
-                os.path.join(directory, "reference.png")
-            ):  # if doesnt exist, consider taking the oldest?
-                image_paths.append(os.path.join(directory, "reference.png"))
-
-            # Find the image that closest matches the last_caption_time
-            if "last_caption_time" in template and template["last_caption_time"] != "":
-                try:
-                    last_caption_time = parser.parse(template["last_caption_time"])
-                    closest_image_filename = find_closest_image(
-                        directory, last_caption_time
-                    )
-                    if closest_image_filename:
-                        closest_image_path = os.path.join(
-                            directory, closest_image_filename
-                        )
-                        logging.debug("last caption.... %s", closest_image_path)
-                        image_paths.append(closest_image_path)
-                except Exception as e:
-                    logging.warning("caption parsing error %s", e)
-                    pass
-
-            image_paths.append(os.path.join(directory, png_files[-1]))
+            image_paths = select_comparison_frames(
+                directory, os.path.join(directory, png_files[-1])
+            )
 
             lctime = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -523,10 +533,15 @@ def update_camera(name, template, image_file=None, motion=False):
             if last_caption_trigger or template.get("last_caption") is None:
                 lprompt = ""
                 if template.get("notes"):
-                    lprompt += " " + template["notes"]
-                #  use Chatgpt_compare
+                    # Split multi-line notes to keep prompts concise.
+                    segments = [
+                        seg.strip()
+                        for seg in re.split(r"\n+", template["notes"])
+                        if seg.strip()
+                    ]
+                    lprompt = PROMPT_SEPARATOR.join(segments)
+                # Use ChatGPT to compare the selected frames.
                 gret = chatgpt_compare(lprompt, image_paths, template_name=name)
-                # TODO: add a separator?
                 # print("  oldgpt:", name, template.get('last_caption'))
                 # print("  newgpt:", name, gret)
                 if gret and re.findall(r"(?:sorry|cannot|can not)", gret):

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Recommendations](recommendations.md)
 - [Troubleshooting](troubleshooting.md)
 - [Architecture Overview](architecture_overview.md)
+- [Summarization Flow](summarization_flow.md)
 - [UI Accessibility Improvements](accessibility.md)
 - [LLM Cost Tracking](cost_tracking.md)
 

--- a/docs/summarization_flow.md
+++ b/docs/summarization_flow.md
@@ -1,0 +1,13 @@
+# Summarization Flow
+
+This document outlines how Glimpser generates captions and summaries from captured images.
+
+1. **Frame Selection** – When motion is detected, `update_camera` picks the most relevant frames for the LLM:
+   - `reference.png` if available.
+   - `prev_motion.png` or the previous `last_motion.png` symlink.
+   - The latest captured frame.
+2. **Prompt Preparation** – Template notes are split on newlines and joined with the `---` separator to keep prompts concise.
+3. **LLM Comparison** – The selected frames and prepared prompt are passed to `chatgpt_compare`, which calls the ChatGPT API to generate a caption.
+4. **Summary Update** – Generated captions are stored and later aggregated by `update_summary` to produce a brief system-wide overview.
+
+These steps ensure only meaningful frames are compared and prompts remain manageable for the language model.

--- a/tests/test_frame_selection.py
+++ b/tests/test_frame_selection.py
@@ -1,0 +1,43 @@
+import unittest
+import tempfile
+import os
+import sys
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.scheduling import select_comparison_frames
+
+
+class TestSelectComparisonFrames(unittest.TestCase):
+    def test_selects_existing_frames(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Image.new("RGB", (1, 1)).save(os.path.join(tmp, "reference.png"))
+            Image.new("RGB", (1, 1)).save(os.path.join(tmp, "prev_motion.png"))
+            latest = os.path.join(tmp, "latest.png")
+            Image.new("RGB", (1, 1)).save(latest)
+
+            frames = select_comparison_frames(tmp, latest)
+            self.assertEqual(
+                frames,
+                [
+                    os.path.join(tmp, "reference.png"),
+                    os.path.join(tmp, "prev_motion.png"),
+                    latest,
+                ],
+            )
+
+    def test_fallback_to_last_motion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Image.new("RGB", (1, 1)).save(os.path.join(tmp, "last_motion.png"))
+            latest = os.path.join(tmp, "new.png")
+            Image.new("RGB", (1, 1)).save(latest)
+
+            frames = select_comparison_frames(tmp, latest)
+            self.assertIn(os.path.join(tmp, "last_motion.png"), frames)
+            self.assertIn(latest, frames)
+            self.assertEqual(len(frames), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refine comparison frame selection for image summarization
- split prompt lines with a separator for the LLM
- document summarization flow
- test new comparison frame helper

## Testing
- `flake8 app/utils/scheduling.py tests/test_frame_selection.py`
- `pytest tests/test_frame_selection.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cffbac58c833395b72ab1bdc95710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved prompt formatting for clearer logical separation in generated captions and summaries.
- **Documentation**
  - Added a new "Summarization Flow" guide outlining the steps for generating captions and summaries.
  - Updated the documentation index to include the new guide.
- **Tests**
  - Introduced new tests to verify the selection of image frames for comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->