### PR TITLE
Improve discovery info gathering

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -455,6 +455,43 @@ def _check_http_endpoint(ip: str, port: int, path: str, timeout: int = 2) -> boo
         return False
 
 
+def _fetch_http_banner(ip: str, port: int, timeout: int = 2) -> dict[str, str]:
+    """Return HTTP metadata such as Server header or page title."""
+
+    request = f"GET / HTTP/1.1\r\nHost: {ip}\r\nConnection: close\r\n\r\n"
+    info: dict[str, str] = {}
+    try:
+        with socket.create_connection((ip, port), timeout=timeout) as sock:
+            sock.sendall(request.encode())
+            response = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                response += chunk
+                if b"\r\n\r\n" in response:
+                    break
+        header, _, body = response.partition(b"\r\n\r\n")
+        for line in header.decode(errors="ignore").split("\r\n"):
+            if line.lower().startswith("server:"):
+                info["server"] = line.split(":", 1)[1].strip()
+            if line.lower().startswith("www-authenticate:") and 'realm="' in line:
+                start = line.lower().find('realm="') + 7
+                end = line.find('"', start)
+                if end != -1:
+                    info["realm"] = line[start:end]
+        body_text = body.decode(errors="ignore")
+        start_idx = body_text.lower().find("<title>")
+        end_idx = body_text.lower().find("</title>", start_idx)
+        if start_idx != -1 and end_idx != -1:
+            title = body_text[start_idx + 7 : end_idx].strip()
+            if title:
+                info["title"] = title
+    except Exception as e:  # pragma: no cover - network
+        logging.debug("HTTP banner error for %s:%s: %s", ip, port, e)
+    return info
+
+
 def _scan_rtsp_ports(subnets):
     found = []
     checked = set()
@@ -761,7 +798,13 @@ def discover_cameras(progress_callback=None, subnets=None):
         if cam.get("protocol") != "local":
             ports = _detect_open_ports(cam["ip"], COMMON_PORTS)
             if ports:
-                cam.setdefault("info", {})["open_ports"] = ports
+                info = cam.setdefault("info", {})
+                info["open_ports"] = ports
+                for p in ports:
+                    if p in (80, 8080, 443):
+                        banner = _fetch_http_banner(cam["ip"], p)
+                        for k, v in banner.items():
+                            info.setdefault(k, v)
 
     _report("trace", len(result), [])
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -154,6 +154,9 @@ Each camera is now also checked for commonly used service ports. Any detected
 ports are listed in the ``open_ports`` field so you can quickly see which
 services are reachable (for example, 80 for HTTP or 554 for RTSP). This scan
 is lightweight and runs after the main discovery steps finish.
+If an HTTP port responds, Glimpser also fetches the web page banner to capture
+the `Server` header, authentication realm, and page title when present. These
+values populate the **Info** column so you can quickly identify each device.
 
 You can then add a discovered camera to your configuration directly from the `/discover` page.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -307,6 +307,82 @@ class TestCameraDiscovery(unittest.TestCase):
         result = camera_discovery._detect_open_ports("192.168.1.6", [80, 443, 554])
         self.assertEqual(result, [80, 554])
 
+    @patch("app.utils.camera_discovery.socket.create_connection")
+    def test_fetch_http_banner(self, mock_conn):
+        class FakeSock:
+            resp = (
+                b"HTTP/1.1 200 OK\r\n"
+                b"Server: Cam/1.0\r\n"
+                b'WWW-Authenticate: Basic realm="demo"\r\n\r\n'
+                b"<html><title>Demo Cam</title></html>"
+            )
+
+            def __init__(self):
+                self._sent = False
+                self._idx = 0
+
+            def sendall(self, data):
+                self._sent = True
+
+            def recv(self, n):
+                if self._idx >= len(self.resp):
+                    return b""
+                chunk = self.resp[self._idx : self._idx + n]
+                self._idx += n
+                return chunk
+
+            def close(self):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                pass
+
+        mock_conn.return_value = FakeSock()
+        result = camera_discovery._fetch_http_banner("1.2.3.4", 80)
+        self.assertEqual(
+            result,
+            {"server": "Cam/1.0", "realm": "demo", "title": "Demo Cam"},
+        )
+
+    @patch("app.utils.camera_discovery._fetch_http_banner")
+    @patch("app.utils.camera_discovery._detect_open_ports")
+    @patch("app.utils.camera_discovery._probe_onvif", return_value=[])
+    @patch("app.utils.camera_discovery._probe_mdns", return_value=[])
+    @patch("app.utils.camera_discovery._probe_ssdp", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtsp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_sip_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_webrtc_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_snmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_http_endpoints", return_value=[])
+    @patch("app.utils.camera_discovery._scan_hls_streams", return_value=[])
+    @patch("app.utils.camera_discovery._local_subnets", return_value=[])
+    def test_banner_in_discover(
+        self,
+        mock_subnets,
+        mock_hls,
+        mock_http,
+        mock_snmp,
+        mock_webrtc,
+        mock_sip,
+        mock_rtmp,
+        mock_rtsp,
+        mock_ssdp,
+        mock_mdns,
+        mock_onvif,
+        mock_detect,
+        mock_fetch,
+    ):
+        mock_detect.return_value = [80]
+        mock_fetch.return_value = {"server": "CamOS"}
+        cams = camera_discovery.discover_cameras()
+        info = cams[0]["info"]
+        self.assertIn("server", info)
+        self.assertEqual(info["server"], "CamOS")
+
     @patch("app.utils.camera_discovery._local_subnets")
     @patch("app.utils.camera_discovery._probe_onvif", return_value=[])
     def test_custom_subnets(self, mock_onvif, mock_local_subnets):


### PR DESCRIPTION
## Summary
- fetch HTTP banners from discovered devices
- surface banner data in discovery results
- document banner detection logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dec3d6390833396c3f08c4ab14577