### PR TITLE
Add toggle for live page details

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -54,8 +54,10 @@
 }
 .control-row {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+    row-gap: 5px;
     width: 100%;
 }
 #error-message {
@@ -70,5 +72,13 @@
     display: none;
 }
 #template-details {
-    margin-top: 10px;
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    padding: 5px;
+    border-radius: 5px;
+    font-size: 0.9rem;
 }

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -251,6 +251,10 @@ updateSpeedContainer();
 }
 
 function updateTemplateDetails() {
+    if (!detailsVisible) {
+        templateDetailsContainer.style.display = 'none';
+        return;
+    }
     const details = templateDetails[currentCamera];
     const isGroupView = currentCamera === 'All' || currentCamera.startsWith('group-');
 
@@ -813,6 +817,13 @@ updateSpeedContainer();
 updateSeekBar();
 playMJPG();
 startCaptionPolling();
+
+if (toggleDetailsButton) {
+    toggleDetailsButton.addEventListener('click', () => {
+        detailsVisible = !detailsVisible;
+        updateTemplateDetails();
+    });
+}
 
 function togglePlayback() {
     if (video.paused) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -26,6 +26,7 @@
 
 	<!-- <button id="cast-button">Cast</button> -->
                 <button id="full-screen" title='fullscreen' aria-label="Toggle fullscreen"><i class="fas fa-expand"></i></button>
+                <button id="toggle-details" title="Show details" aria-label="Toggle details"><i class="fas fa-info-circle"></i></button>
 
     <select id="video-source" onchange="changeVideoSource()">
         <option value="png" title="View a series of PNG images">PNG Stream</option>
@@ -107,12 +108,14 @@
         const loadingIndicator = document.getElementById('loading-indicator');
         const playPauseIndicator = document.getElementById('play-pause-indicator');
         const playButton = document.getElementById('play-pause');
+        const toggleDetailsButton = document.getElementById('toggle-details');
         const offlineIndicator = document.getElementById('offline-indicator');
         const offlineMessage = document.getElementById('offline-message');
         const errorIndicator = document.getElementById('capture-error-indicator');
         const errorIndicatorMessage = document.getElementById('capture-error-message');
         const streamErrorIndicator = document.getElementById('stream-error-indicator');
         const streamErrorMessage = document.getElementById('stream-error-message');
+        let detailsVisible = false;
 
         function resetVideo() {
             if (hlsInstance) {

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -36,3 +36,4 @@ Interactive forms now include additional tooltips:
 - **Captions** – upload and filter controls have descriptive titles.
 - **Danger Mode** – the checkbox, save button and modal controls all include tooltips.
 - **Live video player** – tooltip now refreshes with the full caption as it updates.
+- **Info icon** – toggles camera metadata on the live page.


### PR DESCRIPTION
## Summary
- condense live page controls by adding an info button
- hide camera metadata by default and allow toggling
- note new info icon in documentation

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683e3b5eed7c8333a11378a4b125a33d