### PR TITLE
Add KPI sorting and filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MAC vendor lookup now consults local databases and an online API
 - Footer warns when a newer release is available
 - Stream error overlay distinguishes network and unsupported format errors
+- Sortable KPI table on captions page with filtering
 
 ### Changed
 - Improved screenshot reliability

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -903,6 +903,10 @@ input[type=submit]:hover {
     padding: 15px;
 }
 
+.captions-page .templateDiv {
+    width: 160px;
+}
+
 .filter-controls {
     display: flex;
     flex-wrap: wrap;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -92,6 +92,7 @@ export function initTemplates() {
     loadGroups();
     loadTemplates();
     setupSearch();
+    setupSorting();
   });
 
   window.showStructuredInput = showStructuredInput;
@@ -220,18 +221,37 @@ export function setupSearch() {
   const searchInput = document.getElementById('search-input');
   const groupDropdown = document.getElementById('group-dropdown');
   const cameraRows = document.querySelectorAll('.camera-row');
+  const filterColumn = document.getElementById('filter-column');
+  const filterValue = document.getElementById('filter-value');
+  const applyFilter = document.getElementById('apply-filter');
   const templateList = document.getElementById('template-list');
   if (!searchInput || !groupDropdown) return;
 
   const filterCameras = () => {
     const searchTerm = searchInput.value.toLowerCase();
     const selectedGroup = groupDropdown.value;
+    const column = filterColumn ? filterColumn.value : '';
+    const filterVal = filterValue ? filterValue.value.trim().toLowerCase() : '';
     cameraRows.forEach((row) => {
       const name = row.querySelector('td:first-child').textContent.toLowerCase();
       const groups = row.dataset.groups.split(',');
-      const matchesSearch = name.includes(searchTerm);
+      const rowText = row.textContent.toLowerCase();
+      const matchesSearch = rowText.includes(searchTerm);
       const matchesGroup = selectedGroup === 'all' || groups.includes(selectedGroup);
-      row.style.display = matchesSearch && matchesGroup ? '' : 'none';
+      let matchesKpi = true;
+      if (column && filterVal) {
+        const dataVal = row.dataset[column];
+        if (dataVal) {
+          const numericData = parseFloat(dataVal);
+          const numericFilter = parseFloat(filterVal);
+          if (!Number.isNaN(numericData) && !Number.isNaN(numericFilter)) {
+            matchesKpi = numericData >= numericFilter;
+          } else {
+            matchesKpi = dataVal.toLowerCase().includes(filterVal);
+          }
+        }
+      }
+      row.style.display = matchesSearch && matchesGroup && matchesKpi ? '' : 'none';
     });
   };
 
@@ -241,6 +261,7 @@ export function setupSearch() {
   } else {
     searchInput.addEventListener('input', filterCameras);
     groupDropdown.addEventListener('change', filterCameras);
+    if (applyFilter) applyFilter.addEventListener('click', filterCameras);
   }
 }
 
@@ -392,4 +413,34 @@ export async function loadTemplates() {
       templateContainer.innerHTML = errorMsg;
     }
   }
+}
+
+export function setupSorting() {
+  const headers = document.querySelectorAll('#camera-table th.sortable');
+  headers.forEach((th, index) => {
+    th.addEventListener('click', () => {
+      const type = th.dataset.type || 'string';
+      const tbody = th.closest('table').tBodies[0];
+      const rows = Array.from(tbody.rows);
+      const current = th.dataset.order === 'asc' ? 'asc' : 'desc';
+      rows.sort((a, b) => {
+        const aVal = a.cells[index].dataset.value || a.cells[index].textContent;
+        const bVal = b.cells[index].dataset.value || b.cells[index].textContent;
+        if (type === 'number') {
+          return parseFloat(aVal) - parseFloat(bVal);
+        }
+        if (type === 'date') {
+          return new Date(aVal) - new Date(bVal);
+        }
+        return aVal.localeCompare(bVal);
+      });
+      if (current === 'asc') {
+        rows.reverse();
+        th.dataset.order = 'desc';
+      } else {
+        th.dataset.order = 'asc';
+      }
+      rows.forEach((row) => tbody.appendChild(row));
+    });
+  });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -36,6 +36,18 @@
 
         <label for="search-input" title="Search for cameras or groups">Search:</label>
         <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
+
+        <label for="filter-column" title="KPI to filter">KPI:</label>
+        <select id="filter-column" title="Select KPI">
+            <option value="">All</option>
+            <option value="screenshot_count">Shots</option>
+            <option value="video_count">Videos</option>
+            <option value="storage_usage">Storage</option>
+            <option value="llm_response_count">LLM Resp</option>
+            <option value="llm_cost_estimate">LLM Cost</option>
+        </select>
+        <input type="text" id="filter-value" placeholder="Value" title="Filter value">
+        <button id="apply-filter" type="button">Apply</button>
     </div>
 
 
@@ -93,43 +105,39 @@
 <table id="camera-table" class="camera-table">
     <thead>
         <tr>
-            <th>Camera</th>
-            <th>Details</th>
+            <th class="sortable" data-type="string">Camera</th>
+            <th class="sortable" data-type="date">Last</th>
+            <th class="sortable" data-type="date">Next</th>
+            <th class="sortable" data-type="number">Shots</th>
+            <th class="sortable" data-type="number">Videos</th>
+            <th class="sortable" data-type="number">Storage</th>
+            <th class="sortable" data-type="number">LLM Resp</th>
+            <th class="sortable" data-type="number">LLM Cost</th>
+            <th>Caption</th>
         </tr>
     </thead>
     <tbody>
         {% for camera in template_details %}
-        <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}">
+        <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}" data-screenshot_count="{{ template_details[camera]['screenshot_count'] }}" data-video_count="{{ template_details[camera]['video_count'] }}" data-storage_usage="{{ template_details[camera]['storage_usage'] }}" data-llm_response_count="{{ template_details[camera]['llm_response_count'] }}" data-llm_cost_estimate="{{ template_details[camera]['llm_cost_estimate'] }}">
             <td>
                 <div class="templateDiv">
-                    <div class="video-container">
-			    <div class="camera-name"><a href='/templates/{{camera}}'>{{camera}}</a></div>
-                        <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
+                    <div class="video-container" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
+                        <div class="camera-name"><a href='/templates/{{camera}}'>{{camera}}</a></div>
+                        <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}">
                             <source src="/last_video/{{ camera }}" type="video/mp4">
                             Your browser does not support the video tag.
                         </video>
                     </div>
                 </div>
             </td>
+            <td data-value="{{ template_details[camera]['last_screenshot'] }}"><span class="humanized-time" data-time="{{ template_details[camera]['last_screenshot'] }}">{{ template_details[camera]['last_screenshot'] }}</span></td>
+            <td data-value="{{ template_details[camera]['next_screenshot'] }}"><span class="humanized-time" data-time="{{ template_details[camera]['next_screenshot'] }}">{{ template_details[camera]['next_screenshot'] }}</span></td>
+            <td data-value="{{ template_details[camera]['screenshot_count'] }}">{{ template_details[camera]['screenshot_count'] }}</td>
+            <td data-value="{{ template_details[camera]['video_count'] }}">{{ template_details[camera]['video_count'] }}</td>
+            <td data-value="{{ template_details[camera]['storage_usage'] }}">{{ template_details[camera]['storage_usage'] }}</td>
+            <td data-value="{{ template_details[camera]['llm_response_count'] }}">{{ template_details[camera]['llm_response_count'] }}</td>
+            <td data-value="{{ template_details[camera]['llm_cost_estimate'] }}">{{ template_details[camera]['llm_cost_estimate'] }}</td>
             <td>
-
-		    dark: {{ template_details[camera]['dark'] }}
-		    browser: {{ template_details[camera]['browser'] }}
-		    headless: {{ template_details[camera]['headless'] }}
-		    stealth: {{ template_details[camera]['stealth'] }}
-		    danger: {{ template_details[camera]['danger'] }}
-
-                <table>
-                    <tr>
-                        <td><span class="humanized-time" data-time="{{ template_details[camera]['last_screenshot'] }}">{{ template_details[camera]['last_screenshot'] }}</span></td>
-                        <td><span class="humanized-time" data-time="{{ template_details[camera]['next_screenshot'] }}">{{ template_details[camera]['next_screenshot'] }}</span></td>
-                        <td>{{ template_details[camera]['screenshot_count'] }}</td>
-                        <td>{{ template_details[camera]['video_count'] }}</td>
-                        <td>{{ template_details[camera]['storage_usage'] }}</td>
-                        <td>{{ template_details[camera]['llm_response_count'] }}</td>
-                        <td>{{ template_details[camera]['llm_cost_estimate'] }}</td>
-                    </tr>
-                </table>
                 <details>
                     <summary>Caption</summary>
                     <form id="form-{{ camera }}" class="notes-form">

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. The bulk controls are collapsed by default—expand the **Bulk Caption Management** section when needed. The table now shows relative timestamps and a placeholder when no captions are available.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, and you can filter rows by KPI values. The bulk controls are collapsed by default—expand the **Bulk Caption Management** section when needed. The table now shows relative timestamps and a placeholder when no captions are available.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- shrink thumbnails on captions page
- make KPI columns sortable and filterable
- document KPI sorting

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d7ac5bcb483339dc9cea0287058de