### PR TITLE
Add traceroute to camera discovery

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -10,6 +10,8 @@ import glob
 import time
 from functools import lru_cache
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import subprocess
+import shutil
 
 import requests
 
@@ -83,6 +85,7 @@ DISCOVERY_STAGES = [
     "http",
     "hls",
     "local",
+    "trace",
 ]
 
 
@@ -160,6 +163,34 @@ def _add_mac_info(cam: dict) -> None:
         vendor = _mac_manufacturer(mac)
         if vendor:
             info["manufacturer"] = vendor
+
+
+def _trace_upstream(ip: str, timeout: int = 3) -> str | None:
+    """Return the first hop when tracing ``ip``.
+
+    The function invokes the system ``traceroute`` (or ``tracert`` on
+    Windows) limited to two hops so discovery remains quick.  The IP of
+    the first hop is returned, representing the router or switch just
+    before the camera.  Any errors are ignored and ``None`` is returned.
+    """
+
+    cmd = None
+    if shutil.which("traceroute"):
+        cmd = ["traceroute", "-n", "-m", "2", ip]
+    elif shutil.which("tracert"):
+        cmd = ["tracert", "-d", "-h", "2", ip]
+    if not cmd:
+        return None
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        lines = proc.stdout.splitlines()
+        if len(lines) >= 2:
+            parts = lines[1].split()
+            if len(parts) >= 2 and parts[1] != "*":
+                return parts[1]
+    except Exception as e:  # pragma: no cover - system dependent
+        logging.debug("traceroute error for %s: %s", ip, e)
+    return None
 
 
 def _local_subnets(max_prefixlen: int = 24):
@@ -610,5 +641,11 @@ def discover_cameras(progress_callback=None):
     result = list(unique.values())
     for cam in result:
         _add_mac_info(cam)
+        hop = _trace_upstream(cam["ip"])
+        if hop:
+            cam.setdefault("info", {})["upstream"] = hop
+
+    if progress_callback:
+        progress_callback("trace", len(result), [])
 
     return result

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -2,6 +2,9 @@
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
+After all scanning steps finish, Glimpser performs a two-hop traceroute to each
+discovered camera. The previous hop is stored in the ``upstream`` field so you
+can see which router or switch connects the device.
 
 ## How the `/discover` route works
 
@@ -40,6 +43,8 @@ The discovery code combines multiple approaches:
 9. **HTTP endpoint scan** – `_scan_http_endpoints()` checks ports `80`, `8080`, and `443` for `/snapshot.jpg` or `/video.mjpg` streams.
 10. **HLS detection** – `_scan_hls_streams()` looks for playlist files like `/index.m3u8`.
 11. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.
+12. **Traceroute hop** – `_trace_upstream()` runs a quick traceroute limited to
+    two hops and records the previous hop for each camera.
 
 All discovered entries are merged and returned. The key parts of the implementation are shown below:
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -66,6 +66,11 @@ class TestCameraDiscovery(unittest.TestCase):
         }
         self.assertEqual(set(result), expected)
 
+    def test_get_discovery_stages_has_trace(self):
+        stages = camera_discovery.get_discovery_stages()
+        self.assertIn("trace", stages)
+        self.assertEqual(stages[-1], "trace")
+
     @patch("app.utils.camera_discovery._fetch_sdp")
     @patch("app.utils.camera_discovery.is_port_open")
     def test_scan_rtsp_ports(self, mock_port_open, mock_fetch_sdp):
@@ -151,6 +156,7 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery._trace_upstream", return_value="192.168.1.1")
     @patch("app.utils.camera_discovery._probe_ssdp")
     @patch("app.utils.camera_discovery._probe_mdns")
     @patch("app.utils.camera_discovery._probe_onvif")
@@ -169,6 +175,7 @@ class TestCameraDiscovery(unittest.TestCase):
         mock_onvif,
         mock_mdns,
         mock_ssdp,
+        mock_trace,
     ):
         mock_addrs.return_value = self._mock_interfaces()
         mock_port_open.side_effect = self._port_open_side_effect
@@ -246,6 +253,12 @@ class TestCameraDiscovery(unittest.TestCase):
             {(c["ip"], c["protocol"], c["port"]) for c in result},
             {(c["ip"], c["protocol"], c["port"]) for c in expected},
         )
+        upstreams = [
+            c["info"].get("upstream")
+            for c in result
+            if c["ip"] == "192.168.1.6" and c["protocol"] == "onvif"
+        ]
+        self.assertEqual(upstreams[0], "192.168.1.1")
 
     @patch("app.utils.camera_discovery._local_subnets", return_value=[])
     @patch("app.utils.camera_discovery._local_video_devices", return_value=[])
@@ -261,8 +274,10 @@ class TestCameraDiscovery(unittest.TestCase):
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery._mac_manufacturer")
     @patch("app.utils.camera_discovery._mac_for_ip")
+    @patch("app.utils.camera_discovery._trace_upstream", return_value=None)
     def test_progress_callback_includes_mac(
         self,
+        mock_trace,
         mock_mac,
         mock_vendor,
         mock_onvif,


### PR DESCRIPTION
## Summary
- record upstream hop via traceroute when discovering cameras
- document traceroute stage in discovery docs
- test traceroute integration

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7d735dc8833399c2e1565eb1a88d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a network tracing step to camera discovery, showing the immediate upstream router or switch for each discovered camera.

- **Documentation**
  - Updated documentation to describe the new network tracing feature in the camera discovery process.

- **Tests**
  - Enhanced test coverage to verify the network tracing step and its integration into the camera discovery workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->