### PR TITLE
Improve PNG view fallback

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -953,7 +953,6 @@ def init_routes(app):
             }
         )
 
-
     @app.route("/captions_status")
     @login_required
     def captions_status():
@@ -1347,6 +1346,9 @@ def init_routes(app):
                 most_recent_file = last_file
                 most_recent_time = last_mtime
         if most_recent_file is None:
+            if last_shot and os.path.exists(last_shot):
+                # Fall back to the previously served screenshot
+                return send_file(last_shot)
             abort(404)
 
         last_time = time.time()
@@ -1355,7 +1357,10 @@ def init_routes(app):
         if os.path.exists(most_recent_file):
             return send_file(most_recent_file)
         if last_file and os.path.exists(last_file):
+            last_shot = last_file
             return send_file(last_file)  # better than nothing
+        if last_shot and os.path.exists(last_shot):
+            return send_file(last_shot)
         abort(404)
 
     @app.route(

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -181,6 +181,15 @@ image.addEventListener('error', () => {
         // Ignore errors triggered from clearing the image source
         return;
     }
+    if (src.includes('/stream.png')) {
+        // For the PNG stream view, keep showing the last frame and retry
+        setTimeout(() => {
+            if (typeof updateFeed === 'function') {
+                updateFeed();
+            }
+        }, 2000);
+        return;
+    }
     showError('Error loading image');
     setTimeout(() => {
         if (typeof updateFeed === 'function') {


### PR DESCRIPTION
## Summary
- enhance `/stream.png` to always return last screenshot if new one isn't found
- retry PNG view without showing error overlay on 404

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2c05370483338c460cc7147a5f47