### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,10 +12,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -53,10 +53,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install PyInstaller
         run: python -m pip install --upgrade pip && pip install pyinstaller
       - name: Build Windows executable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FFprobe path configuration
 - Live video streaming endpoint `/live_video`
 - Python 3.11 compatibility
+- Python 3.12 compatibility
 - mDNS/Zeroconf camera discovery
 - MAC vendor lookup now consults local databases and an online API
 - Footer warns when a newer release is available
@@ -37,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package requirements and cleaned up imports
 - Added CPU builds of JAX 0.6.1 and Flax 0.2.0
 - Bumped scikit-image to 0.25.0
-- Bumped numpy to 1.25.0
+- Bumped numpy to 1.26.0
 - Updated default VERSION to 0.2.7 for footer display
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwebp7 unzip poppler-utils xvfb ffmpeg libssl3 libffi8 libbz2-1.0 \
     libreadline8 libncurses5 libncursesw6 libxml2 libxslt1.1 \
     build-essential gcc zlib1g wget gnupg iproute2 wkhtmltopdf \
+    python3-pip python3-setuptools python3-wheel \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 ## Installation
 
 ### Prerequisites
-- Python 3.8 to 3.11
+- Python 3.8 to 3.12
 
 ### Steps
 1. **Install the Package**

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 ## Prerequisites
 
-- Python 3.8 to 3.11
+- Python 3.8 to 3.12
 - Git (for cloning the repository)
 
 ## Installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This guide provides detailed instructions for installing and setting up Glimpser
 - **Architecture**: Glimpser is primarily designed for x86 architecture.
   - ARM support may require additional work and is not guaranteed.
 - **Operating System**: Linux (Ubuntu 20.04 LTS or later recommended)
-- **Python**: Version 3.8 to 3.11
+- **Python**: Version 3.8 to 3.12
 
 ## Installation Steps
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Dependencies fail to install
 
 **Solution:**
-- Ensure you're using Python 3.8 or newer (tested up to 3.11): `python --version`
+- Ensure you're using Python 3.8 or newer (tested up to 3.12): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
 - Double-check that you're working in the correct virtual environment.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==3.1.1
 Flask-APScheduler==1.13.1
 Flask-Login==0.6.3
 Jinja2==3.1.6
-numpy==1.25.0
+numpy==1.26.0
 pdf2image==1.17.0
 Pillow==11.2.1
 psutil==6.0.0

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,9 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.8, <3.13",
     entry_points={
         "console_scripts": [
             "glimpser=main:main",


### PR DESCRIPTION
## Summary
- add Python 3.12 to docs and classifiers
- bump numpy to 1.26.0
- switch Docker image and CI to Python 3.12
- ensure setuptools available in Docker image

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd2e62f008333bd2f9e147dc48744