### PR TITLE
Limit live view ffmpeg retries

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -292,6 +292,12 @@ ANALYZE_DURATION_OTHER = get_setting("ANALYZE_DURATION_OTHER", PROBE_SIZE_OTHER)
 # your hardware can handle the extra load.
 LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
 
+# Stop restarting live streams endlessly when ffmpeg repeatedly fails. If the
+# live view fails this many times in a row without producing any output,
+# ``generate_live_stream`` gives up and closes the connection so resources are
+# not wasted.
+LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
+
 # Email settings
 EMAIL_ENABLED = get_setting("EMAIL_ENABLED", "False")
 EMAIL_SENDER = get_setting("EMAIL_SENDER", "your-email@example.com")

--- a/app/routes.py
+++ b/app/routes.py
@@ -428,10 +428,12 @@ def generate_live_stream(url: str):
         ]
     )
 
+    failures = 0
     while True:
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
+        chunk_yielded = False
 
         try:
             while True:
@@ -439,6 +441,7 @@ def generate_live_stream(url: str):
                 if not chunk:
                     break
                 yield chunk
+                chunk_yielded = True
                 if process.poll() is not None:
                     break
         except GeneratorExit:
@@ -451,6 +454,16 @@ def generate_live_stream(url: str):
 
         if process.returncode == 0:
             return
+
+        if not chunk_yielded:
+            failures += 1
+            if failures >= config.LIVE_MAX_FAILURES:
+                logging.error(
+                    "ffmpeg failed %s times without output, giving up", failures
+                )
+                return
+        else:
+            failures = 0
 
         logging.error("ffmpeg exited with %s, retrying", process.returncode)
         time.sleep(2)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -109,6 +109,7 @@ Settings controlling how frames are captured from video sources:
 - `ANALYZE_DURATION_RTSP` – analyzeduration for RTSP streams (default `10M`)
 - `ANALYZE_DURATION_OTHER` – analyzeduration for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
+- `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
 
 ### Stealth Browser Defaults
 


### PR DESCRIPTION
## Summary
- add `LIVE_MAX_FAILURES` setting to limit ffmpeg restarts
- stop live stream generator after too many ffmpeg failures
- document `LIVE_MAX_FAILURES` in configuration guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d968978508333aa374e195789c8fd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration setting to limit the number of consecutive failures when generating live streams, improving system reliability.
- **Documentation**
  - Updated configuration guide to include details about the new failure limit setting for live streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->