### PR TITLE
Add frontend unit test scaffolding

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,3 +49,27 @@ like:
 python -m coverage run -m pytest
 python -m coverage html
 ```
+
+## JavaScript Unit Tests
+
+Front‑end utilities under `app/static/js` are tested with **Jest**. The tests
+use the JSDOM environment so that DOM APIs are available in Node. Run them with:
+
+```sh
+npx jest --env=jsdom
+```
+
+New tests cover the offline service‑worker toggle and template helpers.
+
+## Playwright End‑to‑End Tests
+
+For critical user flows a minimal Playwright setup lives in
+`tests/playwright`. These tests start the development server defined in
+`playwright.config.js` and drive a headless browser. Execute them with:
+
+```sh
+npx playwright test
+```
+
+Playwright is optional, so the Node dependencies are not included in the
+repository. Install them locally to run the tests.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,18 @@
+// Basic Playwright configuration for e2e tests
+// See https://playwright.dev/docs/test-intro
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  webServer: {
+    command: 'python main.py',
+    port: 5000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+  use: {
+    baseURL: 'http://localhost:5000',
+    headless: true,
+  },
+};
+
+module.exports = config;

--- a/tests/js/offline.test.js
+++ b/tests/js/offline.test.js
@@ -1,0 +1,54 @@
+// tests/js/offline.test.js
+
+// Mock DOM element
+document.body.innerHTML = `
+  <input type="checkbox" id="offline-preview" />
+`;
+
+// Provide mock serviceWorker APIs
+Object.defineProperty(global.navigator, 'serviceWorker', {
+  value: {
+    register: jest.fn(() => Promise.resolve()),
+    getRegistrations: jest.fn(() =>
+      Promise.resolve([
+        { active: { scriptURL: '/sw.js' }, unregister: jest.fn() },
+      ]),
+    ),
+  },
+  configurable: true,
+});
+
+// Import the function to test
+const { initOffline } = require('../../app/static/js/offline.js');
+
+describe('offline.js', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('checking the box registers the service worker', () => {
+    initOffline();
+    const checkbox = document.getElementById('offline-preview');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(localStorage.getItem('offlinePreviewEnabled')).toBe('true');
+    expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
+  });
+
+  test('unchecking the box unregisters the service worker', async () => {
+    initOffline();
+    const checkbox = document.getElementById('offline-preview');
+
+    // enable then disable
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(localStorage.getItem('offlinePreviewEnabled')).toBeNull();
+    expect(navigator.serviceWorker.getRegistrations).toHaveBeenCalled();
+  });
+});

--- a/tests/js/templates_utils.test.js
+++ b/tests/js/templates_utils.test.js
@@ -1,0 +1,65 @@
+// tests/js/templates_utils.test.js
+
+document.body.innerHTML = `
+  <div id="template-list"></div>
+`;
+
+const {
+  isMobile,
+  updateGridLayout,
+  templateBelongsToGroup,
+  templateMatchesSearch,
+} = require('../../app/static/js/templates.js');
+
+describe('templates.js utilities', () => {
+  test('isMobile detects hover capability', () => {
+    window.matchMedia = jest.fn().mockImplementation(query => ({
+      matches: query === '(hover: none)',
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+
+    expect(isMobile()).toBe(true);
+
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+
+    expect(isMobile()).toBe(false);
+  });
+
+  test('updateGridLayout sets grid columns', () => {
+    const list = document.getElementById('template-list');
+    window.matchMedia = jest.fn().mockImplementation(query => ({
+      matches: query === '(hover: none)',
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+    updateGridLayout();
+    expect(list.style.gridTemplateColumns).toBe('1fr');
+
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+    updateGridLayout();
+    expect(list.style.gridTemplateColumns).toBe('repeat(auto-fit, minmax(50px, var(--grid-item-width, 360px)))');
+  });
+
+  test('templateBelongsToGroup correctly matches groups', () => {
+    const template = { groups: 'a,b' };
+    expect(templateBelongsToGroup(template, 'a')).toBe(true);
+    expect(templateBelongsToGroup(template, 'c')).toBe(false);
+    expect(templateBelongsToGroup(template, 'all')).toBe(true);
+  });
+
+  test('templateMatchesSearch checks name and groups', () => {
+    const template = { name: 'Cam1', groups: 'inside,outside' };
+    expect(templateMatchesSearch(template, 'cam')).toBe(true);
+    expect(templateMatchesSearch(template, 'side')).toBe(true);
+    expect(templateMatchesSearch(template, 'none')).toBe(false);
+  });
+});

--- a/tests/playwright/basic.spec.js
+++ b/tests/playwright/basic.spec.js
@@ -1,0 +1,19 @@
+// tests/playwright/basic.spec.js
+// Minimal Playwright test covering login and dashboard load
+const { test, expect } = require('@playwright/test');
+
+test('index redirects to login', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/login$/);
+});
+
+// This test assumes a user exists with username 'e2e' and password 'secret'.
+// It mirrors the Python Selenium test and ensures the dashboard loads.
+test('login and open dashboard', async ({ page }) => {
+  await page.goto('/login');
+  await page.fill('input[name="username"]', 'e2e');
+  await page.fill('input[name="password"]', 'secret');
+  await page.click('input[type="submit"]');
+  await expect(page).toHaveURL('/');
+  await expect(page.locator('text=Add Template')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Jest tests for service worker toggle and template utils
- document JS and Playwright tests
- include Playwright example config and spec

## Testing
- `flake8`
- `pytest tests/test_noop.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683d81dcb4248333ac2a4787d97e3f4e