### PR TITLE
Add relative timestamps to live view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1,3 +1,5 @@
+import { timeAgo, formatExactTime } from './templates.js';
+
 const video = document.getElementById('live-video');
 const image = document.getElementById('live-image');
 const templateDetailsContainer = document.getElementById('template-details');
@@ -458,8 +460,23 @@ video.play();
 
 
 
+function updateFrameTimestamp() {
+    const container = document.querySelector('.video-container');
+    if (!container) return;
+    const details = templateDetails[currentCamera];
+    if (!details || !details.last_screenshot_time) {
+        container.removeAttribute('data-timestamp');
+        container.removeAttribute('title');
+        return;
+    }
+    container.dataset.originalTimestamp = details.last_screenshot_time;
+    container.setAttribute('data-timestamp', timeAgo(details.last_screenshot_time));
+    container.setAttribute('title', formatExactTime(details.last_screenshot_time));
+}
+
 function refreshPNG() {
     image.src = '/last_screenshot/' + encodeURIComponent(currentCamera) + '?time=' + new Date().getTime();
+    updateFrameTimestamp();
 }
 
 function showLastScreenshot() {
@@ -480,6 +497,7 @@ function showLastScreenshot() {
     };
     pre.src = url;
     image.style.display = 'block';
+    updateFrameTimestamp();
 }
 
 
@@ -817,6 +835,8 @@ updateSpeedContainer();
 updateSeekBar();
 playMJPG();
 startCaptionPolling();
+updateFrameTimestamp();
+setInterval(updateFrameTimestamp, 60000);
 
 if (toggleDetailsButton) {
     toggleDetailsButton.addEventListener('click', () => {

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,3 +47,5 @@ The main dashboard now displays the current time in the lower right corner. Hove
 
 Thumbnails also now show the last capture time in a human readable
 "X ago" format, matching the tables on the Captions page.
+The Live View page displays the time of the latest frame in the
+lower-right corner using the same format.


### PR DESCRIPTION
## Summary
- display human-readable timestamp on the live view using data-timestamp overlay
- document the live view timestamp overlay

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e3efeb2148333aa769a821859316b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Live View page now displays the time of the latest frame in the lower-right corner, using a human-readable "X ago" format.
- **Documentation**
  - Updated documentation to note the addition of the latest frame timestamp display on the Live View page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->