### PR TITLE
Fix live view layout when controls hidden

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -609,7 +609,8 @@ button, a {
 
 /* Speed slider and label container */
 #speed-container {
-    display: none;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 /* Cool Clock Styles */

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -313,7 +313,12 @@ function updateFeed() {
 function playM3U8() {
     video.style.display = 'block';
     // HLS streams are live and not seekable
-    document.getElementById('seek-bar').style.display = 'none';
+    const seekBar = document.getElementById('seek-bar');
+    if (seekBar) {
+        seekBar.style.visibility = 'hidden';
+        seekBar.style.pointerEvents = 'none';
+        seekBar.disabled = true;
+    }
 
     image.style.display = 'none';
     stopLiveSwitch();
@@ -483,7 +488,12 @@ video.dataset.currentCamera = nextCamera;
 function playLive() {
     video.style.display = 'block';
     // Live video cannot be scrubbed
-    document.getElementById('seek-bar').style.display = 'none';
+    const seekBar = document.getElementById('seek-bar');
+    if (seekBar) {
+        seekBar.style.visibility = 'hidden';
+        seekBar.style.pointerEvents = 'none';
+        seekBar.disabled = true;
+    }
     stopPNG();
     stopLiveSwitch();
 
@@ -586,7 +596,12 @@ function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
     // MJPEG streams are continuous images, disable scrubbing
-    document.getElementById('seek-bar').style.display = 'none';
+    const seekBar = document.getElementById('seek-bar');
+    if (seekBar) {
+        seekBar.style.visibility = 'hidden';
+        seekBar.style.pointerEvents = 'none';
+        seekBar.disabled = true;
+    }
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
@@ -608,7 +623,12 @@ function playMotion() {
     video.src = '';
     video.style.display = 'none';
     image.style.display = 'block';
-document.getElementById("seek-bar").style.display = "none";
+    const seekBar = document.getElementById('seek-bar');
+    if (seekBar) {
+        seekBar.style.visibility = 'hidden';
+        seekBar.style.pointerEvents = 'none';
+        seekBar.disabled = true;
+    }
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
@@ -681,7 +701,10 @@ if (liveSwitchInterval) {
             }
         }
         const show = isGroupView && cameraCount > 1 && source !== 'mjpg';
-        speedContainer.style.display = show ? 'block' : 'none';
+        speedContainer.style.visibility = show ? 'visible' : 'hidden';
+        speedContainer.style.pointerEvents = show ? 'auto' : 'none';
+        const slider = document.getElementById('speed-slider');
+        if (slider) slider.disabled = !show;
     }
 
     function updateSeekBar() {
@@ -690,7 +713,9 @@ if (liveSwitchInterval) {
         const source = document.getElementById('video-source').value;
         const isSingleCamera = !(currentCamera === 'All' || currentCamera.startsWith('group-'));
         const show = isSingleCamera && (source === 'mp4' || source === 'loop');
-        seekBar.style.display = show ? 'block' : 'none';
+        seekBar.style.visibility = show ? 'visible' : 'hidden';
+        seekBar.style.pointerEvents = show ? 'auto' : 'none';
+        seekBar.disabled = !show;
     }
 
 function checkCameraConnection(cameraName) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -472,7 +472,12 @@ function changeCamera() {
 function playM3U8() {
     video.style.display = 'block';
         // HLS streams cannot be scrubbed
-        document.getElementById("seek-bar").style.display = "none";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "hidden";
+            seekBar.style.pointerEvents = "none";
+            seekBar.disabled = true;
+        }
 
     image.style.display = 'none';
     stopLiveSwitch();
@@ -592,7 +597,12 @@ function showLastScreenshot() {
 
 function playMP4() {
     video.style.display = 'block';
-        document.getElementById("seek-bar").style.display = "block";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "visible";
+            seekBar.style.pointerEvents = "auto";
+            seekBar.disabled = false;
+        }
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
@@ -638,7 +648,12 @@ function handleVideoEnded() {
 function playLive() {
     video.style.display = 'block';
         // Disable scrubbing on live streams
-        document.getElementById("seek-bar").style.display = "none";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "hidden";
+            seekBar.style.pointerEvents = "none";
+            seekBar.disabled = true;
+        }
     stopPNG();
     stopLiveSwitch();
 
@@ -684,7 +699,12 @@ function playPNG() {
     stopLiveSwitch();
         const slider = document.getElementById('speed-slider');
         const speed = Math.pow(2, slider.value);
-        document.getElementById("seek-bar").style.display = "none";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "hidden";
+            seekBar.style.pointerEvents = "none";
+            seekBar.disabled = true;
+        }
     stopPNG();
     if (currentCamera.startsWith('group-')) {
         // Special handling for groups
@@ -721,7 +741,12 @@ function playMJPG() {
     video.style.display = 'none';
     image.style.display = 'block';
         // MJPEG streams show images only, hide the scrub bar
-        document.getElementById("seek-bar").style.display = "none";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "hidden";
+            seekBar.style.pointerEvents = "none";
+            seekBar.disabled = true;
+        }
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
@@ -740,7 +765,12 @@ function playMJPG() {
 function playMotion() {
     video.style.display = 'none';
     image.style.display = 'block';
-        document.getElementById("seek-bar").style.display = "none";
+        const seekBar = document.getElementById("seek-bar");
+        if (seekBar) {
+            seekBar.style.visibility = "hidden";
+            seekBar.style.pointerEvents = "none";
+            seekBar.disabled = true;
+        }
     stopLiveSwitch();
     stopPNG();
     if (currentCamera.startsWith('group-')) {
@@ -805,7 +835,10 @@ function playMotion() {
         const source = document.getElementById('video-source').value;
         const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
         const show = isGroupView && source !== 'mjpg';
-        speedContainer.style.display = show ? 'block' : 'none';
+        speedContainer.style.visibility = show ? 'visible' : 'hidden';
+        speedContainer.style.pointerEvents = show ? 'auto' : 'none';
+        const sliderEl = document.getElementById('speed-slider');
+        if (sliderEl) sliderEl.disabled = !show;
     }
 
     function checkCameraConnection(cameraName) {


### PR DESCRIPTION
## Summary
- preserve layout space when hiding scrub bar or speed bar
- disable bars instead of removing them

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683e28848ca88333ad225ac06dfddb73