### PR TITLE
Make status feed columns sortable

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1030,11 +1030,13 @@ input[type=submit]:hover {
 }
 
 /* Indicate sortable KPI columns */
-.camera-table th.sortable {
+.camera-table th.sortable,
+.feed-status th.sortable {
     cursor: pointer;
 }
 
-.camera-table th.sortable::after {
+.camera-table th.sortable::after,
+.feed-status th.sortable::after {
     content: ' \2195';
     font-size: 0.8em;
     opacity: 0.6;


### PR DESCRIPTION
## Summary
- enable clickable sorting arrows for feed status table

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8ec768b883339d53055ef6906e6e