### PR TITLE
Add dependency caching to CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -34,6 +41,13 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
+    - name: Cache npm
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
     - name: Install Node dependencies
       run: npm install
     - name: Audit npm packages

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -8,5 +8,6 @@ following tasks:
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites.
 - Scans dependencies using `pip safety` and `npm audit`.
+- Caches Python and Node dependencies to speed up builds.
 
 These checks help catch regressions and security issues before code is merged.


### PR DESCRIPTION
## Summary
- cache pip and npm directories in the main workflow
- document dependency caching in CI docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683eb351fd90833398b296da41b63503