### PR TITLE
Refine front-end styling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -909,3 +909,57 @@ details > summary {
     width: 12rem;
 }
 
+/* Utility classes for modals and embedded media */
+.live-embed {
+    margin-bottom: 20px;
+}
+
+.embed-frame {
+    border: none;
+    width: 100%;
+    height: 500px;
+}
+
+.full-size-video {
+    display: block;
+    width: 90vw;
+    height: 90vh;
+}
+
+#camera-metadata {
+    margin: 10px 0;
+    color: #ccc;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+}
+
+.close-icon {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.prompt-textarea {
+    width: 100%;
+    height: 100px;
+}

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -15,7 +15,7 @@
 {% block content %}
     <h2>Discovered Cameras</h2>
     <button id="discover-btn" title="Scan the network for cameras">Discover</button>
-    <progress id="discover-progress" style="display:none;" title="Discovery progress"></progress>
+    <progress id="discover-progress" class="hidden" title="Discovery progress"></progress>
     <div id="discover-message" title="Status messages"></div>
     <table>
         <thead>

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -6,11 +6,11 @@
     const cameraMeta = {{ template_details|tojson }};
 </script>
 
-<div id="live-embed" style="margin-bottom: 20px;">
-    <iframe src="{{ url_for('live') }}?camera={{ template_name }}" width="100%" height="500" title="Embedded Live View" style="border:none;"></iframe>
+<div id="live-embed" class="live-embed">
+    <iframe src="{{ url_for('live') }}?camera={{ template_name }}" width="100%" height="500" title="Embedded Live View" class="embed-frame"></iframe>
 </div>
 
-            <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay style='display: block; height: 90vh; width: 90vw;' width='90%'
+            <video controls poster="/last_screenshot/{{ template_name }}" autoplay muted autoplay class='full-size-video' width='90%'
 			    {% if template_details.last_caption %}
 			    title='{{template_details.last_caption}}'
 			    {% else %}
@@ -109,7 +109,7 @@ function updateVideo(templateName) {
 
 </script>
 
-    <div id="camera-metadata" style="margin: 10px 0; color: #ccc;">
+    <div id="camera-metadata">
         <ul>
             <li><strong>Last Screenshot:</strong> {{ template_details.last_screenshot_time }}</li>
             <li><strong>Last Video:</strong> {{ template_details.last_video_time }}</li>
@@ -413,17 +413,17 @@ function closePromptModal() {
 
 
 
-  <div id="camera-details-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
-    <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
-      <span onclick="closeModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
+  <div id="camera-details-modal" class="modal">
+    <div class="modal-content">
+      <span onclick="closeModal()" class="close-icon">&times;</span>
       <div id="camera-details-content"></div>
     </div>
   </div>
 
-  <div id="prompt-modal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
-    <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
-      <span onclick="closePromptModal()" style="color: #aaa; float: right; font-size: 28px; font-weight: bold; cursor: pointer;">&times;</span>
-      <textarea id="prompt-text" style="width: 100%; height: 100px;"></textarea>
+  <div id="prompt-modal" class="modal">
+    <div class="modal-content">
+      <span onclick="closePromptModal()" class="close-icon">&times;</span>
+      <textarea id="prompt-text" class="prompt-textarea"></textarea>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extract inline CSS from templates to reusable classes
- add modal and video helper classes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d69cc41e88333aa4ddca1b74ec8b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved visual consistency by introducing new CSS classes for modals, embedded media, video display, and camera metadata.
  - Replaced inline styles in templates with reusable CSS classes for cleaner and more maintainable presentation.
  - Updated progress bar visibility handling to use a CSS class instead of inline styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->