### PR TITLE
docs: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,24 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Glimpser is a straightforward yet powerful real-time monitoring application desi
 For more documentation, see the [documentation index](docs/index.md).
 You can find an overview of the docs folder in [docs/README.md](docs/README.md).
 Read a high-level [Architecture Overview](docs/architecture_overview.md) to understand how the pieces fit together.
+See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,4 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
 - [API Resilience](api_resilience.md)
 
+- [OpenSSF Scorecard](scorecard.md)

--- a/docs/scorecard.md
+++ b/docs/scorecard.md
@@ -1,0 +1,7 @@
+# OpenSSF Scorecard
+
+This repository uses the [OpenSSF Scorecard](https://github.com/ossf/scorecard) action to measure supply chain security best practices.
+
+The workflow defined in `.github/workflows/scorecards.yml` runs weekly and on demand. It uploads the results to the repository's Security tab, which allows the public badge to display the latest score.
+
+If the badge in the README shows "Scorecard report not found," make sure the workflow has run successfully at least once on the `main` branch.


### PR DESCRIPTION
## Summary
- add OpenSSF Scorecard workflow
- document Scorecard setup and link from README
- link Scorecard doc from docs index

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d90cd21cc83339f6e242e6ee1a109