### PR TITLE
Add credentials for protected camera feeds

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2454,6 +2454,8 @@ def init_routes(app):
                 "dedicated_xpath": request.form.get("dedicated_xpath"),
                 "callback_url": request.form.get("callback_url"),
                 "proxy": request.form.get("proxy"),
+                "auth_username": request.form.get("auth_username"),
+                "auth_password": request.form.get("auth_password"),
                 "rollback_frames": request.form.get("rollback_frames"),
                 "groups": request.form.get("groups"),
                 "object_filter": request.form.get("object_filter"),

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -51,6 +51,12 @@
                 <label for="proxy" title="Proxy server address">Proxy:</label>
                 <input type="text" id="proxy" name="proxy" title="Enter proxy server address (optional)">
 
+                <label for="auth_username" title="Username for camera authentication">Username:</label>
+                <input type="text" id="auth_username" name="auth_username" title="Camera username">
+
+                <label for="auth_password" title="Password for camera authentication">Password:</label>
+                <input type="password" id="auth_password" name="auth_password" title="Camera password">
+
                 <label for="groups" title="Groups for the template, comma separated ">Groups:</label>
                 <input type="text" id="groups" name="groups" title="Enter comma-separated group names">
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -208,6 +208,16 @@ function updateVideo(templateName) {
             </div>
 
             <div class="form-row">
+                <label for="auth_username" title="Username for camera authentication">Username:</label>
+                <input type="text" id="auth_username" name="auth_username" value="{{ template_details.auth_username }}" title="Camera username">
+            </div>
+
+            <div class="form-row">
+                <label for="auth_password" title="Password for camera authentication">Password:</label>
+                <input type="password" id="auth_password" name="auth_password" value="{{ template_details.auth_password }}" title="Camera password">
+            </div>
+
+            <div class="form-row">
                 <label for="groups" title="Groups for the template">Groups:</label>
                 <input type="text" id="groups" name="groups" value="{{ template_details.groups }}" title="Enter comma-separated group names">
                 {% if template_details.groups %}

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -712,6 +712,8 @@ def download_image(
     dark=False,
     stealth=False,
     proxy=None,
+    username=None,
+    password=None,
 ):
     """Attempt to download an image directly from the URL and convert it to PNG format.
 
@@ -745,9 +747,7 @@ def download_image(
         headers = {"user-agent": lua}
         proxies = {"http": proxy, "https": proxy} if proxy else None
 
-        auth = None
-        for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
-            auth = requests.auth.HTTPBasicAuth(leach[0], leach[1])
+        auth = get_auth(url, username, password)
 
         request_kwargs = dict(
             stream=True,
@@ -761,8 +761,7 @@ def download_image(
 
         response = http_session().get(url, **request_kwargs)
         if response.status_code == 401 and auth is not None:
-            for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
-                auth = requests.auth.HTTPDigestAuth(leach[0], leach[1])
+            auth = get_digest_auth(url, username, password)
             request_kwargs = dict(
                 stream=True,
                 timeout=(timeout, timeout * 3),
@@ -814,6 +813,8 @@ def download_pdf(
     invert=False,
     dark=False,
     stealth=False,
+    username=None,
+    password=None,
 ):
     """
     Attempt to download the first page of a PDF from the URL and convert it to PNG format.
@@ -836,9 +837,7 @@ def download_pdf(
             lua = random_user_agent()
 
         headers = {"user-agent": lua}
-        auth = None
-        for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
-            auth = requests.auth.HTTPBasicAuth(leach[0], leach[1])
+        auth = get_auth(url, username, password)
 
         response = http_session().get(
             url,
@@ -852,8 +851,7 @@ def download_pdf(
 
         # Possibly re-try with DigestAuth if 401
         if response.status_code == 401 and auth is not None:
-            for leach in re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url):
-                auth = requests.auth.HTTPDigestAuth(leach[0], leach[1])
+            auth = get_digest_auth(url, username, password)
             response = http_session().get(
                 url,
                 stream=True,
@@ -1053,6 +1051,8 @@ def capture_or_download(name: str, template: dict) -> bool:
 
     # Extract parameters from the template
     url = template.get("url")
+    username = template.get("auth_username")
+    password = template.get("auth_password")
 
     # Disallow local file paths to avoid unintended file disclosure
     parsed = urlparse(url)
@@ -1106,7 +1106,9 @@ def capture_or_download(name: str, template: dict) -> bool:
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # Determine content type
-    content_type, is_modified = get_content_type(url, danger, stealth=stealth)
+    content_type, is_modified = get_content_type(
+        url, danger, stealth=stealth, username=username, password=password
+    )
 
     # check if modified.
     if is_modified is False and not danger and not browser:
@@ -1124,13 +1126,17 @@ def capture_or_download(name: str, template: dict) -> bool:
             dark,
             stealth,
             template.get("proxy"),
+            username,
+            password,
         )
         if lsuc is True:
             return lsuc
         cas_error(url)
 
     if is_pdf_url(url, content_type) and not danger and not browser:
-        lsuc = download_pdf(url, output_path, timeout, name, invert)
+        lsuc = download_pdf(
+            url, output_path, timeout, name, invert, dark, stealth, username, password
+        )
         if lsuc is True:
             return lsuc
         cas_error(url)
@@ -1240,7 +1246,9 @@ def check_if_modified(url, headers) -> bool:
     return True  # Content has changed or was never checked before
 
 
-def get_content_type(url, danger, stealth=False) -> (str, bool):
+def get_content_type(
+    url, danger, stealth=False, username=None, password=None
+) -> (str, bool):
     """
     Determine the content type of the URL.
 
@@ -1279,7 +1287,7 @@ def get_content_type(url, danger, stealth=False) -> (str, bool):
         try:
             # extra header only for the GET probe
             hdrs = {"Range": "bytes=0-1024"} if verb == "GET" else {}
-            auth = get_auth(url)
+            auth = get_auth(url, username, password)
             resp = sess.request(
                 verb,
                 url,
@@ -1321,7 +1329,7 @@ def get_content_type(url, danger, stealth=False) -> (str, bool):
             if method == requests.get:
                 headers["Range"] = "bytes=0-1024"
 
-            auth = get_auth(url)
+            auth = get_auth(url, username, password)
             response = method(
                 url,
                 stream=True,
@@ -1365,16 +1373,24 @@ def get_content_type(url, danger, stealth=False) -> (str, bool):
     return content_type, modified
 
 
-def get_auth(url):
-    """Extract and return BasicAuth from URL if present."""
+def get_auth(url, username=None, password=None):
+    """Return :class:`HTTPBasicAuth` if credentials are available."""
     auth_match = re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url)
-    return requests.auth.HTTPBasicAuth(*auth_match[0]) if auth_match else None
+    if auth_match:
+        return requests.auth.HTTPBasicAuth(*auth_match[0])
+    if username and password:
+        return requests.auth.HTTPBasicAuth(username, password)
+    return None
 
 
-def get_digest_auth(url):
-    """Extract and return DigestAuth from URL if present."""
+def get_digest_auth(url, username=None, password=None):
+    """Return :class:`HTTPDigestAuth` if credentials are available."""
     auth_match = re.findall(r"\/\/([^\:]+?)\:([^\@]+?)\@", url)
-    return requests.auth.HTTPDigestAuth(*auth_match[0]) if auth_match else None
+    if auth_match:
+        return requests.auth.HTTPDigestAuth(*auth_match[0])
+    if username and password:
+        return requests.auth.HTTPDigestAuth(username, password)
+    return None
 
 
 def is_image_url(url, content_type):

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -63,6 +63,8 @@ class Template(db.Base):
     dedicated_xpath = Column(String, default="")
     callback_url = Column(String, default="")
     proxy = Column(String, default="")
+    auth_username = Column(String, default="")
+    auth_password = Column(String, default="")
     url = Column(String, default="")
     groups = Column(String, default="")
     invert = Column(Boolean, default=False)
@@ -120,6 +122,8 @@ class TemplateManager:
         Template.__table__.create(db.engine, checkfirst=True)
         # Automatically add newer columns when upgrading from older versions
         ensure_column("templates", "capture_failed", "BOOLEAN", "0")
+        ensure_column("templates", "auth_username", "VARCHAR(255)", "''")
+        ensure_column("templates", "auth_password", "VARCHAR(255)", "''")
 
     def get_session(self):
         """Return a new SQLAlchemy session bound to the app database."""

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -173,6 +173,8 @@ def validate_update_data(data: dict) -> dict:
         "proxy",
         "groups",
         "object_filter",
+        "auth_username",
+        "auth_password",
     ]:
         value = data.get(key)
         if key == "proxy":

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -194,4 +194,4 @@ outside the local network.
 
 ## Future improvements
 
-Remaining ideas include discovering cameras on remote networks and improving authentication options for protected feeds.
+Discovering cameras on remote networks remains on the roadmap. Authentication for protected feeds has been enhanced – you can now store a username and password with each template, and the capture routines will automatically supply these credentials.

--- a/tests/test_screenshots_additional.py
+++ b/tests/test_screenshots_additional.py
@@ -60,7 +60,9 @@ class TestScreenshotsExtras(unittest.TestCase):
         self.assertEqual(basic.password, "pass")
         self.assertEqual(digest.username, "user")
         self.assertEqual(digest.password, "pass")
-        self.assertIsNone(ss.get_auth("http://example.com"))
+        fallback = ss.get_auth("http://example.com", "u", "p")
+        self.assertEqual(fallback.username, "u")
+        self.assertEqual(fallback.password, "p")
 
     def test_url_type_helpers(self):
         self.assertTrue(ss.is_image_url("http://x/a.jpg", ""))


### PR DESCRIPTION
## Summary
- support auth_username/auth_password fields for templates
- pass credentials through capture pipeline
- update camera discovery docs about improved authentication
- test fallback basic auth

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eaeb59938833398c6cd3455ec6543