### PR TITLE
Handle server errors in network testing

### DIFF
--- a/app/utils/network_testing.py
+++ b/app/utils/network_testing.py
@@ -46,7 +46,9 @@ def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=Fals
                     .get("status")
                 )
 
-                if 400 <= lstatus <= 499:
+                # Treat any 4xx or 5xx response as a failure so the caller can
+                # bail out early on server errors.
+                if lstatus >= 400:
                     return False, lstatus
         if not events:
             not_moving += 1

--- a/tests/test_network_testing_utils.py
+++ b/tests/test_network_testing_utils.py
@@ -88,6 +88,26 @@ class TestNetworkTestingUtils(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(status, 404)
 
+    def test_network_idle_condition_server_error(self):
+        log = {
+            "message": json.dumps(
+                {
+                    "message": {
+                        "method": "Network.responseReceived",
+                        "params": {"response": {"url": "http://ex", "status": 500}},
+                    }
+                }
+            )
+        }
+        driver = DummyDriver(performance_logs=[[log]])
+        gen = self._time_gen()
+        with patch("time.time", side_effect=gen), patch("time.sleep"):
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=0.1, idle_time=0
+            )
+        self.assertFalse(result)
+        self.assertEqual(status, 500)
+
     def test_network_idle_condition_stealth(self):
         driver = DummyDriver()
         gen = self._time_gen(step=0.2)


### PR DESCRIPTION
## Summary
- treat 5xx responses as failures in network idle condition
- test failure when status is 500

## Testing
- `flake8 app/utils/network_testing.py tests/test_network_testing_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3a98ec2083339e8f278ac85b4637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of network response failures to include both client (4xx) and server (5xx) errors, ensuring more accurate failure handling.

- **Tests**
  - Added a test to verify correct handling of server error responses (status code 500) in network condition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->