### PR TITLE
Update feed status table

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -108,6 +108,7 @@ export function initTemplates() {
     loadTemplates();
     setupSearch();
     setupSorting();
+    updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
   });
 
@@ -189,7 +190,10 @@ export function templateBelongsToGroup(template, group) {
 export function updateHumanizedTimes() {
   document.querySelectorAll('.humanized-time').forEach((element) => {
     const timestamp = element.getAttribute('data-time');
-    if (timestamp) element.textContent = timeAgo(timestamp);
+    if (timestamp) {
+      element.textContent = timeAgo(timestamp);
+      element.title = formatExactTime(timestamp);
+    }
   });
 }
 

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -36,9 +36,25 @@
     <tbody>
     {% for feed in feeds %}
         <tr class="{{ feed.status }}">
-            <td>{{ feed.name }}</td>
-            <td>{{ feed.last_screenshot_time or 'N/A' }}</td>
-            <td>{{ feed.last_caption_time or 'N/A' }}</td>
+            <td><a href="{{ url_for('template_details', template_name=feed.name) }}">{{ feed.name }}</a></td>
+            <td>
+                {% if feed.last_screenshot_time %}
+                <span class="humanized-time" data-time="{{ feed.last_screenshot_time }}" title="{{ feed.last_screenshot_time }}">
+                    {{ feed.last_screenshot_time }}
+                </span>
+                {% else %}
+                N/A
+                {% endif %}
+            </td>
+            <td>
+                {% if feed.last_caption_time %}
+                <span class="humanized-time" data-time="{{ feed.last_caption_time }}" title="{{ feed.last_caption_time }}">
+                    {{ feed.last_caption_time }}
+                </span>
+                {% else %}
+                N/A
+                {% endif %}
+            </td>
             <td><span class="status-dot {{ feed.status }}" title="{{ feed.status }}"></span></td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- add links to each feed in status table
- show screenshot and caption times relative to now with tooltip
- update JS helper to apply titles for timestamps and ensure tables update on page load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8652bd488333a180d0b3665f9ef2