### PR TITLE
Fix camera timestamp display

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -301,7 +301,7 @@ video:hover + .play-icon {
 }
 
 .template-error {
-    border: 5px solid red;
+    border: 5px solid gray;
 }
 
 /* Improve video controls on mobile */
@@ -694,29 +694,6 @@ button, a {
     right: 0;
 }
 
-/* Overlay ISO8601 timestamps using pseudo-elements */
-.video-container[data-timestamp],
-.templateDiv img[data-timestamp],
-video.hover-video[data-timestamp] {
-    position: relative;
-}
-
-.video-container[data-timestamp]::after,
-.templateDiv img[data-timestamp]::after,
-video.hover-video[data-timestamp]::after {
-    content: attr(data-timestamp);
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    padding: 5px;
-    background-color: rgba(0, 0, 0, 0.5);
-    color: white;
-    font-size: var(--timestamp-font-size);
-    font-variant: small-caps;
-    text-shadow: 0 0 3px #000;
-    z-index: 5;
-    pointer-events: none;
-}
 
 .notes-textarea {
     width: 100%;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -346,6 +346,7 @@ export async function loadTemplates() {
                   <source src="/last_video/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
+                <div class="timestamp humanized-time" data-time="${lastScreenshotTime}" title="${formatExactTime(lastScreenshotTime)}">${humanizedTimestamp}</div>
                 <div class="play-icon">&#9658;</div>
               </div>
             </a>
@@ -400,6 +401,7 @@ export async function loadTemplates() {
 
     if (isIndexPage) {
       window.addEventListener('resize', updateGridLayout);
+      updateHumanizedTimes();
     }
     if (isCaptionsPage) {
       updateHumanizedTimes();

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Group and All cameras now bypass offline checks when loading feeds.
 - Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.
+- Camera tiles on the front page show how long ago the last screenshot was captured.
 - The "All" camera MJPEG feed is available via `/stream.mjpg?group=all`.
 - HTML templates are tested for image `alt` text and required form fields.
 - Template storage usage is now verified by unit tests.


### PR DESCRIPTION
## Summary
- show relative timestamps for camera tiles
- gray out failed captures for colorblind users
- document the updated timestamp display

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7dec4bf0833387aa34a28bfcaa42