### PR TITLE
Improve overlay accessibility

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -141,16 +141,16 @@
         <div id="video-overlay" class="video-overlay" role="region" aria-live="polite">
             <div id="loading-indicator" class="hidden" role="status">Loading...</div>
             <div id="play-pause-indicator" class="video-icon hidden" aria-hidden="true">▶</div>
-            <div id="offline-indicator" class="offline-indicator hidden" role="alert">
-                <i class="fas fa-video-slash video-icon"></i>
+            <div id="offline-indicator" class="offline-indicator hidden" role="alert" title="Camera offline">
+                <i class="fas fa-video-slash video-icon" aria-hidden="true"></i>
                 <p id="offline-message"></p>
             </div>
-            <div id="capture-error-indicator" class="error-indicator hidden" role="alert">
-                <i class="fas fa-exclamation-triangle video-icon"></i>
+            <div id="capture-error-indicator" class="error-indicator hidden" role="alert" title="Capture error">
+                <i class="fas fa-exclamation-triangle video-icon" aria-hidden="true"></i>
                 <p id="capture-error-message"></p>
             </div>
-            <div id="stream-error-indicator" class="error-indicator hidden" role="alert">
-                <i class="fas fa-times-circle video-icon"></i>
+            <div id="stream-error-indicator" class="error-indicator hidden" role="alert" title="Streaming error">
+                <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
                 <p id="stream-error-message"></p>
             </div>
         </div>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -13,5 +13,7 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - A "skip to main content" link enables quick keyboard navigation.
 - The base template uses a `<main>` element for semantic structure.
 - Live video overlays use ARIA roles so screen readers announce status changes.
+- Offline and error indicators now include `title` attributes so assistive
+  technology can describe the icon meaning.
 - Focus outlines appear when navigating via keyboard.
 - The delete button text color now meets color contrast guidelines.


### PR DESCRIPTION
## Summary
- add titles and aria-hidden attributes to overlay icons
- document indicator titles in accessibility guide

## Testing
- `flake8`
- `pytest` *(fails: FileNotFoundError for logs and KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_683df19730388333b4f52ed5f18aa211