### PR TITLE
Improve system status table readability

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1126,6 +1126,14 @@ details > summary {
     padding: 6px 8px;
     border: 1px solid #ddd;
 }
+.feed-status a {
+    color: var(--text-color);
+    text-decoration: none;
+}
+.feed-status a:hover {
+    color: var(--accent-color);
+    text-decoration: underline;
+}
 .status-dot {
     display: inline-block;
     width: 12px;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -436,8 +436,8 @@ export async function loadTemplates() {
   }
 }
 
-export function setupSorting() {
-  const headers = document.querySelectorAll('#camera-table th.sortable');
+export function setupTableSorting(tableId) {
+  const headers = document.querySelectorAll(`#${tableId} th.sortable`);
   headers.forEach((th, index) => {
     th.addEventListener('click', () => {
       const type = th.dataset.type || 'string';
@@ -464,4 +464,9 @@ export function setupSorting() {
       rows.forEach((row) => tbody.appendChild(row));
     });
   });
+}
+
+export function setupSorting() {
+  setupTableSorting('camera-table');
+  setupTableSorting('feed-status');
 }

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -24,38 +24,38 @@
 </ul>
 
 <h2>Feed Status</h2>
-<table class="feed-status">
+<table id="feed-status" class="feed-status">
     <thead>
         <tr>
-            <th>Feed</th>
-            <th>Last Image</th>
-            <th>Last Caption</th>
-            <th>Status</th>
+            <th class="sortable" data-type="string">Feed</th>
+            <th class="sortable" data-type="date">Last Image</th>
+            <th class="sortable" data-type="date">Last Caption</th>
+            <th class="sortable" data-type="string">Status</th>
         </tr>
     </thead>
     <tbody>
     {% for feed in feeds %}
         <tr class="{{ feed.status }}">
-            <td><a href="{{ url_for('template_details', template_name=feed.name) }}">{{ feed.name }}</a></td>
-            <td>
-                {% if feed.last_screenshot_time %}
+            <td data-value="{{ feed.name }}"><a href="{{ url_for('template_details', template_name=feed.name) }}">{{ feed.name }}</a></td>
+            <td data-value="{{ feed.last_screenshot_time or '' }}">
+                {% if feed.last_screenshot_display %}
                 <span class="humanized-time" data-time="{{ feed.last_screenshot_time }}" title="{{ feed.last_screenshot_time }}">
-                    {{ feed.last_screenshot_time }}
+                    {{ feed.last_screenshot_display }}
                 </span>
                 {% else %}
                 N/A
                 {% endif %}
             </td>
-            <td>
-                {% if feed.last_caption_time %}
+            <td data-value="{{ feed.last_caption_time or '' }}">
+                {% if feed.last_caption_display %}
                 <span class="humanized-time" data-time="{{ feed.last_caption_time }}" title="{{ feed.last_caption_time }}">
-                    {{ feed.last_caption_time }}
+                    {{ feed.last_caption_display }}
                 </span>
                 {% else %}
                 N/A
                 {% endif %}
             </td>
-            <td><span class="status-dot {{ feed.status }}" title="{{ feed.status }}"></span></td>
+            <td data-value="{{ feed.status }}"><span class="status-dot {{ feed.status }}" title="{{ feed.status }}"></span></td>
         </tr>
     {% endfor %}
     </tbody>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1020,6 +1020,41 @@ def get_feed_status():
     now = datetime.datetime.utcnow()
     feeds = []
 
+    def _humanize(ts: str | None) -> str | None:
+        """Return a simple "time ago" string for the given timestamp."""
+        if not ts:
+            return None
+        try:
+            dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+        except Exception:
+            return ts
+
+        diff = (now - dt).total_seconds()
+        if diff < 0:
+            return "in the future"
+        intervals = (
+            ("year", 31536000),
+            ("month", 2592000),
+            ("day", 86400),
+            ("hour", 3600),
+            ("minute", 60),
+            ("second", 1),
+        )
+        for label, seconds in intervals:
+            count = int(diff // seconds)
+            if count >= 1:
+                return f"{count} {label}{'s' if count > 1 else ''} ago"
+        return "just now"
+
+    def _iso(ts: str | None) -> str | None:
+        if not ts:
+            return None
+        try:
+            dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+            return dt.isoformat() + "Z"
+        except Exception:
+            return ts
+
     for name, template in templates.items():
         last_shot = template.get("last_screenshot_time")
         last_caption = template.get("last_caption_time")
@@ -1044,8 +1079,10 @@ def get_feed_status():
         feeds.append(
             {
                 "name": name,
-                "last_screenshot_time": last_shot,
-                "last_caption_time": last_caption,
+                "last_screenshot_time": _iso(last_shot),
+                "last_screenshot_display": _humanize(last_shot),
+                "last_caption_time": _iso(last_caption),
+                "last_caption_display": _humanize(last_caption),
                 "status": status,
             }
         )

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -18,6 +18,9 @@ Below the system metrics the page lists each configured feed with a color-coded 
 
 The dashboard also shows when the most recent system summary was generated.
 
+The table headers are sortable. Click a column name to reorder feeds by feed
+name, last image time, last caption time, or status.
+
 ### Metrics
 
 - **CPU Usage** – percentage of CPU time used by the process


### PR DESCRIPTION
## Summary
- make feed links easier to read
- display relative timestamps for latest image and caption
- allow sorting of the status table
- document table sorting

## Testing
- `flake8 app/utils/scheduling.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8a4346bc8333a56d9cc6649bb820