### PR TITLE
Fix dashboard auth in tests

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -11,16 +11,23 @@ import app
 
 class TestStatusDashboard(unittest.TestCase):
     def setUp(self):
+        # Disable authentication before routes are registered so the
+        # dashboard can be accessed without a session.
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.session_patch = patch("app.routes.session", {"user_id": 1})
+        self.login_patch.start()
+        self.session_patch.start()
         self.app = app.create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
 
+    def tearDown(self):
+        self.login_patch.stop()
+        self.session_patch.stop()
+
     def test_status_page_has_dashboard(self):
-        with self.app.app_context(), patch("app.routes.session", {"user_id": 1}), patch(
-            "app.routes.login_required", lambda x: x
-        ):
-            resp = self.client.get("/status")
-            self.assertEqual(resp.status_code, 200)
-            self.assertIn(b"Feed Status", resp.data)
+        resp = self.client.get("/status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"Feed Status", resp.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- patch `login_required` before route registration so the dashboard test works
- access `/status` without login in test

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8bbe74f883338b4cb9be63af2214