### PR TITLE
Fix duplicate help in settings page

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -10,12 +10,8 @@
     <form id="add-setting-form" method="POST" action="{{ url_for('settings') }}">
         <input type="hidden" name="action" value="add" title="Add setting action">
         <label for="new_name" title="Name of the new setting">Name:</label>
-    <h3 id="settings-help">Settings Reference</h3>
-    {% include 'settings_help_table.html' %}
         <input type="text" id="new_name" name="new_name" required title="Enter setting name">
         <label for="new_value" title="Initial value for the setting">Value:</label>
-    <h3 id="settings-help">Settings Reference</h3>
-    {% include 'settings_help_table.html' %}
         <input type="text" id="new_value" name="new_value" required title="Enter setting value">
         <div id="setting-error" class="form-error hidden"></div>
         <button type="submit" title="Add setting">Add Setting</button>


### PR DESCRIPTION
## Summary
- remove extra copies of the settings help table in `settings.html`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e2ef13d288333806a3d9cc677ea82