### PR TITLE
Fix MJPEG fallback when cameras offline

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -622,8 +622,21 @@ def generate(
                         )
                         # no need to loop through the directory if we find the symlink file
                         lfiles = []
-                        if os.path.exists(os.path.join(path, filename)):
-                            lfiles = [os.path.join(path, filename)]
+                        file_path = os.path.join(path, filename)
+                        if os.path.exists(file_path):
+                            lfiles = [file_path]
+                        else:
+                            # fall back to the oldest screenshot so the MJPEG
+                            # stream always has an initial frame
+                            pngs = [
+                                os.path.join(path, f)
+                                for f in os.listdir(path)
+                                if f.endswith(".png")
+                                and os.path.isfile(os.path.join(path, f))
+                            ]
+                            if pngs:
+                                pngs.sort(key=os.path.getctime)
+                                lfiles = [pngs[0]]
 
                         last_file = lfiles[-1] if lfiles else None
                         if (

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,3 +1,5 @@
 # Offline Preview
 
 A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. When **Enable offline preview** is checked on the Settings page, the browser registers `/sw.js` which caches the `/status` and `/discover` pages along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
+
+MJPEG endpoints now fall back to the oldest frame stored on disk if no recent frame is available. This means `/stream.mjpg` and related routes always yield at least one image even when the camera is offline.


### PR DESCRIPTION
## Summary
- read oldest screenshot for MJPEG stream when no recent frame exists
- document the MJPEG fallback in offline preview docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2637031c833382176558432a33a8