### PR TITLE
Fix chrome user-data-dir conflicts

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -12,6 +12,7 @@ import shutil
 import socket
 import subprocess
 import time
+import tempfile
 from urllib.parse import urlparse
 import glob
 import base64
@@ -2357,10 +2358,9 @@ def capture_screenshot_and_har(
     user_data_dir = None
     driver = None
     try:
-        # Create ephemeral profile dir in /tmp
-        tmp_profile = f"/tmp/glimpser_{name}"
-        os.makedirs(tmp_profile, exist_ok=True)
-        user_data_dir = tmp_profile  # just to keep track
+        # Create a unique ephemeral profile directory
+        tmp_profile = tempfile.mkdtemp(prefix="glimpser_")
+        user_data_dir = tmp_profile  # track for cleanup
 
         # Using undetected_chromedriver for stealth:
         # driver_options = uc.ChromeOptions()

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -167,6 +167,9 @@ Glimpser writes logs to the console and exposes them via the `/status` page. If 
 - Review recent entries for stack traces or connection errors.
 - If logs show "Failed to open last shot ... invalid image", the screenshot file
   is corrupted. Delete the file so a new capture can replace it.
+- If you see "session not created" with a message about the user data directory
+  already in use, remove any stale `/tmp/glimpser_*` folders or restart Glimpser
+  to clear old Chrome processes.
 
 ## 10. Upgrade Issues
 


### PR DESCRIPTION
## Summary
- ensure capture creates a unique Chrome profile directory
- document how to clean stale user-data directories

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d6a9ef5d88333a1c66c9fd1489de9