### PR TITLE
Add group page navigation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1108,6 +1108,16 @@ def init_routes(app):
         template_details = template_manager.get_templates()
         return render_template("index.html", template_details=template_details)
 
+    @app.route("/group/<string:group_name>")
+    @login_required
+    def group_page(group_name: str):
+        """Render a page listing all cameras in a group."""
+        group_name = secure_filename(group_name)
+        groups = get_active_groups()
+        if group_name not in groups:
+            abort(404)
+        return render_template("group.html", group_name=group_name)
+
     def get_active_templates():
         templates = template_manager.get_templates()
         active_cameras = []

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1190,4 +1190,12 @@ details > summary {
     z-index: 10;
 }
 
+.group-links {
+    margin-top: 0.5em;
+}
+
+.group-links a {
+    margin-right: 0.5em;
+}
+
 

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Group {{ group_name }}</h2>
+<div>
+    <label for="group-dropdown" title="Filter templates by group">Filter by Group:</label>
+    <select id="group-dropdown" title="Select a group to filter templates"></select>
+    <label for="search-input" title="Search for cameras or groups">Search:</label>
+    <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
+    <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
+    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+</div>
+<div id="template-list" title="List of all templates" role="region" aria-label="Templates"></div>
+<div id="index-time" class="corner-time" title=""></div>
+<script type="module">
+    import { loadGroups, loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
+    document.addEventListener('DOMContentLoaded', () => {
+        loadGroups().then(() => {
+            const dropdown = document.getElementById('group-dropdown');
+            if (dropdown) {
+                dropdown.value = '{{ group_name }}';
+            }
+            loadTemplates();
+        });
+    });
+</script>
+{% endblock %}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -266,6 +266,13 @@ function updateVideo(templateName) {
             <div class="form-row">
                 <label for="groups" title="Groups for the template">Groups:</label>
                 <input type="text" id="groups" name="groups" value="{{ template_details.groups }}" title="Enter comma-separated group names">
+                {% if template_details.groups %}
+                <div class="group-links">
+                    {% for g in template_details.groups.split(',') %}
+                    <a href="/group/{{ g.strip() }}" class="group-link" title="View group {{ g.strip() }}">{{ g.strip() }}</a>
+                    {% endfor %}
+                </div>
+                {% endif %}
             </div>
 
             <div class="form-row">

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -5,7 +5,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 ## Navigation Bar
 
 - **Home** – returns to the dashboard.
-- **Group links** – "View group <group>" for each active group.
+- **Group links** – open the page listing cameras in that group.
 - **Template title** – links to the template details page.
 - **System Performance icon** – shows CPU, memory and other metrics.
 - **Danger Mode icon** – explains why danger mode may be disabled.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -551,6 +551,22 @@ class TestRoutes(unittest.TestCase):
             "live.html", template_details={"cam1": mock_get_template.return_value}
         )
 
+    @patch("app.routes.render_template")
+    @patch("app.routes.get_active_groups")
+    @patch("app.routes.session", {"user_id": 1})
+    def test_group_page(self, mock_groups, mock_render_template):
+        mock_groups.return_value = ["group1", "group2"]
+        response = self.client.get("/group/group1")
+        self.assertEqual(response.status_code, 200)
+        mock_render_template.assert_called_with("group.html", group_name="group1")
+
+    @patch("app.routes.get_active_groups")
+    @patch("app.routes.session", {"user_id": 1})
+    def test_group_page_not_found(self, mock_groups):
+        mock_groups.return_value = ["group1"]
+        response = self.client.get("/group/unknown")
+        self.assertEqual(response.status_code, 404)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `/group/<group_name>` route
- display group links in template details
- style group links
- document group links
- test group page route

## Testing
- `pytest tests/test_routes.py::TestRoutes::test_group_page tests/test_routes.py::TestRoutes::test_group_page_not_found -q`

------
https://chatgpt.com/codex/tasks/task_e_683def1ebc248333b05d1f8713be1fd5