### PR TITLE
Add capture failure tracking

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -293,6 +293,10 @@ video:hover + .play-icon {
     border: 5px solid rgba(255, 255, 255, 0.9); /* Faint white border */
 }
 
+.template-error {
+    border: 5px solid red;
+}
+
 /* Improve video controls on mobile */
 @media (max-width: 767px) {
     .templateDiv video::-webkit-media-controls-panel {
@@ -814,6 +818,11 @@ input[type=submit]:hover {
 .offline-indicator {
     text-align: center;
     color: white;
+}
+
+.error-indicator {
+    text-align: center;
+    color: red;
 }
 
 

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -300,6 +300,7 @@ export async function loadTemplates() {
         const oneMinuteAgo = new Date(Date.now() - 60000);
         const isRecent = lastScreenshotDate > oneMinuteAgo;
         const videoContainerClass = isRecent ? 'video-container recent-screenshot' : 'video-container';
+        const errorClass = template.capture_failed ? 'template-error' : '';
 
         if (isIndexPage) {
           const templateDiv = document.createElement('div');
@@ -310,7 +311,7 @@ export async function loadTemplates() {
 
           templateDiv.innerHTML = `
             <a href='/templates/${name}'>
-              <div class="${videoContainerClass}">
+              <div class="${videoContainerClass} ${errorClass}">
                 <div class="camera-name">${name}</div>
                 <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none">
                   <source src="/last_video/${name}" type="video/mp4">

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -144,6 +144,10 @@
                 <i class="fas fa-video-slash video-icon"></i>
                 <p id="offline-message"></p>
             </div>
+            <div id="capture-error-indicator" class="error-indicator hidden">
+                <i class="fas fa-exclamation-triangle video-icon"></i>
+                <p id="capture-error-message"></p>
+            </div>
         </div>
         <div id="error-message"></div>
     </div>
@@ -170,6 +174,8 @@
         const playButton = document.getElementById('play-pause');
         const offlineIndicator = document.getElementById('offline-indicator');
         const offlineMessage = document.getElementById('offline-message');
+        const errorIndicator = document.getElementById('capture-error-indicator');
+        const errorIndicatorMessage = document.getElementById('capture-error-message');
 
         function showLoadingIndicator() {
             videoOverlay.style.display = 'block';
@@ -220,6 +226,26 @@
             offlineIndicator.style.display = 'none';
             offlineMessage.textContent = '';
             if (loadingIndicator.style.display === 'none' && playPauseIndicator.style.display === 'none') {
+                videoOverlay.style.display = 'none';
+            }
+        }
+
+        function showCaptureErrorIndicator(cameraName) {
+            videoOverlay.style.display = 'block';
+            errorIndicator.style.display = 'block';
+            errorIndicatorMessage.textContent = `Capture failed for ${cameraName}`;
+            loadingIndicator.style.display = 'none';
+            playPauseIndicator.style.display = 'none';
+        }
+
+        function hideCaptureErrorIndicator() {
+            errorIndicator.style.display = 'none';
+            errorIndicatorMessage.textContent = '';
+            if (
+                loadingIndicator.style.display === 'none' &&
+                playPauseIndicator.style.display === 'none' &&
+                offlineIndicator.style.display === 'none'
+            ) {
                 videoOverlay.style.display = 'none';
             }
         }
@@ -315,6 +341,7 @@ function changeCamera() {
                     <strong>Last Video:</strong> ${details.last_video_time || 'N/A'}<br/>
                     <strong>Last Caption:</strong> ${details.last_caption || 'N/A'}<br/>
                     ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ''}
+                    ${details.capture_failed ? '<strong>Capture Failed</strong><br/>' : ''}
                 </div>`;
         }
 
@@ -325,6 +352,15 @@ function changeCamera() {
 
             if (!isConnected) {
                 showOfflineIndicator(currentCamera);
+                hideCaptureErrorIndicator();
+                hideLoadingIndicator();
+                video.pause();
+                video.src = '';
+                image.src = '';
+                return;
+            } else if (templateDetails[currentCamera].capture_failed) {
+                hideOfflineIndicator();
+                showCaptureErrorIndicator(currentCamera);
                 hideLoadingIndicator();
                 video.pause();
                 video.src = '';
@@ -332,6 +368,7 @@ function changeCamera() {
                 return;
             } else {
                 hideOfflineIndicator();
+                hideCaptureErrorIndicator();
                 if (!['png', 'mjpg', 'motion'].includes(source)) {
                     showLastScreenshot();
                 }
@@ -698,6 +735,10 @@ function playMotion() {
         }
 
         if (camera.offline_since && camera.offline_since !== "") {
+            return false;
+        }
+
+        if (camera.capture_failed) {
             return false;
         }
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -118,6 +118,9 @@ function updateVideo(templateName) {
             {% if template_details.offline_since %}
             <li><strong>Offline Since:</strong> {{ template_details.offline_since }}</li>
             {% endif %}
+            {% if template_details.capture_failed %}
+            <li><strong>Capture Failed:</strong> Yes</li>
+            {% endif %}
         </ul>
     </div>
 
@@ -337,7 +340,8 @@ function showCameraDetails(templateName) {
         'Last Video Time': meta.last_video_time,
         'Last Caption': meta.last_caption,
         'Caption Time': meta.last_caption_time,
-        'Offline Since': meta.offline_since
+        'Offline Since': meta.offline_since,
+        'Capture Failed': meta.capture_failed
     };
 
     let detailsHtml = '<h3>Camera Endpoints</h3><pre>';

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -46,6 +46,7 @@ from .template_manager import (
     save_template,
     update_last_screenshot_time,
     mark_offline,
+    set_capture_failed,
 )
 from .email_alerts import email_alert
 from .sms_alerts import sms_alert
@@ -241,7 +242,6 @@ def update_camera(name, template, image_file=None, motion=False):
             image = remove_background(image)
             image.save(output_path, "PNG")
             if os.path.exists(output_path):
-                # TODO: add error mark from lerror
                 add_timestamp(output_path, name, invert=template.get("invert", False))
                 os.rename(output_path, output_path.replace(".tmp.png", ".png"))
                 lsuc = True
@@ -250,6 +250,7 @@ def update_camera(name, template, image_file=None, motion=False):
 
     if lsuc is True:
         update_last_screenshot_time(name)
+        set_capture_failed(name, False)
     else:
         entry = throttle_cache.get(url)
         if (
@@ -258,6 +259,7 @@ def update_camera(name, template, image_file=None, motion=False):
             and time.time() - entry.get("first", time.time()) > 60 * 60 * 24
         ):
             mark_offline(name)
+        set_capture_failed(name, True)
 
     if lsuc is True:
         directory = os.path.join(SCREENSHOT_DIRECTORY, name)

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -39,6 +39,7 @@ class Template(Base):
     last_screenshot_time = Column(Text, default="")
     last_video_time = Column(Text, default="")
     offline_since = Column(Text, default="")
+    capture_failed = Column(Boolean, default=False)
     object_filter = Column(String, default="")
     object_confidence = Column(Float, default=0.5)
     popup_xpath = Column(String, default="")
@@ -628,6 +629,7 @@ def update_last_screenshot_time(name: str) -> None:
                 "%Y-%m-%d %H:%M:%S"
             )
             template.offline_since = ""
+            template.capture_failed = False
             session.commit()
     finally:
         session.close()
@@ -645,6 +647,23 @@ def mark_offline(name: str) -> None:
         template = session.query(Template).filter_by(name=name).first()
         if template and not template.offline_since:
             template.offline_since = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            session.commit()
+    finally:
+        session.close()
+
+
+def set_capture_failed(name: str, failed: bool) -> None:
+    """Set ``capture_failed`` flag for ``name``."""
+    name = validate_template_name(name)
+    if name is None:
+        return
+
+    manager = TemplateManager()
+    session = manager.get_session()
+    try:
+        template = session.query(Template).filter_by(name=name).first()
+        if template:
+            template.capture_failed = bool(failed)
             session.commit()
     finally:
         session.close()

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,3 +39,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation menus use a consistent accent color with smooth hover effects.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
+- Templates track capture failures and display a warning icon when screenshots fail.

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -11,6 +11,7 @@ from app.utils.template_manager import (
     Template,
     mark_offline,
     update_last_screenshot_time,
+    set_capture_failed,
     get_storage_usage,
 )
 from app.utils.validators import validate_template_name
@@ -284,6 +285,20 @@ class TestOfflineHandling(unittest.TestCase):
 
         self.assertEqual(template.offline_since, "")
         self.assertNotEqual(template.last_screenshot_time, "")
+        mock_sess.commit.assert_called_once()
+
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_set_capture_failed_updates_flag(self, mock_session):
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        template = Template(name="cam1")
+        mock_sess.query.return_value.filter_by.return_value.first.return_value = (
+            template
+        )
+
+        set_capture_failed("cam1", True)
+
+        self.assertTrue(template.capture_failed)
         mock_sess.commit.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- track screenshot failures in templates
- expose capture_failed flag via TemplateManager
- show error status in live and details views
- style error indicator and grid item borders
- document capture failure indicator
- test new set_capture_failed helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683cffb219888333b95b97ea450b3279