### PR TITLE
Configure jest for ESM modules

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,7 @@ Front‑end utilities under `app/static/js` are tested with **Jest**. The tests
 use the JSDOM environment so that DOM APIs are available in Node. Run them with:
 
 ```sh
-npx jest --env=jsdom
+node --experimental-vm-modules node_modules/jest/bin/jest.js --env=jsdom
 ```
 
 New tests cover the offline service‑worker toggle and template helpers.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', 'tests/playwright/'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint:css": "stylelint 'app/static/css/**/*.css'",
     "lint:js": "eslint 'app/static/js/**/*.js'",
     "format:js": "prettier --check 'app/static/js/**/*.js'",
-    "test:js": "jest --env=jsdom",
+    "test:js": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=jsdom",
     "test": "npm run test:js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- support ESM modules in Jest
- document new command for JS tests

## Testing
- `pytest`
- `npm install` *(fails: unable to fetch packages)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef358d988833386f1dfefbcd1709a