### PR TITLE
Adjust defaults for browser templates

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -184,6 +184,23 @@ class TemplateManager:
                 ldelta = True
             else:
                 ldelta = False
+
+            # Determine whether this template operates in browser/stealth mode.
+            browser_like = bool(details.get("browser", template.browser)) or bool(
+                details.get("stealth", template.stealth)
+            )
+
+            # Default frequency/timeout to higher values when using a real
+            # browser. Pages take longer to load and should be scraped more
+            # politely. This mirrors validation defaults but also covers direct
+            # TemplateManager usage without prior normalization. See
+            # ``docs/configuration_guide.md`` for rationale.
+            default_frequency = 60 if browser_like else 30
+            default_timeout = 30 if browser_like else 10
+            if "frequency" not in details or details.get("frequency") == "":
+                details["frequency"] = default_frequency
+            if "timeout" not in details or details.get("timeout") == "":
+                details["timeout"] = default_timeout
             if template:
                 for key, value in details.items():
                     try:
@@ -191,7 +208,11 @@ class TemplateManager:
                             value = int(value)
                         elif key in ["frequency", "timeout"]:
                             if value == "":
-                                value = 30
+                                value = (
+                                    default_frequency
+                                    if key == "frequency"
+                                    else default_timeout
+                                )
 
                             value = int(value)
                             if key == "frequency" and value > 525600:
@@ -200,7 +221,6 @@ class TemplateManager:
                                 key == "frequency" and value < 0.01
                             ):  # that's less than 1 fps...
                                 value = 0.01
-                            # TODO: adjust for browsers-stealth-etc?  increase the frequency and timeout for those by default??
 
                             if (
                                 key == "timeout"
@@ -710,6 +730,7 @@ def mark_offline(name: str) -> None:
     finally:
         session.close()
 
+
 def set_capture_failed(name: str, failed: bool) -> None:
     """Set ``capture_failed`` flag for ``name``."""
     name = validate_template_name(name)
@@ -725,6 +746,7 @@ def set_capture_failed(name: str, failed: bool) -> None:
             session.commit()
     finally:
         session.close()
+
 
 def set_capture_failed(name: str, failed: bool) -> None:
     """Set ``capture_failed`` flag for ``name``."""

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -115,6 +115,8 @@ Templates that enable `stealth` or `browser` mode require heavier page loads. If
 `frequency` or `timeout` are omitted for such templates, Glimpser defaults to a
 `frequency` of **60 minutes** and a `timeout` of **30 seconds** to reduce the
 load on target sites and allow extra time for rendering.
+These values are enforced by the TemplateManager so that even API clients that
+skip validation adhere to the safer defaults.
 
 ## Advanced Options
 

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -192,6 +192,28 @@ class TestTemplateManager(unittest.TestCase):
         self.assertEqual(mock_session_instance.commit.call_count, 1)
 
     @patch("app.utils.template_manager.SessionLocal")
+    def test_browser_and_stealth_defaults(self, mock_session):
+        """Browser/stealth templates should receive higher defaults."""
+
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        mock_query = mock_sess.query.return_value
+        mock_first = mock_query.filter_by.return_value.first
+        mock_first.return_value = None  # simulate creation
+
+        self.template_manager.save_template("btemp", {"browser": True})
+        args, _ = mock_sess.add.call_args
+        self.assertEqual(args[0].frequency, 60)
+        self.assertEqual(args[0].timeout, 30)
+
+        mock_sess.add.reset_mock()
+
+        self.template_manager.save_template("stemp", {"stealth": True})
+        args, _ = mock_sess.add.call_args
+        self.assertEqual(args[0].frequency, 60)
+        self.assertEqual(args[0].timeout, 30)
+
+    @patch("app.utils.template_manager.SessionLocal")
     def test_get_template_by_id(self, mock_session):
         mock_session_instance = MagicMock()
         mock_session.return_value = mock_session_instance


### PR DESCRIPTION
## Summary
- bump default frequency and timeout when saving stealth or browser templates
- explain defaults in configuration guide
- test TemplateManager browser/stealth defaults

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4da06aa48333aa9a9f5814ccc2c6