### PR TITLE
Remove redundant ffmpeg check

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1535,9 +1535,6 @@ def capture_frame_from_stream(
     stealth=False,
 ):
     """Use ffmpeg to capture multiple frames from a video stream and save the last one."""
-    if shutil.which(FFMPEG_PATH) is None:
-        logging.error("%s is not installed or not in the system path.", FFMPEG_PATH)
-        return False
 
     if timeout < 5:
         timeout = 5


### PR DESCRIPTION
## Summary
- avoid repeatedly checking for ffmpeg in `capture_frame_from_stream`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d59cab73c8333b27b4d9d863a0cfa