### PR TITLE
Improve live view embedding

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1647,10 +1647,26 @@ def init_routes(app):
     @app.route("/live")
     @login_required
     def live():
-        # Get a list of active cameras (with updates within the last 1 day)
-        return render_template(
-            "live.html", template_details=template_manager.get_templates()
-        )
+        """Render the live view page.
+
+        Optionally filter to a single camera when ``camera`` is provided in the
+        query string. This avoids loading metadata for all cameras when embedding
+        the live view for a specific template.
+        """
+
+        camera = request.args.get("camera")
+        if camera:
+            camera = validate_template_name(camera)
+            if camera is None:
+                abort(400, "Invalid camera name")
+            details = template_manager.get_template(camera)
+            if not details:
+                abort(404)
+            templates = {camera: details}
+        else:
+            templates = template_manager.get_templates()
+
+        return render_template("live.html", template_details=templates)
 
     @app.route("/latest_frame/<string:template_name>")
     @login_required

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -3,6 +3,23 @@ const image = document.getElementById('live-image');
 const templateDetailsContainer = document.getElementById('template-details');
 const templateDetails = window.templateDetails || {};
 let currentCamera = 'All'; // Set the default camera to "All"
+
+// Allow embedding the live view for a specific camera by reading the
+// ``camera`` query parameter. When provided and valid, restrict the camera
+// selector to that camera and start playback for it immediately.
+const params = new URLSearchParams(window.location.search);
+const requestedCamera = params.get('camera');
+if (requestedCamera && templateDetails[requestedCamera]) {
+    currentCamera = requestedCamera;
+    const cameraSelector = document.getElementById('camera-selector');
+    if (cameraSelector) {
+        Array.from(cameraSelector.options).forEach((opt) => {
+            if (opt.value !== requestedCamera) opt.remove();
+        });
+        cameraSelector.value = requestedCamera;
+        cameraSelector.style.display = 'none';
+    }
+}
 let pngInterval;
 let liveSwitchInterval;
 let liveSwitchFunction;

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -7,7 +7,7 @@
 </script>
 
 <div id="live-embed" style="margin-bottom: 20px;">
-    <iframe src="{{ url_for('live') }}" width="100%" height="500" title="Embedded Live View" style="border:none;"></iframe>
+    <iframe src="{{ url_for('live') }}?camera={{ template_name }}" width="100%" height="500" title="Embedded Live View" style="border:none;"></iframe>
 </div>
 
             <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay style='display: block; height: 90vh; width: 90vw;' width='90%'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -509,6 +509,40 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         mock_save_template.assert_called()
 
+    @patch("app.routes.SessionLocal")
+    @patch("app.routes.session", {"user_id": 1})
+    @patch("app.routes.template_manager.get_template")
+    @patch("app.routes.render_template")
+    def test_live_single_camera(
+        self, mock_render_template, mock_get_template, mock_session_local
+    ):
+        """The live route should render only the requested camera."""
+
+        mock_get_template.return_value = {"url": "https://example.com"}
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return SimpleNamespace(id=1)
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+
+            def close(self):
+                pass
+
+        mock_session_local.return_value = DummySession()
+
+        response = self.client.get("/live?camera=cam1")
+        self.assertEqual(response.status_code, 200)
+        mock_get_template.assert_called_with("cam1")
+        mock_render_template.assert_called_with(
+            "live.html", template_details={"cam1": mock_get_template.return_value}
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- filter `/live` page by camera when `camera` query param is present
- show filtered live stream in template details
- hide camera selector in embedded view
- test single-camera `/live` usage

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d633f783c83338cd98be1170a8f6a