### PR TITLE
Handle Ctrl-C cleanup

### DIFF
--- a/app/utils/llm_cache.py
+++ b/app/utils/llm_cache.py
@@ -9,6 +9,8 @@ _cache = {}
 
 def _load_cache() -> None:
     """Load cached responses from ``CACHE_PATH``."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
     if not os.path.exists(CACHE_PATH):
         return
     try:
@@ -22,6 +24,8 @@ def _load_cache() -> None:
 
 def _persist_cache() -> None:
     """Persist ``_cache`` to ``CACHE_PATH``."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
     os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
     try:
         with open(CACHE_PATH, "w") as f:
@@ -56,4 +60,5 @@ def store(prompt: str, response: str, tokens: int, image_paths=None) -> None:
     _persist_cache()
 
 
-_load_cache()
+if not os.environ.get("PYTEST_CURRENT_TEST"):
+    _load_cache()

--- a/main.py
+++ b/main.py
@@ -236,37 +236,40 @@ def output_shutdown_stats():
 
 
 display_note = True
+cleanup_called = False
 
 
 def cleanup_resources():
-    # Shutdown the scheduler
+    """Release resources and stop running threads."""
+    global display_note, cleanup_called
+
+    if cleanup_called:
+        return
+    cleanup_called = True
+
     try:
         scheduler.shutdown(wait=True)
     except Exception as e:
         logging.error("Error shutting down scheduler: %s", e)
 
-    # Terminate all non-daemon threads
-    global display_note
     time.sleep(0.01)
     for thread in threading.enumerate():
         if thread != threading.current_thread():
             display_note = False
             try:
-                # concurrent.futures.Future.cancel()
                 thread.join(timeout=0.01)
                 if thread.is_alive():
                     logging.warning("Thread %s is still alive after join", thread.name)
             except Exception as e:
                 logging.error("Error terminating thread %s: %s", thread.name, e)
 
-    # global banner
-    # Add any other cleanup tasks here (e.g., closing database connections)
     output_shutdown_stats()
 
 
 def graceful_shutdown(signum, frame):
-    # time.sleep(random.randint(0,10) * 0.1)
-    # time.sleep(10)
+    """Handle termination signals by cleaning up and exiting."""
+    logging.info("Received signal %s. Shutting down...", signum)
+    cleanup_resources()
     time.sleep(0.01)
     sys.exit(0)
 
@@ -322,10 +325,12 @@ def main(argv=None):
             host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
         )
     except KeyboardInterrupt:
-        logging.info("KeyboardInterrupt received. Exiting...")
+        logging.info("KeyboardInterrupt received. Cleaning up...")
+        cleanup_resources()
     except Exception as e:
         logging.error("An error occurred while running the application: %s", e)
     finally:
+        cleanup_resources()
         logging.info("Glimpser shut down.")
 
 

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -58,12 +58,14 @@ class TestMainUtilities(unittest.TestCase):
         t2.join.assert_called_once_with(timeout=0.01)
         mock_output.assert_called_once()
 
+    @patch("main.cleanup_resources")
     @patch("main.sys.exit")
     @patch("main.time.sleep")
-    def test_graceful_shutdown_exits(self, mock_sleep, mock_exit):
+    def test_graceful_shutdown_exits(self, mock_sleep, mock_exit, mock_cleanup):
         main.graceful_shutdown(
             signal.SIGTERM if hasattr(signal, "SIGTERM") else 0, None
         )
+        mock_cleanup.assert_called_once()
         mock_exit.assert_called_once_with(0)
 
     @patch("main.os.system")


### PR DESCRIPTION
## Summary
- gracefully handle SIGINT/SIGTERM by calling `cleanup_resources`
- ensure cleanup only runs once
- avoid loading/saving llm cache when running under pytest
- update tests for new shutdown behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d6f88316083338f42b756c38e8eae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved application shutdown to ensure cleanup operations are performed only once, preventing repeated resource cleanup during exit.
	- Prevented cache loading and saving during test runs to avoid interference with test environments.

- **Tests**
	- Enhanced tests to verify that cleanup operations are called exactly once during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->