### PR TITLE
Fix duplicate engine creation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,8 +11,7 @@ from dotenv import load_dotenv, find_dotenv
 # Load variables from a `.env` file if present
 load_dotenv(find_dotenv())
 
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy import text
 
 
 # Parse command line arguments when executed directly
@@ -45,10 +44,33 @@ BACKUP_PATH = (
 )
 
 # todo.. make sure this is not duplicate loading...
-engine = create_engine(f"sqlite:///{DATABASE_PATH}")
-SessionLocal = sessionmaker(
-    autocommit=False, autoflush=False, bind=engine
-)  # settings only thread
+# ``SessionLocal`` and ``_engine`` are initialized lazily so importing this
+# module doesn't immediately open a database connection.  Tests may patch
+# ``SessionLocal`` to supply a fake sessionmaker.
+SessionLocal = None
+_engine = None
+
+
+def _get_session():
+    """Return a new database session.
+
+    When ``SessionLocal`` has been patched (e.g. during testing) the patched
+    callable is used.  Otherwise the engine and sessionmaker are created on
+    first use and cached so repeated imports don't create multiple engines.
+    """
+    global _engine, SessionLocal
+
+    if SessionLocal is not None:
+        return SessionLocal()
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    if _engine is None:
+        _engine = create_engine(f"sqlite:///{DATABASE_PATH}")
+        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+    return SessionLocal()
 
 
 def get_setting(name, default=None):
@@ -57,7 +79,7 @@ def get_setting(name, default=None):
     if env_val is not None:
         return env_val
 
-    session = SessionLocal()
+    session = _get_session()
     try:
         result = session.execute(
             text("SELECT value FROM settings WHERE name = :name"),
@@ -78,7 +100,7 @@ def get_setting(name, default=None):
 
 
 def backup_config() -> bool:
-    session = SessionLocal()
+    session = _get_session()
     success = True
     try:
         settings = session.execute(text("SELECT name, value FROM settings")).fetchall()
@@ -97,7 +119,7 @@ def restore_config():
         with open(BACKUP_PATH, "r") as f:
             config_dict = json.load(f)
 
-        session = SessionLocal()
+        session = _get_session()
         try:
             for name, value in config_dict.items():
                 session.execute(
@@ -116,7 +138,7 @@ def sync_version(pkg_version: str) -> None:
     if os.getenv("VERSION"):
         return
 
-    session = SessionLocal()
+    session = _get_session()
     try:
         existing = session.execute(
             text("SELECT value FROM settings WHERE name = :name"),


### PR DESCRIPTION
## Summary
- lazily create the SQLAlchemy engine in `app/config.py` to avoid duplicate
  instances
- use new `_get_session()` helper in configuration functions

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4eda2ce4833386eca9f42d488c7b