### PR TITLE
Fix captions table layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -182,6 +182,10 @@ h1, h2 {
     max-width: 100%;
 }
 
+.captions-page #template-list {
+    display: block;
+}
+
 @media (max-width: 767px) { /* Adjust this value based on your testing */
     select {
         font-size: 16px; /* Larger font size for easier interaction */


### PR DESCRIPTION
## Summary
- ensure captions KPI table stays a single column when adjusting the width slider

## Testing
- `flake8`
- `pytest -q tests/test_noop.py`

------
https://chatgpt.com/codex/tasks/task_e_683df45ef33c8333aac5c430331753c3