### PR TITLE
Handle additional HTTP errors in screenshot capture

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1046,6 +1046,11 @@ def capture_or_download(name: str, template: dict) -> bool:
     ):  # try every 1 hour no matter what??
         return False
 
+    cached_status = get_cached_status_code(url)
+    if cached_status is not None and cached_status >= 400:
+        logging.debug(f"Skipping {url} due to cached status {cached_status}")
+        return False
+
     popup_xpath = template.get("popup_xpath")
     dedicated_selector = template.get("dedicated_xpath")
     timeout = int(template.get("timeout", 30) or 30)
@@ -1275,8 +1280,9 @@ def get_content_type(url, danger, stealth=False) -> (str, bool):
                     stream=(verb == "GET"),
                 )
 
-            if resp.status_code == 404:
-                logging.info(f"Missing {url}")
+            if resp.status_code >= 400:
+                logging.info(f"HTTP error {resp.status_code} for {url}")
+                set_cached_status_code(url, resp.status_code)
                 return "", False
 
             modified = check_if_modified(url, resp.headers)
@@ -1315,8 +1321,9 @@ def get_content_type(url, danger, stealth=False) -> (str, bool):
                     allow_redirects=True,
                 )
 
-            if response.status_code == 404: # todo: consider other 
-                logging.info(f"Missing {url}")
+            if response.status_code >= 400:
+                logging.info(f"HTTP error {response.status_code} for {url}")
+                set_cached_status_code(url, response.status_code)
                 return "", False
 
             modified = check_if_modified(url, response.headers)

--- a/tests/test_capture_status_errors.py
+++ b/tests/test_capture_status_errors.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+import sys
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.utils.screenshots as ss
+
+
+class TestCaptureStatusErrors(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.patcher = patch(
+            "app.utils.screenshots.STATUS_CACHE_PATH",
+            os.path.join(self.tmpdir, "cache.json"),
+        )
+        self.patcher.start()
+        ss.status_code_cache.clear()
+        ss.status_code_cache_time.clear()
+        ss._persist_status_cache()
+
+    def tearDown(self):
+        self.patcher.stop()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    @patch("app.utils.screenshots.is_address_reachable")
+    @patch("app.utils.screenshots.download_image")
+    def test_capture_skips_on_cached_error(self, mock_download, mock_reachable):
+        url = "http://example.com/image.png"
+        ss.set_cached_status_code(url, 403)
+        result = ss.capture_or_download("test", {"url": url})
+        self.assertFalse(result)
+        mock_download.assert_not_called()
+        mock_reachable.assert_not_called()
+
+    @patch("app.utils.screenshots.http_session")
+    def test_get_content_type_caches_error(self, mock_session_factory):
+        url = "http://example.com"
+        mock_session = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.headers = {}
+        mock_session.request.return_value = resp
+        mock_session_factory.return_value = mock_session
+
+        ctype, modified = ss.get_content_type(url, False)
+        self.assertEqual(ctype, "")
+        self.assertFalse(modified)
+        self.assertEqual(ss.get_cached_status_code(url), 500)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip capture when cached status is an error
- persist non-200 statuses in `get_content_type`
- add tests for cached error handling

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d47ce62f883338ba323b9612f386d