### PR TITLE
feat: overlay ISO timestamps on thumbnails

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -685,6 +685,30 @@ button, a {
     right: 0;
 }
 
+/* Overlay ISO8601 timestamps using pseudo-elements */
+.video-container[data-timestamp],
+.templateDiv img[data-timestamp],
+video.hover-video[data-timestamp] {
+    position: relative;
+}
+
+.video-container[data-timestamp]::after,
+.templateDiv img[data-timestamp]::after,
+video.hover-video[data-timestamp]::after {
+    content: attr(data-timestamp);
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    font-size: var(--timestamp-font-size);
+    font-variant: small-caps;
+    text-shadow: 0 0 3px #000;
+    z-index: 5;
+    pointer-events: none;
+}
+
 .notes-textarea {
     width: 100%;
     height: 60px;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -319,13 +319,12 @@ export async function loadTemplates() {
 
           templateDiv.innerHTML = `
             <a href='/templates/${name}'>
-              <div class="${videoContainerClass} ${errorClass}">
+              <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}">
                 <div class="camera-name">${name}</div>
                 <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none">
                   <source src="/last_video/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
-                <div class="timestamp" title="${formatExactTime(lastScreenshotTime)}">${humanizedTimestamp}</div>
                 <div class="play-icon">&#9658;</div>
               </div>
             </a>

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -104,13 +104,10 @@
                 <div class="templateDiv">
                     <div class="video-container">
 			    <div class="camera-name"><a href='/templates/{{camera}}'>{{camera}}</a></div>
-                        <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}">
+                        <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
                             <source src="/last_video/{{ camera }}" type="video/mp4">
                             Your browser does not support the video tag.
                         </video>
-                        <div class="timestamp" title="{{ template_details[camera]['last_screenshot_time'] }}">
-                            {{ template_details[camera]['last_screenshot_time'] }}
-                        </div>
                     </div>
                 </div>
             </td>


### PR DESCRIPTION
## Summary
- overlay ISO timestamps via `::after` pseudo-elements
- set `data-timestamp` attributes for videos and screenshots
- style timestamps with small-caps and text shadow

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7459f474833395e20b6e2e1f7261