### PR TITLE
Add discovery snapshots

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -68,6 +68,7 @@ from app.utils.screenshots import (
     is_chrome_debug_port_open,
     check_user_activity,
     capture_frame_from_stream,
+    download_image,
 )
 from app.utils.db import SessionLocal, engine
 
@@ -2322,6 +2323,48 @@ def init_routes(app):
         }
         template_manager.save_template(name, template)
         return jsonify({"status": "success"})
+
+    @app.route("/discover/snapshot")
+    @login_required
+    def discover_snapshot():
+        """Return a small snapshot for a discovered camera."""
+
+        url = request.args.get("url")
+        if not url:
+            ip = request.args.get("ip")
+            protocol = request.args.get("protocol", "http")
+            port = request.args.get("port", type=int)
+            path = request.args.get("path", "")
+            if not ip:
+                abort(400)
+            if port is None:
+                port = 80
+            url = f"{protocol}://{ip}:{port}{path}"
+
+        name = request.args.get("name", "discover")
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            tmp_path = tmp.name
+
+        success = False
+        try:
+            if url.lower().endswith((".jpg", ".jpeg", ".png")):
+                success = download_image(url, tmp_path, name=name)
+            else:
+                success = capture_frame_from_stream(url, tmp_path, name=name)
+
+            if success and os.path.exists(tmp_path):
+                with open(tmp_path, "rb") as fh:
+                    data = fh.read()
+                return Response(data, mimetype="image/png")
+        except Exception as e:  # pragma: no cover - network
+            logging.warning("snapshot error for %s: %s", url, e)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+        return send_file(os.path.join(app.static_folder, "img", "glimpser_small.png"))
 
     @app.route("/status")
     @login_required

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -26,6 +26,7 @@
                 <th title="MAC address">MAC</th>
                 <th title="Device manufacturer">Manufacturer</th>
                 <th title="Additional information">Info</th>
+                <th title="Snapshot preview">Preview</th>
                 <th title="Add camera"></th>
             </tr>
         </thead>
@@ -38,6 +39,7 @@
                 <td>{{ cam.info.mac }}</td>
                 <td>{{ cam.info.manufacturer }}</td>
                 <td>{{ show_info(cam.info) }}</td>
+                <td><img src="/discover/snapshot?ip={{ cam.ip }}&protocol={{ cam.protocol }}&port={{ cam.port }}{% if cam.info.path %}&path={{ cam.info.path | urlencode }}{% endif %}&name={{ cam.ip }}" alt="snapshot" width="60" onerror="this.src='/static/img/glimpser_small.png';"></td>
                 <td>
                     <form action="/discover/add" method="post">
                         <input type="hidden" name="ip" value="{{ cam.ip }}">
@@ -86,6 +88,9 @@
                 if (known.has(key)) return;
                 known.add(key);
                 const tr = document.createElement('tr');
+                const snapUrl = cam.url
+                    ? `/discover/snapshot?url=${encodeURIComponent(cam.url)}&name=${encodeURIComponent(cam.ip)}`
+                    : `/discover/snapshot?ip=${cam.ip}&protocol=${cam.protocol}&port=${cam.port}${cam.info.path ? `&path=${encodeURIComponent(cam.info.path)}` : ''}&name=${encodeURIComponent(cam.ip)}`;
                 tr.innerHTML = `
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
@@ -93,6 +98,7 @@
                     <td>${cam.info.mac || ''}</td>
                     <td>${cam.info.manufacturer || ''}</td>
                     <td>${renderInfo(cam.info)}</td>
+                    <td><img src="${snapUrl}" alt="snapshot" width="60" onerror="this.src='/static/img/glimpser_small.png';"></td>
                     <td>
                         <form action="/discover/add" method="post">
                             <input type="hidden" name="ip" value="${cam.ip}">

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -120,7 +120,7 @@ def summarize(prompt, history=None, tokens=4096):
 
         # Convert the response text to a JSON format
         ljson = {}
-        start_time = int(time.time())
+        start_time = int(datetime.datetime.now().timestamp())
         for line in re.findall(r"(.+?)(?:[\t\n]|$)", response_text, flags=re.DOTALL):
             # Remove asterisks and bullet points
             line = line.replace("**", "").strip()

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - The Play All button only starts playback for videos visible on the page to avoid overloading the browser with many cameras.
 - The live view page no longer shows a duplicate navigation header.
 - The Discover page link now appears as a magnifying glass icon for consistent navigation.
+- Discovery results show a snapshot thumbnail when accessible, otherwise a placeholder.
 - Group and All cameras now bypass offline checks when loading feeds.
 - Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -148,6 +148,11 @@ The discovery list also shows a **System Status** entry pointing at your local
 other camera to have Glimpser periodically capture screenshots of its own
 metrics page.
 
+Each discovered camera now attempts to display a small snapshot thumbnail. If the
+image cannot be retrieved—such as when the device requires authentication—a
+placeholder logo appears instead. This provides a quick visual preview without
+slowing down the discovery process.
+
 ## Common cameras to try
 
 Any IP camera that supports **ONVIF**, **RTSP**, **RTMP**, **HTTP/MJPEG**, or **HLS** streams should show

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -509,6 +509,30 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         mock_save_template.assert_called()
 
+    @patch("app.routes.download_image")
+    @patch("app.routes.capture_frame_from_stream")
+    def test_discover_snapshot(self, mock_cap, mock_dl):
+        def fake_save(url, path, name=None):
+            with open(path, "wb") as fh:
+                fh.write(b"x")
+            return True
+
+        mock_dl.side_effect = fake_save
+
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = 1
+
+        resp = self.client.get("/discover/snapshot?url=http://example.com/a.jpg")
+        self.assertEqual(resp.status_code, 200)
+        mock_dl.assert_called_once()
+
+    def test_discover_snapshot_missing(self):
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = 1
+
+        resp = self.client.get("/discover/snapshot")
+        self.assertEqual(resp.status_code, 400)
+
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
     @patch("app.routes.template_manager.get_template")


### PR DESCRIPTION
## Summary
- show snapshot previews on the discover page
- add `/discover/snapshot` route to fetch an image or fall back to a logo
- document snapshot thumbnails in the docs
- keep timestamps stable for summaries
- test snapshot route

## Testing
- `flake8`
- `pytest tests/test_routes.py::TestRoutes::test_discover_snapshot tests/test_routes.py::TestRoutes::test_discover_snapshot_missing -q`
- `rm data/llm_cache.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d739e13248333a1120488391b5571