### PR TITLE
fix(live-view): backoff on snapshot errors

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -361,20 +361,27 @@ def generate_live_stream(url: str):
     )
     if image_like:
         session = screenshots.http_session()
+        failures = 0
+        base_delay = 1 / max(config.LIVE_FALLBACK_FPS, 1)
         while True:
             try:
                 resp = session.get(url, timeout=5, stream=True)
                 if resp.status_code == 200:
                     yield resp.content
+                    failures = 0
                 else:
                     logging.error(
                         "Failed to fetch image from %s (HTTP %s)", url, resp.status_code
                     )
+                    failures += 1
             except GeneratorExit:
                 break
             except Exception as e:
                 logging.error("Error fetching image from %s: %s", url, e)
-            time.sleep(1 / max(config.LIVE_FALLBACK_FPS, 1))
+                failures += 1
+
+            delay = min(base_delay * (2**failures), 30)
+            time.sleep(delay)
         return
 
     command = [config.FFMPEG_PATH]

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,3 +41,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - Templates track capture failures and display a warning icon when screenshots fail.
 - Keyboard shortcuts now allow play/pause, mute, and fullscreen toggling when watching live video.
+- Live view image streams now back off exponentially after repeated failures.


### PR DESCRIPTION
## Summary
- slow down retries when fetching live view snapshots fails
- document the backoff behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d574803f88333bdc67351c8085cd4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live view image streams now use exponential backoff when repeated failures occur, improving reliability and reducing unnecessary retries.

- **Documentation**
  - Updated documentation to describe the new exponential backoff behavior for live view image streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->