### PR TITLE
Add log cleaner script

### DIFF
--- a/docs/log_cleaner.md
+++ b/docs/log_cleaner.md
@@ -1,0 +1,15 @@
+# Log Cleaner
+
+`scripts/clean_logs.py` condenses repeated log lines from a file or standard input.
+It outputs unique messages with a prefix indicating how many times each occurred.
+
+```bash
+python scripts/clean_logs.py glimpser.log
+```
+
+To use with piped input:
+
+```bash
+cat glimpser.log | python scripts/clean_logs.py
+```
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,5 +35,6 @@ nav:
       - Testing: testing.md
       - Tooltips: tooltips.md
       - Troubleshooting: troubleshooting.md
+      - Log Cleaner: log_cleaner.md
       - Video Archiver: video_archiver.md
       - Governance: governance.md

--- a/scripts/clean_logs.py
+++ b/scripts/clean_logs.py
@@ -1,0 +1,33 @@
+"""Utility to condense repeated log messages."""
+
+from collections import Counter
+from typing import Iterable
+import sys
+
+
+def _read_lines(file: Iterable[str]) -> list[str]:
+    return [line.strip() for line in file if line.strip()]
+
+
+def clean_lines(lines: Iterable[str]) -> list[str]:
+    counts = Counter(lines)
+    cleaned: list[str] = []
+    for line, count in counts.most_common():
+        prefix = f"[{count}] " if count > 1 else ""
+        cleaned.append(f"{prefix}{line}")
+    return cleaned
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "r", encoding="utf-8") as f:
+            lines = _read_lines(f)
+    else:
+        lines = _read_lines(sys.stdin)
+
+    for out_line in clean_lines(lines):
+        print(out_line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `clean_logs.py` script for condensing log messages
- document usage in `Log Cleaner`
- expose documentation in mkdocs navigation

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e1fe8070c833399a6fa2376cadd8a