### PR TITLE
Fix group screenshot fallback

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -404,10 +404,12 @@ function refreshPNG() {
 }
 
 function showLastScreenshot() {
-    if (currentCamera.startsWith('group-') || currentCamera === 'All') {
-image.src = '/stream.png';
+    if (currentCamera === 'All') {
+        // Show the most recent screenshot across all cameras
+        image.src = '/stream.png';
     } else {
-image.src = '/last_screenshot/' + currentCamera;
+        // Display the latest screenshot for the selected camera or group
+        image.src = '/last_screenshot/' + currentCamera;
     }
     image.style.display = 'block';
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.
 - The "All" camera MJPEG feed is available via `/stream.mjpg?group=all`.
+- Group views display the last screenshot for the selected group using the
+  `/last_screenshot/group-<name>` endpoint.
 - HTML templates are tested for image `alt` text and required form fields.
 - Template storage usage is now verified by unit tests.
 - Prompt optimizer logic is now tested for screenshot handling and prompt restoration.


### PR DESCRIPTION
## Summary
- use `/last_screenshot/group-<name>` when showing group live view
- document the group screenshot behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7c3a72a0833389c33ab848e73b5f