### PR TITLE
Add tooltip log doc and improve nav titles

### DIFF
--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -12,8 +12,8 @@
             <span class="footer-copy">&copy; <span id="current-year"></span> Glimpser. All rights reserved.</span>
             <a href='https://github.com/KristopherKubicki/glimpser/releases'>v{{VERSION}}{% if VERSION_OUTDATED %}<span title="Update available">&#9888;</span>{% endif %}</a>
             <a href="/help" title="View help documentation">Help</a>
-            <a href="https://glimpser.net" target="_blank">About</a>
-            <a href="https://github.com/KristopherKubicki/glimpser/blob/main/LICENSE.md" target="_blank">License</a>
+            <a href="https://glimpser.net" target="_blank" title="Project website">About</a>
+            <a href="https://github.com/KristopherKubicki/glimpser/blob/main/LICENSE.md" target="_blank" title="Software license">License</a>
         </nav>
     </div>
 </footer>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,17 +1,17 @@
 
-                <h1><a href='/'><img src='{{ url_for('static', filename='img/glimpser_small.png') }}' alt='Glimpser logo' title='Glimpser'></a></h1>
+                <h1><a href='/' title="Home"><img src='{{ url_for('static', filename='img/glimpser_small.png') }}' alt='Glimpser logo' title='Glimpser'></a></h1>
         <nav>
             <div class="nav-left">
                 {% for ag in active_groups %}
-                <a href='/group/{{ag}}'>{{ag}}</a>
+                <a href='/group/{{ag}}' title="View group {{ag}}">{{ag}}</a>
                 {% endfor %}
                 <!-- Discover icon moved to nav-right for consistency -->
             </div>
 
             <div class="nav-center">
 {% if template_name %}
-                <h1><a href='/templates/{{template_name}}'>{{template_name}}</a></h1>
-    {% endif %}
+                <h1><a href='/templates/{{template_name}}' title="View template {{template_name}}">{{template_name}}</a></h1>
+{% endif %}
             </div>
 
             <div class="nav-right">

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,4 +26,5 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
 - [LLM Cost Tracking](cost_tracking.md)
+- [UI and Navigation Tooltips](tooltips.md)
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -1,0 +1,24 @@
+# UI and Navigation Tooltips
+
+This document lists the main tooltips available in the Glimpser interface. Hovering over controls reveals short explanations of their function.
+
+## Navigation Bar
+
+- **Home** – returns to the dashboard.
+- **Group links** – "View group <group>" for each active group.
+- **Template title** – links to the template details page.
+- **System Performance indicator** – shows CPU, memory and other metrics.
+- **Danger Mode indicator** – explains why danger mode may be disabled.
+- **Discover Cameras icon** – opens the camera discovery page.
+- **Captions icon** – reads and updates camera language models.
+- **Clock icon** – opens the live page with instructions for real‑time streaming.
+- **Settings icon** – opens the settings page.
+- **Login link** – appears when not authenticated.
+
+## Footer
+
+- **Help** – opens this documentation.
+- **Version** – indicates the installed package version and warns when updates are available.
+- **About/License** – links to project information.
+
+These tooltips aim to make the interface self‑explanatory and easier to navigate.


### PR DESCRIPTION
## Summary
- add tooltips for nav links and footer items
- document available UI tooltips
- link tooltip doc from index

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d665588348333ba1ce9d4eb4ea2d8