### PR TITLE
Improve session timeout message

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -316,6 +316,23 @@ export async function loadTemplates() {
 
   try {
     const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      const message =
+        '<div class="error">Session expired. Please log in again.</div>';
+      if (isIndexPage) {
+        templateList.innerHTML = message;
+      } else if (isCaptionsPage) {
+        templateContainer.innerHTML = message;
+      }
+      return;
+    }
+
     const templates = await response.json();
 
     if (isIndexPage) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ If you're looking for the list of available documents, see [index.md](index.md).
 - Navigation menus use a consistent accent color with smooth hover effects.
  - Navigation bar icons now use the Font Awesome set and retain a unified circular style for a cleaner look.
 - Session cookies are now marked secure/HTTPOnly and expire after a configurable timeout.
+- The front page shows a "Session expired" message when template loading redirects to the login page.
 - Player pages fade the navigation bar when the mouse is idle for a few seconds.
 - The footer now stays fixed at the bottom of the screen and fades when the
   mouse is idle.


### PR DESCRIPTION
## Summary
- show a user-friendly session expired notice when template fetch doesn't return JSON
- document the new login warning in the docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d876a2e608333a395eb2d96b6209e