### PR TITLE
Add CSS theme variables for dark and light modes

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -20,7 +20,7 @@ html {
 }
 
 .camera-list th {
-    background-color: #f2f2f2;
+    background-color: var(--table-header-bg-color);
     font-weight: bold;
 }
 
@@ -51,11 +51,11 @@ html {
 }
 
 .camera-item:nth-child(even) {
-    background-color: #f9f9f9;
+    background-color: var(--table-row-alt-bg-color);
 }
 
 .camera-item:hover {
-    background-color: #f5f5f5;
+    background-color: var(--table-hover-bg-color);
 }
 
 /* Responsive styles for smaller screens */
@@ -134,9 +134,9 @@ h1, h2 {
 #template-form {
     margin: 20px;
     padding: 20px;
-    background-color: white;
+    background-color: var(--form-bg-color);
     border-radius: 8px;
-    color: rgb(91, 91, 91);
+    color: var(--form-text-color);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
@@ -189,7 +189,7 @@ h1, h2 {
 
 select:hover {
     cursor: pointer;
-    background-color: #f7f7f7;
+    background-color: var(--table-hover-bg-color);
 }
 
 .templateDiv {
@@ -271,9 +271,27 @@ video:hover + .play-icon {
     --bg-color: rgb(16, 16, 16);
     --secondary-bg-color: #222;
     --text-color: rgb(191, 191, 191);
+    --form-bg-color: var(--secondary-bg-color);
+    --form-text-color: var(--text-color);
+    --table-header-bg-color: #2a2a2a;
+    --table-row-alt-bg-color: #1a1a1a;
+    --table-hover-bg-color: #333;
     /* Typography */
     /* stylelint-disable-next-line value-keyword-case */
     --font-family: Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --bg-color: #ffffff;
+        --secondary-bg-color: #f2f2f2;
+        --text-color: #222;
+        --form-bg-color: #ffffff;
+        --form-text-color: #222;
+        --table-header-bg-color: #f2f2f2;
+        --table-row-alt-bg-color: #fafafa;
+        --table-hover-bg-color: #e0e0e0;
+    }
 }
 
 .camera-name, .timestamp {
@@ -424,7 +442,7 @@ nav a:hover, nav a.active {
     font-size: 12px;
     cursor: help;
     padding: 2px 5px;
-    background-color: #f0f0f0;
+    background-color: var(--secondary-bg-color);
     border-radius: 3px;
     margin-left: 10px;
 }
@@ -532,7 +550,7 @@ button, a {
     width: 25px;
     height: 25px;
     border-radius: 50%;
-    background-color: #f0f0f0;
+    background-color: var(--secondary-bg-color);
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
     position: relative;
     margin-left: 20px;
@@ -580,7 +598,7 @@ button, a {
 
 /* Template Form Styles */
 #template-form, #edit-template {
-    background-color: var(--secondary-bg-color);
+    background-color: var(--form-bg-color);
     padding: 20px;
     border-radius: 10px;
     max-width: 1000px;
@@ -588,7 +606,7 @@ button, a {
 }
 
 #template-form h3, #edit-template h3 {
-    color: #fff;
+    color: var(--form-text-color);
     text-align: center;
     margin-bottom: 20px;
 }
@@ -598,7 +616,7 @@ button, a {
 }
 
 #template-form label, #edit-template label {
-    color: #fff;
+    color: var(--form-text-color);
 }
 
 #template-form input[type="text"],
@@ -661,7 +679,7 @@ button, a {
 
 /* TSV Controls for Captions Page */
 .tsv-controls {
-    background-color: #f8f9fa;
+    background-color: var(--secondary-bg-color);
     padding: 15px;
     border-radius: 5px;
     margin-bottom: 20px;
@@ -842,7 +860,8 @@ footer.fade-out {
     margin-top: 20px;
 }
 .login-container {
-    background-color: white;
+    background-color: var(--form-bg-color);
+    color: var(--form-text-color);
     padding: 20px;
     border-radius: 5px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
@@ -975,7 +994,7 @@ input[type=submit]:hover {
 .captions-table th,
 .camera-table th,
 .settings-table th {
-    background-color: #f4f4f4;
+    background-color: var(--table-header-bg-color);
 }
 
 /* Indicate sortable KPI columns */
@@ -996,11 +1015,11 @@ details > summary {
 }
 
 .captions-table tr:nth-child(even) {
-    background-color: #fafafa;
+    background-color: var(--table-row-alt-bg-color);
 }
 
 .captions-table tr:hover {
-    background-color: #f1f1f1;
+    background-color: var(--table-hover-bg-color);
 }
 
 .captions-table td:first-child {

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -1,0 +1,6 @@
+# Dark Mode Support
+
+Glimpser's interface now adapts to your system's preferred color scheme.
+The CSS defines variables for background and text colors with light and dark
+variants. Forms and tables use these variables so elements remain readable in
+both themes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Troubleshooting](troubleshooting.md)
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
+- [Dark Mode Support](dark_mode.md)
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)


### PR DESCRIPTION
## Summary
- define theme variables and light scheme overrides
- use variables for forms, tables and login
- document theme support

## Testing
- `black . --check` *(fails: would reformat 19 files)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d81bf99788333990edcdd3ce43719