### PR TITLE
Fix timestamp display on dashboard

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -455,9 +455,7 @@ export async function loadTemplates() {
       window.addEventListener('resize', updateGridLayout);
       if (window.updateSliderLimits) window.updateSliderLimits();
     }
-    if (isCaptionsPage) {
-      updateHumanizedTimes();
-    }
+    updateHumanizedTimes();
   } catch (error) {
     console.error('Error loading templates:', error);
     const errorMsg = '<div class="error">Error loading templates. Please try again.</div>';

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,3 +39,6 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 ## Dashboard Time
 
 The main dashboard now displays the current time in the lower right corner. Hover over the time to view the full ISO 8601 timestamp.
+
+Thumbnails also now show the last capture time in a human readable
+"X ago" format, matching the tables on the Captions page.


### PR DESCRIPTION
## Summary
- show human-readable timestamps on the index page
- document dashboard thumbnail time format

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683deac7163c8333a9ff70ee5820c0f4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Thumbnails now display the last capture time in a human-readable "X ago" format across all relevant pages.

- **Documentation**
  - Updated documentation to reflect the new human-readable time format for thumbnail capture times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->