### PR TITLE
Fix missing export for settings form validation

### DIFF
--- a/app/static/js/form.js
+++ b/app/static/js/form.js
@@ -43,23 +43,25 @@ export function initFormValidation() {
     return true;
   };
 
-  window.initAddSettingValidation = function initAddSettingValidation() {
-    document.addEventListener('DOMContentLoaded', () => {
-      const form = document.getElementById('add-setting-form');
-      if (!form) return;
-      form.addEventListener('submit', (e) => {
-        const name = document.getElementById('new_name').value.trim();
-        const value = document.getElementById('new_value').value.trim();
-        const error = document.getElementById('setting-error');
-        if (!name || !value || !/^[A-Z_]+$/.test(name)) {
-          e.preventDefault();
-          if (error) {
-            error.textContent =
-              'Name must use A-Z characters/underscores and value is required.';
-            error.classList.remove('hidden');
-          }
+  window.initAddSettingValidation = initAddSettingValidation;
+}
+
+export function initAddSettingValidation() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('add-setting-form');
+    if (!form) return;
+    form.addEventListener('submit', (e) => {
+      const name = document.getElementById('new_name').value.trim();
+      const value = document.getElementById('new_value').value.trim();
+      const error = document.getElementById('setting-error');
+      if (!name || !value || !/^[A-Z_]+$/.test(name)) {
+        e.preventDefault();
+        if (error) {
+          error.textContent =
+            'Name must use A-Z characters/underscores and value is required.';
+          error.classList.remove('hidden');
         }
-      });
+      }
     });
-  };
+  });
 }


### PR DESCRIPTION
## Summary
- export `initAddSettingValidation` from the form module

## Testing
- `black . --check` *(fails: 19 files would be reformatted)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8dcfbfbc8333b94be386d3366f3c