### PR TITLE
Add sortable captions table

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1124,12 +1124,14 @@ input[type=submit]:hover {
 
 /* Indicate sortable KPI columns */
 .camera-table th.sortable,
-.feed-status th.sortable {
+.feed-status th.sortable,
+.captions-table th.sortable {
     cursor: pointer;
 }
 
 .camera-table th.sortable::after,
-.feed-status th.sortable::after {
+.feed-status th.sortable::after,
+.captions-table th.sortable::after {
     content: ' \2195';
     font-size: 0.8em;
     opacity: 0.6;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -549,4 +549,5 @@ export function setupTableSorting(tableId) {
 export function setupSorting() {
   setupTableSorting('camera-table');
   setupTableSorting('feed-status');
+  setupTableSorting('captions-table');
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -78,11 +78,14 @@
 {% endwith %}
 
     <details><summary>Captions</summary>
-        <table class="captions-table">
+        <table id="captions-table" class="captions-table">
+            <thead>
             <tr>
-                <th>Timestamp</th>
-                <th>Caption</th>
+                <th class="sortable" data-type="date">Timestamp</th>
+                <th class="sortable" data-type="string">Caption</th>
             </tr>
+            </thead>
+            <tbody>
             {% if not lcaptions %}
             <tr class="no-data">
                 <td colspan="2">No captions available</td>
@@ -99,6 +102,7 @@
             {% endfor %}
             {% endfor %}
             {% endif %}
+            </tbody>
         </table>
     </details>
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and now adjusts their height, capping them at 720&nbsp;px. Caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
+10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI and caption columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and now adjusts their height, capping them at 720&nbsp;px. Caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- enable sorting on Captions table
- hook up table sorting JS for new table
- style sortable captions headers
- document new caption column sorting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e29dfbc748333808649a474ae113f