### PR TITLE
docs: add CI test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 [![Python application](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml)
 [![Pylint](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)
+[![Tests](https://github.com/KristopherKubicki/glimpser/actions/workflows/test.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/glimpser)](https://github.com/KristopherKubicki/glimpser/releases/latest)
 [![Coverage](https://codecov.io/gh/KristopherKubicki/glimpser/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/glimpser)


### PR DESCRIPTION
## Summary
- show CI test health badge in README

## Testing
- `flake8`
- `pytest -q` *(fails: TestStatusDashboard::test_status_page_has_dashboard)*

------
https://chatgpt.com/codex/tasks/task_e_683d8cb8ed588333a02d92bb9de3e556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a badge to the README displaying the status of the "Tests" workflow for improved visibility of test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->