### PR TITLE
Add tooltips to UI

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,6 +1,6 @@
 {% include 'header.html' %}
 <body>
-    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <a href="#main-content" class="skip-link" title="Jump to main area">Skip to main content</a>
     <header>
         {% include 'nav.html' %}
     </header>

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -47,7 +47,7 @@
             <option value="llm_cost_estimate">LLM Cost</option>
         </select>
         <input type="text" id="filter-value" placeholder="Value" title="Filter value">
-        <button id="apply-filter" type="button">Apply</button>
+        <button id="apply-filter" type="button" title="Filter table rows">Apply</button>
     </div>
 
 
@@ -55,11 +55,11 @@
 <details class="tsv-controls">
     <summary>Bulk Caption Management</summary>
     <div class="tsv-buttons">
-        <a href="/download_captions_tsv" class="btn btn-primary">Download Captions as TSV</a>
+        <a href="/download_captions_tsv" class="btn btn-primary" title="Download captions as TSV file">Download Captions as TSV</a>
 
         <form action="/upload_captions_tsv" method="post" enctype="multipart/form-data" class="tsv-upload-form">
-            <input type="file" name="tsv_file" id="tsv_file" accept=".tsv">
-            <button type="submit" class="btn btn-success">Upload TSV</button>
+            <input type="file" name="tsv_file" id="tsv_file" accept=".tsv" title="Select TSV file to upload">
+            <button type="submit" class="btn btn-success" title="Upload caption TSV file">Upload TSV</button>
         </form>
     </div>
     <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
@@ -122,7 +122,7 @@
             <td>
                 <div class="templateDiv">
                     <div class="video-container" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
-                        <div class="camera-name"><a href='/templates/{{camera}}'>{{camera}}</a></div>
+                        <div class="camera-name"><a href='/templates/{{camera}}' title="Open {{ camera }} details">{{camera}}</a></div>
                         <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}">
                             <source src="/last_video/{{ camera }}" type="video/mp4">
                             Your browser does not support the video tag.
@@ -153,7 +153,7 @@
                                 </div>
                             </div>
                         </div>
-                        <button class="update-button" data-template="{{ camera }}">
+                        <button class="update-button" data-template="{{ camera }}" title="Send updated prompt">
                             Send
                         </button>
                     </form>

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -31,26 +31,27 @@
   </section>
 
   <form id="danger-form" method="post">
-    <label for="danger-checkbox">
+    <label for="danger-checkbox" title="Toggle danger mode">
       <input
         id="danger-checkbox"
         type="checkbox"
         name="enabled"
         {% if enabled %}checked{% endif %}
+        title="Enable or disable danger mode"
       />
       Enable Danger Mode
     </label>
-    <button type="submit">Save</button>
+    <button type="submit" title="Save danger mode setting">Save</button>
   </form>
 </main>
 
-<div id="danger-modal" class="modal">
-  <div class="modal-content">
-    <span id="danger-close" class="close-icon">&times;</span>
-    <p id="danger-modal-message"></p>
-    <button id="danger-confirm">Confirm</button>
-    <button id="danger-cancel">Cancel</button>
+  <div id="danger-modal" class="modal">
+    <div class="modal-content">
+      <span id="danger-close" class="close-icon" title="Close dialog">&times;</span>
+      <p id="danger-modal-message"></p>
+      <button id="danger-confirm" title="Confirm this action">Confirm</button>
+      <button id="danger-cancel" title="Cancel and close">Cancel</button>
+    </div>
   </div>
-</div>
 {% endblock %}
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -34,13 +34,13 @@
                 <label for="popup_xpath">Popup XPath:</label>
                 <div class="xpath-input-container">
                     <input type="text" id="popup_xpath" name="popup_xpath">
-                    <button type="button" onclick="showStructuredInput('popup_xpath')">Structured</button>
+                    <button type="button" onclick="showStructuredInput('popup_xpath')" title="Open structured XPath editor">Structured</button>
                 </div>
 
                 <label for="dedicated_xpath">Dedicated XPath:</label>
                 <div class="xpath-input-container">
                     <input type="text" id="dedicated_xpath" name="dedicated_xpath">
-                    <button type="button" onclick="showStructuredInput('dedicated_xpath')">Structured</button>
+                    <button type="button" onclick="showStructuredInput('dedicated_xpath')" title="Open structured XPath editor">Structured</button>
                 </div>
 
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -73,12 +73,12 @@
     </video>
     <video id="preload-video" class="hidden" muted preload="auto"></video>
     <div class="video-controls">
-        <input type="range" id="seek-bar" value="0" />
+        <input type="range" id="seek-bar" value="0" title="Seek position" />
 
         <div class="control-row">
             <button id="play-pause" title="play/pause"><i class="fa-play-pause"></i></button>
             <div id="speed-container">
-                <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()" />
+                <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()" title="Adjust playback speed" />
                 <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
             </div>
             <button id="full-screen" title="fullscreen"><i class="fas fa-expand"></i></button>
@@ -219,8 +219,8 @@ function updateVideo(templateName) {
                 <label for="notes" title="Additional notes">Notes:</label>
                 <textarea id="notes" name="notes" title="Enter any additional notes or comments">{{ template_details.notes }}</textarea>
             </div>
-            <button type="button" onclick="suggestPrompt('{{ template_name }}')">Suggest Prompt</button>
-            <button type="button" onclick="suggestFix('{{ template_name }}')">Suggest Fix</button>
+            <button type="button" onclick="suggestPrompt('{{ template_name }}')" title="Generate a prompt">Suggest Prompt</button>
+            <button type="button" onclick="suggestFix('{{ template_name }}')" title="Suggest troubleshooting tips">Suggest Fix</button>
 
             <div class="form-row">
                 <label for="object_filter" title="Filter for specific objects">Object Filter:</label>
@@ -241,7 +241,7 @@ function updateVideo(templateName) {
                 <label for="popup_xpath">Popup XPath:</label>
                 <div class="xpath-input-container">
                     <input type="text" id="popup_xpath" name="popup_xpath" value="{{ template_details.popup_xpath }}">
-                    <button type="button" onclick="showStructuredInput('popup_xpath')">Structured</button>
+                    <button type="button" onclick="showStructuredInput('popup_xpath')" title="Open structured XPath editor">Structured</button>
                 </div>
             </div>
 
@@ -249,7 +249,7 @@ function updateVideo(templateName) {
                 <label for="dedicated_xpath">Dedicated XPath:</label>
                 <div class="xpath-input-container">
                     <input type="text" id="dedicated_xpath" name="dedicated_xpath" value="{{ template_details.dedicated_xpath }}">
-                    <button type="button" onclick="showStructuredInput('dedicated_xpath')">Structured</button>
+                    <button type="button" onclick="showStructuredInput('dedicated_xpath')" title="Open structured XPath editor">Structured</button>
                 </div>
             </div>
 
@@ -372,7 +372,7 @@ function showUndo(name, data) {
     const container = document.getElementById('undo-container');
     if (!container) return;
     container.style.display = 'block';
-    container.innerHTML = '<button id="undo-btn">Undo Delete</button>';
+    container.innerHTML = '<button id="undo-btn" title="Restore deleted template">Undo Delete</button>';
     document.getElementById('undo-btn').addEventListener('click', () => {
         fetch('/templates', {
             method: 'POST',
@@ -427,7 +427,7 @@ function showCameraDetails(templateName) {
     }
     detailsHtml += '</pre>';
 
-    detailsHtml += '<button onclick="copyToClipboard()">Copy to Clipboard</button>';
+    detailsHtml += '<button onclick="copyToClipboard()" title="Copy details to clipboard">Copy to Clipboard</button>';
 
     document.getElementById('camera-details-content').innerHTML = detailsHtml;
     document.getElementById('camera-details-modal').style.display = 'block';
@@ -481,14 +481,14 @@ function closePromptModal() {
 
   <div id="camera-details-modal" class="modal">
     <div class="modal-content">
-      <span onclick="closeModal()" class="close-icon">&times;</span>
+      <span onclick="closeModal()" class="close-icon" title="Close dialog">&times;</span>
       <div id="camera-details-content"></div>
     </div>
   </div>
 
   <div id="prompt-modal" class="modal">
     <div class="modal-content">
-      <span onclick="closePromptModal()" class="close-icon">&times;</span>
+      <span onclick="closePromptModal()" class="close-icon" title="Close dialog">&times;</span>
       <textarea id="prompt-text" class="prompt-textarea"></textarea>
     </div>
   </div>

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -23,3 +23,12 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - The footer itself hides when the mouse is inactive.
 
 These tooltips aim to make the interface self‑explanatory and easier to navigate.
+
+## Forms
+
+Interactive forms now include additional tooltips:
+
+- **Add Template** – explains each field and the "Structured" XPath buttons.
+- **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
+- **Captions** – upload and filter controls have descriptive titles.
+- **Danger Mode** – the checkbox, save button and modal controls all include tooltips.


### PR DESCRIPTION
## Summary
- add accessible titles to skip link, forms, and buttons
- document new form tooltips

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683daa00d04483338ed5346460cde363