### PR TITLE
Add LLM response cache

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -10,6 +10,7 @@ import requests
 from PIL import Image
 
 from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, LLM_MODEL_VERSION
+from app.utils import llm_cache
 
 last_429_error_time = None
 
@@ -125,8 +126,15 @@ def chatgpt_compare(prompt, image_paths, template_name=None):
     if len(CHATGPT_KEY) < 1:
         return "Missing ChatGPT key"
 
-    chatgpt_comparison = ChatGPTImageComparison()
-    result, tokens = chatgpt_comparison.compare_images(prompt, image_paths)
+    cached = llm_cache.get(prompt, image_paths)
+    if cached is not None:
+        result = cached.get("response")
+        tokens = cached.get("tokens", 0)
+    else:
+        chatgpt_comparison = ChatGPTImageComparison()
+        result, tokens = chatgpt_comparison.compare_images(prompt, image_paths)
+        if result:
+            llm_cache.store(prompt, result, tokens, image_paths)
 
     if template_name and tokens:
         try:

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -10,6 +10,7 @@ import logging
 
 from app.config import CHATGPT_KEY, LLM_MODEL_VERSION, LLM_SUMMARY_PROMPT
 from app.utils.email_alerts import email_alert
+from app.utils import llm_cache
 
 last_429_error_time = None
 
@@ -42,6 +43,12 @@ def summarize(prompt, history=None, tokens=4096):
         return None
     if LLM_SUMMARY_PROMPT is None or len(LLM_SUMMARY_PROMPT) < 1:
         return None
+
+    # Check for cached result
+    cache_key = prompt if history is None else f"{prompt}|{history}"
+    cached = llm_cache.get(cache_key)
+    if cached is not None:
+        return cached.get("response")
 
     # note - if history is None or [], there isnt much to do ..
 
@@ -125,7 +132,9 @@ def summarize(prompt, history=None, tokens=4096):
                 start_time += 5
 
         logging.debug("Processed summary: %s", ljson)
-        return json.dumps(ljson)
+        result_json = json.dumps(ljson)
+        llm_cache.store(cache_key, result_json, ltokens)
+        return result_json
     except Exception as e:
         logging.exception("GPT response processing exception: %s", e)
         if response is not None:

--- a/app/utils/llm_cache.py
+++ b/app/utils/llm_cache.py
@@ -1,0 +1,59 @@
+import hashlib
+import json
+import os
+import logging
+
+CACHE_PATH = "data/llm_cache.json"
+_cache = {}
+
+
+def _load_cache() -> None:
+    """Load cached responses from ``CACHE_PATH``."""
+    if not os.path.exists(CACHE_PATH):
+        return
+    try:
+        with open(CACHE_PATH, "r") as f:
+            data = json.load(f)
+    except Exception:
+        return
+    _cache.clear()
+    _cache.update(data)
+
+
+def _persist_cache() -> None:
+    """Persist ``_cache`` to ``CACHE_PATH``."""
+    os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+    try:
+        with open(CACHE_PATH, "w") as f:
+            json.dump(_cache, f)
+    except Exception:
+        logging.exception("Failed to persist llm cache")
+
+
+def _key(prompt: str, image_paths=None) -> str:
+    if image_paths is None:
+        image_paths = []
+    digest = hashlib.sha256()
+    digest.update(prompt.encode("utf-8"))
+    for path in image_paths:
+        digest.update(path.encode("utf-8"))
+    return digest.hexdigest()
+
+
+def get(prompt: str, image_paths=None):
+    """Return cached entry for the ``prompt`` and ``image_paths`` if present."""
+    key = _key(prompt, image_paths)
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    return entry
+
+
+def store(prompt: str, response: str, tokens: int, image_paths=None) -> None:
+    """Store the ``response`` and ``tokens`` for the given input."""
+    key = _key(prompt, image_paths)
+    _cache[key] = {"response": response, "tokens": int(tokens)}
+    _persist_cache()
+
+
+_load_cache()

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -4,3 +4,10 @@ Glimpser now records the number of tokens used when generating captions.
 Token counts are stored in `data/llm_usage.json` keyed by template name.
 Costs are calculated at `$0.005` per thousand tokens.
 Use the captions page to view each template's estimated cost.
+
+## LLM Response Cache
+
+Glimpser caches LLM responses in `data/llm_cache.json` keyed by a hash of the
+prompt and image filenames. When an identical request is made later, the cached
+result is returned instead of calling the API again. Cached entries also store
+the number of tokens so repeated calls will not incur additional cost.

--- a/tests/test_llm_cache_usage.py
+++ b/tests/test_llm_cache_usage.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.llm import summarize
+from app.utils import image_processing
+from app.utils import llm_cache
+
+
+class TestLLMCache(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.cache_file = os.path.join(self.tmpdir, "cache.json")
+        self.patcher = patch("app.utils.llm_cache.CACHE_PATH", self.cache_file)
+        self.patcher.start()
+        llm_cache._cache.clear()
+        llm_cache._persist_cache()
+
+    def tearDown(self):
+        self.patcher.stop()
+        try:
+            os.remove(self.cache_file)
+        except Exception:
+            pass
+        os.rmdir(self.tmpdir)
+
+    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.CHATGPT_KEY", "k")
+    @patch("app.utils.llm.LLM_MODEL_VERSION", "gpt")
+    @patch("app.utils.llm.LLM_SUMMARY_PROMPT", "prompt")
+    def test_summarize_uses_cache(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "one"}}],
+            "usage": {"total_tokens": 5},
+        }
+        mock_post.return_value = mock_response
+
+        first = summarize("p")
+        second = summarize("p")
+
+        self.assertEqual(first, second)
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("app.utils.image_processing.ChatGPTImageComparison.compare_images")
+    @patch("app.utils.image_processing.os.path.exists", return_value=True)
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
+    def test_chatgpt_compare_uses_cache(self, mock_exists, mock_compare):
+        mock_compare.return_value = ("ok", 5)
+        result1 = image_processing.chatgpt_compare("p", ["img.png"])
+        result2 = image_processing.chatgpt_compare("p", ["img.png"])
+        self.assertEqual(result1, result2)
+        mock_compare.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache LLM API responses keyed by prompt hash
- lookup cached entries in summarization and image comparison helpers
- persist cached tokens and results to `data/llm_cache.json`
- test that repeated calls reuse cached responses
- document LLM caching

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d52c8e09883339d3626f2d21642bb