### PR TITLE
Fix mkdocs build

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,3 @@
+# Governance
+
+This project is governed entirely by a language model (OpenAI or a compatible LLM). The human operator acts only as a conduit, relaying questions and feedback so the AI can continue driving development and decision making.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,4 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
 - [API Resilience](api_resilience.md)
 
-- [Governance](../GOVERNANCE.md)
+- [Governance](governance.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Dark Mode: dark_mode.md
       - Developer Guide: developer_guide.md
       - Docker Build Verification: docker_build.md
+      - CodeQL Security Scanning: codeql.md
       - FAQ: faq.md
       - Getting Started: getting_started.md
       - Help Page: help_page.md
@@ -35,3 +36,4 @@ nav:
       - Tooltips: tooltips.md
       - Troubleshooting: troubleshooting.md
       - Video Archiver: video_archiver.md
+      - Governance: governance.md


### PR DESCRIPTION
## Summary
- add missing governance page to docs
- link to governance file from index
- include codeql page in mkdocs navigation

## Testing
- `flake8`
- `pytest -q`
- ❌ `mkdocs build --strict --site-dir site` *(failed: mkdocs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683d91a1b5c883339963e90b9ceaa3a4