### PR TITLE
Collapse captions controls

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -40,18 +40,18 @@
 
 
 <!-- Bulk management controls -->
-<div class="tsv-controls">
-    <h3>Bulk Caption Management</h3>
+<details class="tsv-controls">
+    <summary>Bulk Caption Management</summary>
     <div class="tsv-buttons">
         <a href="/download_captions_tsv" class="btn btn-primary">Download Captions as TSV</a>
-        
+
         <form action="/upload_captions_tsv" method="post" enctype="multipart/form-data" class="tsv-upload-form">
             <input type="file" name="tsv_file" id="tsv_file" accept=".tsv">
             <button type="submit" class="btn btn-success">Upload TSV</button>
         </form>
     </div>
     <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
-</div>
+</details>
 
 <!-- Add this to display flash messages -->
 {% with messages = get_flashed_messages(with_categories=true) %}
@@ -64,7 +64,7 @@
   {% endif %}
 {% endwith %}
 
-    <details open><summary>Captions</summary>
+    <details><summary>Captions</summary>
         <table class="captions-table">
             <tr>
                 <th>Timestamp</th>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. The table now shows relative timestamps and a placeholder when no captions are available.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. The bulk controls are collapsed by default—expand the **Bulk Caption Management** section when needed. The table now shows relative timestamps and a placeholder when no captions are available.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- collapse bulk caption controls on the captions page
- collapse caption list by default
- document the new collapsed behavior in docs

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d6a4fa6308333b1f039c24ce7c5c5