### PR TITLE
Add dashboard time widget

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1162,3 +1162,16 @@ details > summary {
 .status-dot.error {
     background-color: red;
 }
+
+/* Time display on index page */
+#index-time {
+    position: fixed;
+    bottom: 40px;
+    right: 10px;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    font-size: var(--timestamp-font-size);
+    z-index: 10;
+}
+

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -6,6 +6,7 @@ import { initFormValidation, initAddSettingValidation } from './form.js';
 import { initFooterFade } from './footer.js';
 import { initOffline } from './offline.js';
 import { initDangerToggle } from './danger.js';
+import { initIndexTime } from './time.js';
 
 initTemplates();
 initVideoControls();
@@ -16,3 +17,4 @@ initAddSettingValidation();
 initFooterFade();
 initOffline();
 initDangerToggle();
+initIndexTime();

--- a/app/static/js/time.js
+++ b/app/static/js/time.js
@@ -1,0 +1,14 @@
+export function initIndexTime() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const elem = document.getElementById('index-time');
+    if (!elem) return;
+    const update = () => {
+      const now = new Date();
+      elem.textContent = now.toLocaleTimeString();
+      elem.title = now.toISOString();
+    };
+    update();
+    setInterval(update, 1000);
+  });
+}
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -102,6 +102,8 @@
         <!-- Template list will be populated here -->
     </div>
 
+    <div id="index-time" class="corner-time" title=""></div>
+
 
 {% endblock %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
 - [Dark Mode Support](dark_mode.md)
+- [Dashboard Time Display](#dashboard-time)
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)
@@ -34,3 +35,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
 - [API Resilience](api_resilience.md)
 - [OpenSSF Scorecard](scorecard.md)
+
+## Dashboard Time
+
+The main dashboard now displays the current time in the lower right corner. Hover over the time to view the full ISO 8601 timestamp.

--- a/tests/js/time.test.js
+++ b/tests/js/time.test.js
@@ -1,0 +1,18 @@
+// tests/js/time.test.js
+
+document.body.innerHTML = `<div id="index-time"></div>`;
+
+jest.useFakeTimers();
+
+const { initIndexTime } = require('../../app/static/js/time.js');
+
+describe('time.js', () => {
+  test('initIndexTime updates element with time and ISO title', () => {
+    initIndexTime();
+    jest.advanceTimersByTime(0);
+    const elem = document.getElementById('index-time');
+    expect(elem.textContent).not.toBe('');
+    expect(elem.title).toMatch(/T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- show a small clock on the index page
- support updating the time with a new JS module
- document the new feature
- test the time widget

## Testing
- `flake8`
- `pytest tests/test_html_templates.py tests/test_noop.py -q`
- `npx jest --version` *(fails: request to https://registry.npmjs.org/jest failed)*

------
https://chatgpt.com/codex/tasks/task_e_683db38881988333bcaa40957ac18a2c