### PR TITLE
Add API retries for LLM requests

### DIFF
--- a/app/utils/api_utils.py
+++ b/app/utils/api_utils.py
@@ -1,0 +1,28 @@
+import logging
+import time
+from typing import Any
+
+import requests
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    retries: int = 2,
+    timeout: int = 10,
+    backoff_factor: float = 1.0,
+    **kwargs: Any,
+) -> requests.Response:
+    """Send an HTTP request with retries and exponential backoff."""
+
+    attempt = 0
+    while True:
+        try:
+            return requests.request(method, url, timeout=timeout, **kwargs)
+        except Exception as exc:
+            attempt += 1
+            logging.warning("request error: %s", exc)
+            if attempt > retries:
+                raise
+            time.sleep(min(backoff_factor * (2 ** (attempt - 1)), 30))

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -7,6 +7,9 @@ import time
 
 import requests
 import logging
+from typing import Optional
+
+from .api_utils import request_with_retry
 
 from app.config import CHATGPT_KEY, LLM_MODEL_VERSION, LLM_SUMMARY_PROMPT
 from app.utils.email_alerts import email_alert
@@ -15,7 +18,14 @@ from app.utils import llm_cache
 last_429_error_time = None
 
 
-def summarize(prompt, history=None, tokens=4096):
+def summarize(
+    prompt: str,
+    history: Optional[str] = None,
+    tokens: int = 4096,
+    *,
+    timeout: int = 10,
+    retries: int = 2,
+):
     """
     Generate a summary using OpenAI's GPT model.
 
@@ -27,9 +37,11 @@ def summarize(prompt, history=None, tokens=4096):
         prompt (str): The main prompt for the summary.
         history (str, optional): Previous context or history to consider. Defaults to None.
         tokens (int, optional): Maximum number of tokens for the response. Defaults to 4096.
+        timeout (int, optional): Request timeout in seconds.
+        retries (int, optional): Number of retry attempts on failure.
 
     Returns:
-        str: A JSON string containing the summarized content, or None if an error occurs.
+        str: JSON content with the summary or a message if generation fails.
     """
     global last_429_error_time
 
@@ -89,7 +101,14 @@ def summarize(prompt, history=None, tokens=4096):
 
     # Send the request to the OpenAI API
     try:
-        response = requests.post(url, headers=headers, json=payload)
+        response = request_with_retry(
+            "post",
+            url,
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+            retries=retries,
+        )
         if response.status_code == 429:
             last_429_error_time = datetime.datetime.now()
             logging.warning("429 error encountered. Blocking requests for 15 minutes.")
@@ -97,7 +116,9 @@ def summarize(prompt, history=None, tokens=4096):
         result = response.json()
     except Exception as e:
         logging.warning("API response issue %s", e)
-        return None
+        if cached is not None:
+            return cached.get("response")
+        return json.dumps({int(time.time()): "Summarization delayed"})
 
     # Process the API response
     try:

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -1,0 +1,7 @@
+# API Resilience
+
+Glimpser interacts with external services such as camera endpoints and language models. Network issues or rate limits can cause these APIs to become temporarily unavailable. To avoid blocking the user interface, Glimpser now sends API requests with a timeout and retries using exponential backoff.
+
+The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.request` and will retry failed requests a few times, waiting longer between attempts. When the LLM summarization call fails after retries, the last cached summary is returned if available. Otherwise a short message such as "Summarization delayed" is provided so the UI continues to load.
+
+This approach keeps the application responsive even when external services are slow or offline.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,4 +30,5 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Settings Page Overview](settings_page.md)
 - [Offline Preview](offline_preview.md)
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
+- [API Resilience](api_resilience.md)
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -14,7 +14,7 @@ from app.utils.llm import summarize
 
 
 class TestLLM(unittest.TestCase):
-    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.request_with_retry")
     @patch("app.utils.llm.CHATGPT_KEY", "mock_api_key")
     @patch("app.utils.llm.LLM_MODEL_VERSION", "mock_model_version")
     @patch("app.utils.llm.LLM_SUMMARY_PROMPT", "Mock summary prompt")
@@ -42,17 +42,20 @@ class TestLLM(unittest.TestCase):
         self.assertEqual(call_args["json"]["model"], "mock_model_version")
         self.assertIn("Test prompt", str(call_args["json"]["messages"]))
 
-    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.request_with_retry")
+    @patch("app.utils.llm.CHATGPT_KEY", "mock_api_key")
+    @patch("app.utils.llm.LLM_MODEL_VERSION", "mock_model_version")
+    @patch("app.utils.llm.LLM_SUMMARY_PROMPT", "Mock summary prompt")
     def test_summarize_api_error(self, mock_post):
         # Mock an API error response
         mock_post.side_effect = Exception("API Error")
 
         result = summarize("Test prompt")
 
-        # Check if the result is None when an error occurs
-        self.assertIsNone(result)
+        data = json.loads(result)
+        self.assertIn("Summarization delayed", list(data.values())[0])
 
-    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.request_with_retry")
     @patch(
         "app.utils.llm.last_429_error_time",
         datetime.datetime.now() - datetime.timedelta(minutes=10),
@@ -66,7 +69,7 @@ class TestLLM(unittest.TestCase):
         # Verify that the API was not called
         mock_post.assert_not_called()
 
-    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.request_with_retry")
     @patch("app.utils.llm.CHATGPT_KEY", "mock_api_key")
     @patch("app.utils.llm.LLM_MODEL_VERSION", "mock_model_version")
     @patch("app.utils.llm.LLM_SUMMARY_PROMPT", "Mock summary prompt")

--- a/tests/test_llm_cache_usage.py
+++ b/tests/test_llm_cache_usage.py
@@ -28,7 +28,7 @@ class TestLLMCache(unittest.TestCase):
             pass
         os.rmdir(self.tmpdir)
 
-    @patch("app.utils.llm.requests.post")
+    @patch("app.utils.llm.request_with_retry")
     @patch("app.utils.llm.CHATGPT_KEY", "k")
     @patch("app.utils.llm.LLM_MODEL_VERSION", "gpt")
     @patch("app.utils.llm.LLM_SUMMARY_PROMPT", "prompt")


### PR DESCRIPTION
## Summary
- provide `request_with_retry` helper for resilient HTTP calls
- retry LLM summarization and return a friendly message when it fails
- document API resilience
- update LLM tests
- fix cache usage test to patch the helper

## Testing
- `flake8 app/utils/api_utils.py app/utils/llm.py tests/test_llm.py tests/test_llm_cache_usage.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d81ecac0c8333913995d89453e20b