### PR TITLE
Fix URL injection risk in screenshots

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -74,7 +74,7 @@ from app.config import (
     TZ,
 )
 import app.config as config
-from app.utils.validators import validate_proxy
+from app.utils.validators import validate_proxy, validate_url
 
 last_camera_test = {}
 last_camera_test_time = {}
@@ -1683,6 +1683,10 @@ def capture_screenshot_and_har_light(
     Capture a screenshot of a URL using wkhtmltoimage (WebKit).
     """
     proxy = validate_proxy(proxy)
+    url = validate_url(url)
+    if url is None:
+        logging.warning("Invalid URL provided for screenshot capture")
+        return False
     # Check if wkhtmltoimage is available
     if shutil.which("wkhtmltoimage") is None:
         logging.warning("wkhtmltoimage is not installed or not in the system path.")

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -2,6 +2,7 @@
 
 from werkzeug.utils import secure_filename
 import re
+from urllib.parse import urlparse
 
 
 def validate_proxy(proxy: str | None) -> str | None:
@@ -23,6 +24,32 @@ def validate_proxy(proxy: str | None) -> str | None:
         return None
 
     return proxy
+
+
+def validate_url(url: str | None) -> str | None:
+    """Return the URL string if valid, otherwise ``None``.
+
+    The URL must use the ``http`` or ``https`` scheme and must not contain
+    newline characters or start with a dash. This helps prevent accidental
+    command-line argument injection when the value is passed to subprocess
+    calls.
+    """
+
+    if url is None:
+        return None
+
+    url = str(url).strip()
+
+    if not url or url.startswith("-"):
+        return None
+
+    if "\n" in url or "\r" in url:
+        return None
+
+    if urlparse(url).scheme not in {"http", "https"}:
+        return None
+
+    return url
 
 
 def validate_template_name(template_name: str):


### PR DESCRIPTION
## Summary
- sanitize URLs before running `wkhtmltoimage`
- add `validate_url` helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9113f4bc8333b8e3d7d73dca8625