### PR TITLE
Improve navigation status icons

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -354,16 +354,21 @@ nav a {
 }
 
 .status-indicator {
-    width: 15px;
-    height: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
     background-color: grey;
+    color: var(--text-color);
 }
 
 .nav-right a,
 .nav-right .status-indicator {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     display: flex;
     align-items: center;

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -42,9 +42,11 @@ export function initNav() {
           if (!dangerStatus) return;
           if (data.ready) {
             dangerStatus.style.backgroundColor = 'orange';
+            dangerStatus.textContent = '!';
             dangerStatus.title = 'Danger Mode Ready';
           } else {
             dangerStatus.style.backgroundColor = 'grey';
+            dangerStatus.textContent = '×';
             let reason = [];
             if (!data.port_open) reason.push('Debug port closed');
             if (!data.idle) reason.push('User active');

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -16,9 +16,9 @@
 
             <div class="nav-right">
         {% if session.get('user_id') %}
-                <div id="health-status" class="status-indicator" title="System Performance"><a href='/status'></a></div>
+                <a id="health-status" href="/status" class="status-indicator" title="System Performance"></a>
                 <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
-                <a href='/discover' class="settings-icon" title='Discover Cameras'>&#128269;</a>
+                <a href='/discover' class="settings-icon" title='Discover Cameras'>&#x2315;</a>
                 <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation logic and form validation are now modules to keep templates concise.
 - Core colors and fonts are defined via CSS variables.
 - Navigation menus use a consistent accent color with smooth hover effects.
-- Navigation bar icons have a unified circular style for a cleaner look.
+ - Navigation bar icons have a unified circular style for a cleaner look. The search link now uses a monochrome glyph for consistency.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - Templates track capture failures and display a warning icon when screenshots fail.

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -23,7 +23,7 @@ For now, you can store the launch command in a script and double-click it instea
 
 ## Using Danger Mode in Glimpser
 
-When Chrome's debug port is open and no user input has been detected for a short period, Glimpser shows an orange indicator in the navigation bar. Hover over the dot to see why Danger mode might be disabled.
+When Chrome's debug port is open and no user input has been detected for a short period, Glimpser shows an orange indicator in the navigation bar. A `!` appears in the icon when ready and an `×` explains why it's disabled when you hover over it.
 
 Captures marked as "Danger" in the template editor will use your running Chrome session. Glimpser opens a new tab, performs the capture, and closes the tab when finished. It skips the operation if you become active while the capture is pending.
 


### PR DESCRIPTION
## Summary
- remove inner anchor from health status icon and unify search icon
- show text feedback on danger mode status
- refine status styles for modern look
- document icon changes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d683f89f08333882a25a443ae74bd