### PR TITLE
Potential fix for code scanning alert no. 379: Uncontrolled command line

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1468,6 +1468,13 @@ def capture_frame_with_ytdlp(url, output_path, name="unknown", invert=False):
 
         lurl_cache[url] = "good"
         video_url = result.stdout.decode().strip()
+        
+        # Validate the video_url to ensure it is a legitimate URL
+        parsed_url = urlparse(video_url)
+        if not parsed_url.scheme or not parsed_url.netloc:
+            logging.error(f"Invalid video URL: {video_url}")
+            return False
+        
         # 2) Use ffmpeg to capture a single frame
         ffmpeg_command = [FFMPEG_PATH]
         if FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false":


### PR DESCRIPTION
Potential fix for [https://github.com/KristopherKubicki/glimpser/security/code-scanning/379](https://github.com/KristopherKubicki/glimpser/security/code-scanning/379)

To fix the issue, we need to ensure that the `video_url` passed to the `ffmpeg_command` is validated or sanitized to prevent command injection. The best approach is to:
1. Validate the `video_url` to ensure it is a legitimate URL and does not contain any malicious content.
2. Use a library like `urllib.parse` to parse and validate the URL structure.
3. Reject or sanitize any input that does not conform to expected patterns.

Additionally, we should ensure that the `subprocess.run` call does not invoke a shell and that all arguments are passed as a list to avoid shell injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
