### PR TITLE
Fix CSS lint error

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -422,7 +422,7 @@ nav a {
     width: 18px;
     height: 18px;
     fill: none;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-width: 2;
 }
 


### PR DESCRIPTION
## Summary
- use lowercase `currentcolor` for stylelint

## Testing
- `black . --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8d5f83088333a95890f8fe310d09