### PR TITLE
Default to MJPG streams

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -647,9 +647,11 @@ if (liveSwitchInterval) {
     }
 
     function updateSpeedContainer() {
-if (!speedContainer) return;
-const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
-speedContainer.style.display = isGroupView ? 'block' : 'none';
+        if (!speedContainer) return;
+        const source = document.getElementById('video-source').value;
+        const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
+        const show = isGroupView && source !== 'mjpg';
+        speedContainer.style.display = show ? 'block' : 'none';
     }
 
 function checkCameraConnection(cameraName) {
@@ -678,11 +680,11 @@ const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
 return lastScreenshotTime > oneHourAgo;
 }
 
-// Initially show the latest screenshot and start the MP4 stream
+// Initially show the latest screenshot and start the MJPG stream
 showLastScreenshot();
 updateTemplateDetails();
 updateSpeedContainer();
-playMP4();
+playMJPG();
 
 function togglePlayback() {
     if (video.paused) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -105,10 +105,10 @@
         <option value="png" title="View a series of PNG images">PNG Stream</option>
 	<!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
         <option value="loop" title="Loop through available video clips">Loop Videos</option>
-        <option value="mp4" selected title="View an MP4 video stream">MP4 Stream</option>
+        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
         <option value="live" title="View the direct live stream">Live Video</option>
         <option value="motion" title="View motion-detected frames">Motion</option>
-        <option value="mjpg" title="View an MJPEG (Motion JPEG) stream">MJPG</option>
+        <option value="mjpg" selected title="View an MJPEG (Motion JPEG) stream">MJPG</option>
     </select>
 
 
@@ -872,8 +872,10 @@ function playMotion() {
 
     function updateSpeedContainer() {
         if (!speedContainer) return;
+        const source = document.getElementById('video-source').value;
         const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
-        speedContainer.style.display = isGroupView ? 'block' : 'none';
+        const show = isGroupView && source !== 'mjpg';
+        speedContainer.style.display = show ? 'block' : 'none';
     }
 
     function checkCameraConnection(cameraName) {
@@ -902,11 +904,11 @@ function playMotion() {
         return lastScreenshotTime > oneHourAgo;
     }
 
-        // Initially show the latest screenshot and start the MP4 stream
+        // Initially show the latest screenshot and start the MJPG stream
         showLastScreenshot();
         updateTemplateDetails();
         updateSpeedContainer();
-        playMP4();
+        playMJPG();
         preloadNextCamera();
     </script>
     <script type="module" src="{{ url_for('static', filename='js/live.js') }}"></script>

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -86,10 +86,10 @@
                 <option value="png" title="View a series of PNG images">PNG Stream</option>
                 <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
                 <option value="loop" title="Loop through available video clips">Loop Videos</option>
-                <option value="mp4" selected title="View an MP4 video stream">MP4 Stream</option>
+                <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
                 <option value="live" title="View the direct live stream">Live Video</option>
                 <option value="motion" title="View motion-detected frames">Motion</option>
-                <option value="mjpg" title="View an MJPEG (Motion JPEG) stream">MJPG</option>
+                <option value="mjpg" selected title="View an MJPEG (Motion JPEG) stream">MJPG</option>
             </select>
         </div>
     </div>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 6. Go to the "Monitoring" section to view your live data feed.
 
-7. On the **Live** page, select your camera and choose **Live Video** from the
+7. On the **Live** page, select your camera. MJPG is selected by default, but choose **Live Video** from the
    "Video Source" dropdown for direct streaming.
 
 8. Explore the auto-generated captions and summaries.

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -19,9 +19,7 @@ Key topics covered include:
 
 ## Viewing Captures
 
-On the **Live** page, pick a camera from the drop-down menu and set the **Video
-Source** to **Live Video**. This connects you directly to the realtime feed so
-you can monitor activity as it happens.
+On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** if you want a direct real-time feed.
 
 When watching a live stream, you can use keyboard shortcuts:
 `Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen,


### PR DESCRIPTION
## Summary
- make MJPG the default stream selection
- hide speed slider when MJPG is selected
- update documentation to reflect new defaults

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ded617d6083338c91fe0a31c45436