### PR TITLE
Maintain screen coverage on slider

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -13,10 +13,25 @@ export function initTemplates() {
         slider.max = window.innerWidth;
         const templateCount =
           templateList?.querySelectorAll('.templateDiv').length || 1;
+
+        // Minimum width needed to fit all tiles across the page
+        const widthForColumns = Math.ceil(window.innerWidth / templateCount);
+
+        // Minimum width needed so combined rows fill the screen vertically
+        const aspectRatio = 9 / 16;
+        const widthForHeight = Math.sqrt(
+          (window.innerHeight * window.innerWidth) /
+            (templateCount * aspectRatio),
+        );
+
         const computedMin = Math.max(
           50,
-          Math.min(slider.max, Math.ceil(window.innerWidth / templateCount)),
+          Math.min(
+            slider.max,
+            Math.ceil(Math.max(widthForColumns, widthForHeight)),
+          ),
         );
+
         slider.min = computedMin;
         if (parseFloat(slider.value) < computedMin) {
           slider.value = computedMin;

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The width slider on the index page automatically adjusts to the current browser width and updates if you resize the window. It also won't shrink smaller than the space needed to fit all thumbnails, which prevents excessive columns and lag. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The width slider on the index page automatically adjusts to the current browser size and updates on resize. It now enforces a dynamic minimum based on the number of thumbnails and your viewport height so the screen is never left with empty space below the tiles. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 ### Why is the live feed slightly cropped on small screens?
 Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.


### PR DESCRIPTION
## Summary
- enforce a dynamic minimum width for the front page slider so thumbnails always fill the viewport
- document new slider behavior in FAQ

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dee01f6d08333a2f13c2355cddc6d