### PR TITLE
Improve captions page UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -916,6 +916,22 @@ input[type=submit]:hover {
     width: 160px;
 }
 
+/* Ensure captions thumbnails fill the container and appear dimmed */
+.captions-page .templateDiv img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: grayscale(40%);
+    transition: filter 0.3s;
+}
+
+.captions-page .templateDiv:hover img {
+    filter: none;
+}
+
 .filter-controls {
     display: flex;
     flex-wrap: wrap;
@@ -946,6 +962,17 @@ input[type=submit]:hover {
 .camera-table th,
 .settings-table th {
     background-color: #f4f4f4;
+}
+
+/* Indicate sortable KPI columns */
+.camera-table th.sortable {
+    cursor: pointer;
+}
+
+.camera-table th.sortable::after {
+    content: ' \2195';
+    font-size: 0.8em;
+    opacity: 0.6;
 }
 
 details > summary {

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -93,6 +93,7 @@ export function initTemplates() {
     loadTemplates();
     setupSearch();
     setupSorting();
+    setInterval(updateHumanizedTimes, 60000);
   });
 
   window.showStructuredInput = showStructuredInput;

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, and you can filter rows by KPI values. The bulk controls are collapsed by default—expand the **Bulk Caption Management** section when needed. The table now shows relative timestamps and a placeholder when no captions are available.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. Expand the **Bulk Caption Management** section when needed.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- polish captions page styles
- show sort icon and allow relative timestamps to auto update
- update docs with new captions page tips

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d7f6479808333af1cdc6ab9c5ee9c