### PR TITLE
Update CSS for logical margins

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -83,7 +83,7 @@ html {
     .camera-list td {
         border: none;
         position: relative;
-        padding-left: 50%;
+        padding-inline-start: 50%;
     }
 
     .camera-list td:before {
@@ -91,7 +91,7 @@ html {
         top: 6px;
         left: 6px;
         width: 45%;
-        padding-right: 10px;
+        padding-inline-end: 10px;
         white-space: nowrap;
         content: attr(data-label);
         font-weight: bold;
@@ -374,12 +374,12 @@ nav a {
     align-items: center;
     justify-content: center;
     background-color: var(--secondary-bg-color);
-    margin-left: 5px;
+    margin-inline-start: 5px;
     text-decoration: none;
 }
 
 .nav-right .cool-clock {
-    margin-left: 5px;
+    margin-inline-start: 5px;
 }
 
 .nav-right a:hover {
@@ -406,7 +406,7 @@ nav a:hover, nav a.active {
     padding: 2px 5px;
     background-color: #f0f0f0;
     border-radius: 3px;
-    margin-left: 10px;
+    margin-inline-start: 10px;
 }
 
 .performance-indicator:hover::after {
@@ -512,7 +512,7 @@ button, a {
     background-color: #f0f0f0;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     position: relative;
-    margin-left: 20px;
+    margin-inline-start: 20px;
 }
 
 .clock-face {
@@ -731,7 +731,7 @@ footer.fade-out {
 }
 
 .footer-copy {
-    margin-right: 10px;
+    margin-inline-end: 10px;
     font-size: 0.9em;
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Live view image streams now back off exponentially after repeated failures.
 - Live view preloads the next stream for smoother camera switching.
 - PNG streams hide the loading overlay once a frame is displayed.
+- Margins and padding now use CSS logical properties for RTL support.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Troubleshooting](troubleshooting.md)
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
+- [Right-to-Left Layout Support](rtl_support.md)
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)

--- a/docs/rtl_support.md
+++ b/docs/rtl_support.md
@@ -1,0 +1,8 @@
+# Right-to-Left Layout Support
+
+Glimpser's styles now use logical CSS properties for margins and padding. Rules
+such as `margin-inline-start` and `margin-inline-end` replace `margin-left` and
+`margin-right`. Likewise, `padding-inline-start` and `padding-inline-end` are
+used instead of the old directional properties. These logical properties switch
+automatically when the page uses `dir="rtl"`, allowing right-to-left themes
+without extra markup or scripts.


### PR DESCRIPTION
## Summary
- use margin-inline-* and padding-inline-* in styles
- document right-to-left layout support

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7453b39c83339df67e7b8fdf28fa