### PR TITLE
Add watchdog tuning settings

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,9 @@ from app.config import (
     backup_config,
     restore_config,
     DISCOVERY_AUTOSTART,
+    WATCHDOG_FAILURE_THRESHOLD,
+    WATCHDOG_RESTART_COOLDOWN,
+    WATCHDOG_MAX_FILE_HANDLES,
 )
 from app.utils.email_alerts import email_alert
 from app.utils.sms_alerts import sms_alert
@@ -175,10 +178,10 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         rapid restart loops.
         """
         last_restart_time = 0
-        restart_cooldown = 900  # 15 minutes in seconds
-        max_file_handles = 1000  # Adjust this value based on your system's limits
+        restart_cooldown = WATCHDOG_RESTART_COOLDOWN
+        max_file_handles = WATCHDOG_MAX_FILE_HANDLES
         failure_count = 0
-        failure_threshold = 3
+        failure_threshold = WATCHDOG_FAILURE_THRESHOLD
 
         while True:
             time.sleep(10)  # Check every 10 seconds

--- a/app/config.py
+++ b/app/config.py
@@ -326,6 +326,18 @@ LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
 # not wasted.
 LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
 
+# Watchdog configuration values. These control how aggressively the
+# watchdog restarts the application when health checks fail.
+WATCHDOG_FAILURE_THRESHOLD = int(
+    get_setting("WATCHDOG_FAILURE_THRESHOLD", 3)
+)
+WATCHDOG_RESTART_COOLDOWN = int(
+    get_setting("WATCHDOG_RESTART_COOLDOWN", 900)
+)
+WATCHDOG_MAX_FILE_HANDLES = int(
+    get_setting("WATCHDOG_MAX_FILE_HANDLES", 1000)
+)
+
 # Background discovery runs on a schedule when enabled.  Set this
 # to ``True`` to run an hourly scan automatically.
 DISCOVERY_AUTOSTART = get_setting("DISCOVERY_AUTOSTART", "False") == "True"

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -7,10 +7,11 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Loads configuration values and sets up logging.
 - Initializes routes from `app/routes.py`.
 - Starts the background scheduler and optional watchdog thread.
-  The watchdog performs health checks and only triggers a restart after
-  three consecutive failures to avoid unnecessary restarts during startup.
-  Requests to `/health` include the configured API key so the check
-  succeeds even when login is required.
+  The watchdog performs health checks and only triggers a restart after a
+  configurable number of failures. Tune `WATCHDOG_FAILURE_THRESHOLD`,
+  `WATCHDOG_RESTART_COOLDOWN`, and `WATCHDOG_MAX_FILE_HANDLES` to adjust
+  this behaviour. Requests to `/health` include the configured API key so
+  the check succeeds even when login is required.
 
 ## Configuration Handling (`app/config.py`)
 - Loads environment variables and values stored in the database.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -116,6 +116,9 @@ Settings controlling how frames are captured from video sources:
 - `ANALYZE_DURATION_OTHER` – analyzeduration for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
+- `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
+- `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)
+- `WATCHDOG_MAX_FILE_HANDLES` – open file handle limit before triggering a restart (default `1000`)
 - `DISCOVERY_AUTOSTART` – run hourly background discovery automatically (default `False`)
 
 ### Stealth Browser Defaults


### PR DESCRIPTION
## Summary
- add config variables for watchdog thresholds
- document watchdog settings in config guide
- mention tuning options in architecture overview
- use new variables in watchdog thread

## Testing
- `flake8 app/config.py app/__init__.py` *(fails: command not found)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683eaec84cac83338e1c6301dc5fb99c