### PR TITLE
Fix watchdog exit

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 import time
+import sys
 import psutil
 from datetime import timedelta
 
@@ -207,7 +208,7 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
                             logging.info("Forcing application restart...")
                             last_restart_time = current_time
                             failure_count = 0
-                            os._exit(1)  # Force restart the application
+                            sys.exit(1)  # Force restart the application gracefully
                         else:
                             logging.warning(
                                 "Restart cooldown in effect. Skipping restart."


### PR DESCRIPTION
## Summary
- gracefully exit watchdog using `sys.exit`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d57cac7fc8333ab91830c99108afa