### PR TITLE
Add toast notifications for global errors

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -979,3 +979,22 @@ details > summary {
     width: 100%;
     height: 100px;
 }
+
+.toast-container {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 10000;
+}
+
+.toast {
+    background-color: var(--secondary-bg-color);
+    color: var(--text-color);
+    padding: 8px 12px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    min-width: 200px;
+}

--- a/app/static/js/errors.js
+++ b/app/static/js/errors.js
@@ -1,0 +1,46 @@
+export function initErrorHandling() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.createElement('div');
+    container.className = 'toast-container';
+    document.body.appendChild(container);
+
+    const queue = [];
+
+    function renderQueue() {
+      container.innerHTML = '';
+      queue.forEach((item) => {
+        const div = document.createElement('div');
+        div.className = 'toast';
+        div.textContent = item.message;
+        container.appendChild(div);
+      });
+    }
+
+    function addMessage(message) {
+      const id = Date.now() + Math.random();
+      queue.push({ id, message });
+      renderQueue();
+      setTimeout(() => {
+        const index = queue.findIndex((i) => i.id === id);
+        if (index !== -1) {
+          queue.splice(index, 1);
+          renderQueue();
+        }
+      }, 10000);
+    }
+
+    function handleError(event) {
+      let msg = 'An error occurred';
+      if (event.message) {
+        msg = event.message;
+      } else if (event.reason) {
+        msg = event.reason.message || String(event.reason);
+      }
+      console.error('Captured error:', event);
+      addMessage(msg);
+    }
+
+    window.addEventListener('error', handleError);
+    window.addEventListener('unhandledrejection', handleError);
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -4,6 +4,7 @@ import { initSchedulerToggle } from './scheduler.js';
 import { initNav } from './nav.js';
 import { initFormValidation } from './form.js';
 import { initFooterFade } from './footer.js';
+import { initErrorHandling } from './errors.js';
 
 initTemplates();
 initVideoControls();
@@ -11,3 +12,4 @@ initSchedulerToggle();
 initNav();
 initFormValidation();
 initFooterFade();
+initErrorHandling();

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Live view image streams now back off exponentially after repeated failures.
 - Live view preloads the next stream for smoother camera switching.
 - PNG streams hide the loading overlay once a frame is displayed.
+- Global errors now appear in toast notifications so browser issues are visible.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -196,3 +196,10 @@ snapshot image rather than a true video stream.
 - Use the camera's RTSP or HTTP video stream URL when available.
 - Snapshot-only URLs now work automatically, but they refresh slowly
   since a new JPEG must be fetched for each frame.
+
+## 12. Browser Errors
+
+Glimpser now surfaces JavaScript errors in small toast notifications at the top left of the page.
+These pop-ups disappear automatically after about 10 seconds. If a backend request fails or the
+browser blocks a cross-origin request, the message will appear here so you can immediately see
+what went wrong. Consult the browser console for full details if needed.


### PR DESCRIPTION
## Summary
- notify users about global JS errors
- hook error/unhandledrejection listeners to show toast messages
- document the new behaviour in troubleshooting guide and docs README

## Testing
- `black main.py --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7422a9d4833397c3c2057c99bd1d