### PR TITLE
Add Chrome shortcut patch option to Danger page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -997,8 +997,15 @@ def init_routes(app):
     @login_required
     def danger_mode():
         if request.method == "POST":
-            enabled = "enabled" in request.form
-            update_setting("DANGER_MODE", "True" if enabled else "False")
+            action = request.form.get("action")
+            if action == "update_shortcut":
+                if update_chrome_shortcuts():
+                    flash("Chrome shortcuts updated", "success")
+                else:
+                    flash("Failed to update shortcuts", "error")
+            else:
+                enabled = "enabled" in request.form
+                update_setting("DANGER_MODE", "True" if enabled else "False")
             return redirect(url_for("danger_mode"))
 
         current = config.get_setting("DANGER_MODE", "True") == "True"

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -43,6 +43,21 @@
     </label>
     <button type="submit" title="Save danger mode setting">Save</button>
   </form>
+
+  <section>
+    <h3>Patch Chrome Shortcut</h3>
+    <p>
+      Use this tool to add the debugging flag to your Chrome shortcuts. After
+      running it, restart Chrome and open the browser with the profile you want
+      Danger Mode to use.
+    </p>
+    <form method="post">
+      <input type="hidden" name="action" value="update_shortcut" />
+      <button type="submit" title="Patch shortcuts for Danger mode">
+        Patch Chrome Shortcuts
+      </button>
+    </form>
+  </section>
 </main>
   {% from 'components.html' import confirm_modal %}
   {{ confirm_modal('danger') }}

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -17,7 +17,9 @@ If Chrome is not started with this flag, Danger mode will be unavailable.
 After Chrome updates, shortcuts may revert to their original command line. Two approaches can help keep the debug port enabled:
 
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
-- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page.
+- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page.
+
+After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 
 For now, you can store the launch command in a script and double-click it instead of using the original shortcut.
 


### PR DESCRIPTION
## Summary
- add patch button on Danger page to update Chrome shortcuts
- handle `update_shortcut` action in the Danger route
- document new option in Danger Mode docs

## Testing
- `flake8`
- `pytest` *(fails: FileNotFoundError in thread, but tests overall passed)*

------
https://chatgpt.com/codex/tasks/task_e_683e3c14216c8333b0ddaa9d1f5436e8