### PR TITLE
Improve PNG loading in live view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -135,6 +135,10 @@ function hideStreamErrorIndicator() {
 video.addEventListener('waiting', showLoadingIndicator);
 video.addEventListener('canplay', hideLoadingIndicator);
 video.addEventListener('canplay', () => { image.style.display = 'none'; });
+// Hide the loading overlay when a PNG frame successfully loads so the
+// viewer immediately sees the latest snapshot instead of an indefinite
+// "Loading" message.
+image.addEventListener('load', hideLoadingIndicator);
 video.addEventListener('play', () => showPlayPauseIndicator(false));
 video.addEventListener('pause', () => showPlayPauseIndicator(true));
 video.addEventListener('error', (e) => {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -370,6 +370,9 @@
         video.addEventListener('waiting', showLoadingIndicator);
         video.addEventListener('canplay', hideLoadingIndicator);
         video.addEventListener('canplay', () => { image.style.display = 'none'; });
+        // Hide the loading indicator once the PNG image has loaded so the
+        // viewer isn't stuck with a static "Loading" overlay.
+        image.addEventListener('load', hideLoadingIndicator);
         video.addEventListener('play', () => showPlayPauseIndicator(false));
         video.addEventListener('pause', () => showPlayPauseIndicator(true));
         video.addEventListener('error', (e) => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Keyboard shortcuts now allow play/pause, mute, fullscreen toggling, camera selection with the arrow keys, and speed adjustment with `[` and `]` when watching live video.
 - Live view image streams now back off exponentially after repeated failures.
 - Live view preloads the next stream for smoother camera switching.
+- PNG streams hide the loading overlay once a frame is displayed.


### PR DESCRIPTION
## Summary
- ensure the loading overlay disappears once a PNG frame finishes loading
- document the live PNG overlay fix

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6ffe64d883339aca168556b24499