### PR TITLE
Fix scrub bar for non-seekable streams

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -303,6 +303,8 @@ function updateFeed() {
 
 function playM3U8() {
     video.style.display = 'block';
+    // HLS streams are live and not seekable
+    document.getElementById('seek-bar').style.display = 'none';
 
     image.style.display = 'none';
     stopLiveSwitch();
@@ -472,7 +474,8 @@ video.dataset.currentCamera = nextCamera;
 
 function playLive() {
     video.style.display = 'block';
-    document.getElementById("seek-bar").style.display = "block";
+    // Live video cannot be scrubbed
+    document.getElementById('seek-bar').style.display = 'none';
     stopPNG();
     stopLiveSwitch();
 
@@ -567,7 +570,8 @@ pngInterval = setInterval(refreshPNG, 10000 / speed);
 function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
-document.getElementById("seek-bar").style.display = "block";
+    // MJPEG streams are continuous images, disable scrubbing
+    document.getElementById('seek-bar').style.display = 'none';
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -545,6 +545,8 @@ function changeCamera() {
 
 function playM3U8() {
     video.style.display = 'block';
+        // HLS streams cannot be scrubbed
+        document.getElementById("seek-bar").style.display = "none";
 
     image.style.display = 'none';
     stopLiveSwitch();
@@ -709,7 +711,8 @@ function handleVideoEnded() {
 
 function playLive() {
     video.style.display = 'block';
-    document.getElementById("seek-bar").style.display = "block";
+        // Disable scrubbing on live streams
+        document.getElementById("seek-bar").style.display = "none";
     stopPNG();
     stopLiveSwitch();
 
@@ -791,7 +794,8 @@ function playPNG() {
 function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
-        document.getElementById("seek-bar").style.display = "block";
+        // MJPEG streams show images only, hide the scrub bar
+        document.getElementById("seek-bar").style.display = "none";
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {


### PR DESCRIPTION
## Summary
- hide the seek bar when playing live, HLS, or MJPEG streams
- disable seeking for those media types in live view

## Testing
- `black --check .` *(fails: would reformat 19 files)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df4a0337883338e5f0defca59b1c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The seek bar is now consistently hidden during live, HLS (M3U8), and MJPEG video playback, preventing users from attempting to seek in non-seekable streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->