### PR TITLE
Improve captions page layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1382,3 +1382,30 @@ details > summary {
 }
 
 
+
+.tabs {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.tab-link {
+    padding: 0.5rem 1rem;
+    background-color: var(--secondary-bg-color);
+    border: 1px solid #444;
+    border-radius: 4px 4px 0 0;
+    cursor: pointer;
+}
+
+.tab-link.active {
+    background-color: var(--accent-color);
+    color: #000;
+}
+
+.tab-content {
+    display: none;
+}
+
+.tab-content.active {
+    display: block;
+}

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -1,0 +1,18 @@
+export function initCaptions() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const tabs = document.querySelectorAll('.tab-link');
+    const contents = document.querySelectorAll('.tab-content');
+    if (!tabs.length) return;
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const target = tab.dataset.tab;
+        tabs.forEach((t) => t.classList.remove('active'));
+        contents.forEach((c) => c.classList.remove('active'));
+        tab.classList.add('active');
+        document.getElementById(target)?.classList.add('active');
+      });
+    });
+  });
+}
+

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -9,6 +9,7 @@ import { initOffline } from './offline.js';
 import { initDangerToggle } from './danger.js';
 import { initIndexTime } from './time.js';
 import { initWelcome } from './welcome.js';
+import { initCaptions } from './captions.js';
 
 initTemplates();
 initVideoControls();
@@ -22,3 +23,4 @@ initOffline();
 initDangerToggle();
 initIndexTime();
 initWelcome();
+initCaptions();

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -28,90 +28,42 @@
          });
      </script>
 
-    <details class="filter-controls">
-        <summary>Search &amp; Filters</summary>
-        <div class="controls-inner">
-            <label for="group-dropdown" title="Filter templates by group">Group:</label>
-            <select id="group-dropdown" title="Select a group to filter templates">
-                <!-- Options will be populated here -->
-            </select>
-
-            <label for="search-input" title="Search for cameras or groups">Search:</label>
-            <input type="search" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
-
-            <label for="filter-column" title="KPI to filter">KPI:</label>
-            <select id="filter-column" title="Select KPI">
-                <option value="">All</option>
-                <option value="screenshot_count">Shots</option>
-                <option value="video_count">Videos</option>
-                <option value="storage_usage">Storage</option>
-                <option value="llm_response_count">LLM Resp</option>
-                <option value="llm_cost_estimate">LLM Cost</option>
-            </select>
-            <input type="text" id="filter-value" placeholder="Value" title="Filter value">
-            <button id="apply-filter" type="button" title="Filter table rows">Apply</button>
-            <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust thumbnail width">
-        </div>
-    </details>
-
-
-<!-- Bulk management controls -->
-<details class="tsv-controls">
-    <summary>Bulk Caption Management</summary>
-    <div class="tsv-buttons">
-        <a href="/download_captions_tsv" class="btn btn-primary" title="Download captions as TSV file">Download Captions as TSV</a>
-
-        <form action="/upload_captions_tsv" method="post" enctype="multipart/form-data" class="tsv-upload-form">
-            <input type="file" name="tsv_file" id="tsv_file" accept=".tsv" title="Select TSV file to upload">
-            <button type="submit" class="btn btn-success" title="Upload caption TSV file">Upload TSV</button>
-        </form>
+    <div class="tabs">
+        <button class="tab-link active" data-tab="prompts-tab">Prompts</button>
+        <button class="tab-link" data-tab="history-tab">History</button>
+        <button class="tab-link" data-tab="bulk-tab">Bulk Tools</button>
     </div>
-    <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
-</details>
 
-<!-- Add this to display flash messages -->
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    <div class="flash-messages">
-    {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
-    {% endfor %}
-    </div>
-  {% endif %}
-{% endwith %}
+    <div id="prompts-tab" class="tab-content active">
+        <details class="filter-controls">
+            <summary>Search &amp; Filters</summary>
+            <div class="controls-inner">
+                <label for="group-dropdown" title="Filter templates by group">Group:</label>
+                <select id="group-dropdown" title="Select a group to filter templates">
+                    <!-- Options will be populated here -->
+                </select>
 
-    <details><summary>Captions</summary>
-        <table id="captions-table" class="captions-table">
-            <thead>
-            <tr>
-                <th class="sortable" data-type="date">Timestamp</th>
-                <th class="sortable" data-type="string">Caption</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% if not lcaptions %}
-            <tr class="no-data">
-                <td colspan="2">No captions available</td>
-            </tr>
-            {% else %}
-            {% for caption in lcaptions %}
-            {% for lc in caption %}
-            {% if caption[lc] != "" %}
-            <tr>
-                <td><span class="humanized-time" data-time="{{ lc }}">{{ lc }}</span></td>
-                <td>{{ caption[lc] }}</td>
-            </tr>
-            {% endif %}
-            {% endfor %}
-            {% endfor %}
-            {% endif %}
-            </tbody>
-        </table>
-    </details>
+                <label for="search-input" title="Search for cameras or groups">Search:</label>
+                <input type="search" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
 
-<h2>Camera Notes</h2>
-<div id="template-list">
-<table id="camera-table" class="camera-table">
+                <label for="filter-column" title="KPI to filter">KPI:</label>
+                <select id="filter-column" title="Select KPI">
+                    <option value="">All</option>
+                    <option value="screenshot_count">Shots</option>
+                    <option value="video_count">Videos</option>
+                    <option value="storage_usage">Storage</option>
+                    <option value="llm_response_count">LLM Resp</option>
+                    <option value="llm_cost_estimate">LLM Cost</option>
+                </select>
+                <input type="text" id="filter-value" placeholder="Value" title="Filter value">
+                <button id="apply-filter" type="button" title="Filter table rows">Apply</button>
+                <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust thumbnail width">
+            </div>
+        </details>
+
+        <h2>Camera Notes</h2>
+        <div id="template-list">
+        <table id="camera-table" class="camera-table">
     <thead>
         <tr>
             <th class="sortable" data-type="string">Camera</th>
@@ -170,6 +122,62 @@
     </tbody>
 </table>
 </div>
+</div>
+
+<div id="history-tab" class="tab-content">
+    <details><summary>Captions</summary>
+        <table id="captions-table" class="captions-table">
+            <thead>
+            <tr>
+                <th class="sortable" data-type="date">Timestamp</th>
+                <th class="sortable" data-type="string">Caption</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% if not lcaptions %}
+            <tr class="no-data">
+                <td colspan="2">No captions available</td>
+            </tr>
+            {% else %}
+            {% for caption in lcaptions %}
+            {% for lc in caption %}
+            {% if caption[lc] != "" %}
+            <tr>
+                <td><span class="humanized-time" data-time="{{ lc }}">{{ lc }}</span></td>
+                <td>{{ caption[lc] }}</td>
+            </tr>
+            {% endif %}
+            {% endfor %}
+            {% endfor %}
+            {% endif %}
+            </tbody>
+        </table>
+    </details>
+</div>
+
+<div id="bulk-tab" class="tab-content">
+    <details class="tsv-controls">
+        <summary>Bulk Caption Management</summary>
+        <div class="tsv-buttons">
+            <a href="/download_captions_tsv" class="btn btn-primary" title="Download captions as TSV file">Download Captions as TSV</a>
+
+            <form action="/upload_captions_tsv" method="post" enctype="multipart/form-data" class="tsv-upload-form">
+                <input type="file" name="tsv_file" id="tsv_file" accept=".tsv" title="Select TSV file to upload">
+                <button type="submit" class="btn btn-success" title="Upload caption TSV file">Upload TSV</button>
+            </form>
+        </div>
+        <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
+    </details>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <div class="flash-messages">
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
 </div>
 {% endblock %}
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review recent captions and update prompts. Use the group filter and search box to quickly find a camera, or manage captions in bulk with the TSV controls. KPI and caption columns can be sorted by clicking their headers, which now display a ↕ icon. Rows show relative timestamps, thumbnail overlays display human-readable times, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and now adjusts their height, capping them at 720&nbsp;px. Caption text is expanded for easier editing. Expand the **Bulk Caption Management** section when needed.
+10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. Use the group filter and search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 720&nbsp;px.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- redesign captions page with tabs for Prompts, History, and Bulk Tools
- add tab styling and JS initialization
- document new layout in getting started guide

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e3f900f5c83339ba4bcbde4d1c5fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a tabbed interface on the Captions page, allowing users to switch between Prompts, History, and Bulk Tools sections.
- **Style**
	- Added new styles to support the tabbed navigation and highlight the active tab.
- **Documentation**
	- Updated the Getting Started guide to describe the new tabbed layout and navigation on the Captions page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->