### PR TITLE
Add MJPEG fallback for snapshot URLs

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -231,6 +231,7 @@ function updateTemplateDetails() {
 function updateFeed() {
     const source = document.getElementById('video-source').value;
     const isConnected = checkCameraConnection(currentCamera);
+    const details = templateDetails[currentCamera];
     updateSpeedContainer();
     hideStreamErrorIndicator();
 
@@ -256,6 +257,11 @@ function updateFeed() {
         if (!['png', 'mjpg', 'motion'].includes(source)) {
             showLastScreenshot();
         }
+    }
+
+    if (source === 'live' && details && details.snapshot_only) {
+        playMJPG();
+        return;
     }
 
     switch (source) {
@@ -448,6 +454,14 @@ function playLive() {
     document.getElementById("seek-bar").style.display = "block";
     stopPNG();
     stopLiveSwitch();
+
+    if (!(currentCamera.startsWith('group-') || currentCamera === 'All')) {
+        const details = templateDetails[currentCamera];
+        if (details && details.snapshot_only) {
+            playMJPG();
+            return;
+        }
+    }
 
     if (currentCamera.startsWith('group-') || currentCamera === 'All') {
 let groupCameras;

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -28,6 +28,17 @@ LLM_USAGE_PATH = "data/llm_usage.json"
 LLM_COST_PER_TOKEN = 0.005 / 1000  # OpenAI pricing example
 
 
+def is_snapshot_url(url: str) -> bool:
+    """Return ``True`` when ``url`` points to a still image endpoint."""
+
+    if not url:
+        return False
+    url = url.lower()
+    return (
+        url.endswith((".jpg", ".jpeg", ".png")) or "snapshot" in url or "picture" in url
+    )
+
+
 class Template(db.Base):
     __tablename__ = "templates"
 
@@ -312,6 +323,8 @@ class TemplateManager:
             result = template.__dict__ if template else {}
             if "_sa_instance_state" in result:
                 del result["_sa_instance_state"]
+            if result:
+                result["snapshot_only"] = is_snapshot_url(result.get("url", ""))
             return result
         finally:
             session.close()
@@ -398,6 +411,7 @@ def get_templates():
         video_path = os.path.join(VIDEO_DIRECTORY, secure_filename(valid_name))
         details["last_screenshot_time"] = get_latest_screenshot_date(camera_path)
         details["last_video_time"] = get_latest_video_date(video_path)
+        details["snapshot_only"] = is_snapshot_url(details.get("url", ""))
     return templates
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -194,5 +194,5 @@ snapshot image rather than a true video stream.
 
 **Solution:**
 - Use the camera's RTSP or HTTP video stream URL when available.
-- Snapshot-only URLs now work automatically, but they refresh slowly
-  since a new JPEG must be fetched for each frame.
+- Snapshot-only URLs now fall back to an MJPEG feed so the live view
+  behaves like a regular video stream.

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -13,6 +13,7 @@ from app.utils.template_manager import (
     update_last_screenshot_time,
     set_capture_failed,
     get_storage_usage,
+    get_templates,
 )
 from app.utils.validators import validate_template_name
 
@@ -350,6 +351,39 @@ class TestStorageUsage(unittest.TestCase):
             ), patch("app.utils.template_manager.VIDEO_DIRECTORY", vid_dir):
                 result = get_storage_usage("cam1")
                 self.assertEqual(result, "3.0 KB")
+
+
+class TestSnapshotDetection(unittest.TestCase):
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_snapshot_flag_in_get_templates(self, mock_session):
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        mock_query = mock_sess.query.return_value
+        mock_all = mock_query.all
+
+        t1 = Template(name="cam1", url="http://example.com/snapshot.jpg")
+        t2 = Template(name="cam2", url="http://example.com/stream.m3u8")
+        mock_all.return_value = [t1, t2]
+
+        result = get_templates()
+
+        self.assertTrue(result["cam1"]["snapshot_only"])
+        self.assertFalse(result["cam2"]["snapshot_only"])
+
+    @patch("app.utils.template_manager.SessionLocal")
+    def test_snapshot_flag_in_get_template(self, mock_session):
+        mock_sess = MagicMock()
+        mock_session.return_value = mock_sess
+        mock_query = mock_sess.query.return_value
+        mock_first = mock_query.filter_by.return_value.first
+
+        t1 = Template(name="cam1", url="http://example.com/snapshot.jpg")
+        mock_first.return_value = t1
+
+        manager = TemplateManager()
+        result = manager.get_template("cam1")
+
+        self.assertTrue(result["snapshot_only"])
 
 
 class TestSchedulerUpdates(unittest.TestCase):


### PR DESCRIPTION
## Summary
- treat template URLs ending in images as snapshot-only
- stream MJPEG automatically when a live view requests a snapshot camera
- note MJPEG fallback in troubleshooting guide
- test snapshot flag logic

## Testing
- `flake8`
- `pytest` *(fails: FileNotFoundError in cache_logs, LLM tests)*

------
https://chatgpt.com/codex/tasks/task_e_683d70353bbc8333ae2862c4ed97eaf9