### PR TITLE
feat: add micro QR overlay

### DIFF
--- a/app/utils/qrcode_overlay.py
+++ b/app/utils/qrcode_overlay.py
@@ -1,0 +1,55 @@
+"""Minimal utilities for embedding a tiny QR-style code in screenshots."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import List
+
+from PIL import Image, ImageDraw
+
+
+def generate_micro_qr(data: str) -> List[List[bool]]:
+    """Return an 8x8 boolean matrix representing a tiny QR-like code."""
+    bits = "".join(f"{b:08b}" for b in hashlib.sha1(data.encode()).digest())
+    matrix = [[False] * 8 for _ in range(8)]
+
+    # 2x2 orientation squares in three corners
+    for i in range(2):
+        for j in range(2):
+            matrix[i][j] = True
+            matrix[i][6 + j] = True
+            matrix[6 + i][j] = True
+
+    idx = 0
+    for y in range(2, 8):
+        for x in range(2, 8):
+            if x >= 6 and y >= 6:
+                continue
+            matrix[y][x] = bits[idx] == "1"
+            idx = (idx + 1) % len(bits)
+    return matrix
+
+
+def add_micro_qr(image_path: str, data: str) -> None:
+    """Overlay a tiny QR-like code onto ``image_path`` in the bottom-right corner."""
+    matrix = generate_micro_qr(data)
+    scale = 2
+    qr_size = len(matrix) * scale
+    with Image.open(image_path) as img:
+        img = img.convert("RGB")
+        draw = ImageDraw.Draw(img)
+        x0 = img.width - qr_size - 1
+        y0 = img.height - qr_size - 1
+        for y, row in enumerate(matrix):
+            for x, val in enumerate(row):
+                color = (0, 0, 0) if val else (255, 255, 255)
+                draw.rectangle(
+                    [
+                        x0 + x * scale,
+                        y0 + y * scale,
+                        x0 + (x + 1) * scale - 1,
+                        y0 + (y + 1) * scale - 1,
+                    ],
+                    fill=color,
+                )
+        img.save(image_path, "PNG")

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -684,6 +684,13 @@ def add_timestamp(image_path, name="unknown", invert=False):
             # Save the image
             image.save(image_path, "PNG")
 
+        try:
+            from .qrcode_overlay import add_micro_qr
+
+            add_micro_qr(image_path, name)
+        except Exception as e:  # pragma: no cover - overlay failures are non-critical
+            logging.debug(f"Micro QR overlay failed: {e}")
+
 
 def download_image(
     url,

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -79,8 +79,9 @@ After capturing the content, Glimpser applies several post-processing steps:
 4. **Caption Overlay**: When captions or motion indicators are added, the text
    is wrapped and rendered with the same improved font styling to avoid
    overlapping the content.
-5. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
-6. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
+5. **Micro QR Overlay**: A tiny QR-style code containing the camera name is placed in the lower-right corner so screenshots can be tracked within the system.
+6. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
+7. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
 
 ## Status Code Caching
 

--- a/tests/test_micro_qr.py
+++ b/tests/test_micro_qr.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import tempfile
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.qrcode_overlay import generate_micro_qr, add_micro_qr
+
+
+def test_generate_micro_qr_size():
+    matrix = generate_micro_qr("abc")
+    assert len(matrix) == 8
+    assert len(matrix[0]) == 8
+
+
+def test_add_micro_qr_overlay():
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        Image.new("RGB", (50, 50), (255, 255, 255)).save(tmp.name)
+        add_micro_qr(tmp.name, "test")
+        with Image.open(tmp.name) as img:
+            # top-left pixel of the overlay should be dark
+            assert img.getpixel((33, 33)) != (255, 255, 255)
+    os.unlink(tmp.name)


### PR DESCRIPTION
## Summary
- embed mini QR code overlay to track screenshots
- document the new QR overlay post-processing step
- test QR generation and overlay logic

## Testing
- `flake8 app/utils/qrcode_overlay.py app/utils/screenshots.py tests/test_micro_qr.py`
- `pytest -q tests/test_micro_qr.py`

------
https://chatgpt.com/codex/tasks/task_e_683e42a61f54833390c848a4c3cc6098