### PR TITLE
Improve Danger mode page

### DIFF
--- a/app/static/js/danger.js
+++ b/app/static/js/danger.js
@@ -1,0 +1,38 @@
+export function initDangerToggle() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('danger-form');
+    if (!form) return;
+    const modal = document.getElementById('danger-modal');
+    const message = document.getElementById('danger-modal-message');
+    const confirmBtn = document.getElementById('danger-confirm');
+    const cancelBtn = document.getElementById('danger-cancel');
+    const closeBtn = document.getElementById('danger-close');
+
+    const hide = () => {
+      if (modal) modal.style.display = 'none';
+    };
+
+    if (cancelBtn) cancelBtn.addEventListener('click', hide);
+    if (closeBtn) closeBtn.addEventListener('click', hide);
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const enable = form.elements['enabled'].checked;
+      if (modal && message) {
+        message.textContent = enable
+          ? 'Enable Danger Mode? Glimpser will use your current Chrome session.'
+          : 'Disable Danger Mode? Captures marked as Danger will be skipped.';
+        modal.style.display = 'block';
+      } else {
+        form.submit();
+      }
+    });
+
+    if (confirmBtn) {
+      confirmBtn.addEventListener('click', () => {
+        hide();
+        form.submit();
+      });
+    }
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -5,6 +5,7 @@ import { initNav } from './nav.js';
 import { initFormValidation } from './form.js';
 import { initFooterFade } from './footer.js';
 import { initOffline } from './offline.js';
+import { initDangerToggle } from './danger.js';
 
 initTemplates();
 initVideoControls();
@@ -13,3 +14,4 @@ initNav();
 initFormValidation();
 initFooterFade();
 initOffline();
+initDangerToggle();

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -1,14 +1,56 @@
 {% extends 'base.html' %}
 {% block content %}
-<main class="danger-page">
+<main class="container danger-page">
   <h2>Danger Mode</h2>
-  <form method="post">
-    <label>
-      <input type="checkbox" name="enabled" {% if enabled %}checked{% endif %}>
+
+  <section>
+    <h3>What is it?</h3>
+    <p>
+      Danger Mode reuses your running Chrome instance so Glimpser can capture
+      pages that rely on your logged-in session. Chrome must be started with the
+      <code>--remote-debugging-port=9222</code> flag.
+    </p>
+  </section>
+
+  <section>
+    <h3>How it works</h3>
+    <p>
+      When the debug port is detected and you are idle, an orange icon appears
+      in the navigation bar. Captures marked as "Danger" then open in your
+      browser and close automatically when finished.
+    </p>
+  </section>
+
+  <section>
+    <h3>Why use it?</h3>
+    <p>
+      Use this mode for dynamic sites that need your real browser context or
+      authenticated session. It allows Glimpser to interact with pages that a
+      headless browser cannot easily access.
+    </p>
+  </section>
+
+  <form id="danger-form" method="post">
+    <label for="danger-checkbox">
+      <input
+        id="danger-checkbox"
+        type="checkbox"
+        name="enabled"
+        {% if enabled %}checked{% endif %}
+      />
       Enable Danger Mode
     </label>
     <button type="submit">Save</button>
   </form>
 </main>
+
+<div id="danger-modal" class="modal">
+  <div class="modal-content">
+    <span id="danger-close" class="close-icon">&times;</span>
+    <p id="danger-modal-message"></p>
+    <button id="danger-confirm">Confirm</button>
+    <button id="danger-cancel">Cancel</button>
+  </div>
+</div>
 {% endblock %}
 

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -32,3 +32,10 @@ Be cautious with this feature, as it can interact with your browser while you ar
 ## Enabling or Disabling Danger Mode
 
 Visit `/danger` to toggle the feature on or off. When disabled, captures marked as "Danger" are skipped even if Chrome's debugging port is open.
+
+## Danger Page Overview
+
+The `/danger` page explains what the feature does and when to use it. It notes
+that Glimpser attaches to your Chrome session via the debugging port and only
+activates when you are idle. Toggling the option now shows a confirmation modal
+so the feature is not enabled or disabled accidentally.


### PR DESCRIPTION
## Summary
- expand Danger mode page with usage details
- add confirmation modal when toggling Danger mode
- expose modal logic in new `danger.js`
- document the updated Danger page

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d822dd1c0833388314469c4ddce7c