### PR TITLE
Add background discovery job

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,6 +14,7 @@ from app.utils.retention_policy import retention_cleanup
 from app.utils.scheduling import (
     schedule_crawlers,
     schedule_summarization,
+    schedule_discovery,
     scheduler,
     start_log_caching,
 )
@@ -148,6 +149,7 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
                 id="retention_cleanup", func=retention_cleanup, trigger="cron", day="*"
             )
             schedule_summarization()
+            schedule_discovery()
 
         # Perform initial cleanup
         retention_cleanup()

--- a/app/routes.py
+++ b/app/routes.py
@@ -940,6 +940,13 @@ def init_routes(app):
             }
         )
 
+    @app.route("/discovery_status")
+    @login_required
+    @profile_route("/discovery_status")
+    def discovery_status():
+        """Return cached background discovery status."""
+        return jsonify(scheduling.get_discovery_status())
+
     @app.route("/danger", methods=["GET", "POST"])
     @login_required
     def danger_mode():
@@ -967,6 +974,12 @@ def init_routes(app):
                     "path": "/danger_status",
                     "method": "GET",
                     "description": "Check if Danger mode is ready",
+                    "authentication_required": False,
+                },
+                {
+                    "path": "/discovery_status",
+                    "method": "GET",
+                    "description": "Check background discovery status",
                     "authentication_required": False,
                 },
                 {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -2,6 +2,7 @@ export function initNav() {
   document.addEventListener('DOMContentLoaded', () => {
     const healthStatus = document.getElementById('health-status');
     const dangerStatus = document.getElementById('danger-status');
+    const discoveryStatus = document.getElementById('discover-status');
     const nav = document.querySelector('nav');
     const menuToggle = document.getElementById('menu-toggle');
 
@@ -61,6 +62,26 @@ export function initNav() {
       }
     };
 
+    const checkDiscovery = async () => {
+      if (!discoveryStatus) return;
+      try {
+        const res = await fetch('/discovery_status');
+        const data = await res.json();
+        if (data.status === 'running') {
+          discoveryStatus.style.color = 'orange';
+        } else if (data.status === 'ready') {
+          discoveryStatus.style.color = 'green';
+        } else if (data.status === 'error') {
+          discoveryStatus.style.color = 'red';
+        } else {
+          discoveryStatus.style.color = 'grey';
+        }
+      } catch (error) {
+        console.error('Error fetching discovery status:', error);
+        discoveryStatus.style.color = 'red';
+      }
+    };
+
     const updateCoolClock = () => {
       const now = new Date();
       const secondsDegrees = (now.getSeconds() / 60) * 360;
@@ -97,6 +118,8 @@ export function initNav() {
     setInterval(checkHealth, 5000);
     checkDanger();
     setInterval(checkDanger, 5000);
+    checkDiscovery();
+    setInterval(checkDiscovery, 60000);
     updateCoolClock();
     setInterval(updateCoolClock, 1000);
     setupNavFade();

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -30,7 +30,7 @@
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
       </svg>
     </a>
-    <a href="/discover" class="settings-icon" title="Discover Cameras">
+    <a id="discover-status" href="/discover" class="status-indicator" title="Discover Cameras">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#search" />
       </svg>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1106,3 +1106,64 @@ def get_last_summary_time() -> str | None:
     finally:
         session.close()
     return None
+
+
+# Background discovery cache
+
+discovery_cache = {
+    "results": [],
+    "timestamp": 0.0,
+    "running": False,
+    "error": None,
+}
+
+
+def run_discovery() -> None:
+    """Run camera discovery and cache the results."""
+
+    discovery_cache["running"] = True
+    discovery_cache["error"] = None
+    try:
+        discovery_cache["results"] = camera_discovery.discover_cameras()
+        discovery_cache["timestamp"] = time.time()
+    except Exception as e:  # pragma: no cover - network dependent
+        logging.error("background discovery failed: %s", e)
+        discovery_cache["error"] = str(e)
+    finally:
+        discovery_cache["running"] = False
+
+
+def get_discovery_status(max_age: int = 3600) -> dict:
+    """Return cached discovery status."""
+
+    age = time.time() - discovery_cache["timestamp"]
+    status = "stale"
+    if discovery_cache["running"]:
+        status = "running"
+    elif discovery_cache["error"]:
+        status = "error"
+    elif age <= max_age:
+        status = "ready"
+    return {
+        "status": status,
+        "age": age,
+        "results": discovery_cache["results"] if age <= max_age else [],
+        "running": discovery_cache["running"],
+        "error": discovery_cache["error"],
+    }
+
+
+def schedule_discovery() -> None:
+    """Schedule periodic background discovery."""
+
+    try:
+        scheduler.add_job(
+            func=run_discovery,
+            trigger="interval",
+            hours=1,
+            id="background_discovery",
+            replace_existing=True,
+        )
+    except Exception as e:
+        logging.error("job schedule error: %s", e)
+    run_discovery()

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -2,6 +2,7 @@
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
+Background discovery runs automatically every hour and caches the results for an hour. The search icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
 discovered camera. The previous hop is stored in the ``upstream`` field so you
 can see which router or switch connects the device. Each progress message now

--- a/tests/test_discovery_status_endpoint.py
+++ b/tests/test_discovery_status_endpoint.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestDiscoveryStatusEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.scheduling.get_discovery_status")
+    def test_status(self, mock_status):
+        mock_status.return_value = {"status": "ready"}
+        resp = self.client.get("/discovery_status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"status": "ready"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- run discovery hourly in the scheduler
- expose `/discovery_status` API
- update nav to show discovery state
- document background scans
- test the new endpoint

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e26ab6f6c8333a07bd9bbd0bc87d3