### PR TITLE
Fix caption slider scaling

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -7,10 +7,13 @@ export function initTemplates() {
       .getElementById('template-form')?.closest('details');
     const slider = document.getElementById('grid-width-slider');
     const templateList = document.getElementById('template-list');
+    const MAX_THUMBNAIL_HEIGHT = 720;
+    const ASPECT_RATIO = 9 / 16;
+    const MAX_THUMBNAIL_WIDTH = Math.round(MAX_THUMBNAIL_HEIGHT / ASPECT_RATIO);
 
     if (slider) {
       const updateSliderLimits = () => {
-        slider.max = window.innerWidth;
+        slider.max = Math.min(window.innerWidth, MAX_THUMBNAIL_WIDTH);
         const templateCount =
           templateList?.querySelectorAll('.templateDiv').length || 1;
 
@@ -23,6 +26,8 @@ export function initTemplates() {
           (window.innerHeight * window.innerWidth) /
             (templateCount * aspectRatio),
         );
+        const widthForMaxHeight = MAX_THUMBNAIL_HEIGHT / aspectRatio;
+        slider.max = Math.min(slider.max, widthForMaxHeight);
 
         const computedMin = Math.max(
           50,
@@ -37,11 +42,19 @@ export function initTemplates() {
           slider.value = computedMin;
           if (templateList) {
             templateList.style.setProperty('--grid-item-width', `${computedMin}px`);
+            const height = Math.min(
+              Math.round((computedMin * 9) / 16),
+              MAX_THUMBNAIL_HEIGHT,
+            );
+            templateList.style.setProperty('--grid-item-height', `${height}px`);
           }
         }
         if (templateList) {
           const width = parseFloat(slider.value);
-          const height = Math.round((width * 9) / 16);
+          const height = Math.min(
+            Math.round((width * 9) / 16),
+            MAX_THUMBNAIL_HEIGHT,
+          );
           templateList.style.setProperty('--grid-item-height', `${height}px`);
         }
       };
@@ -76,10 +89,19 @@ export function initTemplates() {
 
     if (slider && templateList) {
       slider.addEventListener('input', () => {
-        const value = slider.value;
+        let value = Math.min(parseFloat(slider.value), MAX_THUMBNAIL_WIDTH);
+        const height = Math.min(
+          Math.round((value * 9) / 16),
+          MAX_THUMBNAIL_HEIGHT,
+        );
         templateList.style.setProperty('--grid-item-width', `${value}px`);
-        const height = Math.round((value * 9) / 16);
         templateList.style.setProperty('--grid-item-height', `${height}px`);
+        templateList
+          .querySelectorAll('.templateDiv')
+          .forEach((div) => {
+            div.style.width = `${value}px`;
+            div.style.height = `${height}px`;
+          });
 
         const cameraNameFontSize = Math.max(10, Math.min(14, value / 25));
         const timestampFontSize = Math.max(8, Math.min(12, value / 30));

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The width slider on the index and captions pages automatically adjusts to the current browser width and updates if you resize the window. It also won't shrink smaller than the space needed to fit all thumbnails, which prevents excessive columns and lag. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The slider automatically adjusts to the current browser width and now scales thumbnails vertically as well as horizontally. Sizes are capped around 720&nbsp;px high so oversized images don't bog down the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 
 ### Why is the live feed slightly cropped on small screens?

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider lets you resize thumbnails, and caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and now adjusts their height, capping them at 720&nbsp;px. Caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- resize captions thumbnails vertically when the width slider moves
- cap thumbnail size at 720px height
- document the capped size

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2598d9cc83339eea783a88e5d5fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Thumbnails now resize both vertically and horizontally when using the slider, with height capped at 720 pixels for optimal performance.

- **Documentation**
  - Updated FAQ and getting started guides to reflect changes in thumbnail resizing behavior and new height limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->