### PR TITLE
Add auto-hiding footer

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -701,7 +701,14 @@ footer {
     padding: 10px 10px 0 10px;
     border-top: 2px solid #444;
     box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
-    margin-top: auto;
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    transition: opacity 0.5s;
+}
+
+footer.fade-out {
+    opacity: 0;
 }
 
 .footer-content {

--- a/app/static/js/footer.js
+++ b/app/static/js/footer.js
@@ -1,0 +1,20 @@
+export function initFooterFade() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const footer = document.querySelector('footer');
+    if (!footer) return;
+
+    let fadeTimeout;
+
+    const showFooter = () => {
+      footer.classList.remove('fade-out');
+      clearTimeout(fadeTimeout);
+      fadeTimeout = setTimeout(() => footer.classList.add('fade-out'), 3000);
+    };
+
+    ['mousemove', 'scroll'].forEach((evt) => {
+      document.addEventListener(evt, showFooter);
+    });
+
+    showFooter();
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -3,9 +3,11 @@ import { initVideoControls } from './video.js';
 import { initSchedulerToggle } from './scheduler.js';
 import { initNav } from './nav.js';
 import { initFormValidation } from './form.js';
+import { initFooterFade } from './footer.js';
 
 initTemplates();
 initVideoControls();
 initSchedulerToggle();
 initNav();
 initFormValidation();
+initFooterFade();

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation bar icons have a unified circular style for a cleaner look.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
+- The footer now stays fixed at the bottom of the screen and fades when the
+  mouse is idle.
 - Templates track capture failures and display a warning icon when screenshots fail.
 - Keyboard shortcuts now allow play/pause, mute, fullscreen toggling, camera selection with the arrow keys, and speed adjustment with `[` and `]` when watching live video.
 - Live view image streams now back off exponentially after repeated failures.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -20,5 +20,6 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Help** – opens this documentation.
 - **Version** – indicates the installed package version and warns when updates are available.
 - **About/License** – links to project information.
+- The footer itself hides when the mouse is inactive.
 
 These tooltips aim to make the interface self‑explanatory and easier to navigate.


### PR DESCRIPTION
## Summary
- make footer fixed and fade when inactive
- fade footer with new JS module
- document footer behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6a6d672083338d1e91ca3e817cd9