### PR TITLE
fix template save for unknown fields

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -224,6 +224,12 @@ class TemplateManager:
                 details["timeout"] = default_timeout
             if template:
                 for key, value in details.items():
+                    if not hasattr(template, key):
+                        # Ignore keys that are not valid attributes on
+                        # the Template model. This prevents errors when
+                        # extraneous fields like ``snapshot_only`` are
+                        # submitted from the UI.
+                        continue
                     try:
                         if key == "rollback_frames":
                             value = int(value)


### PR DESCRIPTION
## Summary
- skip unknown fields when saving template

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d76aeee208333bbdc1b91c7d7431b