### PR TITLE
Allow custom subnets in discovery

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -38,6 +38,7 @@ from PIL import Image
 from sqlalchemy import text
 from werkzeug.security import check_password_hash
 from werkzeug.utils import secure_filename
+from ipaddress import ip_network
 import subprocess
 import struct
 import random
@@ -2334,17 +2335,42 @@ def init_routes(app):
     @app.route("/discover/scan", methods=["POST"])
     @login_required
     def discover_cameras_scan():
-        cameras = camera_discovery.discover_cameras()
+        cidr = request.form.get("cidr") if request.form else request.args.get("cidr")
+        nets = None
+        if cidr:
+            try:
+                nets = [ip_network(cidr, strict=False)]
+            except ValueError:
+                pass
+        cameras = camera_discovery.discover_cameras(subnets=nets)
         return jsonify(cameras)
 
     @app.route("/discover/scan_stream")
     @login_required
     def discover_cameras_scan_stream():
         def generate():
+            cidr = request.args.get("cidr")
+            nets = None
+            if cidr:
+                try:
+                    nets = [ip_network(cidr, strict=False)]
+                except ValueError:
+                    pass
+
+            stages = camera_discovery.get_discovery_stages()
+
             q = queue.Queue()
             # Provide the client with the number of discovery stages so it
-            # can display a progress bar.
-            q.put({"total": len(camera_discovery.get_discovery_stages())})
+            # can display a progress bar and show subnet information.
+            q.put(
+                {
+                    "total": len(stages),
+                    "subnets": [
+                        str(n) for n in (nets or camera_discovery._local_subnets())
+                    ],
+                    "stages": stages,
+                }
+            )
 
             sent = set()
 
@@ -2358,7 +2384,9 @@ def init_routes(app):
                 q.put({"stage": stage, "count": count, "cameras": fresh})
 
             def run():
-                camera_discovery.discover_cameras(progress_callback=progress)
+                camera_discovery.discover_cameras(
+                    progress_callback=progress, subnets=nets
+                )
                 q.put({"done": True})
 
             thread = Thread(target=run, daemon=True)

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -14,6 +14,7 @@
 {%- endmacro %}
 {% block content %}
     <h2>Discovered Cameras</h2>
+    <input id="cidr-input" type="text" placeholder="192.168.1.0/24" title="Optional CIDR to scan">
     <button id="discover-btn" title="Scan the network for cameras">Discover</button>
     <progress id="discover-progress" class="hidden" title="Discovery progress"></progress>
     <div id="discover-message" title="Status messages"></div>
@@ -79,7 +80,9 @@
             progress.style.display = 'inline';
             progress.removeAttribute('value');
             body.innerHTML = '';
-            const source = new EventSource('/discover/scan_stream');
+            const cidr = document.getElementById('cidr-input').value.trim();
+            const url = cidr ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}` : '/discover/scan_stream';
+            const source = new EventSource(url);
             const known = new Set();
             const addRow = (cam) => {
                 const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
@@ -105,11 +108,16 @@
                     </td>`;
                 body.appendChild(tr);
             };
+            let plan = [];
             source.onmessage = (event) => {
                 const data = JSON.parse(event.data);
                 if (data.total) {
                     progress.max = data.total;
                     progress.value = 0;
+                    plan = data.stages || [];
+                    if (data.subnets) {
+                        msg.textContent = `Scanning networks: ${data.subnets.join(', ')}. Plan: ${plan.join(', ')}`;
+                    }
                     return;
                 }
                 if (data.done) {
@@ -119,7 +127,10 @@
                     return;
                 }
                 progress.value += 1;
-                msg.textContent = `Scanning ${data.stage} (${data.count} found)...`;
+                if (plan.length && plan[0] === data.stage) {
+                    plan.shift();
+                }
+                msg.textContent = `Scanning ${data.stage} (${data.count} found)...` + (plan.length ? ` Next: ${plan[0]}` : '');
                 if (data.cameras) {
                     data.cameras.forEach(addRow);
                 }

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -569,8 +569,8 @@ def _local_video_devices(base_path="/dev"):
     return devices
 
 
-def discover_cameras(progress_callback=None):
-    """Discover cameras on the local network.
+def discover_cameras(progress_callback=None, subnets=None):
+    """Discover cameras on the local network or provided ``subnets``.
 
     Parameters
     ----------
@@ -581,11 +581,12 @@ def discover_cameras(progress_callback=None):
     """
     cameras: list[dict] = []
 
-    try:
-        subnets = _local_subnets()
-    except Exception as e:  # pragma: no cover - system dependent
-        logging.warning("subnet discovery error: %s", e)
-        subnets = []
+    if subnets is None:
+        try:
+            subnets = _local_subnets()
+        except Exception as e:  # pragma: no cover - system dependent
+            logging.warning("subnet discovery error: %s", e)
+            subnets = []
 
     tasks = {
         "onvif": _probe_onvif,

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -24,7 +24,9 @@ def discover_cameras_scan_stream():
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
 ```
 
-When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message reports the total number of discovery stages so the progress bar can show overall completion. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with ``{"done": true}`` simply signals completion.
+When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message now includes the list of subnets that will be scanned and the full plan of discovery stages. The progress bar is initialized with the total number of stages. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with ``{"done": true}`` simply signals completion.
+
+An optional CIDR can be supplied via the new input field to restrict discovery to a specific Class C network. The value is sent as the ``cidr`` query parameter and parsed by ``discover_cameras()``.
 
 During the scan you will see messages like `Scanning onvif (3 found)...`. The stage name shows which discovery method just finished, while the number in parentheses reflects how many cameras have been detected so far.
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -299,6 +299,13 @@ class TestCameraDiscovery(unittest.TestCase):
         self.assertEqual(seen[0]["info"].get("mac"), "000c29aabbcc")
         self.assertEqual(seen[0]["info"].get("manufacturer"), "VMware")
 
+    @patch("app.utils.camera_discovery._local_subnets")
+    @patch("app.utils.camera_discovery._probe_onvif", return_value=[])
+    def test_custom_subnets(self, mock_onvif, mock_local_subnets):
+        nets = [ip_network("10.1.1.0/30")]
+        camera_discovery.discover_cameras(subnets=nets)
+        mock_local_subnets.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- accept optional CIDR for discovery scans
- expose subnet list and stage plan via SSE
- add subnet field and status messages on discovery page
- document new CIDR option
- test custom subnet usage

## Testing
- `python -m flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d869950c883339de79084501b903f