### PR TITLE
Add manual control for discovery feature

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,12 @@ from app.utils.scheduling import (
     start_log_caching,
 )
 from app.utils.video_archiver import archive_screenshots, compile_to_teaser
-from app.config import LOG_LEVEL, backup_config, restore_config
+from app.config import (
+    LOG_LEVEL,
+    backup_config,
+    restore_config,
+    DISCOVERY_AUTOSTART,
+)
 from app.utils.email_alerts import email_alert
 from app.utils.sms_alerts import sms_alert
 
@@ -149,7 +154,8 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
                 id="retention_cleanup", func=retention_cleanup, trigger="cron", day="*"
             )
             schedule_summarization()
-            schedule_discovery()
+            if DISCOVERY_AUTOSTART:
+                schedule_discovery()
 
         # Perform initial cleanup
         retention_cleanup()

--- a/app/config.py
+++ b/app/config.py
@@ -316,6 +316,10 @@ LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
 # not wasted.
 LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
 
+# Background discovery runs on a schedule when enabled.  Set this
+# to ``True`` to run an hourly scan automatically.
+DISCOVERY_AUTOSTART = get_setting("DISCOVERY_AUTOSTART", "False") == "True"
+
 # Email settings
 EMAIL_ENABLED = get_setting("EMAIL_ENABLED", "False")
 EMAIL_SENDER = get_setting("EMAIL_SENDER", "your-email@example.com")

--- a/app/routes.py
+++ b/app/routes.py
@@ -960,6 +960,23 @@ def init_routes(app):
         """Return cached background discovery status."""
         return jsonify(scheduling.get_discovery_status())
 
+    @app.route("/toggle_discovery", methods=["POST"])
+    @login_required
+    @profile_route("/toggle_discovery")
+    def toggle_discovery():
+        """Start or stop hourly background discovery."""
+        try:
+            job = scheduling.scheduler.get_job("background_discovery")
+            if job:
+                scheduling.stop_discovery()
+                update_setting("DISCOVERY_AUTOSTART", "False")
+                return jsonify({"status": "stopped"})
+            scheduling.schedule_discovery()
+            update_setting("DISCOVERY_AUTOSTART", "True")
+            return jsonify({"status": "running"})
+        except Exception as e:
+            return jsonify({"status": "error", "message": str(e)}), 500
+
     @app.route("/danger", methods=["GET", "POST"])
     @login_required
     def danger_mode():

--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -1,0 +1,37 @@
+import { fetchJson } from './fetch_utils.js';
+
+export function initDiscoveryToggle() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = document.getElementById('toggle-discovery');
+    const statusSpan = document.getElementById('discovery-bg-status');
+    if (!toggleBtn || !statusSpan) return;
+
+    toggleBtn.addEventListener('click', async () => {
+      const confirmToggle = confirm(
+        `Are you sure you want to ${
+          toggleBtn.textContent.includes('Stop') ? 'stop' : 'start'
+        } background discovery?`
+      );
+      if (!confirmToggle) return;
+      try {
+        const data = await fetchJson('/toggle_discovery', { method: 'POST' });
+        statusSpan.textContent = data.status;
+        toggleBtn.textContent =
+          data.status === 'running' ? 'Stop Discovery' : 'Start Discovery';
+      } catch (err) {
+        statusSpan.textContent = 'error';
+        alert('Unable to toggle discovery.');
+      }
+    });
+
+    fetchJson('/discovery_status')
+      .then((data) => {
+        statusSpan.textContent = data.status;
+        toggleBtn.textContent =
+          data.status === 'running' ? 'Stop Discovery' : 'Start Discovery';
+      })
+      .catch(() => {
+        statusSpan.textContent = 'error';
+      });
+  });
+}

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -67,7 +67,9 @@ export function initNav() {
       try {
         const res = await fetch('/discovery_status');
         const data = await res.json();
-        if (data.status === 'running') {
+        if (data.status === 'none') {
+          discoveryStatus.style.color = 'white';
+        } else if (data.status === 'running') {
           discoveryStatus.style.color = 'orange';
         } else if (data.status === 'ready') {
           discoveryStatus.style.color = 'green';

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,6 +1,7 @@
 import { initTemplates } from './templates.js';
 import { initVideoControls } from './video.js';
 import { initSchedulerToggle } from './scheduler.js';
+import { initDiscoveryToggle } from './discovery.js';
 import { initNav } from './nav.js';
 import { initFormValidation, initAddSettingValidation } from './form.js';
 import { initFooterFade } from './footer.js';
@@ -12,6 +13,7 @@ import { initWelcome } from './welcome.js';
 initTemplates();
 initVideoControls();
 initSchedulerToggle();
+initDiscoveryToggle();
 initNav();
 initFormValidation();
 initAddSettingValidation();

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -14,6 +14,10 @@
 {%- endmacro %}
 {% block content %}
     <h2>Discovered Cameras</h2>
+    <div class="discovery-controls" title="Start or stop background discovery">
+        <button id="toggle-discovery" class="btn btn-primary" title="Start or stop automatic discovery">Loading...</button>
+        <span id="discovery-bg-status" title="Current background discovery status">Checking...</span>
+    </div>
     <div class="wizard-step" title="Enter an optional network range">
         <input id="cidr-input" type="text" placeholder="192.168.1.0/24" title="Optional CIDR to scan">
         <button id="discover-btn" title="Scan the network for cameras">Discover</button>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1142,6 +1142,8 @@ def get_discovery_status(max_age: int = 3600) -> dict:
         status = "running"
     elif discovery_cache["error"]:
         status = "error"
+    elif discovery_cache["timestamp"] == 0:
+        status = "none"
     elif age <= max_age:
         status = "ready"
     return {
@@ -1167,3 +1169,12 @@ def schedule_discovery() -> None:
     except Exception as e:
         logging.error("job schedule error: %s", e)
     run_discovery()
+
+
+def stop_discovery() -> None:
+    """Remove the scheduled background discovery job."""
+
+    try:
+        scheduler.remove_job("background_discovery")
+    except Exception:
+        pass

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -2,7 +2,7 @@
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
-Background discovery runs automatically every hour and caches the results for an hour. The search icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed.
+Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from `/discover`. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
 discovered camera. The previous hop is stored in the ``upstream`` field so you
 can see which router or switch connects the device. Each progress message now

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -113,6 +113,7 @@ Settings controlling how frames are captured from video sources:
 - `ANALYZE_DURATION_OTHER` – analyzeduration for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
+- `DISCOVERY_AUTOSTART` – run hourly background discovery automatically (default `False`)
 
 ### Stealth Browser Defaults
 

--- a/tests/test_toggle_discovery_endpoint.py
+++ b/tests/test_toggle_discovery_endpoint.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestToggleDiscoveryEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.scheduling.scheduler")
+    @patch("app.routes.scheduling.schedule_discovery")
+    @patch("app.routes.update_setting")
+    def test_start_discovery(self, mock_update, mock_schedule, mock_sched):
+        mock_sched.get_job.return_value = None
+        resp = self.client.post("/toggle_discovery")
+        self.assertEqual(resp.status_code, 200)
+        mock_schedule.assert_called_once()
+        mock_update.assert_called_once_with("DISCOVERY_AUTOSTART", "True")
+        self.assertEqual(resp.get_json(), {"status": "running"})
+
+    @patch("app.routes.scheduling.scheduler")
+    @patch("app.routes.scheduling.stop_discovery")
+    @patch("app.routes.update_setting")
+    def test_stop_discovery(self, mock_update, mock_stop, mock_sched):
+        mock_sched.get_job.return_value = object()
+        resp = self.client.post("/toggle_discovery")
+        self.assertEqual(resp.status_code, 200)
+        mock_stop.assert_called_once()
+        mock_update.assert_called_once_with("DISCOVERY_AUTOSTART", "False")
+        self.assertEqual(resp.get_json(), {"status": "stopped"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `DISCOVERY_AUTOSTART` setting
- honor the setting during app init
- expose `/toggle_discovery` endpoint
- show new controls on the discovery page
- update nav icon logic and include discovery toggle script
- document discovery autostart behaviour
- test the new toggle route

## Testing
- `black app/__init__.py app/config.py app/routes.py app/utils/scheduling.py tests/test_toggle_discovery_endpoint.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2aa8e3188333af1127b995d104f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a toggle button on the discovery page to start or stop automatic background discovery scans.
  - Introduced a new configuration option to control whether background discovery runs automatically.
  - The discovery status indicator now explicitly displays a unique color when no discovery has been run yet.

- **Bug Fixes**
  - Improved status handling for the discovery indicator to better reflect when no scans have occurred.

- **Documentation**
  - Updated documentation to describe the new background discovery toggle and configuration setting.

- **Tests**
  - Added tests to verify the correct behavior of the background discovery toggle endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->