### PR TITLE
Fix overlay alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Offline cameras now display an overlay and keep the camera selector usable
 - `download_image` now reuses cached HTTP status codes to reduce retry overhead
 - Fixed unclosed `.form-error` block in `style.css` causing CSS lint failures
+- Timestamp and caption overlays now align correctly with their tinted
+  backgrounds
 
 ## [0.2.7] - 2025-06-02
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -178,10 +178,11 @@ def apply_motion_icon(image, draw, font, font_size, top_offset, padding=6):
 def apply_caption(image, draw, font, font_size, caption, top_offset, padding=6):
     caption = caption[:64].replace("\n", " ")
     wrapped = textwrap.fill(caption, width=32)
-    text_w = int(draw.textlength(wrapped.split("\n")[0], font=font))
-    text_h = font_size * len(wrapped.split("\n"))
     x = padding
     y = int(image.height - int(font_size * 3) - top_offset)
+    bbox = draw.multiline_textbbox((x, y), wrapped, font=font, stroke_width=1)
+    text_w = bbox[2] - bbox[0]
+    text_h = bbox[3] - bbox[1]
     background = Image.new(
         "RGBA",
         (text_w + padding * 2, text_h + padding * 2),

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -622,10 +622,11 @@ def add_timestamp(image_path, name="unknown", invert=False):
             padding = 6
 
             # Render the name in the upper-left corner
-            text_w = int(draw.textlength(name, font=font))
-            text_h = font_size
             x = padding
             y = int(padding + top_offset)
+            bbox = draw.textbbox((x, y), name, font=font, stroke_width=1)
+            text_w = bbox[2] - bbox[0]
+            text_h = bbox[3] - bbox[1]
             background = Image.new(
                 "RGBA",
                 (text_w + padding * 2, text_h + padding * 2),
@@ -642,16 +643,18 @@ def add_timestamp(image_path, name="unknown", invert=False):
             )
 
             # Timestamp in the lower-right corner
-            text_w = int(draw.textlength(timestamp, font=font))
-            text_h = font_size
+            text_w = draw.textbbox((0, 0), timestamp, font=font, stroke_width=1)[2]
             x = image.width - text_w - padding
             y = int(image.height - top_offset - font_size * 2)
+            bbox = draw.textbbox((x, y), timestamp, font=font, stroke_width=1)
+            text_w = bbox[2] - bbox[0]
+            text_h = bbox[3] - bbox[1]
             background = Image.new(
                 "RGBA",
                 (text_w + padding * 2, text_h + padding * 2),
                 (0, 0, 0, 128),
             )
-            image.paste(background, (x - padding, y - padding), background)
+            image.paste(background, (bbox[0] - padding, bbox[1] - padding), background)
 
             draw.text(
                 (x, y),
@@ -663,17 +666,25 @@ def add_timestamp(image_path, name="unknown", invert=False):
             )
 
             if utc_timestamp != timestamp:
-                text_w = int(draw.textlength(utc_timestamp + "Z", font=font_small))
+                tz_bbox = draw.textbbox(
+                    (0, 0), utc_timestamp + "Z", font=font_small, stroke_width=1
+                )
+                text_w = tz_bbox[2] - tz_bbox[0]
+                text_h = tz_bbox[3] - tz_bbox[1]
                 background = Image.new(
                     "RGBA",
-                    (text_w + padding * 2, font_small.size + padding * 2),
+                    (text_w + padding * 2, text_h + padding * 2),
                     (0, 0, 0, 128),
                 )
+                tz_x = x
+                tz_y = y + font_size + padding
                 image.paste(
-                    background, (x - padding, y + font_size - padding), background
+                    background,
+                    (tz_x - padding, tz_y - padding),
+                    background,
                 )
                 draw.text(
-                    (x, y + font_size + padding),
+                    (tz_x, tz_y),
                     utc_timestamp + "Z",
                     font=font_small,
                     fill=(255, 255, 255, 255),

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -75,10 +75,11 @@ After capturing the content, Glimpser applies several post-processing steps:
 3. **Timestamp Addition**: Overlay the capture with the current time in the
    configured timezone. When different from UTC, the UTC time is displayed just
    below the local timestamp. The overlay uses a semi-transparent background and
-   stroked fonts to improve readability without obscuring the image.
+   stroked fonts to improve readability without obscuring the image. Bounding
+   boxes ensure the tint precisely covers the text.
 4. **Caption Overlay**: When captions or motion indicators are added, the text
-   is wrapped and rendered with the same improved font styling to avoid
-   overlapping the content.
+   is wrapped and rendered with the same improved font styling. Bounding-box
+   sizing keeps the overlay aligned with the caption.
 5. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
 6. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
 


### PR DESCRIPTION
## Summary
- improve timestamp and caption tint alignment using bounding boxes
- document overlay change
- note overlay update in changelog

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e42592838833380e26b16a3dd7c0f