### PR TITLE
Fix PNG stream preload

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -404,13 +404,22 @@ function refreshPNG() {
 }
 
 function showLastScreenshot() {
+    const ts = '?time=' + new Date().getTime();
+    let url;
     if (currentCamera === 'All') {
         // Show the most recent screenshot across all cameras
-        image.src = '/stream.png';
+        url = '/stream.png' + ts;
     } else {
         // Display the latest screenshot for the selected camera or group
-        image.src = '/last_screenshot/' + currentCamera;
+        url = '/last_screenshot/' + currentCamera + ts;
     }
+
+    // Preload the image so the viewer always sees a frame when switching
+    const pre = new Image();
+    pre.onload = () => {
+        image.src = pre.src;
+    };
+    pre.src = url;
     image.style.display = 'block';
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Group and All cameras now bypass offline checks when loading feeds.
 - Live view groups stream each camera sequentially with the speed slider and hide the slider for single cameras.
 - The "All" camera PNG stream now refreshes automatically.
+- PNG streams preload images so live view always shows a frame for any camera or group.
 - The "All" camera MJPEG feed is available via `/stream.mjpg?group=all`.
 - Group views display the last screenshot for the selected group using the
   `/last_screenshot/group-<name>` endpoint.


### PR DESCRIPTION
## Summary
- preload the first PNG image so live view always shows a frame when switching sources
- document PNG stream reliability

## Testing
- `flake8`
- `pytest tests/test_stream_png_route.py::TestStreamPngRoute::test_returns_latest_image -q`

------
https://chatgpt.com/codex/tasks/task_e_683d86f5c4a88333a2186a7ed2556b1f