### PR TITLE
Fix discovery completion on multi-network hosts

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -166,26 +166,29 @@ def _local_subnets(max_prefixlen: int = 24):
     """Return local IPv4 subnets limited to ``max_prefixlen``.
 
     Some interfaces report very large networks (e.g. ``10.0.0.0/8``) which makes
-    discovery scans effectively unbounded.  To keep discovery responsive we cap
-    the size of each subnet to at most ``max_prefixlen``.
+    discovery scans effectively unbounded. To keep discovery responsive we cap
+    the size of each subnet to at most ``max_prefixlen``. Duplicate networks are
+    removed so multi-homed interfaces only scan each subnet once.
     """
 
-    subnets = []
-    for _iface, addrs in psutil.net_if_addrs().items():
+    subnets: set[ip_network] = set()
+    for addrs in psutil.net_if_addrs().values():
         for addr in addrs:
-            if addr.family == socket.AF_INET:
-                ip = addr.address
-                netmask = addr.netmask
-                if not ip or not netmask:
-                    continue
-                try:
-                    net = ip_network(f"{ip}/{netmask}", strict=False)
-                    if net.prefixlen < max_prefixlen:
-                        net = ip_network(f"{ip}/{max_prefixlen}", strict=False)
-                    subnets.append(net)
-                except Exception:
-                    pass
-    return subnets
+            if addr.family != socket.AF_INET:
+                continue
+            ip = addr.address
+            netmask = addr.netmask
+            if not ip or not netmask:
+                continue
+            try:
+                net = ip_network(f"{ip}/{netmask}", strict=False)
+                if net.prefixlen < max_prefixlen:
+                    net = ip_network(f"{ip}/{max_prefixlen}", strict=False)
+                subnets.add(net)
+            except Exception:
+                continue
+
+    return sorted(subnets, key=lambda n: (n.network_address.packed, n.prefixlen))
 
 
 def _probe_onvif(timeout=2):

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1853,15 +1853,14 @@ def is_port_open(host, port, timeout=5):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(timeout)
         try:
-            sock.connect((host, port))
-            logging.debug("should close?? %s", host)
-            sock.close()
-            logging.debug("closed %s", host)
-            return True
-        except (socket.timeout, ConnectionRefusedError, socket.gaierror):
-            if host in ("google.com", "www.google.com") and port == 80:
-                return True
+            result = sock.connect_ex((host, port))
+        except OSError:
             return False
+        if result == 0:
+            return True
+        if host in ("google.com", "www.google.com") and port == 80:
+            return True
+        return False
 
 
 def is_chrome_debug_port_open(host="127.0.0.1", port=9222, timeout=1):

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -1,6 +1,7 @@
 # Camera Discovery
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
+The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
 
 ## How the `/discover` route works
 


### PR DESCRIPTION
## Summary
- ensure discovery skips unreachable ports
- dedupe scanned subnets so each network only scanned once
- document fast fail for unreachable networks

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7b0ff2688333b2a4f9eaeb63ff5f