### PR TITLE
Fix dashboard slider and legend

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -371,7 +371,7 @@ video:hover + .play-icon {
 .status-box {
     width: 16px;
     height: 16px;
-    border: 5px solid transparent;
+    border: 2px solid transparent;
     display: inline-block;
 }
 

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -62,6 +62,7 @@ export function initTemplates() {
       updateSliderLimits();
       window.addEventListener('resize', updateSliderLimits);
       window.updateSliderLimits = updateSliderLimits;
+      slider.dispatchEvent(new Event('input'));
     }
 
     function autofillGroup() {
@@ -88,7 +89,7 @@ export function initTemplates() {
     }
 
     if (slider && templateList) {
-      slider.addEventListener('input', () => {
+      const handleSlider = () => {
         let value = Math.min(parseFloat(slider.value), MAX_THUMBNAIL_WIDTH);
         const height = Math.min(
           Math.round((value * 9) / 16),
@@ -107,7 +108,11 @@ export function initTemplates() {
         const timestampFontSize = Math.max(8, Math.min(12, value / 30));
         document.documentElement.style.setProperty('--camera-name-font-size', `${cameraNameFontSize}px`);
         document.documentElement.style.setProperty('--timestamp-font-size', `${timestampFontSize}px`);
-      });
+      };
+
+      slider.addEventListener('input', handleSlider);
+      slider.addEventListener('change', handleSlider);
+      handleSlider();
     }
 
     if (form) {
@@ -178,7 +183,7 @@ export async function loadGroups() {
     });
   } catch (error) {
     console.error('Error loading groups:', error);
-    groupDropdown.innerHTML = '<option value="all">Error loading groups</option>';
+    groupDropdown.innerHTML = '<option value="all">All Groups</option>';
   } finally {
     groupDropdown.disabled = false;
   }
@@ -501,6 +506,8 @@ export async function loadTemplates() {
       window.addEventListener('resize', updateGridLayout);
     }
     if (window.updateSliderLimits) window.updateSliderLimits();
+    const slider = document.getElementById('grid-width-slider');
+    if (slider) slider.dispatchEvent(new Event('input'));
     updateHumanizedTimes();
     window.dispatchEvent(
       new CustomEvent('templatesLoaded', { detail: { count: templateCount } }),

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -1,6 +1,8 @@
 # Dashboard Border Legend
 
 The index page shows each camera tile with a colored border.
+Border thickness is now slimmer (2&nbsp;px) so the legend key no longer 
+dominates the layout.
 
 - **Accent border** – the last screenshot was captured within the last minute.
 - **Red border** – the most recent capture attempt failed.


### PR DESCRIPTION
## Summary
- make status legend less obtrusive
- initialize the grid width slider on load and listen for changes
- keep group dropdown usable if fetching groups fails
- trigger slider updates after templates load
- document thinner borders

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2bc2b8e88333a23a9bae23e8c262