### PR TITLE
Fix jest tests imports

### DIFF
--- a/tests/js/logs.test.js
+++ b/tests/js/logs.test.js
@@ -8,8 +8,12 @@ document.body.innerHTML = `
   <select id="level-select"></select>
 `;
 
-// Import function to test
-const { updateTable } = require('../../app/static/js/logs.js');
+let updateTable;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/logs.js');
+  updateTable = mod.updateTable;
+});
 
 describe('logs.js', () => {
   beforeEach(() => {

--- a/tests/js/offline.test.js
+++ b/tests/js/offline.test.js
@@ -18,8 +18,12 @@ Object.defineProperty(global.navigator, 'serviceWorker', {
   configurable: true,
 });
 
-// Import the function to test
-const { initOffline } = require('../../app/static/js/offline.js');
+let initOffline;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/offline.js');
+  initOffline = mod.initOffline;
+});
 
 describe('offline.js', () => {
   beforeEach(() => {

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -20,11 +20,16 @@ canvas.getContext = jest.fn(() => ({
   stroke: jest.fn(),
 }));
 
-// Import functions to test
-const {
-  updatePerformanceMetrics,
-  updateCPUSparkline,
-} = require('../../app/static/js/performance.js');
+let updatePerformanceMetrics;
+let updateCPUSparkline;
+
+beforeAll(async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+  global.setInterval = jest.fn();
+  const mod = await import('../../app/static/js/performance.js');
+  updatePerformanceMetrics = mod.updatePerformanceMetrics;
+  updateCPUSparkline = mod.updateCPUSparkline;
+});
 
 describe('performance.js', () => {
   beforeEach(() => {

--- a/tests/js/script.test.js
+++ b/tests/js/script.test.js
@@ -12,12 +12,16 @@ document.body.innerHTML = `
   <input id="grid-width-slider" type="range">
 `;
 
-// Import the functions to test
-const {
-  loadTemplates,
-  updateGridLayout,
-  timeAgo,
-} = require('../../app/static/js/script.js');
+let loadTemplates;
+let updateGridLayout;
+let timeAgo;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/templates.js');
+  loadTemplates = mod.loadTemplates;
+  updateGridLayout = mod.updateGridLayout;
+  timeAgo = mod.timeAgo;
+});
 
 describe('script.js', () => {
   beforeEach(() => {

--- a/tests/js/slider_height.test.js
+++ b/tests/js/slider_height.test.js
@@ -5,7 +5,12 @@ document.body.innerHTML = `
   <input id="grid-width-slider" type="range" value="360">
 `;
 
-const { initTemplates } = require('../../app/static/js/templates.js');
+let initTemplates;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/templates.js');
+  initTemplates = mod.initTemplates;
+});
 
 describe('grid width slider', () => {
   beforeEach(() => {

--- a/tests/js/templates_utils.test.js
+++ b/tests/js/templates_utils.test.js
@@ -4,12 +4,18 @@ document.body.innerHTML = `
   <div id="template-list"></div>
 `;
 
-const {
-  isMobile,
-  updateGridLayout,
-  templateBelongsToGroup,
-  templateMatchesSearch,
-} = require('../../app/static/js/templates.js');
+let isMobile;
+let updateGridLayout;
+let templateBelongsToGroup;
+let templateMatchesSearch;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/templates.js');
+  isMobile = mod.isMobile;
+  updateGridLayout = mod.updateGridLayout;
+  templateBelongsToGroup = mod.templateBelongsToGroup;
+  templateMatchesSearch = mod.templateMatchesSearch;
+});
 
 describe('templates.js utilities', () => {
   test('isMobile detects hover capability', () => {

--- a/tests/js/time.test.js
+++ b/tests/js/time.test.js
@@ -4,7 +4,12 @@ document.body.innerHTML = `<div id="index-time"></div>`;
 
 jest.useFakeTimers();
 
-const { initIndexTime } = require('../../app/static/js/time.js');
+let initIndexTime;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/time.js');
+  initIndexTime = mod.initIndexTime;
+});
 
 describe('time.js', () => {
   test('initIndexTime updates element with time and ISO title', () => {


### PR DESCRIPTION
## Summary
- adjust test imports to load ESM modules via dynamic `import`

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ef0ff2580833397f26b8fcbf0ee36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test files to use asynchronous dynamic imports for loading modules before tests run, replacing previous static imports. This improves test setup and ensures modules are loaded after necessary mocks or configurations are applied. No changes to test logic or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->