### PR TITLE
Fix discovery MAC display

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -73,6 +73,20 @@ def _mac_manufacturer(mac: str | None) -> str | None:
     return OUI_MAP.get(prefix)
 
 
+def _add_mac_info(cam: dict) -> None:
+    """Augment ``cam`` with MAC and vendor information if possible."""
+
+    if cam.get("protocol") == "local":
+        return
+    mac = _mac_for_ip(cam.get("ip"))
+    if mac:
+        info = cam.setdefault("info", {})
+        info["mac"] = mac
+        vendor = _mac_manufacturer(mac)
+        if vendor:
+            info["manufacturer"] = vendor
+
+
 def _local_subnets(max_prefixlen: int = 24):
     """Return local IPv4 subnets limited to ``max_prefixlen``.
 
@@ -487,6 +501,8 @@ def discover_cameras(progress_callback=None):
             stage_cameras = []
             try:
                 stage_cameras = fut.result()
+                for cam in stage_cameras:
+                    _add_mac_info(cam)
                 cameras.extend(stage_cameras)
             except Exception as e:  # pragma: no cover - network
                 logging.warning("%s discovery error: %s", stage, e)
@@ -515,12 +531,6 @@ def discover_cameras(progress_callback=None):
 
     result = list(unique.values())
     for cam in result:
-        if cam["protocol"] != "local":
-            mac = _mac_for_ip(cam["ip"])
-            if mac:
-                cam.setdefault("info", {})["mac"] = mac
-                vendor = _mac_manufacturer(mac)
-                if vendor:
-                    cam["info"]["manufacturer"] = vendor
+        _add_mac_info(cam)
 
     return result

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -131,8 +131,10 @@ After scanning, `discover_cameras()` removes duplicates and returns the final li
 Each entry is also augmented with the device's MAC address and, when known,
 the manufacturer derived from its OUI prefix.  These details appear as separate
 columns in the discovery table so you can quickly identify where each camera
-originates. The **Info** column now summarizes key details such as a camera's
-name, ONVIF address, or HTTP path instead of showing the raw JSON dictionary.
+originates. This information is now available in the incremental results
+streamed back to the page during scanning. The **Info** column summarizes key
+details such as a camera's name, ONVIF address, or HTTP path instead of showing
+the raw JSON dictionary.
 
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -247,6 +247,43 @@ class TestCameraDiscovery(unittest.TestCase):
             {(c["ip"], c["protocol"], c["port"]) for c in expected},
         )
 
+    @patch("app.utils.camera_discovery._local_subnets", return_value=[])
+    @patch("app.utils.camera_discovery._local_video_devices", return_value=[])
+    @patch("app.utils.camera_discovery._scan_hls_streams", return_value=[])
+    @patch("app.utils.camera_discovery._scan_http_endpoints", return_value=[])
+    @patch("app.utils.camera_discovery._scan_snmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_webrtc_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_sip_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtsp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._probe_ssdp", return_value=[])
+    @patch("app.utils.camera_discovery._probe_mdns", return_value=[])
+    @patch("app.utils.camera_discovery._probe_onvif")
+    @patch("app.utils.camera_discovery._mac_manufacturer")
+    @patch("app.utils.camera_discovery._mac_for_ip")
+    def test_progress_callback_includes_mac(
+        self,
+        mock_mac,
+        mock_vendor,
+        mock_onvif,
+        *_mocks,
+    ):
+        mock_onvif.return_value = [
+            {"ip": "192.168.1.6", "protocol": "rtsp", "port": 554, "info": {}}
+        ]
+        mock_mac.return_value = "000c29aabbcc"
+        mock_vendor.return_value = "VMware"
+
+        seen = []
+
+        def cb(stage, count, cams):
+            seen.extend(cams)
+
+        camera_discovery.discover_cameras(progress_callback=cb)
+
+        self.assertEqual(seen[0]["info"].get("mac"), "000c29aabbcc")
+        self.assertEqual(seen[0]["info"].get("manufacturer"), "VMware")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- augment discovered cameras with MAC info before streaming progress
- clarify docs about MAC/manufacturer info availability
- test that streaming scan results include MAC and manufacturer

## Testing
- `flake8`
- `pytest -q` *(fails: 236 passed, 3 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_683d655092448333b4b691f22e86a926