### PR TITLE
feat(video): make FFmpeg threads configurable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -248,6 +248,8 @@ FFMPEG_PATH = get_setting("FFMPEG_PATH", "ffmpeg")
 FFPROBE_PATH = get_setting("FFPROBE_PATH", "ffprobe")
 # Enable GPU acceleration if supported (e.g. "auto", "cuda", etc.)
 FFMPEG_HWACCEL = get_setting("FFMPEG_HWACCEL", "False")
+# Number of threads FFmpeg should use when encoding/decoding
+FFMPEG_THREADS = int(get_setting("FFMPEG_THREADS", 5))
 
 # CLIP model used for object filtering in scheduling
 CLIP_MODEL_NAME = get_setting(

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -25,6 +25,7 @@ from app.config import (
     FFMPEG_PATH,
     FFPROBE_PATH,
     FFMPEG_HWACCEL,
+    FFMPEG_THREADS,
 )
 
 from .template_manager import get_templates
@@ -265,7 +266,7 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
             concat_command.extend(
                 [
                     "-threads",
-                    "5",  # todo, make this a config
+                    str(FFMPEG_THREADS),
                     # "-safe",  Option not found?  But it is found and used elsewhere?  Not surewhy this is..
                     # "0",
                     "-err_detect",

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -129,6 +129,7 @@ Additional variables control AI behaviour and external tools:
 - `FFMPEG_PATH` – path to the `ffmpeg` binary (default `ffmpeg`)
 - `FFPROBE_PATH` – path to the `ffprobe` binary (default `ffprobe`)
 - `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (`False` disables)
+- `FFMPEG_THREADS` – number of threads ffmpeg uses when encoding (default `5`)
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
 


### PR DESCRIPTION
## Summary
- add `FFMPEG_THREADS` option to config
- use `FFMPEG_THREADS` in video concatenation
- document `FFMPEG_THREADS` in the configuration guide

## Testing
- `black app/config.py app/utils/video_archiver.py`
- `flake8 app/config.py app/utils/video_archiver.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d57d9e1708333a71dbd73d65413c2