### PR TITLE
Add throttled fetch generator

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,62 +1,57 @@
+import { pollingFetch } from './polling.js';
+
 export function initNav() {
   document.addEventListener('DOMContentLoaded', () => {
-    function checkHealth() {
-      fetch('/health')
-        .then((response) => response.json())
-        .then((data) => {
-          const healthStatus = document.getElementById('health-status');
-          if (!healthStatus) return;
-          if (data.status === 'healthy') {
-            healthStatus.style.backgroundColor = 'green';
-            healthStatus.title = 'System Status: Healthy\n\n';
-          } else {
-            healthStatus.style.backgroundColor = 'red';
-            healthStatus.title = 'System Status: Degraded\n\n';
-          }
-          healthStatus.title += `CPU: ${data.metrics.cpu_usage}%\n` +
-            `Memory: ${data.metrics.memory_usage}%\n` +
-            `Disk: ${data.metrics.disk_usage}%\n` +
-            `Open Files: ${data.metrics.open_files}\n` +
-            `Threads: ${data.metrics.thread_count}\n` +
-            `Uptime: ${data.metrics.uptime}\n`;
+    function renderHealth(data) {
+      const healthStatus = document.getElementById('health-status');
+      if (!healthStatus || !data) return;
+      if (data.status === 'healthy') {
+        healthStatus.style.backgroundColor = 'green';
+        healthStatus.title = 'System Status: Healthy\n\n';
+      } else {
+        healthStatus.style.backgroundColor = 'red';
+        healthStatus.title = 'System Status: Degraded\n\n';
+      }
+      healthStatus.title += `CPU: ${data.metrics.cpu_usage}%\n` +
+        `Memory: ${data.metrics.memory_usage}%\n` +
+        `Disk: ${data.metrics.disk_usage}%\n` +
+        `Open Files: ${data.metrics.open_files}\n` +
+        `Threads: ${data.metrics.thread_count}\n` +
+        `Uptime: ${data.metrics.uptime}\n`;
 
-          if (data.error_messages && data.error_messages.length > 0) {
-            healthStatus.title += '\nErrors:\n' + data.error_messages.join('\n');
-          }
-        })
-        .catch((error) => {
-          console.error('Error fetching health status:', error);
-          const healthStatus = document.getElementById('health-status');
-          if (healthStatus) {
-            healthStatus.style.backgroundColor = 'red';
-            healthStatus.title = 'Error: Unable to fetch health status';
-          }
-        });
+      if (data.error_messages && data.error_messages.length > 0) {
+        healthStatus.title += '\nErrors:\n' + data.error_messages.join('\n');
+      }
     }
 
-    function checkDanger() {
-      fetch('/danger_status')
-        .then((response) => response.json())
-        .then((data) => {
-          const dangerStatus = document.getElementById('danger-status');
-          if (!dangerStatus) return;
-          if (data.ready) {
-            dangerStatus.style.backgroundColor = 'orange';
-            dangerStatus.textContent = '!';
-            dangerStatus.title = 'Danger Mode Ready';
-          } else {
-            dangerStatus.style.backgroundColor = 'grey';
-            dangerStatus.textContent = '×';
-            let reason = [];
-            if (!data.port_open) reason.push('Debug port closed');
-            if (!data.idle) reason.push('User active');
-            dangerStatus.title = 'Danger Mode Off';
-            if (reason.length) dangerStatus.title += '\n' + reason.join(', ');
-          }
-        })
-        .catch((error) => {
-          console.error('Error fetching danger status:', error);
-        });
+    function renderHealthError() {
+      const healthStatus = document.getElementById('health-status');
+      if (healthStatus) {
+        healthStatus.style.backgroundColor = 'red';
+        healthStatus.title = 'Error: Unable to fetch health status';
+      }
+    }
+
+    function renderDanger(data) {
+      const dangerStatus = document.getElementById('danger-status');
+      if (!dangerStatus || !data) return;
+      if (data.ready) {
+        dangerStatus.style.backgroundColor = 'orange';
+        dangerStatus.textContent = '!';
+        dangerStatus.title = 'Danger Mode Ready';
+      } else {
+        dangerStatus.style.backgroundColor = 'grey';
+        dangerStatus.textContent = '×';
+        let reason = [];
+        if (!data.port_open) reason.push('Debug port closed');
+        if (!data.idle) reason.push('User active');
+        dangerStatus.title = 'Danger Mode Off';
+        if (reason.length) dangerStatus.title += '\n' + reason.join(', ');
+      }
+    }
+
+    function renderDangerError() {
+      console.error('Error fetching danger status');
     }
 
     function updateCoolClock() {
@@ -93,11 +88,25 @@ export function initNav() {
       showNav();
     }
 
-    setInterval(checkHealth, 5000);
-    checkHealth();
+    (async () => {
+      for await (const data of pollingFetch(
+        () => fetch('/health').then((r) => r.json()),
+        5000,
+      )) {
+        if (data) renderHealth(data);
+        else renderHealthError();
+      }
+    })();
 
-    setInterval(checkDanger, 5000);
-    checkDanger();
+    (async () => {
+      for await (const data of pollingFetch(
+        () => fetch('/danger_status').then((r) => r.json()),
+        5000,
+      )) {
+        if (data) renderDanger(data);
+        else renderDangerError();
+      }
+    })();
 
     setInterval(updateCoolClock, 1000);
     updateCoolClock();

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -1,20 +1,27 @@
+import { pollingFetch } from './polling.js';
+
 let cpuData = [];
 const maxDataPoints = 60;
 
 function updatePerformanceMetrics() {
-    fetch('/health')
+    return fetch('/health')
         .then(response => response.json())
         .then(data => {
-            document.getElementById('cpu-value').textContent = `${data.cpu_usage}%`;
-            document.getElementById('cpu-bar').style.width = `${data.cpu_usage}%`;
-            
-            document.getElementById('memory-value').textContent = `${data.memory_usage}%`;
-            document.getElementById('memory-bar').style.width = `${data.memory_usage}%`;
-            
-            document.getElementById('uptime-value').textContent = data.uptime;
-            
-            updateCPUSparkline(data.cpu_usage);
+            renderPerformanceMetrics(data);
+            return data;
         });
+}
+
+function renderPerformanceMetrics(data) {
+    document.getElementById('cpu-value').textContent = `${data.cpu_usage}%`;
+    document.getElementById('cpu-bar').style.width = `${data.cpu_usage}%`;
+
+    document.getElementById('memory-value').textContent = `${data.memory_usage}%`;
+    document.getElementById('memory-bar').style.width = `${data.memory_usage}%`;
+
+    document.getElementById('uptime-value').textContent = data.uptime;
+
+    updateCPUSparkline(data.cpu_usage);
 }
 
 function updateCPUSparkline(newValue) {
@@ -47,7 +54,8 @@ function updateCPUSparkline(newValue) {
 }
 
 // Update metrics every 5 seconds
-setInterval(updatePerformanceMetrics, 5000);
-
-// Initial update
-updatePerformanceMetrics();
+(async () => {
+    for await (const _ of pollingFetch(updatePerformanceMetrics, 5000)) {
+        // pollingFetch handles errors and throttling
+    }
+})();

--- a/app/static/js/polling.js
+++ b/app/static/js/polling.js
@@ -1,0 +1,25 @@
+export async function* pollingFetch(fetchFn, interval = 5000) {
+  let lastFrame = performance.now();
+  while (true) {
+    if (!document.hidden) {
+      try {
+        yield await fetchFn();
+      } catch (e) {
+        console.error('Polling error:', e);
+        yield undefined;
+      }
+    }
+    await new Promise(r => setTimeout(r, interval));
+    const before = performance.now();
+    await new Promise(requestAnimationFrame);
+    const after = performance.now();
+    if (document.hidden || after - before > 33) {
+      while (document.hidden || after - before > 33) {
+        await new Promise(requestAnimationFrame);
+        const now = performance.now();
+        if (!document.hidden && now - after <= 33) break;
+      }
+    }
+    lastFrame = performance.now();
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,3 +49,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Live view image streams now back off exponentially after repeated failures.
 - Live view preloads the next stream for smoother camera switching.
 - PNG streams hide the loading overlay once a frame is displayed.
+- Health and danger polling now throttles fetches when the tab is hidden or running below 30 FPS.


### PR DESCRIPTION
## Summary
- throttle nav & performance polling with `pollingFetch`
- add new `polling.js` helper
- document visibility-aware polling

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d747318808333bf375498b8129759