### PR TITLE
Add validation to forms

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -992,8 +992,11 @@ def init_routes(app):
             return render_template("login.html"), 429
 
         if request.method == "POST":
-            username = request.form["username"]
-            password = request.form["password"]
+            username = (request.form.get("username") or "").strip()
+            password = (request.form.get("password") or "").strip()
+            if not username or not password:
+                flash("Username and password are required", "error")
+                return render_template("login.html"), 400
 
             db_session = SessionLocal()
             try:
@@ -2161,10 +2164,18 @@ def init_routes(app):
             ]
             action = request.form.get("action")
             if action == "add":
-                new_name = request.form.get("new_name")
-                new_value = request.form.get("new_value")
-                if new_name and new_value:
-                    update_setting(new_name, new_value)
+                new_name = (request.form.get("new_name") or "").strip()
+                new_value = (request.form.get("new_value") or "").strip()
+                if not new_name or not new_value:
+                    flash("Setting name and value are required", "error")
+                    return redirect(url_for("settings")), 400
+                if not re.fullmatch(r"[A-Z_]+", new_name):
+                    flash(
+                        "Setting names must contain only uppercase letters and underscores",
+                        "error",
+                    )
+                    return redirect(url_for("settings")), 400
+                update_setting(new_name, new_value)
             elif action == "delete":
                 name_to_delete = request.form.get("name_to_delete")
                 if name_to_delete:

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1062,3 +1062,9 @@ details > summary {
     width: 100%;
     height: 100px;
 }
+
+.form-error {
+    color: red;
+    font-size: 0.9rem;
+    margin-top: 4px;
+}

--- a/app/static/js/form.js
+++ b/app/static/js/form.js
@@ -42,4 +42,24 @@ export function initFormValidation() {
 
     return true;
   };
+
+  window.initAddSettingValidation = function initAddSettingValidation() {
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('add-setting-form');
+      if (!form) return;
+      form.addEventListener('submit', (e) => {
+        const name = document.getElementById('new_name').value.trim();
+        const value = document.getElementById('new_value').value.trim();
+        const error = document.getElementById('setting-error');
+        if (!name || !value || !/^[A-Z_]+$/.test(name)) {
+          e.preventDefault();
+          if (error) {
+            error.textContent =
+              'Name must use A-Z characters/underscores and value is required.';
+            error.classList.remove('hidden');
+          }
+        }
+      });
+    });
+  };
 }

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -1,0 +1,20 @@
+export function initLogin() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('login-form');
+    if (!form) return;
+    form.addEventListener('submit', (e) => {
+      const user = form.elements['username'].value.trim();
+      const pass = form.elements['password'].value.trim();
+      const error = document.getElementById('login-error');
+      if (!user || !pass) {
+        e.preventDefault();
+        if (error) {
+          error.textContent = 'Username and password are required.';
+          error.classList.remove('hidden');
+        }
+      }
+    });
+  });
+}
+
+initLogin();

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -2,7 +2,7 @@ import { initTemplates } from './templates.js';
 import { initVideoControls } from './video.js';
 import { initSchedulerToggle } from './scheduler.js';
 import { initNav } from './nav.js';
-import { initFormValidation } from './form.js';
+import { initFormValidation, initAddSettingValidation } from './form.js';
 import { initFooterFade } from './footer.js';
 import { initOffline } from './offline.js';
 
@@ -11,5 +11,6 @@ initVideoControls();
 initSchedulerToggle();
 initNav();
 initFormValidation();
+initAddSettingValidation();
 initFooterFade();
 initOffline();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,11 +3,12 @@
     <div class="login-wrapper">
     <div class="login-container" title="Login form">
         <h2>Login Required</h2>
-        <form method="post" title="Enter your credentials to log in">
+        <form id="login-form" method="post" title="Enter your credentials to log in">
             Username:<br>
             <input type="text" name="username" required title="Enter your username"><br>
             Password:<br>
             <input type="password" name="password" required title="Enter your password"><br><br>
+            <div id="login-error" class="form-error hidden"></div>
 
             {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
@@ -22,5 +23,6 @@
         </form>
     </div>
     </div>
+    <script type="module" src="{{ url_for('static', filename='js/login.js') }}"></script>
 {% endblock %}
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -7,12 +7,13 @@
     <p><a href="{{ url_for('settings_help') }}" title="Detailed explanation of each option">What does each setting do?</a></p>
 
     <h3>Add New Setting</h3>
-    <form method="POST" action="{{ url_for('settings') }}">
+    <form id="add-setting-form" method="POST" action="{{ url_for('settings') }}">
         <input type="hidden" name="action" value="add" title="Add setting action">
         <label for="new_name" title="Name of the new setting">Name:</label>
         <input type="text" id="new_name" name="new_name" required title="Enter setting name">
         <label for="new_value" title="Initial value for the setting">Value:</label>
         <input type="text" id="new_value" name="new_value" required title="Enter setting value">
+        <div id="setting-error" class="form-error hidden"></div>
         <button type="submit" title="Add setting">Add Setting</button>
     </form>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,3 +57,4 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Live view preloads the next stream for smoother camera switching.
 - PNG streams hide the loading overlay once a frame is displayed.
 - Icon sprite is preloaded and can be pushed via HTTP/2 to shave ~120 ms from the first paint on 4G.
+- Form inputs now validate on both the client and server to prevent malformed submissions.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -64,4 +64,5 @@ When adding new features, include corresponding tests under the `tests/` directo
 - Scheduler helpers are tested in `tests/test_scheduling_more.py`.
 - Template update validation ensures numeric fields remain in range and
   required values are present.
+- Forms validate input client-side with JavaScript and fall back to server-side checks.
 - `save_template` now reschedules APScheduler jobs when a template is edited.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -188,6 +188,14 @@ class TestRoutes(unittest.TestCase):
         mock_render_template.assert_called_with("login.html")
 
     @patch("app.routes.SessionLocal")
+    @patch("app.routes.login_attempts", {})
+    @patch("app.routes.render_template")
+    def test_login_missing_fields(self, mock_render_template, mock_session_local):
+        response = self.client.post("/login", data={"username": "", "password": ""})
+        self.assertEqual(response.status_code, 400)
+        mock_render_template.assert_called_with("login.html")
+
+    @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
     def test_logout(self, mock_session_local):
         dummy_user = SimpleNamespace(id=1)


### PR DESCRIPTION
## Summary
- validate login and settings forms client-side
- enforce form requirements on the server
- provide inline error areas
- document validation improvements
- test missing field handling

## Testing
- `flake8 app/routes.py tests/test_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8278f6a883338d14e98d2b92ac09