### PR TITLE
Improve Play All performance

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -4,23 +4,40 @@ export function initVideoControls() {
     setupVideoControls();
 
     const playAllButton = document.getElementById('play-all-button');
-    let isPlaying = false;
+    let playAllActive = false;
+    let playAllObserver;
+
+    function handlePlayAll(entries) {
+      entries.forEach((entry) => {
+        if (!playAllActive) return;
+        if (entry.isIntersecting) {
+          entry.target
+            .play()
+            .catch((e) => console.error('Error playing video:', e));
+        } else {
+          entry.target.pause();
+        }
+      });
+    }
+
     if (playAllButton) {
       playAllButton.addEventListener('click', () => {
         const videos = document.querySelectorAll('.templateDiv video');
-        if (isPlaying) {
+        if (playAllActive) {
+          if (playAllObserver) playAllObserver.disconnect();
           videos.forEach((video) => {
             video.pause();
             video.currentTime = 0;
           });
           playAllButton.textContent = 'Play All';
         } else {
-          videos.forEach((video) => {
-            video.play().catch((e) => console.error('Error playing video:', e));
+          playAllObserver = new IntersectionObserver(handlePlayAll, {
+            threshold: 0.25,
           });
+          videos.forEach((video) => playAllObserver.observe(video));
           playAllButton.textContent = 'Stop All';
         }
-        isPlaying = !isPlaying;
+        playAllActive = !playAllActive;
       });
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Template and live views now show camera metadata, and PNG streams stop when switching sources.
 - Templates are rescheduled when saved to apply the new settings.
 - The front page 'Play All' button now works again after moving its script initialization to DOMContentLoaded.
+- The Play All button only starts playback for videos visible on the page to avoid overloading the browser with many cameras.
 - The live view page no longer shows a duplicate navigation header.
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
 - Group and All cameras now bypass offline checks when loading feeds.


### PR DESCRIPTION
## Summary
- use IntersectionObserver so `Play All` only plays visible videos
- document the lightweight behaviour in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6e225fa88333beeeef07b199e089