### PR TITLE
Fix FileNotFoundError in live view

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1231,17 +1231,24 @@ def init_routes(app):
                 SCREENSHOT_DIRECTORY,
                 name,
             )
-            lfiles = [f for f in glob.glob(path + "/*.png") if os.path.isfile(f)]
-            if not lfiles:
+            files_with_mtime = []
+            for f in glob.glob(path + "/*.png"):
+                if not os.path.isfile(f) or f.endswith(".tmp.png"):
+                    # Ignore in-progress screenshots
+                    continue
+                try:
+                    mtime = os.path.getmtime(f)
+                except OSError:
+                    # File might have been removed between glob and stat
+                    continue
+                files_with_mtime.append((f, mtime))
+            if not files_with_mtime:
                 continue
-            lfiles.sort(key=os.path.getmtime)
-            last_file = lfiles[-1]
-            if (
-                os.path.exists(last_file)
-                and os.path.getmtime(last_file) > most_recent_time
-            ):
+            files_with_mtime.sort(key=lambda t: t[1])
+            last_file, last_mtime = files_with_mtime[-1]
+            if last_mtime > most_recent_time:
                 most_recent_file = last_file
-                most_recent_time = os.path.getmtime(last_file)
+                most_recent_time = last_mtime
         if most_recent_file is None:
             abort(404)
 

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -44,6 +44,29 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png")
         self.assertEqual(resp.status_code, 200)
 
+    def test_ignores_missing_files(self):
+        self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
+        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        valid = os.path.join(img_dir, "cam1_valid.png")
+        missing = os.path.join(img_dir, "cam1_missing.png")
+        Image.new("RGB", (1, 1)).save(valid)
+
+        def fake_glob(_):
+            return [missing, valid]
+
+        orig_getmtime = os.path.getmtime
+
+        def fake_getmtime(path):
+            if path == missing:
+                raise FileNotFoundError
+            return orig_getmtime(path)
+
+        with patch("glob.glob", side_effect=fake_glob), patch(
+            "os.path.getmtime", side_effect=fake_getmtime
+        ):
+            resp = self.client.get("/stream.png")
+        self.assertEqual(resp.status_code, 200)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- ignore temporary and missing screenshot files when serving `/stream.png`
- test that missing screenshots do not break the route

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683dbcd2075c8333b3f62916647a299c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of the screenshot stream by ignoring temporary and missing files, reducing errors when accessing the latest screenshot.

- **Tests**
	- Added a test to ensure the screenshot stream endpoint correctly handles missing files without failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->