### PR TITLE
Fix video error flashing

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -148,7 +148,12 @@ image.addEventListener('load', hideLoadingIndicator);
 video.addEventListener('play', () => showPlayPauseIndicator(false));
 video.addEventListener('pause', () => showPlayPauseIndicator(true));
 video.addEventListener('error', (e) => {
-    showError('Error loading video: ' + e.target.error.message);
+    const msg = e.target.error ? e.target.error.message : '';
+    if (msg && msg.includes('Empty src attribute')) {
+        // Ignore errors from blank sources when switching cameras
+        return;
+    }
+    showError('Error loading video: ' + msg);
     setTimeout(() => {
         if (typeof updateFeed === 'function') {
             updateFeed();


### PR DESCRIPTION
## Summary
- suppress noisy error when video src is cleared

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2336fbe0833391c67b768133814f