### PR TITLE
Add feed dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bulk caption management with TSV import and export
 - Configuration backup and restore
 - System status and log viewing pages
+- Feed dashboard on the `/status` page summarizing camera health
 - Real-time log streaming with improved filtering
 - Console clearing command
 - Google Cast support

--- a/app/routes.py
+++ b/app/routes.py
@@ -2382,7 +2382,11 @@ def init_routes(app):
     @login_required
     def status():
         metrics = scheduling.get_system_metrics()
-        return render_template("status.html", metrics=metrics)
+        feeds = scheduling.get_feed_status()
+        last_summary = scheduling.get_last_summary_time()
+        return render_template(
+            "status.html", metrics=metrics, feeds=feeds, last_summary=last_summary
+        )
 
     @app.route("/logs")
     @login_required

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1062,3 +1062,30 @@ details > summary {
     width: 100%;
     height: 100px;
 }
+
+/* Status dashboard */
+.feed-status {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+.feed-status th,
+.feed-status td {
+    padding: 6px 8px;
+    border: 1px solid #ddd;
+}
+.status-dot {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+.status-dot.ok {
+    background-color: green;
+}
+.status-dot.slow {
+    background-color: orange;
+}
+.status-dot.error {
+    background-color: red;
+}

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -23,6 +23,30 @@
     <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
 </ul>
 
+<h2>Feed Status</h2>
+<table class="feed-status">
+    <thead>
+        <tr>
+            <th>Feed</th>
+            <th>Last Image</th>
+            <th>Last Caption</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for feed in feeds %}
+        <tr class="{{ feed.status }}">
+            <td>{{ feed.name }}</td>
+            <td>{{ feed.last_screenshot_time or 'N/A' }}</td>
+            <td>{{ feed.last_caption_time or 'N/A' }}</td>
+            <td><span class="status-dot {{ feed.status }}" title="{{ feed.status }}"></span></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<p>Last summary generated: {{ last_summary or 'N/A' }}</p>
+
 
 {% include 'logs.html' %}
 {% endblock %}

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1011,3 +1011,61 @@ def start_log_caching():
     # No longer schedule cache_logs via the APScheduler.  The background thread
     # itself handles continuous log caching and avoids spawning additional
     # threads on scheduler restarts.
+
+
+def get_feed_status():
+    """Return a list of status dictionaries for each configured feed."""
+
+    templates = get_templates()
+    now = datetime.datetime.utcnow()
+    feeds = []
+
+    for name, template in templates.items():
+        last_shot = template.get("last_screenshot_time")
+        last_caption = template.get("last_caption_time")
+        frequency = int(template.get("frequency", 0) or 0)
+        capture_failed = template.get("capture_failed", False)
+        offline_since = template.get("offline_since")
+
+        status = "ok"
+        if capture_failed or offline_since:
+            status = "error"
+        elif last_shot:
+            try:
+                shot_time = datetime.datetime.strptime(last_shot, "%Y-%m-%d %H:%M:%S")
+                diff = (now - shot_time).total_seconds()
+                if frequency and diff > frequency * 120:
+                    status = "slow"
+            except Exception:
+                status = "error"
+        else:
+            status = "error"
+
+        feeds.append(
+            {
+                "name": name,
+                "last_screenshot_time": last_shot,
+                "last_caption_time": last_caption,
+                "status": status,
+            }
+        )
+
+    feeds.sort(key=lambda f: f["name"])
+    return feeds
+
+
+def get_last_summary_time() -> str | None:
+    """Return the timestamp of the most recent summary if available."""
+
+    session = SessionLocal()
+    try:
+        record = session.query(Summary).order_by(Summary.timestamp.desc()).first()
+        if record:
+            return datetime.datetime.utcfromtimestamp(record.timestamp).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+    except Exception:
+        return None
+    finally:
+        session.close()
+    return None

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -8,6 +8,16 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint.
 
+### Feed Dashboard
+
+Below the system metrics the page lists each configured feed with a color-coded indicator.
+
+- **Green** – the feed is updating on schedule.
+- **Yellow** – the last capture is behind its configured frequency.
+- **Red** – capturing failed or the feed is offline.
+
+The dashboard also shows when the most recent system summary was generated.
+
 ### Metrics
 
 - **CPU Usage** – percentage of CPU time used by the process

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import patch
+
+import app
+
+
+class TestStatusDashboard(unittest.TestCase):
+    def setUp(self):
+        self.app = app.create_app(enable_watchdog=False, schedule=False)
+        self.client = self.app.test_client()
+
+    def test_status_page_has_dashboard(self):
+        with self.app.app_context(), patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
+            resp = self.client.get("/status")
+            self.assertEqual(resp.status_code, 200)
+            self.assertIn(b"Feed Status", resp.data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/status` feed dashboard logic
- display feed table and last summary on the status page
- style feed dashboard and indicators
- document feed dashboard in system monitoring docs
- cover dashboard with tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d81fbc4f483338364f63ce3f547c0