### PR TITLE
Add confirmation dialogs for dangerous actions

### DIFF
--- a/app/static/js/scheduler.js
+++ b/app/static/js/scheduler.js
@@ -4,6 +4,12 @@ export function initSchedulerToggle() {
     const schedulerStatus = document.getElementById('scheduler-status');
     if (toggleSchedulerButton && schedulerStatus) {
       toggleSchedulerButton.addEventListener('click', () => {
+        const shouldToggle = confirm(
+          `Are you sure you want to ${
+            toggleSchedulerButton.textContent.includes('Stop') ? 'stop' : 'start'
+          } the scheduler?`
+        );
+        if (!shouldToggle) return;
         fetch('/toggle_scheduler', { method: 'POST' })
           .then((res) => res.json())
           .then((data) => {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -33,7 +33,7 @@
                         <input type="text" name="{{ setting.name }}" value="{{ setting.value }}" title="Edit value for {{ setting.name }}">
                     </td>
                     <td>
-                        <button type="submit" name="action" value="delete" title="Delete {{ setting.name }}" onclick="document.getElementById('name_to_delete').value='{{ setting.name }}'">Delete</button>
+                        <button type="submit" name="action" value="delete" title="Delete {{ setting.name }}" onclick="return confirmDeleteSetting('{{ setting.name }}')">Delete</button>
                     </td>
                 </tr>
                 {% endfor %}
@@ -48,7 +48,7 @@
         <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
         <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
         <input type="file" name="file" accept=".json" title="Select configuration file to upload">
-        <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file">Upload Configuration</button>
+        <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
     </form>
 
     <h3>Danger Mode</h3>
@@ -63,4 +63,17 @@
     </label>
 </main>
     <script src="{{ url_for('static', filename='js/performance.js') }}"></script>
+    <script>
+        function confirmDeleteSetting(name) {
+            if (confirm('Are you sure you want to delete ' + name + '?')) {
+                document.getElementById('name_to_delete').value = name;
+                return true;
+            }
+            return false;
+        }
+
+        function confirmRestore() {
+            return confirm('Restore configuration from the selected file? This will overwrite existing settings.');
+        }
+    </script>
 {% endblock %}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -305,6 +305,7 @@ function updateVideo(templateName) {
     <div id="delete-template" class="form-actions">
         <button id="delete-btn" onclick="confirmDelete('{{ template_name }}')" title="Delete this template permanently">Delete Template</button>
     </div>
+    <div id="undo-container" style="display:none" class="form-actions"></div>
 </details>
 
 <script>
@@ -348,24 +349,41 @@ function validateForm() {
 
 function confirmDelete(templateName) {
     const confirmed = confirm("Are you sure you want to delete this template?");
-    if (confirmed) {
-        // Send a DELETE request to the server
+    if (!confirmed) return;
+    const templateData = window.templateDetails[templateName] || {};
+    fetch('/templates', {
+        method: 'DELETE',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name: templateName })
+    })
+    .then(response => response.json())
+    .then(data => {
+        alert(data.message);
+        if(data.status === 'success') {
+            showUndo(templateName, templateData);
+        }
+    })
+    .catch(error => console.error('Error:', error));
+}
+
+function showUndo(name, data) {
+    const container = document.getElementById('undo-container');
+    if (!container) return;
+    container.style.display = 'block';
+    container.innerHTML = '<button id="undo-btn">Undo Delete</button>';
+    document.getElementById('undo-btn').addEventListener('click', () => {
         fetch('/templates', {
-            method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ name: templateName })
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(Object.assign({ name }, data))
         })
-        .then(response => response.json())
-        .then(data => {
-            alert(data.message);
-            if(data.status === 'success') {
-                window.location.href = '/'; // Redirect to the homepage or another appropriate page
-            }
-        })
-        .catch(error => console.error('Error:', error));
-    }
+        .then(resp => resp.json())
+        .then(() => { window.location.reload(); })
+        .catch(err => console.error('Error:', err));
+    });
+    setTimeout(() => { container.style.display = 'none'; }, 10000);
 }
 
 function showCameraDetails(templateName) {


### PR DESCRIPTION
## Summary
- prompt before deleting settings or restoring config
- require confirmation to toggle scheduler
- allow undo after template deletion

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d820f9d908333a5250f9d4443499f