### PR TITLE
Add captions overlay to live tiles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -176,8 +176,8 @@ h1, h2 {
 #template-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(50px, var(--grid-item-width, 360px))); /* Use CSS variable */
-    gap: 10px;
-    padding: 20px;
+    gap: 5px;
+    padding: 10px;
     justify-content: center;
     max-width: 100%;
 }
@@ -352,11 +352,26 @@ video:hover + .play-icon {
 }
 
 .recent-screenshot {
-    border: 5px solid var(--accent-color);
+    border: 2px solid var(--accent-color);
 }
 
 .template-error {
-    border: 5px solid red;
+    border: 2px solid red;
+}
+
+.caption-overlay {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    padding: 5px;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    font-size: calc(12px * var(--tile-scale, 1));
+    z-index: 5;
+    pointer-events: none;
+    max-height: 40%;
+    overflow-y: auto;
 }
 
 #status-legend {

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -464,6 +464,7 @@ export async function loadTemplates() {
                   <source src="/last_video/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
+                <div class="caption-overlay">${template.last_caption || ''}</div>
                 <div class="play-icon">&#9658;</div>
               </div>
             </a>


### PR DESCRIPTION
## Summary
- show last caption text on dashboard tiles
- tighten spacing and border width

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3dc235a0833388e4b56c30766bce