### PR TITLE
Fix default camera on template page

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -2,7 +2,13 @@ const video = document.getElementById('live-video');
 const image = document.getElementById('live-image');
 const templateDetailsContainer = document.getElementById('template-details');
 const templateDetails = window.templateDetails || {};
-let currentCamera = 'All'; // Set the default camera to "All"
+let currentCamera = 'All'; // Default to showing all cameras
+
+// If only a single camera is available, default to that camera instead
+const templateKeys = Object.keys(templateDetails);
+if (templateKeys.length === 1) {
+    currentCamera = templateKeys[0];
+}
 
 // Allow embedding the live view for a specific camera by reading the
 // ``camera`` query parameter. When provided and valid, restrict the camera


### PR DESCRIPTION
## Summary
- ensure template view selects the sole camera by default

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d959f792083338e026b8ec86a5645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved camera selection behavior so that if only one camera is available, it is automatically selected by default instead of showing 'All'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->