### PR TITLE
Add discovery timeout guidance

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -400,8 +400,14 @@ def _probe_mdns(timeout=2):
     return cameras
 
 
-def _probe_ssdp(timeout=2):
-    """Probe for devices announcing themselves via SSDP/UPnP."""
+def _probe_ssdp(timeout: int = 2, max_duration: int = 5) -> list[dict]:
+    """Probe for devices announcing themselves via SSDP/UPnP.
+
+    The loop ends after ``max_duration`` seconds regardless of how many
+    responses arrive. This prevents very large networks from delaying the
+    entire discovery run indefinitely.
+    """
+
     cameras = []
     request = (
         "M-SEARCH * HTTP/1.1\r\n"
@@ -411,14 +417,20 @@ def _probe_ssdp(timeout=2):
         "ST:ssdp:all\r\n\r\n"
     )
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    start = time.time()
     sock.settimeout(timeout)
     try:
         sock.sendto(request.encode(), ("239.255.255.250", 1900))
         while True:
+            # Break once the overall limit has expired even if the socket keeps
+            # receiving new announcements. Without this check discovery could
+            # stall on busy networks.
+            if time.time() - start >= max_duration:
+                break
             try:
                 resp, addr = sock.recvfrom(1024)
             except socket.timeout:
-                break
+                continue
             ip = addr[0]
             port = 80
             headers = resp.decode(errors="ignore").split("\r\n")

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -43,7 +43,7 @@ The discovery code combines multiple approaches:
 5. **WebRTC/STUN scan** – `_scan_webrtc_ports()` detects WebRTC servers by checking ports `3478` and `5349`.
 6. **mDNS/Zeroconf** – `_probe_mdns()` looks for services like `_onvif._tcp` and `_rtsp._tcp` advertised on the local network.
 7. **SNMP scan** – `_scan_snmp_ports()` checks port `161` for SNMP agents and reads the device name if possible.
-8. **SSDP/UPnP probe** – `_probe_ssdp()` sends an M-SEARCH request to detect cameras announcing via SSDP.
+8. **SSDP/UPnP probe** – `_probe_ssdp()` sends an M-SEARCH request to detect cameras announcing via SSDP. The scan now stops after five seconds so large networks do not slow the entire process.
 9. **HTTP endpoint scan** – `_scan_http_endpoints()` checks ports `80`, `8080`, and `443` for `/snapshot.jpg` or `/video.mjpg` streams.
 10. **HLS detection** – `_scan_hls_streams()` looks for playlist files like `/index.m3u8`.
 11. **Local devices** – `_local_video_devices()` lists available `/dev/video*` entries for webcams or other direct-attached cameras.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -212,3 +212,13 @@ could overlap the last buttons.
 - Glimpser now adds extra padding to the `main` element so page content scrolls
   fully above the footer. Update to the latest version or add a similar rule in
   your custom CSS.
+
+## 13. Camera Discovery Issues
+
+### Problem: Discovery page times out or stops on "Scanning SSDP"
+
+**Solution:**
+- Networks with many SSDP devices can delay this step. Wait a little longer or restrict scanning using the CIDR field (e.g., `192.168.1.0/24`).
+- Since v0.9.1 SSDP scanning stops after five seconds so discovery continues even on busy networks.
+- Ensure UDP multicast traffic is allowed; blocked multicast causes timeouts.
+- Check `logs/glimpser.log` for `SSDP probe error` messages if the scan never finishes.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -422,6 +422,50 @@ class TestCameraDiscovery(unittest.TestCase):
         camera_discovery.discover_cameras(subnets=nets)
         mock_local_subnets.assert_not_called()
 
+    @patch("app.utils.camera_discovery.socket.socket")
+    @patch("app.utils.camera_discovery.time.time")
+    def test_ssdp_scan_duration(self, mock_time, mock_socket):
+        """_probe_ssdp should exit after ``max_duration`` seconds."""
+
+        # Simulate time advancing by 0.05s on each call so the loop
+        # breaks after a few iterations instead of spinning endlessly.
+        t = [0.0]
+
+        def fake_time():
+            t[0] += 0.05
+            return t[0]
+
+        mock_time.side_effect = fake_time
+
+        class FakeSock:
+            def __init__(self):
+                self.responses = [
+                    (
+                        b"HTTP/1.1 200 OK\r\nLOCATION: http://1.2.3.4\r\n\r\n",
+                        ("1.2.3.4", 1900),
+                    )
+                ] * 10
+
+            def settimeout(self, _):
+                pass
+
+            def sendto(self, data, addr):
+                pass
+
+            def recvfrom(self, n):
+                if self.responses:
+                    return self.responses.pop(0)
+                raise socket.timeout
+
+            def close(self):
+                pass
+
+        mock_socket.return_value = FakeSock()
+        cams = camera_discovery._probe_ssdp(timeout=0.1, max_duration=0.2)
+        # With 0.05s per iteration and a 0.2s limit we should process about
+        # three responses.
+        self.assertLessEqual(len(cams), 4)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- document a new troubleshooting tip for slow SSDP discovery
- add a timeout limit to SSDP scans and test it

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e1e1417f88333817c2b1ae086f407