### PR TITLE
Add video shortcuts for camera navigation and speed control

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -106,6 +106,32 @@ export function setupVideoControls() {
         else if (video.webkitRequestFullscreen) video.webkitRequestFullscreen();
         else if (video.msRequestFullscreen) video.msRequestFullscreen();
         break;
+      case 'ArrowLeft':
+      case 'ArrowRight': {
+        const selector = document.getElementById('camera-selector');
+        if (!selector) break;
+        const step = e.key === 'ArrowLeft' ? -1 : 1;
+        const newIndex = selector.selectedIndex + step;
+        if (newIndex >= 0 && newIndex < selector.options.length) {
+          selector.selectedIndex = newIndex;
+          if (typeof changeCamera === 'function') changeCamera();
+        }
+        break;
+      }
+      case '[':
+      case ']': {
+        const slider = document.getElementById('speed-slider');
+        if (!slider) break;
+        const step = parseFloat(slider.step) || 1;
+        const delta = e.key === '[' ? -step : step;
+        const newValue = Math.min(
+          parseFloat(slider.max),
+          Math.max(parseFloat(slider.min), parseFloat(slider.value) + delta)
+        );
+        slider.value = newValue;
+        if (typeof updatePlaybackSpeed === 'function') updatePlaybackSpeed();
+        break;
+      }
       default:
         break;
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,5 +40,5 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - Templates track capture failures and display a warning icon when screenshots fail.
-- Keyboard shortcuts now allow play/pause, mute, and fullscreen toggling when watching live video.
+- Keyboard shortcuts now allow play/pause, mute, fullscreen toggling, camera selection with the arrow keys, and speed adjustment with `[` and `]` when watching live video.
 - Live view image streams now back off exponentially after repeated failures.

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -24,7 +24,8 @@ Source** to **Live Video**. This connects you directly to the realtime feed so
 you can monitor activity as it happens.
 
 When watching a live stream, you can use keyboard shortcuts:
-`Space` or `k` toggles play/pause, `m` toggles mute, and `f` toggles fullscreen.
+`Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen,
+Left/Right arrows change the selected camera, and `[`/`]` adjust playback speed.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the
 bottom of the help page.


### PR DESCRIPTION
## Summary
- handle arrow and bracket keys in `setupVideoControls`
- document the new shortcuts on the help page and docs README

## Testing
- `black app/static/js/video.js docs/help_page.md docs/README.md` *(fails: cannot parse)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d59f1fa308333ae8351710a23de84