### PR TITLE
Add danger camera list

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1003,7 +1003,16 @@ def init_routes(app):
             return redirect(url_for("danger_mode"))
 
         current = config.get_setting("DANGER_MODE", "True") == "True"
-        return render_template("danger.html", enabled=current, page_title="Danger Mode")
+        templates = template_manager.get_templates()
+        danger_cameras = sorted(
+            [name for name, t in templates.items() if t.get("danger")]
+        )
+        return render_template(
+            "danger.html",
+            enabled=current,
+            danger_cameras=danger_cameras,
+            page_title="Danger Mode",
+        )
 
     @app.route("/api/discover")
     @profile_route("/api/discover")

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -30,6 +30,19 @@
     </p>
   </section>
 
+  {% if danger_cameras %}
+  <section>
+    <h3>Cameras with Danger Enabled</h3>
+    <ul>
+      {% for camera in danger_cameras %}
+      <li>
+        <a href="{{ url_for('template_details', template_name=camera) }}" title="Open {{ camera }} details">{{ camera }}</a>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
   <form id="danger-form" method="post">
     <label for="danger-checkbox" title="Toggle danger mode">
       <input

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -39,3 +39,7 @@ The `/danger` page explains what the feature does and when to use it. It notes
 that Glimpser attaches to your Chrome session via the debugging port and only
 activates when you are idle. Toggling the option now shows a confirmation modal
 so the feature is not enabled or disabled accidentally.
+
+Below the description, the page lists any cameras flagged as using Danger mode.
+Each item links directly to the camera's template details so you can quickly
+review or disable the setting.


### PR DESCRIPTION
## Summary
- list cameras with danger flag on the Danger page
- update Danger Mode docs about the new camera list

## Testing
- `flake8`
- `pytest tests/test_danger_status_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3deefc6c8333a21da9cbe41c58fd