### PR TITLE
Enable lazy loading for images

### DIFF
--- a/app/templates/404.html
+++ b/app/templates/404.html
@@ -3,7 +3,7 @@
 <div class="error-container">
     <h1 class="error-title">404: Page Not Found</h1>
     <div class="error-image">
-        <img src="{{ url_for('static', filename='img/404_camera.png') }}" alt="Broken camera">
+        <img src="{{ url_for('static', filename='img/404_camera.png') }}" loading="lazy" alt="Broken camera">
     </div>
     <p class="error-message">Oops! Looks like this glimpse is out of focus.</p>
     <p class="error-description">The page you're looking for seems to have vanished into thin air. Maybe it's hiding behind the lens?</p>

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -3,7 +3,7 @@
 <div class="error-container">
     <h1 class="error-title">Oops! Something went wrong</h1>
     <div class="error-image">
-        <img src="{{ url_for('static', filename='img/error_camera.png') }}" alt="Glitchy camera">
+        <img src="{{ url_for('static', filename='img/error_camera.png') }}" loading="lazy" alt="Glitchy camera">
     </div>
     <p class="error-message">Error {{ error.code }}: {{ error.name }}</p>
     <p class="error-description">{{ error.description }}</p>

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -4,7 +4,7 @@
         <div class="footer-logo">
             <!--
             <a href="/">
-                <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" alt="Glimpser" title="Glimpser">
+                <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" loading="lazy" alt="Glimpser" title="Glimpser">
             </a>
             -->
         </div>

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -82,7 +82,7 @@
     </style>
 
     <div class="video-container" role="region" aria-label="Live video feed">
-        <img id="live-image" alt="Live feed frame" title="Current frame from the live feed">
+        <img id="live-image" loading="lazy" alt="Live feed frame" title="Current frame from the live feed">
         <video id="live-video" class="hidden" autoplay muted tabindex="0">
             <source src="" type="video/mp4">
             Your browser does not support the video tag.

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,6 +1,6 @@
 <h1>
   <a href="/" title="Home">
-    <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" alt="Glimpser logo" title="Glimpser" />
+    <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
   </a>
 </h1>
 <nav>

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -66,7 +66,7 @@
 </style>
 
 <div class="video-container">
-    <img id="live-image" alt="Live feed frame" title="Current frame from the live feed" />
+    <img id="live-image" loading="lazy" alt="Live feed frame" title="Current frame from the live feed" />
     <video id="live-video" class="hidden" autoplay muted>
         <source src="" type="video/mp4" />
         Your browser does not support the video tag.
@@ -187,7 +187,7 @@ function updateVideo(templateName) {
     <div id="screenshots">
         {% for screenshot in screenshots %}
             <div class="screenshot">
-                    <a href='/screenshots/{{template_name}}/{{screenshot}}' title="View full-size screenshot"><img src="/screenshots/{{template_name}}/{{screenshot }}" alt="Screenshot" height='200' title="Recent screenshot: {{screenshot}}"></a>
+                    <a href='/screenshots/{{template_name}}/{{screenshot}}' title="View full-size screenshot"><img src="/screenshots/{{template_name}}/{{screenshot }}" loading="lazy" alt="Screenshot" height='200' title="Recent screenshot: {{screenshot}}"></a>
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- enable `loading="lazy"` on static images to reduce initial load time

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1c46cca083339ebdabaa484c7604