### PR TITLE
Fix video stream cleanup when switching sources

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -29,6 +29,8 @@ if (requestedCamera && templateDetails[requestedCamera]) {
 let pngInterval;
 let liveSwitchInterval;
 let liveSwitchFunction;
+let hlsInstance = null;
+let loopHandler = null;
 const speedContainer = document.getElementById('speed-container');
 const videoOverlay = document.getElementById('video-overlay');
 const loadingIndicator = document.getElementById('loading-indicator');
@@ -41,6 +43,18 @@ const errorIndicator = document.getElementById('capture-error-indicator');
 const errorIndicatorMessage = document.getElementById('capture-error-message');
 const streamErrorIndicator = document.getElementById('stream-error-indicator');
 const streamErrorMessage = document.getElementById('stream-error-message');
+
+function resetVideo() {
+    if (hlsInstance) {
+        hlsInstance.destroy();
+        hlsInstance = null;
+    }
+    if (loopHandler) {
+        video.removeEventListener('ended', loopHandler);
+        loopHandler = null;
+    }
+    video.removeEventListener('ended', handleVideoEnded);
+}
 
 function showLoadingIndicator() {
     videoOverlay.style.display = 'block';
@@ -244,6 +258,7 @@ function updateTemplateDetails() {
 }
 
 function updateFeed() {
+    resetVideo();
     const source = document.getElementById('video-source').value;
     const isConnected = checkCameraConnection(currentCamera);
     const details = templateDetails[currentCamera];
@@ -311,6 +326,7 @@ function updateFeed() {
 }
 
 function playM3U8() {
+    resetVideo();
     video.style.display = 'block';
     // HLS streams are live and not seekable
     document.getElementById('seek-bar').style.display = 'none';
@@ -331,27 +347,28 @@ function playM3U8() {
     }
 
     if (Hls.isSupported()) {
-        const hls = new Hls();
-        hls.loadSource(m3u8Url);
-        hls.attachMedia(video);
-        hls.on(Hls.Events.MANIFEST_PARSED, function() {
+        hlsInstance = new Hls();
+        hlsInstance.loadSource(m3u8Url);
+        hlsInstance.attachMedia(video);
+        hlsInstance.on(Hls.Events.MANIFEST_PARSED, function() {
             video.play().catch(e => console.error("Error playing video:", e));
         });
-        hls.on(Hls.Events.ERROR, function(event, data) {
+        hlsInstance.on(Hls.Events.ERROR, function(event, data) {
             console.error("HLS error:", data);
             if (data.fatal) {
                 switch(data.type) {
                     case Hls.ErrorTypes.NETWORK_ERROR:
                         console.error("Fatal network error encountered, trying to recover...");
-                        hls.startLoad();
+                        hlsInstance.startLoad();
                         break;
                     case Hls.ErrorTypes.MEDIA_ERROR:
                         console.error("Fatal media error encountered, trying to recover...");
-                        hls.recoverMediaError();
+                        hlsInstance.recoverMediaError();
                         break;
                     default:
                         console.error("Fatal error, cannot recover");
-                        hls.destroy();
+                        hlsInstance.destroy();
+                        hlsInstance = null;
                         break;
                 }
             }
@@ -371,6 +388,7 @@ function playM3U8() {
 
 
 function playLoop() {
+    resetVideo();
     video.style.display = 'block';
 
     image.style.display = 'none';
@@ -392,7 +410,7 @@ if (currentCamera === 'All') {
 
 let cameraIndex = 0;
 
-const cycleCameras = () => {
+loopHandler = () => {
     if (cameraIndex >= groupCameras.length) {
         cameraIndex = 0; // Reset the index to loop through the cameras again
     }
@@ -403,8 +421,8 @@ const cycleCameras = () => {
     cameraIndex++; // Move to the next camera
 };
 
-cycleCameras(); // Start the loop
-video.addEventListener('ended', cycleCameras); // Continue the loop when the video ends
+loopHandler(); // Start the loop
+video.addEventListener('ended', loopHandler); // Continue the loop when the video ends
     } else {
 // Handling for individual cameras
 video.src = `/last_video/${currentCamera}`;
@@ -442,6 +460,7 @@ function showLastScreenshot() {
 
 
 function playMP4() {
+    resetVideo();
     video.style.display = 'block';
     stopLiveSwitch();
     stopPNG();
@@ -481,6 +500,7 @@ video.dataset.currentCamera = nextCamera;
 }
 
 function playLive() {
+    resetVideo();
     video.style.display = 'block';
     // Live video cannot be scrubbed
     document.getElementById('seek-bar').style.display = 'none';
@@ -530,6 +550,7 @@ video.play();
 function playPNG() {
     // When switching from video playback to PNG images, ensure any
     // ongoing video stream is stopped to avoid "media element" errors.
+    resetVideo();
     video.pause();
     video.src = '';
     video.style.display = 'none';
@@ -581,6 +602,7 @@ pngInterval = setInterval(refreshPNG, 10000 / speed);
 
 function playMJPG() {
     // Stop any existing video stream before showing MJPEG frames
+    resetVideo();
     video.pause();
     video.src = '';
     video.style.display = 'none';
@@ -604,6 +626,7 @@ image.src = '/stream.mjpg?camera=' + currentCamera + '&time=' + new Date().getTi
 
 function playMotion() {
     // Stop any existing video stream before showing motion JPEG frames
+    resetVideo();
     video.pause();
     video.src = '';
     video.style.display = 'none';

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -100,6 +100,8 @@
         let liveSwitchInterval;
         let liveSwitchFunction;
         let preloadedCamera = null;
+        let hlsInstance = null;
+        let loopHandler = null;
         const speedContainer = document.getElementById('speed-container');
         const videoOverlay = document.getElementById('video-overlay');
         const loadingIndicator = document.getElementById('loading-indicator');
@@ -111,6 +113,18 @@
         const errorIndicatorMessage = document.getElementById('capture-error-message');
         const streamErrorIndicator = document.getElementById('stream-error-indicator');
         const streamErrorMessage = document.getElementById('stream-error-message');
+
+        function resetVideo() {
+            if (hlsInstance) {
+                hlsInstance.destroy();
+                hlsInstance = null;
+            }
+            if (loopHandler) {
+                video.removeEventListener('ended', loopHandler);
+                loopHandler = null;
+            }
+            video.removeEventListener('ended', handleVideoEnded);
+        }
 
         function showLoadingIndicator() {
             videoOverlay.style.display = 'block';
@@ -397,6 +411,7 @@ function changeCamera() {
         }
 
         function updateFeed() {
+            resetVideo();
             const source = document.getElementById('video-source').value;
             const isConnected = checkCameraConnection(currentCamera);
             updateSpeedContainer();
@@ -470,6 +485,7 @@ function changeCamera() {
         }
 
 function playM3U8() {
+    resetVideo();
     video.style.display = 'block';
         // HLS streams cannot be scrubbed
         document.getElementById("seek-bar").style.display = "none";
@@ -490,27 +506,28 @@ function playM3U8() {
             }
 
             if (Hls.isSupported()) {
-                const hls = new Hls();
-                hls.loadSource(m3u8Url);
-                hls.attachMedia(video);
-                hls.on(Hls.Events.MANIFEST_PARSED, function() {
+                hlsInstance = new Hls();
+                hlsInstance.loadSource(m3u8Url);
+                hlsInstance.attachMedia(video);
+                hlsInstance.on(Hls.Events.MANIFEST_PARSED, function() {
                     video.play().catch(e => console.error("Error playing video:", e));
                 });
-                hls.on(Hls.Events.ERROR, function(event, data) {
+                hlsInstance.on(Hls.Events.ERROR, function(event, data) {
                     console.error("HLS error:", data);
                     if (data.fatal) {
                         switch(data.type) {
                             case Hls.ErrorTypes.NETWORK_ERROR:
                                 console.error("Fatal network error encountered, trying to recover...");
-                                hls.startLoad();
+                                hlsInstance.startLoad();
                                 break;
                             case Hls.ErrorTypes.MEDIA_ERROR:
                                 console.error("Fatal media error encountered, trying to recover...");
-                                hls.recoverMediaError();
+                                hlsInstance.recoverMediaError();
                                 break;
                             default:
                                 console.error("Fatal error, cannot recover");
-                                hls.destroy();
+                                hlsInstance.destroy();
+                                hlsInstance = null;
                                 break;
                         }
                     }
@@ -530,6 +547,7 @@ function playM3U8() {
 
 
 function playLoop() {
+    resetVideo();
     video.style.display = 'block';
 
     image.style.display = 'none';
@@ -551,7 +569,7 @@ function playLoop() {
 
         let cameraIndex = 0;
 
-        const cycleCameras = () => {
+        loopHandler = () => {
             if (cameraIndex >= groupCameras.length) {
                 cameraIndex = 0; // Reset the index to loop through the cameras again
             }
@@ -563,8 +581,8 @@ function playLoop() {
             cameraIndex++; // Move to the next camera
         };
 
-        cycleCameras(); // Start the loop
-        video.addEventListener('ended', cycleCameras); // Continue the loop when the video ends
+        loopHandler(); // Start the loop
+        video.addEventListener('ended', loopHandler); // Continue the loop when the video ends
     } else {
         // Handling for individual cameras
         video.src = `/last_video/${currentCamera}`;
@@ -591,6 +609,7 @@ function showLastScreenshot() {
 
 
 function playMP4() {
+    resetVideo();
     video.style.display = 'block';
         document.getElementById("seek-bar").style.display = "block";
     stopLiveSwitch();
@@ -636,6 +655,7 @@ function handleVideoEnded() {
 }
 
 function playLive() {
+    resetVideo();
     video.style.display = 'block';
         // Disable scrubbing on live streams
         document.getElementById("seek-bar").style.display = "none";
@@ -679,6 +699,7 @@ function playLive() {
 }
 
 function playPNG() {
+    resetVideo();
     video.style.display = 'none';
     image.style.display = 'block';
     stopLiveSwitch();
@@ -718,6 +739,7 @@ function playPNG() {
 }
 
 function playMJPG() {
+    resetVideo();
     video.style.display = 'none';
     image.style.display = 'block';
         // MJPEG streams show images only, hide the scrub bar
@@ -738,6 +760,7 @@ function playMJPG() {
 }
 
 function playMotion() {
+    resetVideo();
     video.style.display = 'none';
     image.style.display = 'block';
         document.getElementById("seek-bar").style.display = "none";

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -201,6 +201,16 @@ snapshot image rather than a true video stream.
 - Snapshot-only URLs now fall back to an MJPEG feed so the live view
   behaves like a regular video stream.
 
+### Problem: Playback continues in the background after switching types
+
+Older versions kept preloading the previous stream when you changed the video
+source. That could cause extra network requests and confusing behavior.
+
+**Solution:**
+- Update to the latest version.
+- The player now destroys any active HLS or looping handlers before starting the
+  new stream, so switching sources cleanly stops the old one.
+
 ## 12. Layout Issues
 
 ### Problem: Buttons at the bottom of the Templates page are hidden


### PR DESCRIPTION
## Summary
- destroy active streams before playing a new one
- ensure HLS and loop handlers are cleared
- document playback cleanup in troubleshooting guide

## Testing
- `black . --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2802b4bc8333b365055ae6ec2dc9