### PR TITLE
Implement LLM response counting

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -628,10 +628,31 @@ def record_llm_usage(name: str, tokens: int) -> None:
 def get_llm_response_count(name: str) -> int:
     """Return the number of LLM responses recorded for ``name``.
 
-    This is currently a placeholder that returns a random number.
+    Counts how many response entries are stored for the template in
+    ``LLM_USAGE_PATH``. The function is tolerant of the existing data format
+    where token usage may be recorded as either a list of entries or a single
+    cumulative integer.
     """
 
-    return random.randint(10, 100)
+    name = validate_template_name(name)
+    if name is None:
+        return 0
+
+    if not os.path.exists(LLM_USAGE_PATH):
+        return 0
+
+    try:
+        with open(LLM_USAGE_PATH, "r") as f:
+            data = json.load(f)
+    except Exception:
+        return 0
+
+    entry = data.get(name, [])
+    if isinstance(entry, list):
+        return len(entry)
+    if isinstance(entry, int):
+        return 1 if entry > 0 else 0
+    return 0
 
 
 def get_llm_cost_estimate(name: str) -> str:
@@ -690,7 +711,6 @@ def mark_offline(name: str) -> None:
         session.close()
 
 
-
 def set_capture_failed(name: str, failed: bool) -> None:
     """Set ``capture_failed`` flag for ``name``."""
     name = validate_template_name(name)
@@ -706,6 +726,7 @@ def set_capture_failed(name: str, failed: bool) -> None:
             session.commit()
     finally:
         session.close()
+
 
 def _update_scheduler_job(name: str, frequency: int) -> None:
     """Reschedule the APScheduler job for ``name`` if it exists.
@@ -734,4 +755,3 @@ def _update_scheduler_job(name: str, frequency: int) -> None:
         )
     except Exception as e:
         logging.error("job schedule error: %s", e)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Retention policy file sorting is also verified by tests.
 - Screenshot utility functions now have dedicated unit tests.
 - Shutdown helpers and port checks are validated by new tests.
-- LLM response count is now verified by a unit test that patches `random.randint`.
+- LLM response count now reads the number of stored entries in `data/llm_usage.json`.
 - Footer now displays the package version from installed metadata.
 - Footer version link shows a warning icon when a newer release is available.
 - The VERSION setting now syncs with the installed package version on startup.

--- a/tests/test_llm_response_count.py
+++ b/tests/test_llm_response_count.py
@@ -1,20 +1,30 @@
 import sys
 import os
+import json
 import unittest
-from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.utils.template_manager import get_llm_response_count
+from app.utils.template_manager import get_llm_response_count, LLM_USAGE_PATH
 
 
 class TestLLMResponseCount(unittest.TestCase):
-    @patch("app.utils.template_manager.random.randint", return_value=42)
-    def test_get_llm_response_count(self, mock_randint):
-        """get_llm_response_count should return the patched random value."""
+    def setUp(self):
+        if os.path.exists(LLM_USAGE_PATH):
+            os.remove(LLM_USAGE_PATH)
+
+    def tearDown(self):
+        if os.path.exists(LLM_USAGE_PATH):
+            os.remove(LLM_USAGE_PATH)
+
+    def test_get_llm_response_count(self):
+        """Counts the number of stored responses for the template."""
+        os.makedirs(os.path.dirname(LLM_USAGE_PATH), exist_ok=True)
+        with open(LLM_USAGE_PATH, "w") as f:
+            json.dump({"cam1": [1, 2, 3]}, f)
+
         result = get_llm_response_count("cam1")
-        self.assertEqual(result, 42)
-        mock_randint.assert_called_once_with(10, 100)
+        self.assertEqual(result, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement counting logic in `get_llm_response_count`
- test the new behaviour with a real usage file
- document how LLM response count works

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d47cbfb448333826c6c4a4624c98d