### PR TITLE
Add SEO metadata and page titles

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -949,7 +949,7 @@ def init_routes(app):
             return redirect(url_for("danger_mode"))
 
         current = config.get_setting("DANGER_MODE", "True") == "True"
-        return render_template("danger.html", enabled=current)
+        return render_template("danger.html", enabled=current, page_title="Danger Mode")
 
     @app.route("/api/discover")
     @profile_route("/api/discover")
@@ -1040,14 +1040,14 @@ def init_routes(app):
         ):
             flash("Too many failed attempts. Please try again later.", "error")
             logging.warning("Locked login attempt from %s", ip_address)
-            return render_template("login.html"), 429
+            return render_template("login.html", page_title="Login"), 429
 
         if request.method == "POST":
             username = (request.form.get("username") or "").strip()
             password = (request.form.get("password") or "").strip()
             if not username or not password:
                 flash("Username and password are required", "error")
-                return render_template("login.html"), 400
+                return render_template("login.html", page_title="Login"), 400
 
             db_session = SessionLocal()
             try:
@@ -1088,7 +1088,7 @@ def init_routes(app):
                     "Failed login attempt for %s from %s", username, ip_address
                 )
                 flash("Invalid username or password", "error")
-        return render_template("login.html")
+        return render_template("login.html", page_title="Login")
 
     @app.route("/sso", methods=["GET"])
     def sso_login():
@@ -1123,13 +1123,13 @@ def init_routes(app):
     @app.route("/help")
     @login_required
     def help_page():
-        return render_template("help.html")
+        return render_template("help.html", page_title="Help")
 
     @app.route("/settings_help")
     @login_required
     def settings_help():
         """Display detailed explanations for each configuration option."""
-        return render_template("settings_explanation.html")
+        return render_template("settings_explanation.html", page_title="Settings Guide")
 
     @app.route("/logout")
     @login_required
@@ -1143,7 +1143,9 @@ def init_routes(app):
     def index():
         """Render the index page with available templates."""
         template_details = template_manager.get_templates()
-        return render_template("index.html", template_details=template_details)
+        return render_template(
+            "index.html", template_details=template_details, page_title="Dashboard"
+        )
 
     @app.route("/group/<string:group_name>")
     @login_required
@@ -1153,7 +1155,9 @@ def init_routes(app):
         groups = get_active_groups()
         if group_name not in groups:
             abort(404)
-        return render_template("group.html", group_name=group_name)
+        return render_template(
+            "group.html", group_name=group_name, page_title=f"Group – {group_name}"
+        )
 
     def get_active_templates():
         templates = template_manager.get_templates()
@@ -1642,7 +1646,7 @@ def init_routes(app):
     @login_required
     def stream():
         # Get a list of active cameras (with updates within the last 1 day)
-        return render_template("stream.html")
+        return render_template("stream.html", page_title="Stream")
 
     @app.route("/groups")
     @login_required
@@ -1715,6 +1719,7 @@ def init_routes(app):
             "captions.html",
             template_details=templates,
             lcaptions=entries,
+            page_title="Captions",
         )
 
     @app.route("/download_captions_tsv")
@@ -1829,7 +1834,9 @@ def init_routes(app):
         else:
             templates = template_manager.get_templates()
 
-        return render_template("live.html", template_details=templates)
+        return render_template(
+            "live.html", template_details=templates, page_title="Live View"
+        )
 
     @app.route("/latest_frame/<string:template_name>")
     @login_required
@@ -2137,6 +2144,7 @@ def init_routes(app):
             template_details=template_details,
             screenshots=lscreenshots,
             videos=lvideos,
+            page_title="Camera Details",
         )
 
     @app.route("/screenshots/<string:name>")
@@ -2327,7 +2335,9 @@ def init_routes(app):
             return redirect(url_for("settings"))
 
         settings = get_all_settings()
-        return render_template("settings.html", settings=settings)
+        return render_template(
+            "settings.html", settings=settings, page_title="Settings"
+        )
 
     # Retained for backwards compatibility; redirect to the health endpoint.
     @app.route("/system_metrics")
@@ -2428,7 +2438,9 @@ def init_routes(app):
     @app.route("/discover", methods=["GET"])
     @login_required
     def discover_cameras_route():
-        return render_template("discover.html", cameras=[])
+        return render_template(
+            "discover.html", cameras=[], page_title="Discover Cameras"
+        )
 
     @app.route("/discover/scan", methods=["POST"])
     @login_required
@@ -2567,13 +2579,17 @@ def init_routes(app):
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
         return render_template(
-            "status.html", metrics=metrics, feeds=feeds, last_summary=last_summary
+            "status.html",
+            metrics=metrics,
+            feeds=feeds,
+            last_summary=last_summary,
+            page_title="System Status",
         )
 
     @app.route("/logs")
     @login_required
     def logs():
-        return render_template("logs.html")
+        return render_template("logs.html", page_title="Logs")
 
     @app.route("/stream_logs")
     @login_required

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -4,7 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Glimpser</title>
+    <title>{% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif %}</title>
+    <meta name="description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
+    <meta property="og:title" content="{% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif %}">
+    <meta property="og:description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/fonts.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="preload" as="image" href="{{ url_for('static', filename='icons/sprite.svg') }}">

--- a/docs/seo_metadata.md
+++ b/docs/seo_metadata.md
@@ -1,0 +1,7 @@
+# SEO Metadata
+
+Glimpser templates now include basic search engine optimization tags.
+Every page renders a unique `<title>` and the HTML header provides a
+`description` meta tag used by search engines and social media links.
+These tags help browsers display descriptive titles for each page and
+improve how links to Glimpser appear when shared.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - System Monitoring: system_monitoring.md
       - Testing: testing.md
       - Tooltips: tooltips.md
+      - SEO Metadata: seo_metadata.md
       - Troubleshooting: troubleshooting.md
       - Video Archiver: video_archiver.md
       - Governance: governance.md

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -185,7 +185,7 @@ class TestRoutes(unittest.TestCase):
             "/login", data={"username": "testuser", "password": "wrongpassword"}
         )
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("login.html")
+        mock_render_template.assert_called_with("login.html", page_title="Login")
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.login_attempts", {})
@@ -193,7 +193,7 @@ class TestRoutes(unittest.TestCase):
     def test_login_missing_fields(self, mock_render_template, mock_session_local):
         response = self.client.post("/login", data={"username": "", "password": ""})
         self.assertEqual(response.status_code, 400)
-        mock_render_template.assert_called_with("login.html")
+        mock_render_template.assert_called_with("login.html", page_title="Login")
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
@@ -263,7 +263,7 @@ class TestRoutes(unittest.TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         mock_render_template.assert_called_with(
-            "index.html", template_details={"camera": {}}
+            "index.html", template_details={"camera": {}}, page_title="Dashboard"
         )
 
     @patch("app.routes.SessionLocal")
@@ -297,6 +297,7 @@ class TestRoutes(unittest.TestCase):
             "captions.html",
             template_details=mock_get_templates.return_value,
             lcaptions=[],
+            page_title="Captions",
         )
 
     @patch("app.routes.SessionLocal")
@@ -406,7 +407,7 @@ class TestRoutes(unittest.TestCase):
         mock_session_local.return_value = DummySession()
         response = self.client.get("/stream")
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("stream.html")
+        mock_render_template.assert_called_with("stream.html", page_title="Stream")
 
     def test_api_discover(self):
         response = self.client.get("/api/discover")
@@ -455,7 +456,9 @@ class TestRoutes(unittest.TestCase):
         response = self.client.get("/discover")
         self.assertEqual(response.status_code, 200)
         mock_discover.assert_not_called()
-        mock_render_template.assert_called_with("discover.html", cameras=[])
+        mock_render_template.assert_called_with(
+            "discover.html", cameras=[], page_title="Discover Cameras"
+        )
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.camera_discovery.discover_cameras")
@@ -548,7 +551,9 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         mock_get_template.assert_called_with("cam1")
         mock_render_template.assert_called_with(
-            "live.html", template_details={"cam1": mock_get_template.return_value}
+            "live.html",
+            template_details={"cam1": mock_get_template.return_value},
+            page_title="Live View",
         )
 
     @patch("app.routes.render_template")
@@ -558,7 +563,9 @@ class TestRoutes(unittest.TestCase):
         mock_groups.return_value = ["group1", "group2"]
         response = self.client.get("/group/group1")
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("group.html", group_name="group1")
+        mock_render_template.assert_called_with(
+            "group.html", group_name="group1", page_title="Group – group1"
+        )
 
     @patch("app.routes.get_active_groups")
     @patch("app.routes.session", {"user_id": 1})


### PR DESCRIPTION
## Summary
- include meta tags in `header.html`
- set page titles in routes
- document SEO metadata feature
- update documentation index
- fix tests for new arguments

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1c6837108333970544fab1830eda