### PR TITLE
Fix slider minimum width

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -9,11 +9,26 @@ export function initTemplates() {
     const templateList = document.getElementById('template-list');
 
     if (slider) {
-      const updateSliderMax = () => {
+      const updateSliderLimits = () => {
         slider.max = window.innerWidth;
+        const templateCount =
+          templateList?.querySelectorAll('.templateDiv').length || 1;
+        const computedMin = Math.max(
+          50,
+          Math.min(slider.max, Math.ceil(window.innerWidth / templateCount)),
+        );
+        slider.min = computedMin;
+        if (parseFloat(slider.value) < computedMin) {
+          slider.value = computedMin;
+          if (templateList) {
+            templateList.style.setProperty('--grid-item-width', `${computedMin}px`);
+          }
+        }
       };
-      updateSliderMax();
-      window.addEventListener('resize', updateSliderMax);
+
+      updateSliderLimits();
+      window.addEventListener('resize', updateSliderLimits);
+      window.updateSliderLimits = updateSliderLimits;
     }
 
     function autofillGroup() {
@@ -400,6 +415,7 @@ export async function loadTemplates() {
 
     if (isIndexPage) {
       window.addEventListener('resize', updateGridLayout);
+      if (window.updateSliderLimits) window.updateSliderLimits();
     }
     if (isCaptionsPage) {
       updateHumanizedTimes();

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The width slider on the index page automatically adjusts to the current browser width and updates if you resize the window. If it still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The width slider on the index page automatically adjusts to the current browser width and updates if you resize the window. It also won't shrink smaller than the space needed to fit all thumbnails, which prevents excessive columns and lag. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 ### Why is the live feed slightly cropped on small screens?
 Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.


### PR DESCRIPTION
## Summary
- prevent the index width slider from shrinking below page width
- document the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7e23db6c8333a2340530186b57d6