### PR TITLE
Improve discovery timing feedback

### DIFF
--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -6,6 +6,20 @@ export function initDiscoveryToggle() {
     const statusSpan = document.getElementById('discovery-bg-status');
     if (!toggleBtn || !statusSpan) return;
 
+    const minutes = (s) => `${Math.round(s / 60)}m`;
+    const formatStatus = (d) => {
+      let text = d.status;
+      if (d.running_for) {
+        text += ` (${minutes(d.running_for)})`;
+      } else if (Number.isFinite(d.age) && d.status !== 'none') {
+        text += ` (${minutes(d.age)} ago)`;
+      }
+      if (d.next_run_in) {
+        text += `, next in ${minutes(d.next_run_in)}`;
+      }
+      return text;
+    };
+
     toggleBtn.addEventListener('click', async () => {
       const confirmToggle = confirm(
         `Are you sure you want to ${
@@ -15,7 +29,7 @@ export function initDiscoveryToggle() {
       if (!confirmToggle) return;
       try {
         const data = await fetchJson('/toggle_discovery', { method: 'POST' });
-        statusSpan.textContent = data.status;
+        statusSpan.textContent = formatStatus(data);
         toggleBtn.textContent =
           data.status === 'running' ? 'Stop Discovery' : 'Start Discovery';
       } catch (err) {
@@ -26,7 +40,7 @@ export function initDiscoveryToggle() {
 
     fetchJson('/discovery_status')
       .then((data) => {
-        statusSpan.textContent = data.status;
+        statusSpan.textContent = formatStatus(data);
         toggleBtn.textContent =
           data.status === 'running' ? 'Stop Discovery' : 'Start Discovery';
       })

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -99,6 +99,7 @@ export function initNav() {
       try {
         const res = await fetch('/discovery_status');
         const data = await res.json();
+        const fmt = (s) => `${Math.round(s / 60)}m`;
         if (data.status === 'none') {
           discoveryStatus.style.color = 'white';
         } else if (data.status === 'running') {
@@ -110,6 +111,16 @@ export function initNav() {
         } else {
           discoveryStatus.style.color = 'grey';
         }
+        let title = `Background discovery: ${data.status}`;
+        if (data.running_for) {
+          title += `\nRunning for ${fmt(data.running_for)}`;
+        } else if (Number.isFinite(data.age) && data.status !== 'none') {
+          title += `\nLast run ${fmt(data.age)} ago`;
+        }
+        if (data.next_run_in) {
+          title += `\nNext in ${fmt(data.next_run_in)}`;
+        }
+        discoveryStatus.title = title;
       } catch (error) {
         console.error('Error fetching discovery status:', error);
         discoveryStatus.style.color = 'red';

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1116,6 +1116,7 @@ discovery_cache = {
     "timestamp": 0.0,
     "running": False,
     "error": None,
+    "started": 0.0,
 }
 
 
@@ -1124,6 +1125,7 @@ def run_discovery() -> None:
 
     discovery_cache["running"] = True
     discovery_cache["error"] = None
+    discovery_cache["started"] = time.time()
     try:
         discovery_cache["results"] = camera_discovery.discover_cameras()
         discovery_cache["timestamp"] = time.time()
@@ -1138,6 +1140,15 @@ def get_discovery_status(max_age: int = 3600) -> dict:
     """Return cached discovery status."""
 
     age = time.time() - discovery_cache["timestamp"]
+    running_for = None
+    if discovery_cache["running"]:
+        running_for = time.time() - discovery_cache["started"]
+    job = scheduler.get_job("background_discovery")
+    next_run_in = None
+    if job and job.next_run_time:
+        next_run_in = (
+            job.next_run_time - datetime.datetime.now(job.next_run_time.tzinfo)
+        ).total_seconds()
     status = "stale"
     if discovery_cache["running"]:
         status = "running"
@@ -1150,6 +1161,8 @@ def get_discovery_status(max_age: int = 3600) -> dict:
     return {
         "status": status,
         "age": age,
+        "running_for": running_for,
+        "next_run_in": next_run_in,
         "results": discovery_cache["results"] if age <= max_age else [],
         "running": discovery_cache["running"],
         "error": discovery_cache["error"],

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -2,7 +2,7 @@
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The `/discover` page now loads immediately and only scans when you click the **Discover** button. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger.
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
-Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from `/discover`. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed.
+Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from `/discover`. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
 discovered camera. The previous hop is stored in the ``upstream`` field so you
 can see which router or switch connects the device. Each progress message now


### PR DESCRIPTION
## Summary
- include start and next-run timing in `get_discovery_status`
- show detailed discovery timing in nav and background toggle
- document hover tooltip for discovery icon

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3bede8e88333a53ff31d00219ad9