### PR TITLE
Fix live view scrollbar

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -5,7 +5,8 @@
     height: 92vh;
     max-height: 92vh;
     position: relative;
-    overflow: auto;
+    /* Hide scroll bars for a cleaner live view */
+    overflow: hidden;
 }
 #live-video,
 #live-image {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ The slider automatically adjusts to the current browser width and now scales thu
 
 
 ### Why is the live feed slightly cropped on small screens?
-Older styles fixed the video container height with `overflow: hidden`, which could cut off controls on short displays. The container now allows scrolling so everything stays visible.
+The default `player.css` hides overflow to remove scroll bars. On very short displays this can clip the video controls. Change the `.video-container` rule to `overflow: auto` if you need to keep them in view.
 
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- hide overflowing content so the live view doesn't show scrollbars
- note how to re-enable scrolling in the FAQ

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3e9aa8548333bd18bfde288761b3