### PR TITLE
Add onboarding modal

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -7,6 +7,7 @@ import { initFooterFade } from './footer.js';
 import { initOffline } from './offline.js';
 import { initDangerToggle } from './danger.js';
 import { initIndexTime } from './time.js';
+import { initWelcome } from './welcome.js';
 
 initTemplates();
 initVideoControls();
@@ -18,3 +19,4 @@ initFooterFade();
 initOffline();
 initDangerToggle();
 initIndexTime();
+initWelcome();

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -383,12 +383,14 @@ export async function loadTemplates() {
     }, { threshold: 0.5 });
 
     let hasTemplates = false;
+    let templateCount = 0;
     Object.entries(templates).forEach(([name, template], index) => {
       if (
         templateBelongsToGroup(template, selectedGroup) &&
         templateMatchesSearch(template, searchQuery)
       ) {
         hasTemplates = true;
+        templateCount += 1;
         const lastScreenshotTime = template.last_screenshot_time;
         const humanizedTimestamp = timeAgo(lastScreenshotTime);
         const nextCaptureTime = timeAgo(template.next_screenshot_time);
@@ -471,6 +473,9 @@ export async function loadTemplates() {
       if (window.updateSliderLimits) window.updateSliderLimits();
     }
     updateHumanizedTimes();
+    window.dispatchEvent(
+      new CustomEvent('templatesLoaded', { detail: { count: templateCount } }),
+    );
   } catch (error) {
     console.error('Error loading templates:', error);
     const errorMsg = '<div class="error">Error loading templates. Please try again.</div>';

--- a/app/static/js/welcome.js
+++ b/app/static/js/welcome.js
@@ -1,0 +1,29 @@
+export function initWelcome() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('welcome-modal');
+    const closeBtn = document.getElementById('welcome-close');
+    const okBtn = document.getElementById('welcome-ok');
+
+    if (!modal) return;
+
+    const hide = () => {
+      modal.style.display = 'none';
+      // Remember dismissal so returning users are not prompted again
+      localStorage.setItem('welcomeSeen', 'true');
+    };
+
+    const maybeShow = (count) => {
+      if (count === 0 && !localStorage.getItem('welcomeSeen')) {
+        modal.style.display = 'block';
+      }
+    };
+
+    if (closeBtn) closeBtn.addEventListener('click', hide);
+    if (okBtn) okBtn.addEventListener('click', hide);
+
+    window.addEventListener('templatesLoaded', (e) => {
+      const c = e.detail?.count ?? 0;
+      maybeShow(c);
+    });
+  });
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -104,6 +104,20 @@
 
     <div id="index-time" class="corner-time" title=""></div>
 
+    <div id="welcome-modal" class="modal">
+        <div class="modal-content">
+            <span id="welcome-close" class="close-icon" title="Close dialog">&times;</span>
+            <h3>Welcome to Glimpser</h3>
+            <ol>
+                <li>Add a camera using <strong>Add Template</strong>.</li>
+                <li>Configure monitoring options.</li>
+                <li>View live feeds and summaries.</li>
+            </ol>
+            <p>Use the <strong>Discover Cameras</strong> icon in the navigation bar to scan your network.</p>
+            <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
+        </div>
+    </div>
+
 
 {% endblock %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Danger Mode](danger_mode.md)
 - [FAQ](faq.md)
 - [Getting Started](getting_started.md)
+- [In-App Onboarding](onboarding.md)
 - [Installation Guide](installation.md)
 - [Integration Guide](integration_guide.md)
 - [Camera Discovery](camera_discovery.md)

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,9 @@
+# In-App Onboarding
+
+The dashboard now includes a built-in welcome dialog for new users. When no templates are defined, a short guide explains the basic setup steps:
+
+1. **Add a camera using _Add Template_.**
+2. **Configure monitoring options.**
+3. **View live feeds and summaries.**
+
+The dialog also highlights the *Discover Cameras* icon in the navigation bar. Dismissing the dialog stores a flag in your browser so it does not reappear.


### PR DESCRIPTION
## Summary
- show welcome modal when no templates exist
- trigger the modal from templates.js
- load the modal via new welcome.js module
- document the onboarding guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1c3c871c8333b357e0f0b0c53155