### PR TITLE
Improve accessibility of templates

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -82,7 +82,7 @@
     </style>
 
     <div class="video-container" role="region" aria-label="Live video feed">
-        <img id="live-image" alt="Live feed frame" title="Current frame from the live feed">
+        <img id="live-image" alt="Live view from selected camera" title="Current frame from the live feed">
         <video id="live-video" class="hidden" autoplay muted tabindex="0">
             <source src="" type="video/mp4">
             Your browser does not support the video tag.

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,10 +4,10 @@
     <div class="login-container" title="Login form">
         <h2>Login Required</h2>
         <form id="login-form" method="post" title="Enter your credentials to log in">
-            Username:<br>
-            <input type="text" name="username" required title="Enter your username"><br>
-            Password:<br>
-            <input type="password" name="password" required title="Enter your password"><br><br>
+            <label for="username">Username:</label><br>
+            <input type="text" id="username" name="username" required title="Enter your username"><br>
+            <label for="password">Password:</label><br>
+            <input type="password" id="password" name="password" required title="Enter your password"><br><br>
             <div id="login-error" class="form-error hidden"></div>
 
             {% with messages = get_flashed_messages(with_categories=true) %}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,5 +1,5 @@
 <h1>
-  <a href="/" title="Home">
+  <a href="/" title="Home" aria-label="Home">
     <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" alt="Glimpser logo" title="Glimpser" />
   </a>
 </h1>
@@ -19,27 +19,27 @@
 
   <div class="nav-right">
     {% if session.get('user_id') %}
-    <a id="health-status" href="/status" class="status-indicator" title="System Performance">
+    <a id="health-status" href="/status" class="status-indicator" title="System Performance" aria-label="System Performance">
       <svg width="18" height="18">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#check" />
       </svg>
     </a>
-    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode">
+    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode" aria-label="Danger Mode">
       <svg width="18" height="18">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
       </svg>
     </a>
-    <a href="/discover" class="settings-icon" title="Discover Cameras">
+    <a href="/discover" class="settings-icon" title="Discover Cameras" aria-label="Discover Cameras">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#search" />
       </svg>
     </a>
-    <a href="/captions" id="captions" class="settings-icon" title="Read and update camera LLMs">
+    <a href="/captions" id="captions" class="settings-icon" title="Read and update camera LLMs" aria-label="Camera captions">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#comment" />
       </svg>
     </a>
-    <a href="/live" id="live">
+    <a href="/live" id="live" aria-label="Live view">
       <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming.">
         <div id="dateDisplay" class="clock-face">
           <div id="digitalTime" class="clock-hands" title="">
@@ -50,13 +50,13 @@
         </div>
       </div>
     </a>
-    <a href="/settings" class="settings-icon" title="Update settings">
+    <a href="/settings" class="settings-icon" title="Update settings" aria-label="Settings">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
       </svg>
     </a>
     {% else %}
-    <a href="{{ url_for('login') }}" class="settings-icon" title="Login">
+    <a href="{{ url_for('login') }}" class="settings-icon" title="Login" aria-label="Login">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#login" />
       </svg>

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -66,7 +66,7 @@
 </style>
 
 <div class="video-container">
-    <img id="live-image" alt="Live feed frame" title="Current frame from the live feed" />
+    <img id="live-image" alt="Live view from {{ template_name }}" title="Current frame from the live feed" />
     <video id="live-video" class="hidden" autoplay muted>
         <source src="" type="video/mp4" />
         Your browser does not support the video tag.
@@ -76,12 +76,12 @@
         <input type="range" id="seek-bar" value="0" title="Seek position" />
 
         <div class="control-row">
-            <button id="play-pause" title="play/pause"><i class="fa-play-pause"></i></button>
+            <button id="play-pause" title="play/pause" aria-label="Play or pause video"><i class="fa-play-pause" aria-hidden="true"></i></button>
             <div id="speed-container">
                 <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()" title="Adjust playback speed" />
                 <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
             </div>
-            <button id="full-screen" title="fullscreen"><i class="fas fa-expand"></i></button>
+            <button id="full-screen" title="fullscreen" aria-label="Toggle fullscreen"><i class="fas fa-expand" aria-hidden="true"></i></button>
             <select id="video-source" onchange="changeVideoSource()">
                 <option value="png" title="View a series of PNG images">PNG Stream</option>
                 <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
@@ -95,17 +95,17 @@
     </div>
     <div id="video-overlay" class="video-overlay">
         <div id="loading-indicator" class="hidden">Loading...</div>
-        <div id="play-pause-indicator" class="video-icon hidden">▶</div>
+        <div id="play-pause-indicator" class="video-icon hidden" aria-hidden="true">▶</div>
         <div id="offline-indicator" class="offline-indicator hidden">
-            <i class="fas fa-video-slash video-icon"></i>
+            <i class="fas fa-video-slash video-icon" aria-hidden="true"></i>
             <p id="offline-message"></p>
         </div>
         <div id="capture-error-indicator" class="error-indicator hidden">
-            <i class="fas fa-exclamation-triangle video-icon"></i>
+            <i class="fas fa-exclamation-triangle video-icon" aria-hidden="true"></i>
             <p id="capture-error-message"></p>
         </div>
         <div id="stream-error-indicator" class="error-indicator hidden">
-            <i class="fas fa-times-circle video-icon"></i>
+            <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
             <p id="stream-error-message"></p>
         </div>
     </div>
@@ -187,7 +187,7 @@ function updateVideo(templateName) {
     <div id="screenshots">
         {% for screenshot in screenshots %}
             <div class="screenshot">
-                    <a href='/screenshots/{{template_name}}/{{screenshot}}' title="View full-size screenshot"><img src="/screenshots/{{template_name}}/{{screenshot }}" alt="Screenshot" height='200' title="Recent screenshot: {{screenshot}}"></a>
+                    <a href='/screenshots/{{template_name}}/{{screenshot}}' title="View full-size screenshot"><img src="/screenshots/{{template_name}}/{{screenshot }}" alt="Screenshot from {{ template_name }}" height='200' title="Recent screenshot: {{screenshot}}"></a>
             </div>
         {% endfor %}
     </div>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -4,6 +4,11 @@ The user interface now includes additional tooltips and descriptive alt text to 
 
 - Navigation and login logos include descriptive `alt` attributes.
 - The live feed image has both `alt` text and a tooltip.
+- Live and screenshot images now use more descriptive `alt` text such as
+  "Live view from Camera 1".
+- Icon-only links and buttons include `aria-label` attributes so screen readers
+  announce their purpose.
+- The login form uses proper `<label>` elements for username and password.
 - The footer Help link displays a tooltip describing its purpose.
 - The navigation Settings link has a single descriptive `title` attribute.
 - The Discover page icon also uses a descriptive `title` attribute.


### PR DESCRIPTION
## Summary
- add labels to login form inputs
- add aria labels to nav icons
- clarify alt text on live feed and screenshots
- mark overlay icons decorative
- document accessibility adjustments

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1c555b208333978dc4bcbff36672