### PR TITLE
Add Playwright smoke tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,6 +34,8 @@ jobs:
         node-version: '18'
     - name: Install Node dependencies
       run: npm install
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps
     - name: Lint CSS
       run: npm run lint:css
     - name: Lint with flake8
@@ -42,6 +44,8 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run Playwright smoke tests
+      run: npm run test:e2e
     - name: Test with coverage
       run: |
         python -m coverage run -m pytest

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,3 +49,8 @@ like:
 python -m coverage run -m pytest
 python -m coverage html
 ```
+
+## Playwright Smoke Tests
+
+Playwright verifies that login succeeds and navigation links render the grid correctly. These tests run headless in CI on every push. A green bar means the basics still work until we expand to full component coverage.
+

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "lint:css": "stylelint 'app/static/css/**/*.css'"
+    "lint:css": "stylelint 'app/static/css/**/*.css'",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "stylelint": "^15.10.0",
-    "stylelint-config-standard": "^34.0.0"
+    "stylelint-config-standard": "^34.0.0",
+    "playwright": "^1.41.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/playwright',
+  use: { baseURL: 'http://127.0.0.1:5000', headless: true },
+  webServer: {
+    command: 'python scripts/start_playwright_server.py',
+    port: 5000,
+    timeout: 60000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/scripts/start_playwright_server.py
+++ b/scripts/start_playwright_server.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+import argparse
+import importlib
+from threading import Thread
+from werkzeug.serving import make_server
+
+import generate_credentials
+import app.config as config
+import app.utils.db as db
+import app.routes as routes
+import app
+
+
+class ServerThread(Thread):
+    def __init__(self, app, port: int):
+        super().__init__(daemon=True)
+        self.server = make_server("127.0.0.1", port, app)
+
+    def run(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.shutdown()
+
+
+def main(port: int = 5000):
+    data_dir = tempfile.mkdtemp(prefix="pwdata")
+    db_path = os.path.join(data_dir, "test.db")
+
+    args = argparse.Namespace(
+        db_path=db_path,
+        username="e2e",
+        password="secret",
+        update_password=False,
+        secret_key="secretkey",
+        update_key=False,
+    )
+    generate_credentials.generate_credentials(args)
+
+    importlib.reload(config)
+    importlib.reload(db)
+    importlib.reload(routes)
+    importlib.reload(app)
+
+    application = app.create_app(enable_watchdog=False, schedule=False)
+
+    server = ServerThread(application, port)
+    server.start()
+    print("Server started", flush=True)
+    try:
+        server.join()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PW_PORT", "5000"))
+    main(port)

--- a/tests/playwright/login-renders-grid.spec.ts
+++ b/tests/playwright/login-renders-grid.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('login renders grid', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="username"]', 'e2e');
+  await page.fill('input[name="password"]', 'secret');
+  await page.click('input[type="submit"]');
+  await expect(page).toHaveURL('/');
+  await expect(page.locator('#template-list')).toBeVisible();
+});

--- a/tests/playwright/nav-links-work.spec.ts
+++ b/tests/playwright/nav-links-work.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('nav links work', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="username"]', 'e2e');
+  await page.fill('input[name="password"]', 'secret');
+  await page.click('input[type="submit"]');
+
+  await page.click('a[href="/settings"]');
+  await expect(page).toHaveURL('/settings');
+
+  await page.click('a[title="Home"]');
+  await expect(page).toHaveURL('/');
+});


### PR DESCRIPTION
## Summary
- add simple Playwright test suite
- make npm script to run smoke tests
- invoke Playwright in CI
- document Playwright basics

## Testing
- `flake8`
- `pytest -q`
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d743cbe8c8333a1140471ac0ea21f