### PR TITLE
Enable configurable log cache path

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -25,6 +25,7 @@ from app.config import (
     SUMMARIES_DIRECTORY,
     VIDEO_DIRECTORY,
     CLIP_MODEL_NAME,
+    LOGGING_PATH,
 )
 from app.utils.db import SessionLocal
 from app.models import Summary
@@ -964,7 +965,9 @@ log_cache_lock = threading.Lock()
 
 
 def cache_logs():
-    log_file_path = "logs/glimpser.log"
+    log_file_path = LOGGING_PATH
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+    open(log_file_path, "a").close()
 
     try:
         with open(log_file_path, "r") as file:


### PR DESCRIPTION
## Summary
- read log file path from `LOGGING_PATH`
- ensure log file exists before starting the cache thread

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d65d736588333b1f97ab05115117b