### PR TITLE
Use FontAwesome icons in nav

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glimpser</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+    <link
+        rel="stylesheet"
+        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+        integrity="sha512-d+QeMAyl8RckY6SLlmRu9yckYv12LT4QcQuw2fbfbVzquSeQj0DnI1W6RKssYhh7j8A2Pn6GvmXwFbr1Qr1Zyg=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
      <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     {% if session.get('user_id') %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -18,8 +18,8 @@
         {% if session.get('user_id') %}
                 <a id="health-status" href="/status" class="status-indicator" title="System Performance"></a>
                 <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
-                <a href='/discover' class="settings-icon" title='Discover Cameras'>&#x2315;</a>
-                <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'>&#9000;</a>
+                <a href='/discover' class="settings-icon" title='Discover Cameras'><i class="fas fa-search"></i></a>
+                <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'><i class="fas fa-comment-dots"></i></a>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
                         <div id="dateDisplay" class="clock-face">
@@ -31,9 +31,9 @@
                         </div>
                     </div>
                 </a>
-                <a href='/settings' class="settings-icon" title="Update settings">&#9881;</a>
+                <a href='/settings' class="settings-icon" title="Update settings"><i class="fas fa-cog"></i></a>
         {% else %}
-                <a href="{{ url_for('login') }}" class="settings-icon" title="Login">Login</a>
+                <a href="{{ url_for('login') }}" class="settings-icon" title="Login"><i class="fas fa-sign-in-alt"></i></a>
         {% endif %}
             </div>
         </nav>

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation logic and form validation are now modules to keep templates concise.
 - Core colors and fonts are defined via CSS variables.
 - Navigation menus use a consistent accent color with smooth hover effects.
- - Navigation bar icons have a unified circular style for a cleaner look. The search link now uses a monochrome glyph for consistency.
+ - Navigation bar icons now use the Font Awesome set and retain a unified circular style for a cleaner look.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - Templates track capture failures and display a warning icon when screenshots fail.


### PR DESCRIPTION
## Summary
- integrate Font Awesome via CDN
- switch navigation glyphs to Font Awesome icons
- document Font Awesome usage in documentation

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6c53d8c48333996665bb27e4be28