### PR TITLE
Add open port discovery metadata

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -71,6 +71,22 @@ def _load_local_ouis() -> dict[str, str]:
 
 OUI_MAP.update(_load_local_ouis())
 
+# Ports checked for additional metadata after discovery. The list focuses on
+# common services exposed by cameras and network appliances. New ports can be
+# added here without affecting the scanning steps.
+COMMON_PORTS = [
+    80,
+    443,
+    554,
+    8554,
+    1935,
+    5060,
+    5061,
+    3478,
+    5349,
+    161,
+]
+
 # Discovery steps executed by :func:`discover_cameras`.  The list order
 # defines both the execution order and the number of progress updates.
 DISCOVERY_STAGES = [
@@ -191,6 +207,16 @@ def _trace_upstream(ip: str, timeout: int = 3) -> str | None:
     except Exception as e:  # pragma: no cover - system dependent
         logging.debug("traceroute error for %s: %s", ip, e)
     return None
+
+
+def _detect_open_ports(ip: str, ports: list[int]) -> list[int]:
+    """Return ports from ``ports`` that are reachable on ``ip``."""
+
+    open_ports = []
+    for port in ports:
+        if is_port_open(ip, port, timeout=1):
+            open_ports.append(port)
+    return open_ports
 
 
 def _local_subnets(max_prefixlen: int = 24):
@@ -645,6 +671,10 @@ def discover_cameras(progress_callback=None, subnets=None):
         hop = _trace_upstream(cam["ip"])
         if hop:
             cam.setdefault("info", {})["upstream"] = hop
+        if cam.get("protocol") != "local":
+            ports = _detect_open_ports(cam["ip"], COMMON_PORTS)
+            if ports:
+                cam.setdefault("info", {})["open_ports"] = ports
 
     if progress_callback:
         progress_callback("trace", len(result), [])

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -148,6 +148,11 @@ streamed back to the page during scanning. The **Info** column summarizes key
 details such as a camera's name, ONVIF address, or HTTP path instead of showing
 the raw JSON dictionary.
 
+Each camera is now also checked for commonly used service ports. Any detected
+ports are listed in the ``open_ports`` field so you can quickly see which
+services are reachable (for example, 80 for HTTP or 554 for RTSP). This scan
+is lightweight and runs after the main discovery steps finish.
+
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.
 
@@ -174,3 +179,10 @@ Locally attached USB webcams (for example, Logitech devices) will appear under
 Remote sources such as **GOES16**, **ZoomEarth**, and **Dopler** can be added
 manually, but they are not discovered automatically because they are hosted
 outside the local network.
+
+## Future improvements
+
+- Provide more granular progress updates with estimated completion times.
+- Offer a wizard-style interface with clearer instructions and tooltips.
+- Include additional metadata such as firmware versions.
+- Allow exporting discovery results to CSV or JSON.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -274,10 +274,12 @@ class TestCameraDiscovery(unittest.TestCase):
     @patch("app.utils.camera_discovery._probe_onvif")
     @patch("app.utils.camera_discovery._mac_manufacturer")
     @patch("app.utils.camera_discovery._mac_for_ip")
+    @patch("app.utils.camera_discovery.is_port_open", return_value=False)
     @patch("app.utils.camera_discovery._trace_upstream", return_value=None)
     def test_progress_callback_includes_mac(
         self,
         mock_trace,
+        mock_is_port_open,
         mock_mac,
         mock_vendor,
         mock_onvif,
@@ -298,6 +300,12 @@ class TestCameraDiscovery(unittest.TestCase):
 
         self.assertEqual(seen[0]["info"].get("mac"), "000c29aabbcc")
         self.assertEqual(seen[0]["info"].get("manufacturer"), "VMware")
+
+    @patch("app.utils.camera_discovery.is_port_open")
+    def test_detect_open_ports(self, mock_open):
+        mock_open.side_effect = lambda ip, port, timeout=1: port in (80, 554)
+        result = camera_discovery._detect_open_ports("192.168.1.6", [80, 443, 554])
+        self.assertEqual(result, [80, 554])
 
     @patch("app.utils.camera_discovery._local_subnets")
     @patch("app.utils.camera_discovery._probe_onvif", return_value=[])


### PR DESCRIPTION
## Summary
- record common open ports for each discovered camera
- document new open port metadata in discovery docs
- test open port detection

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da66db580833388587de72a00d991