### PR TITLE
Add video keyboard shortcuts

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -87,6 +87,29 @@ export function setupVideoControls() {
   if (castButton) {
     castButton.addEventListener('click', startCasting);
   }
+
+  document.addEventListener('keydown', (e) => {
+    const tag = e.target.tagName.toLowerCase();
+    if (tag === 'input' || tag === 'textarea') return;
+    switch (e.key) {
+      case ' ': // Spacebar
+      case 'k':
+        e.preventDefault();
+        video.paused ? video.play() : video.pause();
+        break;
+      case 'm':
+        video.muted = !video.muted;
+        break;
+      case 'f':
+        if (video.requestFullscreen) video.requestFullscreen();
+        else if (video.mozRequestFullScreen) video.mozRequestFullScreen();
+        else if (video.webkitRequestFullscreen) video.webkitRequestFullscreen();
+        else if (video.msRequestFullscreen) video.msRequestFullscreen();
+        break;
+      default:
+        break;
+    }
+  });
 }
 
 export function setupStatusPageVideoHover() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,3 +39,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation menus use a consistent accent color with smooth hover effects.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
+- Keyboard shortcuts now allow play/pause, mute, and fullscreen toggling when watching live video.

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -23,5 +23,8 @@ On the **Live** page, pick a camera from the drop-down menu and set the **Video
 Source** to **Live Video**. This connects you directly to the realtime feed so
 you can monitor activity as it happens.
 
+When watching a live stream, you can use keyboard shortcuts:
+`Space` or `k` toggles play/pause, `m` toggles mute, and `f` toggles fullscreen.
+
 Navigate back to the main interface using the **Back to Glimpser** link at the
 bottom of the help page.


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for play/pause, mute and fullscreen
- document shortcuts in the help page and README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cff8a22b08333bba3ebca89692b46