### PR TITLE
Fix video alignment on captions page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -988,6 +988,13 @@ input[type=submit]:hover {
     width: var(--grid-item-width, 360px);
 }
 
+/* Position the video container to cover the entire tile */
+.captions-page .video-container {
+    position: absolute;
+    inset: 0;
+    padding: 0;
+}
+
 /* Ensure captions thumbnails fill the container and appear dimmed */
 .captions-page .templateDiv video {
     position: absolute;


### PR DESCRIPTION
## Summary
- overlay the video container on captions page so thumbnails fill the tile

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683deaa9b7b48333aaca7ac39cd97c0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the layout of the video container on the captions page so it now fills the entire available space without padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->