### PR TITLE
Fix undefined capture error in live view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -247,7 +247,7 @@ function updateFeed() {
         video.src = '';
         image.src = '';
         return;
-    } else if (templateDetails[currentCamera].capture_failed) {
+    } else if (details && details.capture_failed) {
         hideOfflineIndicator();
         showCaptureErrorIndicator(currentCamera);
         hideLoadingIndicator();


### PR DESCRIPTION
## Summary
- guard against missing template details before checking for `capture_failed`

## Testing
- `black . --check` *(fails: would reformat 20 files)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d92b69fcc8333b16004c94cee675e