### PR TITLE
Fix footer overlap on templates page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -146,6 +146,8 @@ body {
 main {
     padding: 1rem;
     flex-grow: 1;
+    /* Reserve space for fixed footer so content isn't hidden */
+    padding-bottom: 60px;
 }
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -196,3 +196,15 @@ snapshot image rather than a true video stream.
 - Use the camera's RTSP or HTTP video stream URL when available.
 - Snapshot-only URLs now fall back to an MJPEG feed so the live view
   behaves like a regular video stream.
+
+## 12. Layout Issues
+
+### Problem: Buttons at the bottom of the Templates page are hidden
+
+The footer uses a fixed position at the bottom of the screen. On long pages this
+could overlap the last buttons.
+
+**Solution:**
+- Glimpser now adds extra padding to the `main` element so page content scrolls
+  fully above the footer. Update to the latest version or add a similar rule in
+  your custom CSS.


### PR DESCRIPTION
## Summary
- ensure page content can scroll above the fixed footer
- document the footer overlap fix in troubleshooting guide

## Testing
- `flake8`
- `pytest -q` *(76 passed)*

------
https://chatgpt.com/codex/tasks/task_e_683dd7666ff48333887bac2cebc29b7f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Added extra padding to the bottom of the main content area to prevent it from being hidden by the footer.

- **Documentation**
  - Updated the troubleshooting guide with a new section addressing layout issues caused by the footer overlapping page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->