### PR TITLE
Fix Captions page layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -993,7 +993,7 @@ input[type=submit]:hover {
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     filter: grayscale(40%);
     transition: filter 0.3s;
 }

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -195,6 +195,22 @@ export function updateHumanizedTimes() {
       element.title = formatExactTime(timestamp);
     }
   });
+
+  document
+    .querySelectorAll(
+      '.video-container[data-timestamp], .templateDiv img[data-timestamp], video.hover-video[data-timestamp]'
+    )
+    .forEach((element) => {
+      const original =
+        element.dataset.originalTimestamp || element.getAttribute('data-timestamp');
+      if (!element.dataset.originalTimestamp) {
+        element.dataset.originalTimestamp = original;
+      }
+      if (original) {
+        element.setAttribute('data-timestamp', timeAgo(original));
+        element.setAttribute('title', formatExactTime(original));
+      }
+    });
 }
 
 export function showStructuredInput(inputId) {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. Expand the **Bulk Caption Management** section when needed.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. Expand the **Bulk Caption Management** section when needed.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- prevent video squishing on the captions page
- show human-readable timestamps in thumbnail overlays
- mention overlay update in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683db36660108333b7c39daffafc022d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved timestamp displays on video and image overlays by showing human-readable times and tooltips with exact times.
  - Updated video scaling on the captions page so videos now fill their containers, which may crop content for a better fit.

- **Documentation**
  - Clarified that thumbnail overlays on the Captions page now display human-readable times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->