### PR TITLE
Fix camera-specific MP4 streams

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1434,6 +1434,27 @@ def init_routes(app):
     @app.route("/stream.mp4")
     @login_required
     def stream_mp4():
+        """Stream the latest MP4 for a camera or group."""
+
+        camera = request.args.get("camera")
+        if camera:
+            camera = validate_template_name(camera)
+            if camera is None:
+                abort(400, "Invalid camera name")
+            video_path = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "..",
+                VIDEO_DIRECTORY,
+                camera,
+                "in_process.mp4",
+            )
+            if not os.path.exists(video_path):
+                abort(404)
+            return Response(
+                stream_with_context(generate_video_stream(video_path)),
+                mimetype="video/mp4",
+            )
+
         # Default group
         lgroup = "all"
 

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -430,15 +430,15 @@ document.getElementById("seek-bar").style.display = "block";
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
-// Special handling for groups
-const groupName = currentCamera.split('group-')[1];
-video.src = `/stream.mp4?group=${encodeURIComponent(groupName)}`;
+        // Special handling for groups
+        const groupName = currentCamera.split('group-')[1];
+        video.src = `/stream.mp4?group=${encodeURIComponent(groupName)}`;
     } else if (currentCamera === 'All') {
-// Special handling for the "All" option
-video.src = '/stream.mp4';
+        // Special handling for the "All" option
+        video.src = '/stream.mp4';
     } else {
-// URL for individual cameras
-video.src = '/last_video/' + currentCamera;
+        // Stream a single camera
+        video.src = `/stream.mp4?camera=${encodeURIComponent(currentCamera)}`;
     }
     video.load();
     video.play();

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -87,10 +87,13 @@ Requires authentication. Submit form data to modify configuration values. A succ
 
 **GET /stream.mp4**
 
-Stream the most recent MP4 video for a group. Specify `group` as a query parameter. The
-video is served in small chunks and loops continuously.
+Stream the most recent MP4 video. Provide either a `camera` or `group` query
+parameter to restrict the feed. When a camera is specified the current
+`in_process.mp4` for that camera is streamed; otherwise the latest group video
+is returned. The video is served in small chunks and loops continuously.
 
-Example: `/stream.mp4?group=frontdoor`
+Examples:
+`/stream.mp4?camera=frontdoor` or `/stream.mp4?group=frontdoor`
 
 ### 4. Stream Live Video
 


### PR DESCRIPTION
## Summary
- support `camera` parameter for `/stream.mp4`
- switch live view MP4 source to `/stream.mp4?camera=` for individual cameras
- document camera parameter in API docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d8e4600e483339017504eb40470df