### PR TITLE
Fix duplicate helper and docs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-ignore = E,W,F
+ignore = E203,E266,E302,E305,E401,E402,E501,E722,E721,E741,E265,E301,E303,F401,F541,F811,F841,W291,W293,W391,W503,W504
 exclude =
     .git,
     __pycache__,

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -778,23 +778,6 @@ def set_capture_failed(name: str, failed: bool) -> None:
         session.close()
 
 
-def set_capture_failed(name: str, failed: bool) -> None:
-    """Set ``capture_failed`` flag for ``name``."""
-    name = validate_template_name(name)
-    if name is None:
-        return
-
-    manager = TemplateManager()
-    session = manager.get_session()
-    try:
-        template = session.query(Template).filter_by(name=name).first()
-        if template:
-            template.capture_failed = bool(failed)
-            session.commit()
-    finally:
-        session.close()
-
-
 def _update_scheduler_job(name: str, frequency: int) -> None:
     """Reschedule the APScheduler job for ``name`` if it exists.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation Overview
+
+This directory contains all of the guides and references for Glimpser.
+For a full index of available documentation, see [index.md](index.md).


### PR DESCRIPTION
## Summary
- add `docs/README.md` so the README link works
- remove duplicate `set_capture_failed` in `template_manager`
- narrow flake8 ignore list

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d9dfc583c8333956ead5cfca27ecc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a README to the documentation directory with an overview and navigation guidance.

- **Chores**
  - Updated code style configuration for more precise error and warning handling.
  - Removed a duplicate function definition to streamline internal code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->