### PR TITLE
Update digital clock title

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -23,7 +23,7 @@
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
                         <div id="dateDisplay" class="clock-face">
-                            <div id="digitalTime" class="clock-hands" title="todo $digitalTime">
+                            <div id="digitalTime" class="clock-hands" title="">
                                 <div class="hand hour-hand"></div>
                                 <div class="hand minute-hand"></div>
                                 <div class="hand second-hand"></div>


### PR DESCRIPTION
## Summary
- sanitize the title attribute on the digital clock element so it starts empty

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d47ba0a548333a3800327591e63cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed placeholder text from the clock component's tooltip in the navigation bar for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->