### PR TITLE
Integrate settings help into settings page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1207,8 +1207,8 @@ def init_routes(app):
     @app.route("/settings_help")
     @login_required
     def settings_help():
-        """Display detailed explanations for each configuration option."""
-        return render_template("settings_explanation.html", page_title="Settings Guide")
+        """Redirect old help route to the main settings page."""
+        return redirect(url_for("settings"))
 
     @app.route("/logout")
     @login_required

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -4,9 +4,10 @@
     <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
 
     <h2>Current Settings</h2>
-    <p>
-        <a href="{{ url_for('settings_help') }}" title="Open detailed reference">What does each setting do?</a>
-    </p>
+    <details class="settings-help">
+        <summary>What does each setting do?</summary>
+        {% include 'settings_help_table.html' %}
+    </details>
 
     <h3>Add New Setting</h3>
     <form id="add-setting-form" method="POST" action="{{ url_for('settings') }}">

--- a/app/templates/settings_explanation.html
+++ b/app/templates/settings_explanation.html
@@ -1,7 +1,0 @@
-{% extends 'base.html' %}
-{% block content %}
-<main class="container">
-    <h2 class="page-title">Settings Reference</h2>
-    {% include 'settings_help_table.html' %}
-</main>
-{% endblock %}

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -1,6 +1,6 @@
 # Settings Page Overview
 
-The **Settings** interface lets you manage configuration values stored in the database. Each field includes a tooltip that explains its purpose. Use the "What does each setting do?" link to open a dedicated reference page.
+The **Settings** interface lets you manage configuration values stored in the database. Each field includes a tooltip that explains its purpose. A collapsible **Settings Reference** table on the page lists every configuration option with detailed descriptions.
 
 ## Sections
 
@@ -9,6 +9,4 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Danger Mode** – update Chrome shortcuts with the required flags.
 - **Offline Preview** – toggle a Service Worker that caches recent images.
-- **Settings Reference** – available on a separate page with detailed explanations.
-
-You can also visit `/settings_help` directly if you prefer a standalone page.
+- **Settings Reference** – expand the table to read explanations for each setting.


### PR DESCRIPTION
## Summary
- integrate `/settings_help` into `/settings`
- add collapsible reference table to settings page
- redirect old `/settings_help` route to `/settings`
- remove obsolete template
- update documentation

## Testing
- `black . --quiet`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e42e7d19c83338eb963ae772a2948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Settings reference information is now embedded directly on the Settings page as a collapsible section, allowing users to view detailed descriptions for each option without leaving the page.

- **Documentation**
  - Updated documentation to reflect that the settings help is now accessible as an expandable section on the Settings page instead of a separate page.

- **Chores**
  - Removed the standalone settings help page and its associated link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->