### PR TITLE
Expose typed dangerActive

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,5 +1,19 @@
 export function initNav() {
   document.addEventListener('DOMContentLoaded', () => {
+    /** @type {boolean} */
+    let _dangerActive = false;
+
+    Object.defineProperty(window, 'dangerActive', {
+      get() {
+        return _dangerActive;
+      },
+      set(value) {
+        if (typeof value !== 'boolean') {
+          throw new TypeError('dangerActive must be a boolean');
+        }
+        _dangerActive = value;
+      },
+    });
     function checkHealth() {
       fetch('/health')
         .then((response) => response.json())
@@ -38,6 +52,7 @@ export function initNav() {
       fetch('/danger_status')
         .then((response) => response.json())
         .then((data) => {
+          window.dangerActive = data.ready;
           const dangerStatus = document.getElementById('danger-status');
           if (!dangerStatus) return;
           if (data.ready) {

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -28,3 +28,5 @@ When Chrome's debug port is open and no user input has been detected for a short
 Captures marked as "Danger" in the template editor will use your running Chrome session. Glimpser opens a new tab, performs the capture, and closes the tab when finished. It skips the operation if you become active while the capture is pending.
 
 Be cautious with this feature, as it can interact with your browser while you are away. Ensure you trust the pages being captured.
+
+The UI exposes a global `window.dangerActive` property that reflects when Danger mode is ready. This property is typed as a boolean so assigning anything else throws an error in strict mode.


### PR DESCRIPTION
## Summary
- expose `window.dangerActive` via getter/setter with type checking
- document the new property in Danger Mode docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d7477f4d083339d95cf9eb893be7a