### PR TITLE
Improve discovery info display

### DIFF
--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -1,4 +1,17 @@
 {% extends 'base.html' %}
+{% macro show_info(info) -%}
+    {%- set pieces = [] %}
+    {%- if info.name %}{% set _ = pieces.append(info.name) %}{% endif %}
+    {%- if info.xaddr %}{% set _ = pieces.append(info.xaddr) %}{% endif %}
+    {%- if info.path %}{% set _ = pieces.append(info.path) %}{% endif %}
+    {%- if info.sdp %}{% set _ = pieces.append('SDP available') %}{% endif %}
+    {%- for k, v in info.items() %}
+        {%- if k not in ['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'] %}
+            {%- set _ = pieces.append(k ~ ': ' ~ v) %}
+        {%- endif %}
+    {%- endfor %}
+    {{ pieces|join(' ') }}
+{%- endmacro %}
 {% block content %}
     <h2>Discovered Cameras</h2>
     <button id="discover-btn" title="Scan the network for cameras">Discover</button>
@@ -24,7 +37,7 @@
                 <td>{{ cam.port }}</td>
                 <td>{{ cam.info.mac }}</td>
                 <td>{{ cam.info.manufacturer }}</td>
-                <td>{{ cam.info }}</td>
+                <td>{{ show_info(cam.info) }}</td>
                 <td>
                     <form action="/discover/add" method="post">
                         <input type="hidden" name="ip" value="{{ cam.ip }}">
@@ -46,6 +59,20 @@
     const msg = document.getElementById('discover-message');
     const progress = document.getElementById('discover-progress');
     const body = document.getElementById('discover-body');
+    const renderInfo = (info) => {
+        if (!info) return '';
+        const pieces = [];
+        if (info.name) pieces.push(info.name);
+        if (info.xaddr) pieces.push(info.xaddr);
+        if (info.path) pieces.push(info.path);
+        if (info.sdp) pieces.push('SDP available');
+        Object.entries(info).forEach(([k, v]) => {
+            if (!['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'].includes(k)) {
+                pieces.push(`${k}: ${v}`);
+            }
+        });
+        return pieces.join(' ');
+    };
     if (button) {
         button.addEventListener('click', () => {
             msg.textContent = 'Searching...';
@@ -65,7 +92,7 @@
                     <td>${cam.port}</td>
                     <td>${cam.info.mac || ''}</td>
                     <td>${cam.info.manufacturer || ''}</td>
-                    <td>${JSON.stringify(cam.info)}</td>
+                    <td>${renderInfo(cam.info)}</td>
                     <td>
                         <form action="/discover/add" method="post">
                             <input type="hidden" name="ip" value="${cam.ip}">

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -131,7 +131,8 @@ After scanning, `discover_cameras()` removes duplicates and returns the final li
 Each entry is also augmented with the device's MAC address and, when known,
 the manufacturer derived from its OUI prefix.  These details appear as separate
 columns in the discovery table so you can quickly identify where each camera
-originates.
+originates. The **Info** column now summarizes key details such as a camera's
+name, ONVIF address, or HTTP path instead of showing the raw JSON dictionary.
 
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.


### PR DESCRIPTION
## Summary
- format discovery "Info" column with camera name, path, etc.
- document the friendlier info display

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cff7748448333a62a57c93c114713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the display of camera information in the discovery table with a cleaner, more readable summary of key details.
  - Ensured consistent formatting of camera info for both initial page load and live discovery updates.

- **Documentation**
  - Updated documentation to clarify the new summarized presentation of camera information in the discovery table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->