### PR TITLE
Add tile status legend

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -352,11 +352,38 @@ video:hover + .play-icon {
 }
 
 .recent-screenshot {
-    border: 5px solid rgba(255, 255, 255, 0.9); /* Faint white border */
+    border: 5px solid var(--accent-color);
 }
 
 .template-error {
     border: 5px solid red;
+}
+
+#status-legend {
+    display: flex;
+    gap: 10px;
+    margin: 10px 0;
+}
+
+.status-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.status-box {
+    width: 16px;
+    height: 16px;
+    border: 5px solid transparent;
+    display: inline-block;
+}
+
+.status-box.recent {
+    border-color: var(--accent-color);
+}
+
+.status-box.error {
+    border-color: red;
 }
 
 /* Improve video controls on mobile */

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -99,6 +99,11 @@
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
 </section>
 
+<section id="status-legend">
+    <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent screenshot</span>
+    <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Capture failed</span>
+</section>
+
 <section id="template-list-section">
     <div id="template-list" title="List of all templates" role="region" aria-label="Templates">
         <!-- Template list will be populated here -->

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -1,0 +1,6 @@
+# Dashboard Border Legend
+
+The index page shows each camera tile with a colored border.
+
+- **Accent border** – the last screenshot was captured within the last minute.
+- **Red border** – the most recent capture attempt failed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [UI Component Guide](style_guide.md)
 - [UI Design Guidelines](design_guidelines.md)
 - [Dashboard Time Display](#dashboard-time)
+- [Dashboard Border Legend](border_legend.md)
 - [LLM Cost Tracking](cost_tracking.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)


### PR DESCRIPTION
## Summary
- update border color for recent screenshot tiles
- add CSS/HTML for border legend on the index page
- document tile border meanings

## Testing
- `black . --check --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e270b8db08333afa303cfb3a92488