### PR TITLE
Improve captions page display

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1646,6 +1646,9 @@ def init_routes(app):
             )
             templates[name]["video_count"] = template_manager.get_video_count(name)
             templates[name]["storage_usage"] = template_manager.get_storage_usage(name)
+            templates[name]["storage_usage_bytes"] = (
+                template_manager.get_storage_usage_bytes(name)
+            )
             templates[name]["llm_response_count"] = (
                 template_manager.get_llm_response_count(name)
             )

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1011,6 +1011,22 @@ input[type=submit]:hover {
     filter: none;
 }
 
+.caption-box {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.caption-box textarea {
+    width: 100%;
+}
+
+.caption-box .last-caption {
+    max-height: 6rem;
+    overflow-y: auto;
+    white-space: pre-wrap;
+}
+
 .filter-controls {
     display: flex;
     flex-wrap: wrap;

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -48,6 +48,7 @@
         </select>
         <input type="text" id="filter-value" placeholder="Value" title="Filter value">
         <button id="apply-filter" type="button" title="Filter table rows">Apply</button>
+        <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust thumbnail width">
     </div>
 
 
@@ -102,6 +103,7 @@
     </details>
 
 <h2>Camera Notes</h2>
+<div id="template-list">
 <table id="camera-table" class="camera-table">
     <thead>
         <tr>
@@ -118,7 +120,7 @@
     </thead>
     <tbody>
         {% for camera in template_details %}
-        <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}" data-screenshot_count="{{ template_details[camera]['screenshot_count'] }}" data-video_count="{{ template_details[camera]['video_count'] }}" data-storage_usage="{{ template_details[camera]['storage_usage'] }}" data-llm_response_count="{{ template_details[camera]['llm_response_count'] }}" data-llm_cost_estimate="{{ template_details[camera]['llm_cost_estimate'] }}">
+        <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}" data-screenshot_count="{{ template_details[camera]['screenshot_count'] }}" data-video_count="{{ template_details[camera]['video_count'] }}" data-storage_usage="{{ template_details[camera]['storage_usage_bytes'] }}" data-llm_response_count="{{ template_details[camera]['llm_response_count'] }}" data-llm_cost_estimate="{{ template_details[camera]['llm_cost_estimate'] }}">
             <td>
                 <div class="templateDiv">
                     <div class="video-container" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
@@ -134,13 +136,11 @@
             <td data-value="{{ template_details[camera]['next_screenshot'] }}"><span class="humanized-time" data-time="{{ template_details[camera]['next_screenshot'] }}">{{ template_details[camera]['next_screenshot'] }}</span></td>
             <td data-value="{{ template_details[camera]['screenshot_count'] }}">{{ template_details[camera]['screenshot_count'] }}</td>
             <td data-value="{{ template_details[camera]['video_count'] }}">{{ template_details[camera]['video_count'] }}</td>
-            <td data-value="{{ template_details[camera]['storage_usage'] }}">{{ template_details[camera]['storage_usage'] }}</td>
+            <td data-value="{{ template_details[camera]['storage_usage_bytes'] }}">{{ template_details[camera]['storage_usage'] }}</td>
             <td data-value="{{ template_details[camera]['llm_response_count'] }}">{{ template_details[camera]['llm_response_count'] }}</td>
             <td data-value="{{ template_details[camera]['llm_cost_estimate'] }}">{{ template_details[camera]['llm_cost_estimate'] }}</td>
             <td>
-                <details>
-                    <summary>Caption</summary>
-                    <form id="form-{{ camera }}" class="notes-form">
+                <form id="form-{{ camera }}" class="notes-form caption-box">
                         <div class="chat-box">
                             <div class="chat-prompt">
                                 <label for="notes-{{ camera }}">Prompt:</label>
@@ -156,13 +156,13 @@
                         <button class="update-button" data-template="{{ camera }}" title="Send updated prompt">
                             Send
                         </button>
-                    </form>
-                </details>
+                </form>
             </td>
         </tr>
         {% endfor %}
     </tbody>
 </table>
+</div>
 </div>
 {% endblock %}
 

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -645,6 +645,28 @@ def get_storage_usage(name: str) -> str:
     return f"{total_size:.1f} {unit}"
 
 
+def get_storage_usage_bytes(name: str) -> int:
+    """Return total storage used for ``name`` in bytes."""
+
+    name = validate_template_name(name)
+    if name is None:
+        return 0
+
+    screenshot_path = os.path.join(SCREENSHOT_DIRECTORY, name)
+    video_path = os.path.join(VIDEO_DIRECTORY, name)
+    total_size = 0
+
+    for path in [screenshot_path, video_path]:
+        if os.path.exists(path):
+            for dirpath, _, filenames in os.walk(path):
+                for f in filenames:
+                    fp = os.path.join(dirpath, f)
+                    if os.path.exists(fp):
+                        total_size += os.path.getsize(fp)
+
+    return total_size
+
+
 def record_llm_usage(name: str, tokens: int) -> None:
     """Record token usage for ``name`` in ``LLM_USAGE_PATH``.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The width slider on the index page automatically adjusts to the current browser width and updates if you resize the window. It also won't shrink smaller than the space needed to fit all thumbnails, which prevents excessive columns and lag. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The width slider on the index and captions pages automatically adjusts to the current browser width and updates if you resize the window. It also won't shrink smaller than the space needed to fit all thumbnails, which prevents excessive columns and lag. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 ### Why is the live feed slightly cropped on small screens?
 Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. Expand the **Bulk Caption Management** section when needed.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider lets you resize thumbnails, and caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
 
 ## Next Steps
 

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -13,6 +13,7 @@ from app.utils.template_manager import (
     update_last_screenshot_time,
     set_capture_failed,
     get_storage_usage,
+    get_storage_usage_bytes,
     get_templates,
 )
 from app.utils.validators import validate_template_name
@@ -351,6 +352,26 @@ class TestStorageUsage(unittest.TestCase):
             ), patch("app.utils.template_manager.VIDEO_DIRECTORY", vid_dir):
                 result = get_storage_usage("cam1")
                 self.assertEqual(result, "3.0 KB")
+
+    def test_get_storage_usage_bytes(self):
+        """Returns raw byte count for sorting."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sshot_dir = os.path.join(temp_dir, "shots")
+            vid_dir = os.path.join(temp_dir, "vid")
+            os.makedirs(os.path.join(sshot_dir, "cam1"))
+            os.makedirs(os.path.join(vid_dir, "cam1"))
+
+            with open(os.path.join(sshot_dir, "cam1", "cam1.png"), "wb") as f:
+                f.write(b"0" * 1024)
+            with open(os.path.join(vid_dir, "cam1", "cam1.mp4"), "wb") as f:
+                f.write(b"0" * 2048)
+
+            with patch(
+                "app.utils.template_manager.SCREENSHOT_DIRECTORY",
+                sshot_dir,
+            ), patch("app.utils.template_manager.VIDEO_DIRECTORY", vid_dir):
+                result = get_storage_usage_bytes("cam1")
+                self.assertEqual(result, 3072)
 
 
 class TestSnapshotDetection(unittest.TestCase):


### PR DESCRIPTION
## Summary
- normalize storage usage for numeric sorting
- expand captions for easier editing
- add width slider to captions page
- style caption editing box
- document new controls
- test byte-count function

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dee7b266883339ea6ea5b0278a808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a slider on the Captions page to adjust thumbnail width.
  - Caption form is now always visible for easier editing, with improved layout and expanded caption text area.
  - Displayed storage usage now includes both a human-readable format and raw byte count for each template.

- **Style**
  - Updated caption form styling for better structure and usability, including scrollable caption display.

- **Documentation**
  - Updated guides to reflect the new thumbnail width slider and expanded caption editing features.

- **Tests**
  - Added tests to verify accurate calculation of storage usage in bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->