### PR TITLE
Improve settings UI with help link

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1032,6 +1032,12 @@ def init_routes(app):
     def help_page():
         return render_template("help.html")
 
+    @app.route("/settings_help")
+    @login_required
+    def settings_help():
+        """Display detailed explanations for each configuration option."""
+        return render_template("settings_explanation.html")
+
     @app.route("/logout")
     @login_required
     def logout():

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -871,7 +871,8 @@ input[type=submit]:hover {
 }
 
 .captions-table,
-.camera-table {
+.camera-table,
+.settings-table {
     width: 100%;
     border-collapse: collapse;
     margin-bottom: 20px;
@@ -880,13 +881,16 @@ input[type=submit]:hover {
 .captions-table th,
 .captions-table td,
 .camera-table th,
-.camera-table td {
+.camera-table td,
+.settings-table th,
+.settings-table td {
     padding: 8px;
     border: 1px solid #ddd;
 }
 
 .captions-table th,
-.camera-table th {
+.camera-table th,
+.settings-table th {
     background-color: #f4f4f4;
 }
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,25 +1,23 @@
-
 {% extends 'base.html' %}
 {% block content %}
-
-
-        <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger">Logout</a>
-
+<main class="container settings-page">
+    <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
 
     <h2>Current Settings</h2>
+    <p><a href="{{ url_for('settings_help') }}" title="Detailed explanation of each option">What does each setting do?</a></p>
 
     <h3>Add New Setting</h3>
     <form method="POST" action="{{ url_for('settings') }}">
         <input type="hidden" name="action" value="add" title="Add setting action">
-        <label for="new_name" title="Setting name">Name:</label>
+        <label for="new_name" title="Name of the new setting">Name:</label>
         <input type="text" id="new_name" name="new_name" required title="Enter setting name">
-        <label for="new_value" title="Setting value">Value:</label>
+        <label for="new_value" title="Initial value for the setting">Value:</label>
         <input type="text" id="new_value" name="new_value" required title="Enter setting value">
         <button type="submit" title="Add setting">Add Setting</button>
     </form>
 
     <form method="POST" action="{{ url_for('settings') }}">
-        <table>
+        <table class="settings-table">
             <thead>
                 <tr>
                     <th>Setting</th>
@@ -47,17 +45,16 @@
 
     <h3>Configuration Management</h3>
     <form method="POST" action="{{ url_for('settings') }}" enctype="multipart/form-data">
-        <button type="submit" name="action" value="backup" title="Backup configuration">Backup Configuration</button>
-        <button type="submit" name="action" value="download" title="Download configuration">Download Configuration</button>
-        <input type="file" name="file" accept=".json" title="Select configuration file">
-        <button type="submit" name="action" value="upload" title="Upload configuration">Upload Configuration</button>
+        <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
+        <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
+        <input type="file" name="file" accept=".json" title="Select configuration file to upload">
+        <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file">Upload Configuration</button>
     </form>
 
     <h3>Danger Mode</h3>
     <form method="POST" action="{{ url_for('settings') }}">
         <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
     </form>
-
+</main>
     <script src="{{ url_for('static', filename='js/performance.js') }}"></script>
 {% endblock %}
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 
 - The Settings page now includes descriptive `title` attributes on form controls
   to improve accessibility.
+- A new help link on the Settings page opens a detailed overview of each option.
 - The navigation bar's Settings link now uses a single descriptive `title` attribute.
 - Unit tests now cover configuration retrieval and Chrome debug port detection.
 - Retention policy file sorting is also verified by tests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,5 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [UI Accessibility Improvements](accessibility.md)
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
+- [Settings Page Overview](settings_page.md)
 

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -1,0 +1,12 @@
+# Settings Page Overview
+
+The **Settings** interface lets you manage configuration values stored in the database. Each field includes a tooltip that explains its purpose. Use the "What does each setting do?" link to open a table describing the built-in options.
+
+## Sections
+
+- **Add New Setting** – quickly create additional key/value pairs.
+- **Current Settings** – edit existing values or delete them.
+- **Configuration Management** – backup, download, and upload the JSON configuration file.
+- **Danger Mode** – update Chrome shortcuts with the required flags.
+
+You can also visit `/settings_help` directly to read the full explanation page.


### PR DESCRIPTION
## Summary
- link to new `/settings_help` page from settings
- add tooltips and style for settings table
- describe settings page in docs

## Testing
- `flake8`
- `black app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6aeff3688333a62353993c7dbcd2