### PR TITLE
Add global CSP and remove CDN assets

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -745,6 +745,9 @@ def init_routes(app):
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["Cache-Control"] = "no-store"
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; img-src 'self' data: blob:"
+        )
         return response
 
     @app.context_processor

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -5,14 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glimpser</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
-    <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-        integrity="sha512-d+QeMAyl8RckY6SLlmRu9yckYv12LT4QcQuw2fbfbVzquSeQj0DnI1W6RKssYhh7j8A2Pn6GvmXwFbr1Qr1Zyg=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-    />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
      <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     {% if session.get('user_id') %}

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -92,14 +92,14 @@
             <input type="range" id="seek-bar" value="0">
 
             <div class="control-row">
-                <button id="play-pause" title="play/pause"><i class="fa-play-pause"></i></button>
+                <button id="play-pause" title="play/pause"><span aria-hidden="true">⏯</span></button>
                 <div id="speed-container">
                     <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()">
                     <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
                 </div>
 
 	<!-- <button id="cast-button">Cast</button> -->
-                <button id="full-screen" title='fullscreen'><i class="fas fa-expand"></i></button>
+                <button id="full-screen" title='fullscreen'><span aria-hidden="true">⛶</span></button>
 
     <select id="video-source" onchange="changeVideoSource()">
         <option value="png" title="View a series of PNG images">PNG Stream</option>
@@ -142,15 +142,15 @@
             <div id="loading-indicator" class="hidden">Loading...</div>
             <div id="play-pause-indicator" class="video-icon hidden">▶</div>
             <div id="offline-indicator" class="offline-indicator hidden">
-                <i class="fas fa-video-slash video-icon"></i>
+                <span class="video-icon" aria-hidden="true">🚫</span>
                 <p id="offline-message"></p>
             </div>
             <div id="capture-error-indicator" class="error-indicator hidden">
-                <i class="fas fa-exclamation-triangle video-icon"></i>
+                <span class="video-icon" aria-hidden="true">⚠️</span>
                 <p id="capture-error-message"></p>
             </div>
             <div id="stream-error-indicator" class="error-indicator hidden">
-                <i class="fas fa-times-circle video-icon"></i>
+                <span class="video-icon" aria-hidden="true">❌</span>
                 <p id="stream-error-message"></p>
             </div>
         </div>
@@ -161,7 +161,6 @@
 
     <div id="template-details"></div>
 
-    <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
     <script>
 
         const video = document.getElementById('live-video');

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -18,8 +18,8 @@
         {% if session.get('user_id') %}
                 <a id="health-status" href="/status" class="status-indicator" title="System Performance"></a>
                 <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
-                <a href='/discover' class="settings-icon" title='Discover Cameras'><i class="fas fa-search"></i></a>
-                <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'><i class="fas fa-comment-dots"></i></a>
+                <a href='/discover' class="settings-icon" title='Discover Cameras'><span aria-hidden="true">🔍</span></a>
+                <a href='/captions' id='captions' class="settings-icon" title='Read and update camera LLMs'><span aria-hidden="true">💬</span></a>
                 <a href='/live' id='live'>
                     <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
                         <div id="dateDisplay" class="clock-face">
@@ -31,9 +31,9 @@
                         </div>
                     </div>
                 </a>
-                <a href='/settings' class="settings-icon" title="Update settings"><i class="fas fa-cog"></i></a>
+                <a href='/settings' class="settings-icon" title="Update settings"><span aria-hidden="true">⚙️</span></a>
         {% else %}
-                <a href="{{ url_for('login') }}" class="settings-icon" title="Login"><i class="fas fa-sign-in-alt"></i></a>
+                <a href="{{ url_for('login') }}" class="settings-icon" title="Login"><span aria-hidden="true">→</span></a>
         {% endif %}
             </div>
         </nav>

--- a/docs/content_security_policy.md
+++ b/docs/content_security_policy.md
@@ -1,0 +1,12 @@
+The application now enforces a strict Content Security Policy (CSP) on all responses.
+The policy restricts resources to the local origin and allows images from data and
+blob URLs:
+
+```
+Content-Security-Policy: default-src 'self'; img-src 'self' data: blob:
+```
+
+This reduces the risk of cross-site scripting (XSS) and prevents mixed‑content
+warnings when running behind corporate proxies.
+
+

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -22,6 +22,10 @@ class TestSecurityHeaders(unittest.TestCase):
         self.assertEqual(resp.headers.get("X-XSS-Protection"), "1; mode=block")
         self.assertEqual(resp.headers.get("Referrer-Policy"), "no-referrer")
         self.assertEqual(resp.headers.get("Cache-Control"), "no-store")
+        self.assertEqual(
+            resp.headers.get("Content-Security-Policy"),
+            "default-src 'self'; img-src 'self' data: blob:",
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- enforce strict `Content-Security-Policy`
- replace Font Awesome icons with Unicode characters
- drop external CDN links from templates
- document the CSP policy
- update security header test

## Testing
- `flake8 app/routes.py tests/test_security_headers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d74412c748333ace126347aaf9b7f