### PR TITLE
Fix captions tile layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -971,23 +971,24 @@ input[type=submit]:hover {
     padding: 15px;
 }
 
+/* Use the same tile width as the front page */
 .captions-page .templateDiv {
-    width: 160px;
+    width: var(--grid-item-width, 360px);
 }
 
 /* Ensure captions thumbnails fill the container and appear dimmed */
-.captions-page .templateDiv img {
+.captions-page .templateDiv video {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     filter: grayscale(40%);
     transition: filter 0.3s;
 }
 
-.captions-page .templateDiv:hover img {
+.captions-page .templateDiv:hover video {
     filter: none;
 }
 

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -108,6 +108,7 @@ export function initTemplates() {
     loadTemplates();
     setupSearch();
     setupSorting();
+    updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
   });
 


### PR DESCRIPTION
## Summary
- make captions page video tiles match front page
- show relative times immediately

## Testing
- `pytest tests/test_dashboard.py::TestStatusDashboard::test_status_page_has_dashboard -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d857ab4008333adcce29266bf665c