### PR TITLE
Handle offline scheduling

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -1,0 +1,12 @@
+import socket
+import logging
+
+
+def is_system_online(timeout: int = 3) -> bool:
+    """Return ``True`` if an external network connection can be opened."""
+    try:
+        socket.create_connection(("8.8.8.8", 53), timeout=timeout)
+        return True
+    except OSError as exc:  # pragma: no cover - network depends on environment
+        logging.warning("offline check failed: %s", exc)
+        return False

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -29,6 +29,7 @@ from app.config import (
 )
 from app.utils.db import SessionLocal
 from app.models import Summary
+from .network import is_system_online
 
 from .detect import calculate_difference_fast
 from .image_processing import chatgpt_compare
@@ -96,8 +97,39 @@ scheduler = GracefulAPScheduler()
 
 
 def run_with_timeout(func, args=(), timeout=300):
-    process = multiprocessing.Process(target=func, args=args)
-    process.start()
+    """Run *func* in a separate process with a timeout.
+
+    If the system appears offline or process creation fails, the job is skipped
+    and the associated template is marked offline when possible.
+    """
+
+    if not is_system_online():
+        logging.warning(
+            "System offline, skipping job %s", getattr(func, "__name__", "unknown")
+        )
+        if args and isinstance(args[0], str):
+            try:
+                mark_offline(args[0])
+            except Exception:
+                pass
+        return
+
+    try:
+        process = multiprocessing.Process(target=func, args=args)
+        process.start()
+    except OSError as exc:
+        logging.error(
+            "Failed to start process for %s: %s",
+            getattr(func, "__name__", "unknown"),
+            exc,
+        )
+        if args and isinstance(args[0], str):
+            try:
+                mark_offline(args[0])
+            except Exception:
+                pass
+        return
+
     process.join(timeout)
     if process.is_alive():
         process.terminate()

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -5,3 +5,5 @@ Glimpser interacts with external services such as camera endpoints and language 
 The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.request` and will retry failed requests a few times, waiting longer between attempts. When the LLM summarization call fails after retries, the last cached summary is returned if available. Otherwise a short message such as "Summarization delayed" is provided so the UI continues to load.
 
 This approach keeps the application responsive even when external services are slow or offline.
+
+The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors.

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -19,7 +19,8 @@ from app.utils.scheduling import (
 
 
 class TestRunWithTimeout(unittest.TestCase):
-    def test_run_completes_before_timeout(self):
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    def test_run_completes_before_timeout(self, _online):
         manager = multiprocessing.Manager()
         d = manager.dict()
 
@@ -29,7 +30,8 @@ class TestRunWithTimeout(unittest.TestCase):
         run_with_timeout(quick, args=(d,), timeout=2)
         self.assertTrue(d.get("done"))
 
-    def test_run_terminated_on_timeout(self):
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    def test_run_terminated_on_timeout(self, _online):
         manager = multiprocessing.Manager()
         d = manager.dict()
 


### PR DESCRIPTION
## Summary
- add `is_system_online` helper
- skip scheduler jobs when offline
- test `run_with_timeout` with offline detection
- document new offline check in scheduler

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ef33035088333a6b630c7c61bba98