### PR TITLE
Fix camera notes table

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -154,7 +154,10 @@ export function initTemplates() {
     }
 
     loadGroups();
-    loadTemplates();
+    const cameraTable = document.getElementById('camera-table');
+    if (!cameraTable) {
+      loadTemplates();
+    }
     setupSearch();
     setupSorting();
     updateHumanizedTimes();


### PR DESCRIPTION
## Summary
- avoid replacing camera notes table with async load

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e3b33efb8833381adf4e2faed120f