### PR TITLE
Add offline preview service worker

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -30,6 +30,7 @@ from flask import (
     session,
     url_for,
     Response,
+    make_response,
     stream_with_context,
 )
 
@@ -2364,6 +2365,12 @@ def init_routes(app):
                 time.sleep(1)  # Send updates every second
 
         return Response(generate(), mimetype="text/event-stream")
+
+    @app.route("/sw.js")
+    def service_worker():
+        response = make_response(app.send_static_file("sw.js"))
+        response.headers["Cache-Control"] = "no-cache"
+        return response
 
     @app.route("/toggle_scheduler", methods=["POST"])
     @login_required

--- a/app/static/js/offline.js
+++ b/app/static/js/offline.js
@@ -1,0 +1,38 @@
+export function initOffline() {
+  const checkbox = document.getElementById('offline-preview');
+  if (!checkbox) return;
+
+  checkbox.checked = localStorage.getItem('offlinePreviewEnabled') === 'true';
+
+  checkbox.addEventListener('change', () => {
+    if (checkbox.checked) {
+      localStorage.setItem('offlinePreviewEnabled', 'true');
+      registerSW();
+    } else {
+      localStorage.removeItem('offlinePreviewEnabled');
+      unregisterSW();
+    }
+  });
+
+  if (checkbox.checked) {
+    registerSW();
+  }
+}
+
+function registerSW() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/sw.js').catch(console.error);
+  }
+}
+
+function unregisterSW() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(regs => {
+      regs.forEach(reg => {
+        if (reg.active && reg.active.scriptURL.includes('sw.js')) {
+          reg.unregister();
+        }
+      });
+    });
+  }
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -4,6 +4,7 @@ import { initSchedulerToggle } from './scheduler.js';
 import { initNav } from './nav.js';
 import { initFormValidation } from './form.js';
 import { initFooterFade } from './footer.js';
+import { initOffline } from './offline.js';
 
 initTemplates();
 initVideoControls();
@@ -11,3 +12,4 @@ initSchedulerToggle();
 initNav();
 initFormValidation();
 initFooterFade();
+initOffline();

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = 'glimpser-offline-v1';
+const MAX_SHOTS = 20;
+const OFFLINE_URLS = ['/status', '/discover'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (OFFLINE_URLS.includes(url.pathname)) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (/\.jpe?g$/i.test(url.pathname) || url.pathname.startsWith('/last_screenshot') || url.pathname.endsWith('/stream.png')) {
+    event.respondWith(cacheLatestShots(request));
+    return;
+  }
+});
+
+function networkFirst(request) {
+  return fetch(request)
+    .then(response => {
+      caches.open(CACHE_NAME).then(cache => cache.put(request, response.clone()));
+      return response;
+    })
+    .catch(() => caches.match(request));
+}
+
+function cacheLatestShots(request) {
+  return promiseTimeout(fetch(request), 3000)
+    .then(response => {
+      if (response.status === 504) throw new Error('Gateway timeout');
+      const clone = response.clone();
+      caches.open(CACHE_NAME).then(async cache => {
+        await cache.put(request, clone);
+        const keys = (await cache.keys()).filter(k => k.url.includes('/last_screenshot') || /\.jpe?g$/i.test(k.url));
+        while (keys.length > MAX_SHOTS) {
+          await cache.delete(keys.shift());
+        }
+      });
+      return response;
+    })
+    .catch(() => caches.match(request));
+}
+
+function promiseTimeout(promise, ms) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error('timeout')), ms);
+  });
+  return Promise.race([promise.finally(() => clearTimeout(timeoutId)), timeout]);
+}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -55,6 +55,12 @@
     <form method="POST" action="{{ url_for('settings') }}">
         <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
     </form>
+
+    <h3>Offline Preview</h3>
+    <label>
+        <input type="checkbox" id="offline-preview" title="Cache snapshots for offline viewing">
+        Enable offline preview
+    </label>
 </main>
     <script src="{{ url_for('static', filename='js/performance.js') }}"></script>
 {% endblock %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,5 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)
+- [Offline Preview](offline_preview.md)
 

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,0 +1,3 @@
+# Offline Preview
+
+A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. When **Enable offline preview** is checked on the Settings page, the browser registers `/sw.js` which caches the `/status` and `/discover` pages along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -8,5 +8,6 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Current Settings** – edit existing values or delete them.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Danger Mode** – update Chrome shortcuts with the required flags.
+- **Offline Preview** – toggle a Service Worker that caches recent images.
 
 You can also visit `/settings_help` directly to read the full explanation page.


### PR DESCRIPTION
## Summary
- add service worker that caches /status, /discover and last 20 snapshots
- allow enabling offline preview from Settings
- register/unregister service worker with offline.js
- document offline preview feature

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d7411e3208333b0ed655f1032a882