### PR TITLE
Add internal caption stream

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -34,7 +34,8 @@ from flask import (
     stream_with_context,
 )
 
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
+import textwrap
 from sqlalchemy import text
 from werkzeug.security import check_password_hash
 from werkzeug.utils import secure_filename
@@ -742,6 +743,42 @@ def generate_fast_mjpg(camera: str):
             time.sleep(delay - elapsed)
 
 
+def generate_caption_loop():
+    """Yield MJPEG frames showing the most recent caption."""
+
+    boundary = b"frame"
+    while True:
+        session_db = SessionLocal()
+        caption = "No captions available"
+        try:
+            rec = session_db.query(Summary).order_by(Summary.timestamp.desc()).first()
+            if rec:
+                try:
+                    data = json.loads(rec.content)
+                    if data:
+                        caption = next(iter(data.values()))
+                except Exception:
+                    caption = rec.content
+        finally:
+            session_db.close()
+
+        img = Image.new("RGB", (1280, 720), "black")
+        draw = ImageDraw.Draw(img)
+        font = ImageFont.load_default()
+        wrapped = textwrap.fill(caption, width=60)
+        bbox = draw.textbbox((0, 0), wrapped, font=font)
+        w = bbox[2] - bbox[0]
+        h = bbox[3] - bbox[1]
+        draw.text(((1280 - w) / 2, (720 - h) / 2), wrapped, fill="white", font=font)
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        frame = buf.getvalue()
+
+        yield b"--" + boundary + b"\r\n"
+        yield b"Content-Type: image/jpeg\r\n\r\n" + frame + b"\r\n"
+        time.sleep(5)
+
+
 def allowed_filename(filename: str) -> bool:
     r"""Return ``True`` when ``filename`` contains only safe characters.
 
@@ -1419,6 +1456,13 @@ def init_routes(app):
         logging.debug("last caption")
         return Response(
             generate(group=group, camera=camera, filename="last_caption.png"),
+            mimetype="multipart/x-mixed-replace; boundary=frame",
+        )
+
+    @app.route("/internal_caption.mjpg", methods=["GET"])
+    def internal_caption_mjpg():
+        return Response(
+            generate_caption_loop(),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -770,7 +770,7 @@ def discover_cameras(progress_callback=None, subnets=None):
             finally:
                 _report(stage, len(cameras), stage_cameras)
 
-    # Always include the internal status page so the system can monitor itself
+    # Always include internal views so the system can monitor itself
     from app.config import PORT
 
     cameras.append(
@@ -782,10 +782,21 @@ def discover_cameras(progress_callback=None, subnets=None):
             "url": f"http://127.0.0.1:{PORT}/status",
         }
     )
-    # remove duplicates
+
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "Internal Caption"},
+            "url": f"http://127.0.0.1:{PORT}/internal_caption.mjpg",
+        }
+    )
+
+    # remove duplicates but keep distinct URLs
     unique = {}
     for cam in cameras:
-        key = (cam["ip"], cam["protocol"], cam["port"])
+        key = (cam["ip"], cam["protocol"], cam["port"], cam.get("url"))
         if key not in unique:
             unique[key] = cam
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -116,6 +116,7 @@ Several other routes provide streaming functionality:
 - **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `camera` or `group` as query parameters.
 - **GET /caption.mjpg** – MJPEG stream of the last caption frame for a group.
 - **GET /motion_caption.mjpg** – Combines motion and caption frames in a single MJPEG stream.
+- **GET /internal_caption.mjpg** – Loops the latest caption text as an MJPEG stream.
 - **GET /stream.m3u8** – HLS playlist referencing the latest videos.
   Optional `camera` or `group` query parameters filter the playlist to a
   single camera or group of cameras.

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -165,6 +165,8 @@ The discovery list also shows a **System Status** entry pointing at your local
 `/status` page (`http://127.0.0.1:8082/status`). You can add this item like any
 other camera to have Glimpser periodically capture screenshots of its own
 metrics page.
+It now also includes an **Internal Caption** entry streaming `/internal_caption.mjpg`,
+which loops recent caption text for convenient review.
 
 ## Common cameras to try
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -54,6 +54,8 @@ The log viewer reads log lines from memory, ensuring minimal disk overhead.
 The `/status` page also appears on the `/discover` screen as a **System Status**
 camera. Adding it lets Glimpser capture periodic screenshots of its own health
 metrics.
+An accompanying **Internal Caption** camera shows `/internal_caption.mjpg` so you
+can monitor recent caption text without leaving the dashboard.
 
 ## Danger Mode Indicator
 


### PR DESCRIPTION
## Summary
- implement `internal_caption.mjpg` stream
- expose the caption stream in camera discovery
- document new internal caption camera and API endpoint

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683df540f5488333b01f37e3d3aee368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new MJPEG streaming endpoint that displays the latest caption text in real time.
  - Added an "Internal Caption" camera feed to the camera discovery list for easy access to caption streams.

- **Documentation**
  - Updated API documentation to include the new streaming endpoint.
  - Enhanced camera discovery and system monitoring documentation to describe the new "Internal Caption" feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->