### PR TITLE
Fix live error overlay

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -149,8 +149,9 @@ video.addEventListener('play', () => showPlayPauseIndicator(false));
 video.addEventListener('pause', () => showPlayPauseIndicator(true));
 video.addEventListener('error', (e) => {
     const msg = e.target.error ? e.target.error.message : '';
-    if (msg && msg.includes('Empty src attribute')) {
-        // Ignore errors from blank sources when switching cameras
+    const src = video.getAttribute('src');
+    if (!src || src.trim() === '' || (msg && msg.includes('Empty src attribute'))) {
+        // Ignore errors from blank or cleared sources when switching cameras
         return;
     }
     showError('Error loading video: ' + msg);
@@ -161,6 +162,11 @@ video.addEventListener('error', (e) => {
     }, 2000);
 });
 image.addEventListener('error', () => {
+    const src = image.getAttribute('src');
+    if (!src || src.trim() === '') {
+        // Ignore errors triggered from clearing the image source
+        return;
+    }
     showError('Error loading image');
     setTimeout(() => {
         if (typeof updateFeed === 'function') {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -302,6 +302,12 @@
         video.addEventListener('play', () => showPlayPauseIndicator(false));
         video.addEventListener('pause', () => showPlayPauseIndicator(true));
         video.addEventListener('error', (e) => {
+            const msg = e.target && e.target.error ? e.target.error.message : '';
+            const src = video.getAttribute('src');
+            if (!src || src.trim() === '' || (msg && msg.includes('Empty src attribute'))) {
+                // Ignore errors from blank or cleared sources when switching cameras
+                return;
+            }
             showError(e);
             setTimeout(() => {
                 if (typeof updateFeed === 'function') {
@@ -310,6 +316,11 @@
             }, 2000);
         });
         image.addEventListener('error', () => {
+            const src = image.getAttribute('src');
+            if (!src || src.trim() === '') {
+                // Ignore errors triggered from clearing the image source
+                return;
+            }
             setTimeout(() => {
                 if (typeof updateFeed === 'function') {
                     updateFeed();


### PR DESCRIPTION
## Summary
- prevent false error messages in live view when switching sources

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e27881fdc8333995def5be77375d1