### PR TITLE
Fix release workflow triggers

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2,8 +2,12 @@ name: Build Release Packages
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build_debian:


### PR DESCRIPTION
## Summary
- ensure Debian and Windows builds run on main

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683eb389afb48333bde0470174a0f90b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded the conditions under which automated workflows run, now including pushes and pull requests to the main branch, as well as manual triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->