### PR TITLE
Improve accessibility elements

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -5,6 +5,32 @@ html {
     max-width: 100vw;
 }
 
+/* Skip link for keyboard users */
+.skip-link {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+}
+
+.skip-link:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: 10px;
+    background: #000;
+    color: #fff;
+    z-index: 1000;
+}
+
+/* Visible outline when navigating with keyboard */
+:focus-visible {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
 /* Camera list styles */
 .camera-list {
     width: 100%;
@@ -642,7 +668,7 @@ button, a {
 #delete-btn {
     padding: 10px 20px;
     background-color: #e74c3c;
-    color: #fff;
+    color: #000;
     border: none;
     border-radius: 5px;
     cursor: pointer;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,10 +1,13 @@
 {% include 'header.html' %}
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <header>
         {% include 'nav.html' %}
     </header>
 
-    {% block content %}{% endblock %}
+    <main id="main-content" tabindex="-1">
+        {% block content %}{% endblock %}
+    </main>
 
     {% include 'footer.html' %}
 </body>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -98,7 +98,7 @@
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
 </div>
 
-    <div id="template-list" title="List of all templates">
+    <div id="template-list" title="List of all templates" role="region" aria-label="Templates">
         <!-- Template list will be populated here -->
     </div>
 

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -81,9 +81,9 @@
         }
     </style>
 
-    <div class="video-container">
+    <div class="video-container" role="region" aria-label="Live video feed">
         <img id="live-image" alt="Live feed frame" title="Current frame from the live feed">
-        <video id="live-video" class="hidden" autoplay muted>
+        <video id="live-video" class="hidden" autoplay muted tabindex="0">
             <source src="" type="video/mp4">
             Your browser does not support the video tag.
         </video>
@@ -92,14 +92,14 @@
             <input type="range" id="seek-bar" value="0">
 
             <div class="control-row">
-                <button id="play-pause" title="play/pause"><i class="fa-play-pause"></i></button>
+                <button id="play-pause" title="play/pause" aria-label="Play or pause video"><i class="fa-play-pause"></i></button>
                 <div id="speed-container">
                     <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()">
                     <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
                 </div>
 
 	<!-- <button id="cast-button">Cast</button> -->
-                <button id="full-screen" title='fullscreen'><i class="fas fa-expand"></i></button>
+                <button id="full-screen" title='fullscreen' aria-label="Toggle fullscreen"><i class="fas fa-expand"></i></button>
 
     <select id="video-source" onchange="changeVideoSource()">
         <option value="png" title="View a series of PNG images">PNG Stream</option>
@@ -138,28 +138,28 @@
 
 
         </div>
-        <div id="video-overlay" class="video-overlay">
-            <div id="loading-indicator" class="hidden">Loading...</div>
-            <div id="play-pause-indicator" class="video-icon hidden">▶</div>
-            <div id="offline-indicator" class="offline-indicator hidden">
+        <div id="video-overlay" class="video-overlay" role="region" aria-live="polite">
+            <div id="loading-indicator" class="hidden" role="status">Loading...</div>
+            <div id="play-pause-indicator" class="video-icon hidden" aria-hidden="true">▶</div>
+            <div id="offline-indicator" class="offline-indicator hidden" role="alert">
                 <i class="fas fa-video-slash video-icon"></i>
                 <p id="offline-message"></p>
             </div>
-            <div id="capture-error-indicator" class="error-indicator hidden">
+            <div id="capture-error-indicator" class="error-indicator hidden" role="alert">
                 <i class="fas fa-exclamation-triangle video-icon"></i>
                 <p id="capture-error-message"></p>
             </div>
-            <div id="stream-error-indicator" class="error-indicator hidden">
+            <div id="stream-error-indicator" class="error-indicator hidden" role="alert">
                 <i class="fas fa-times-circle video-icon"></i>
                 <p id="stream-error-message"></p>
             </div>
         </div>
-        <div id="error-message"></div>
+        <div id="error-message" role="alert"></div>
     </div>
 
 
 
-    <div id="template-details"></div>
+    <div id="template-details" role="region" aria-live="polite"></div>
 
     <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
     <script>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -10,3 +10,8 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.
 - Deprecated `<center>` tags were removed from templates and replaced with CSS-based centering.
 - Error pages, the status dashboard, and video players now include tooltips on buttons and metrics.
+- A "skip to main content" link enables quick keyboard navigation.
+- The base template uses a `<main>` element for semantic structure.
+- Live video overlays use ARIA roles so screen readers announce status changes.
+- Focus outlines appear when navigating via keyboard.
+- The delete button text color now meets color contrast guidelines.


### PR DESCRIPTION
## Summary
- add skip link and `<main>` for improved keyboard navigation
- define keyboard focus outline styles
- label live video region and controls with ARIA roles
- ensure delete button color contrast
- document accessibility updates

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d81cfaaa88333bfd1a0c7ed5c41a9