### PR TITLE
Add keyboard shortcut cheat sheet

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -103,5 +103,34 @@ export function initNav() {
     updateCoolClock();
 
     setupNavFade();
+
+    const cheatSheetModal = document.getElementById('cheat-sheet-modal');
+    const cheatSheetClose = document.getElementById('cheat-sheet-close');
+    if (cheatSheetClose) {
+      cheatSheetClose.addEventListener('click', () => {
+        cheatSheetModal.style.display = 'none';
+      });
+    }
+
+    document.addEventListener('keydown', (e) => {
+      const tag = e.target.tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea') return;
+      if (e.key === '?') {
+        e.preventDefault();
+        if (cheatSheetModal) cheatSheetModal.style.display = 'block';
+        return;
+      }
+      if (e.key === 'Escape' && cheatSheetModal && cheatSheetModal.style.display === 'block') {
+        cheatSheetModal.style.display = 'none';
+        return;
+      }
+      const routes = { s: 'status', d: 'danger', c: 'captions', l: 'live', k: 'settings' };
+      const route = routes[e.key];
+      if (route) {
+        e.preventDefault();
+        const target = document.querySelector(`[data-route="${route}"]`);
+        if (target) target.click();
+      }
+    });
   });
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,5 +7,20 @@
     {% block content %}{% endblock %}
 
     {% include 'footer.html' %}
+
+    <div id="cheat-sheet-modal" class="modal">
+        <div class="modal-content">
+            <span id="cheat-sheet-close" class="close-icon">&times;</span>
+            <h3>Keyboard Shortcuts</h3>
+            <ul>
+                <li>s: Status</li>
+                <li>d: Danger</li>
+                <li>c: Captions</li>
+                <li>l: Live</li>
+                <li>k: Settings</li>
+                <li>?: Help</li>
+            </ul>
+        </div>
+    </div>
 </body>
 </html>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -16,11 +16,11 @@
 
             <div class="nav-right">
         {% if session.get('user_id') %}
-                <a id="health-status" href="/status" class="status-indicator" title="System Performance"></a>
-                <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
+                <a id="health-status" href="/status" data-route="status" class="status-indicator" title="System Performance"></a>
+                <div id="danger-status" data-route="danger" class="status-indicator" title="Danger Mode"></div>
                 <a href='/discover' class="settings-icon" title='Discover Cameras'><i class="fas fa-search"></i></a>
-                <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'><i class="fas fa-comment-dots"></i></a>
-                <a href='/live' id='live'>
+                <a href='/captions' id='captions' data-route="captions" class="settings-icon" title='Read and update camera LLMs'><i class="fas fa-comment-dots"></i></a>
+                <a href='/live' id='live' data-route="live">
                     <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
                         <div id="dateDisplay" class="clock-face">
                             <div id="digitalTime" class="clock-hands" title="">
@@ -31,7 +31,7 @@
                         </div>
                     </div>
                 </a>
-                <a href='/settings' class="settings-icon" title="Update settings"><i class="fas fa-cog"></i></a>
+                <a href='/settings' class="settings-icon" data-route="settings" title="Update settings"><i class="fas fa-cog"></i></a>
         {% else %}
                 <a href="{{ url_for('login') }}" class="settings-icon" title="Login"><i class="fas fa-sign-in-alt"></i></a>
         {% endif %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
   mouse is idle.
 - Templates track capture failures and display a warning icon when screenshots fail.
 - Keyboard shortcuts now allow play/pause, mute, fullscreen toggling, camera selection with the arrow keys, and speed adjustment with `[` and `]` when watching live video.
+- Press `?` at any time to show a cheat-sheet of navigation shortcuts.
 - Live view image streams now back off exponentially after repeated failures.
 - Live view preloads the next stream for smoother camera switching.
 - PNG streams hide the loading overlay once a frame is displayed.

--- a/docs/keyboard_shortcuts.md
+++ b/docs/keyboard_shortcuts.md
@@ -1,0 +1,11 @@
+# Keyboard Shortcuts
+
+Press `?` to display a quick reference modal listing available shortcuts.
+
+- `s` – go to the Status page
+- `d` – open Danger
+- `c` – open Captions
+- `l` – open Live view
+- `k` – open Settings
+
+Use `Esc` to close the modal.


### PR DESCRIPTION
## Summary
- bind quick nav keys via `data-route` attributes
- open a cheat sheet modal with the `?` key
- document the new keyboard shortcuts

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d744d2c648333b7203f3864b91312