### PR TITLE
Improve front-end validation and fetch handling

### DIFF
--- a/app/static/js/fetch_utils.js
+++ b/app/static/js/fetch_utils.js
@@ -1,0 +1,15 @@
+export async function fetchJson(url, options = {}) {
+  // Wrapper to fetch JSON with basic error handling
+  try {
+    const res = await fetch(url, options);
+    if (!res.ok) {
+      // Read text for more informative error messages
+      const text = await res.text();
+      throw new Error(text || res.statusText);
+    }
+    return await res.json();
+  } catch (err) {
+    console.error(`Fetch failed for ${url}:`, err);
+    throw err;
+  }
+}

--- a/app/static/js/form.js
+++ b/app/static/js/form.js
@@ -14,6 +14,11 @@ export function initFormValidation() {
       return false;
     }
 
+    if (!/^https?:\/\//.test(url)) {
+      alert('URL must start with http:// or https://');
+      return false;
+    }
+
     if (frequency < 1 || frequency > 525600) {
       alert('Frequency must be between 1 and 525600 minutes (1 year).');
       return false;

--- a/app/static/js/scheduler.js
+++ b/app/static/js/scheduler.js
@@ -1,37 +1,35 @@
+import { fetchJson } from './fetch_utils.js';
+
 export function initSchedulerToggle() {
   document.addEventListener('DOMContentLoaded', () => {
     const toggleSchedulerButton = document.getElementById('toggle-scheduler');
     const schedulerStatus = document.getElementById('scheduler-status');
     if (toggleSchedulerButton && schedulerStatus) {
-      toggleSchedulerButton.addEventListener('click', () => {
+      toggleSchedulerButton.addEventListener('click', async () => {
         const shouldToggle = confirm(
           `Are you sure you want to ${
             toggleSchedulerButton.textContent.includes('Stop') ? 'stop' : 'start'
           } the scheduler?`
         );
         if (!shouldToggle) return;
-        fetch('/toggle_scheduler', { method: 'POST' })
-          .then((res) => res.json())
-          .then((data) => {
-            schedulerStatus.textContent = data.status;
-            toggleSchedulerButton.textContent =
-              data.status === 'running' ? 'Stop Scheduler' : 'Start Scheduler';
-          })
-          .catch((error) => {
-            console.error('Error:', error);
-            schedulerStatus.textContent = 'Error occurred';
-          });
+        try {
+          const data = await fetchJson('/toggle_scheduler', { method: 'POST' });
+          schedulerStatus.textContent = data.status;
+          toggleSchedulerButton.textContent =
+            data.status === 'running' ? 'Stop Scheduler' : 'Start Scheduler';
+        } catch (error) {
+          schedulerStatus.textContent = 'Error occurred';
+          alert('Unable to toggle scheduler.');
+        }
       });
 
-      fetch('/scheduler_status')
-        .then((res) => res.json())
+      fetchJson('/scheduler_status')
         .then((data) => {
           schedulerStatus.textContent = data.status;
           toggleSchedulerButton.textContent =
             data.status === 'running' ? 'Stop Scheduler' : 'Start Scheduler';
         })
-        .catch((error) => {
-          console.error('Error:', error);
+        .catch(() => {
           schedulerStatus.textContent = 'Error occurred';
         });
     }

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -65,4 +65,5 @@ When adding new features, include corresponding tests under the `tests/` directo
 - Template update validation ensures numeric fields remain in range and
   required values are present.
 - Forms validate input client-side with JavaScript and fall back to server-side checks.
+- URLs in the template form must begin with http:// or https:// and fetch helpers provide consistent error handling.
 - `save_template` now reschedules APScheduler jobs when a template is edited.


### PR DESCRIPTION
## Summary
- add fetch helper for consistent JSON requests
- tighten template URL validation
- use new fetch helper in scheduler widget
- document new checks in developer guide

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e1c4f959c83338cef6e3dab6ef1ae