### PR TITLE
Auto-add capture_failed column

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -24,3 +24,19 @@ def init_db():
     import app.models  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
+
+
+def ensure_column(
+    table_name: str, column_name: str, column_type: str, default: str
+) -> None:
+    """Add a column to a table if it doesn't already exist."""
+
+    with engine.begin() as conn:
+        result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+        columns = [row[1] for row in result]
+        if column_name not in columns:
+            conn.execute(
+                text(
+                    f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type} DEFAULT {default}"
+                )
+            )

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -13,16 +13,22 @@ from .validators import validate_template_name
 
 from app.config import SCREENSHOT_DIRECTORY, VIDEO_DIRECTORY
 
-from .db import Base, SessionLocal, init_db
+import app.utils.db as db
 from .video_details import get_latest_screenshot_date, get_latest_video_date
 
 from sqlalchemy.orm import validates
+
+# Keep aliases for backward compatibility and testing mocks
+SessionLocal = db.SessionLocal
+init_db = db.init_db
+ensure_column = db.ensure_column
+Base = db.Base
 
 LLM_USAGE_PATH = "data/llm_usage.json"
 LLM_COST_PER_TOKEN = 0.005 / 1000  # OpenAI pricing example
 
 
-class Template(Base):
+class Template(db.Base):
     __tablename__ = "templates"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -99,6 +105,10 @@ class TemplateManager:
 
     def __init__(self):
         init_db()
+        # Ensure the templates table exists even when Base has been reloaded
+        Template.__table__.create(db.engine, checkfirst=True)
+        # Automatically add newer columns when upgrading from older versions
+        ensure_column("templates", "capture_failed", "BOOLEAN", "0")
 
     def get_session(self):
         """Return a new SQLAlchemy session bound to the app database."""
@@ -710,6 +720,7 @@ def mark_offline(name: str) -> None:
     finally:
         session.close()
 
+
 def set_capture_failed(name: str, failed: bool) -> None:
     """Set ``capture_failed`` flag for ``name``."""
     name = validate_template_name(name)
@@ -725,6 +736,7 @@ def set_capture_failed(name: str, failed: bool) -> None:
             session.commit()
     finally:
         session.close()
+
 
 def set_capture_failed(name: str, failed: bool) -> None:
     """Set ``capture_failed`` flag for ``name``."""

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -175,6 +175,7 @@ Glimpser writes logs to the console and exposes them via the `/status` page. If 
 **Solution:**
 - Run `pip install -r requirements.txt --upgrade` to update dependencies.
 - Apply any new database migrations as described in the release notes.
+- The `capture_failed` column is added automatically if missing.
 - Clear your browser cache to avoid stale JavaScript files.
 
 ### Problem: Search bar does not filter templates


### PR DESCRIPTION
## Summary
- add ensure_column helper
- create templates table before ensuring the column
- document automatic capture_failed migration

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d4e92880c8333b5ec3268b94a0935