### PR TITLE
Fix MJPEG all endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -496,6 +496,12 @@ lock = Lock()
 def generate(
     group=None, camera=None, filename="latest_camera.png", rtsp=False, session_id=None
 ):
+    # Treat explicit "all" values as no filter
+    if group == "all":
+        group = None
+    if camera == "all":
+        camera = None
+
     # pretty hacky but it works ok
     global last_time, last_shot
     boundary = b"frame"
@@ -1313,6 +1319,10 @@ def init_routes(app):
     def stream_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
+        if group == "all":
+            group = None
+        if camera == "all":
+            camera = None
         return Response(
             generate(group=group, camera=camera, filename="latest_camera.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
@@ -1322,6 +1332,10 @@ def init_routes(app):
     def motion_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
+        if group == "all":
+            group = None
+        if camera == "all":
+            camera = None
         return Response(
             generate(group=group, camera=camera, filename="last_motion.png"),
             mimetype="multipart/x-mixed-replace; boundary=frame",
@@ -1331,6 +1345,10 @@ def init_routes(app):
     def caption_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
+        if group == "all":
+            group = None
+        if camera == "all":
+            camera = None
         logging.debug("last caption")
         return Response(
             generate(group=group, camera=camera, filename="last_caption.png"),
@@ -1341,6 +1359,10 @@ def init_routes(app):
     def motion_caption_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
+        if group == "all":
+            group = None
+        if camera == "all":
+            camera = None
         logging.debug("last motion caption")
         return Response(
             generate(group=group, camera=camera, filename="last_motion_caption.png"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Group and All cameras now bypass offline checks when loading feeds.
 - Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.
+- The "All" camera MJPEG feed is available via `/stream.mjpg?group=all`.
 - HTML templates are tested for image `alt` text and required form fields.
 - Template storage usage is now verified by unit tests.
 - Prompt optimizer logic is now tested for screenshot handling and prompt restoration.

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -108,7 +108,7 @@ stream whenever the camera becomes available again.
 
 Several other routes provide streaming functionality:
 
-- **GET /stream.mjpg** – Continuous MJPEG stream of the latest camera image. Optional `camera` or `group` query parameters limit the feed.
+- **GET /stream.mjpg** – Continuous MJPEG stream of the latest camera image. Optional `camera` or `group` query parameters limit the feed. Passing `group=all` shows the newest frame from any camera.
 - **GET /stream.png** – Returns the most recent screenshot across all cameras.
 - **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `camera` or `group` as query parameters.
 - **GET /caption.mjpg** – MJPEG stream of the last caption frame for a group.


### PR DESCRIPTION
## Summary
- handle `group=all` in MJPEG routes
- mention all camera MJPEG stream in docs

## Testing
- `flake8 app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d75b2f26083338c7a20e69ba1efb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using "all" as a value for camera or group filters in MJPEG streaming endpoints, allowing users to view feeds from all cameras.

- **Documentation**
  - Updated user and API documentation to describe the new "all" camera MJPEG feed option and clarify its usage in query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->