### PR TITLE
Fix slider width scaling

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -8,6 +8,14 @@ export function initTemplates() {
     const slider = document.getElementById('grid-width-slider');
     const templateList = document.getElementById('template-list');
 
+    if (slider) {
+      const updateSliderMax = () => {
+        slider.max = window.innerWidth;
+      };
+      updateSliderMax();
+      window.addEventListener('resize', updateSliderMax);
+    }
+
     function autofillGroup() {
       if (groupsInput && groupDropdown && groupDropdown.value !== 'all') {
         groupsInput.value = groupDropdown.value;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,7 +94,7 @@
     <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
 
 
-        <input type="range" id="grid-width-slider" min="50" max="3840" value="360" onload="this.max = window.innerWidth;" title="Adjust the width of the template grid">
+        <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
 </div>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The width slider on the index page now scales with the browser window. If it appears cramped, try widening the window or adjust the CSS in `style.css` to suit your layout.
+The width slider on the index page automatically adjusts to the current browser width and updates if you resize the window. If it still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 ### Why is the live feed slightly cropped on small screens?
 Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.


### PR DESCRIPTION
## Summary
- adjust the grid width slider max dynamically
- remove stale `onload` attribute from the slider
- clarify FAQ entry about the width slider

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6c7bc9108333a384a13985d06e16