### PR TITLE
Fix JS tests by enabling ESM

### DIFF
--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -1,7 +1,7 @@
 let cpuData = [];
 const maxDataPoints = 60;
 
-function updatePerformanceMetrics() {
+export function updatePerformanceMetrics() {
   fetch("/health")
     .then((response) => response.json())
     .then((data) => {
@@ -22,7 +22,7 @@ function updatePerformanceMetrics() {
     });
 }
 
-function updateCPUSparkline(newValue) {
+export function updateCPUSparkline(newValue) {
   cpuData.push(newValue);
   if (cpuData.length > maxDataPoints) {
     cpuData.shift();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "glimpser",
   "version": "1.0.0",
+  "type": "module",
   "private": true,
   "scripts": {
     "lint:css": "stylelint 'app/static/css/**/*.css'",


### PR DESCRIPTION
## Summary
- enable ESM modules for Node
- export performance helpers so tests can import them

## Testing
- `black .`
- `flake8 .`
- `pytest -q`
- `npm test` *(fails: Cannot find module '.../jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_683f029af47c833389623780cb859465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated module settings to use ECMAScript modules (ESM) by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->