### PR TITLE
Display build metadata in footer

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -71,6 +71,16 @@ from app.utils.screenshots import (
 )
 from app.utils.db import SessionLocal, engine
 
+try:
+    COMMIT_HASH = (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        .decode()
+        .strip()
+    )
+except Exception:
+    COMMIT_HASH = "unknown"
+NODE_ENV = os.getenv("NODE_ENV", "development")
+
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
@@ -757,7 +767,12 @@ def init_routes(app):
         except Exception:
             pass
 
-        return dict(VERSION=VERSION, VERSION_OUTDATED=outdated)
+        return dict(
+            VERSION=VERSION,
+            VERSION_OUTDATED=outdated,
+            COMMIT_HASH=COMMIT_HASH,
+            NODE_ENV=NODE_ENV,
+        )
 
     # Add a new route for the extended health check
     @app.route("/health")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -735,6 +735,11 @@ footer.fade-out {
     font-size: 0.9em;
 }
 
+.footer-build {
+    font-size: 0.8em;
+    opacity: 0.7;
+}
+
 .tsv-buttons {
     display: flex;
     gap: 15px;

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -15,6 +15,9 @@
             <a href="https://glimpser.net" target="_blank" title="Project website">About</a>
             <a href="https://github.com/KristopherKubicki/glimpser/blob/main/LICENSE.md" target="_blank" title="Software license">License</a>
         </nav>
+        <div class="footer-build">
+            {{ COMMIT_HASH }} - {{ NODE_ENV }}
+        </div>
     </div>
 </footer>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - The footer now stays fixed at the bottom of the screen and fades when the
   mouse is idle.
+- A tiny footer badge shows the current commit hash and `NODE_ENV` for easier
+  support.
 - Templates track capture failures and display a warning icon when screenshots fail.
 - Keyboard shortcuts now allow play/pause, mute, fullscreen toggling, camera selection with the arrow keys, and speed adjustment with `[` and `]` when watching live video.
 - Live view image streams now back off exponentially after repeated failures.


### PR DESCRIPTION
## Summary
- display short git commit hash and environment in footer
- show build metadata with subtle style
- document the new footer badge

## Testing
- `flake8 app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d747e17588333876a15d4acac8ae1