### PR TITLE
Add danger mode settings page and simplify nav icons

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -879,9 +879,26 @@ def init_routes(app):
         """Return whether Danger mode can be used."""
         port_open = is_chrome_debug_port_open("127.0.0.1", 9222)
         idle = not check_user_activity(timeout=1)
+        enabled = config.get_setting("DANGER_MODE", "True") == "True"
         return jsonify(
-            {"port_open": port_open, "idle": idle, "ready": port_open and idle}
+            {
+                "port_open": port_open,
+                "idle": idle,
+                "enabled": enabled,
+                "ready": port_open and idle and enabled,
+            }
         )
+
+    @app.route("/danger", methods=["GET", "POST"])
+    @login_required
+    def danger_mode():
+        if request.method == "POST":
+            enabled = "enabled" in request.form
+            update_setting("DANGER_MODE", "True" if enabled else "False")
+            return redirect(url_for("danger_mode"))
+
+        current = config.get_setting("DANGER_MODE", "True") == "True"
+        return render_template("danger.html", enabled=current)
 
     @app.route("/api/discover")
     @profile_route("/api/discover")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -372,17 +372,25 @@ nav a {
     color: var(--text-color);
 }
 
-.nav-right a,
+
+.nav-right a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 5px;
+    text-decoration: none;
+    color: var(--text-color);
+}
+
 .nav-right .status-indicator {
-    width: 28px;
-    height: 28px;
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--secondary-bg-color);
+    background-color: grey;
     margin-left: 5px;
-    text-decoration: none;
 }
 
 .nav-right .cool-clock {
@@ -390,21 +398,26 @@ nav a {
 }
 
 .nav-right a:hover {
-    background-color: var(--accent-color);
-    color: #fff;
+    color: var(--accent-color);
 }
 
 nav a:hover, nav a.active {
-    background-color: var(--accent-color); /* Highlight for hover and active link */
-    color: #fff;
+    color: var(--accent-color);
 }
 
 .settings-icon {
-    font-size: 24px; /* Adjust the size of the icon */
-    text-decoration: none; /* Remove underline */
+    text-decoration: none;
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.settings-icon svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
 }
 
 .performance-indicator {
@@ -444,8 +457,9 @@ nav a:hover, nav a.active {
         margin-bottom: 5px; /* Add margin for stacked items */
     }
 
-    .settings-icon {
-        font-size: 20px; /* Slightly smaller icon on mobile */
+    .settings-icon svg {
+        width: 18px;
+        height: 18px;
     }
 
     .performance-indicator {

--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg"></svg>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="search" viewBox="0 0 24 24">
+    <circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2" fill="none" />
+    <line x1="16" y1="16" x2="22" y2="22" stroke="currentColor" stroke-width="2" />
+  </symbol>
+  <symbol id="comment" viewBox="0 0 24 24">
+    <path d="M4 4h16v10H8l-4 4z" stroke="currentColor" stroke-width="2" fill="none" />
+  </symbol>
+  <symbol id="settings" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none" />
+    <path d="M2 12l2-2.5 2.5.7a7 7 0 011.3-1.3L7.1 6.1 9 5l1 2.5c.5-.1 1-.2 1.5-.2s1 .1 1.5.2L14 5l1.9 1.1-.7 2.4a7 7 0 011.3 1.3l2.5-.7L22 12l-2.5 2.5-2.5-.7a7 7 0 01-1.3 1.3l.7 2.4L14 19l-1-2.5c-.5.1-1 .2-1.5.2s-1-.1-1.5-.2L9 19l-1.9-1.1.7-2.4a7 7 0 01-1.3-1.3l-2.5.7L2 12z" stroke="currentColor" stroke-width="2" fill="none" />
+  </symbol>
+  <symbol id="login" viewBox="0 0 24 24">
+    <path d="M10 8l4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M4 4v16h7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  </symbol>
+</svg>

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<main class="danger-page">
+  <h2>Danger Mode</h2>
+  <form method="post">
+    <label>
+      <input type="checkbox" name="enabled" {% if enabled %}checked{% endif %}>
+      Enable Danger Mode
+    </label>
+    <button type="submit">Save</button>
+  </form>
+</main>
+{% endblock %}
+

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -6,13 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Glimpser</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts.css') }}">
-    <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-        integrity="sha512-d+QeMAyl8RckY6SLlmRu9yckYv12LT4QcQuw2fbfbVzquSeQj0DnI1W6RKssYhh7j8A2Pn6GvmXwFbr1Qr1Zyg=="
-        crossorigin="anonymous"
-        referrerpolicy="no-referrer"
-    />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="preload" as="image" href="{{ url_for('static', filename='icons/sprite.svg') }}">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -20,9 +20,17 @@
   <div class="nav-right">
     {% if session.get('user_id') %}
     <a id="health-status" href="/status" class="status-indicator" title="System Performance"></a>
-    <div id="danger-status" class="status-indicator" title="Danger Mode"></div>
-    <a href="/discover" class="settings-icon" title="Discover Cameras"><i class="fas fa-search"></i></a>
-    <a href="/captions" id="captions" class="settings-icon" title="Read and update camera LLMs"><i class="fas fa-comment-dots"></i></a>
+    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode"></a>
+    <a href="/discover" class="settings-icon" title="Discover Cameras">
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#search" />
+      </svg>
+    </a>
+    <a href="/captions" id="captions" class="settings-icon" title="Read and update camera LLMs">
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#comment" />
+      </svg>
+    </a>
     <a href="/live" id="live">
       <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
         <div id="dateDisplay" class="clock-face">
@@ -34,9 +42,17 @@
         </div>
       </div>
     </a>
-    <a href="/settings" class="settings-icon" title="Update settings"><i class="fas fa-cog"></i></a>
+    <a href="/settings" class="settings-icon" title="Update settings">
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#settings" />
+      </svg>
+    </a>
     {% else %}
-    <a href="{{ url_for('login') }}" class="settings-icon" title="Login"><i class="fas fa-sign-in-alt"></i></a>
+    <a href="{{ url_for('login') }}" class="settings-icon" title="Login">
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#login" />
+      </svg>
+    </a>
     {% endif %}
   </div>
 </nav>

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -73,6 +73,7 @@ from app.config import (
     ANALYZE_DURATION_OTHER,
     TZ,
 )
+import app.config as config
 from app.utils.validators import validate_proxy
 
 last_camera_test = {}
@@ -2321,7 +2322,7 @@ def capture_screenshot_and_har(
     ############
     # Danger Mode
     ############
-    if danger:
+    if danger and config.get_setting("DANGER_MODE", "True") == "True":
         # If we rely on the user's local Chrome with remote-debugging-port=9222,
         # let's confirm it's actually open.
         if not is_chrome_debug_port_open("127.0.0.1", 9222):

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -28,3 +28,7 @@ When Chrome's debug port is open and no user input has been detected for a short
 Captures marked as "Danger" in the template editor will use your running Chrome session. Glimpser opens a new tab, performs the capture, and closes the tab when finished. It skips the operation if you become active while the capture is pending.
 
 Be cautious with this feature, as it can interact with your browser while you are away. Ensure you trust the pages being captured.
+
+## Enabling or Disabling Danger Mode
+
+Visit `/danger` to toggle the feature on or off. When disabled, captures marked as "Danger" are skipped even if Chrome's debugging port is open.

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -26,7 +26,13 @@ class TestDangerStatusEndpoint(unittest.TestCase):
         resp = self.client.get("/danger_status")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            resp.get_json(), {"port_open": True, "idle": True, "ready": True}
+            resp.get_json(),
+            {
+                "port_open": True,
+                "idle": True,
+                "enabled": True,
+                "ready": True,
+            },
         )
 
 


### PR DESCRIPTION
## Summary
- clean up nav bar icons with local SVG sprite
- add clickable Danger Mode status
- create Danger Mode toggle page
- integrate new setting into screenshot capture
- document danger mode toggle
- update tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7bd722f48333ba6bd30fccc1cd6f