### PR TITLE
Fix jest environment setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "stylelint-config-standard": "^34.0.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add missing `jest-environment-jsdom` dev dependency

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ee6b414048333bc290e96b5918d6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added "jest-environment-jsdom" as a development dependency to improve the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->