### PR TITLE
Add release badge generation

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           python -m pip install build
           python -m build
+      - name: Generate release badges
+        run: |
+          python scripts/generate_release_badges.py
       - name: Publish to PyPI
         if: ${{ secrets.PYPI_API_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -49,6 +52,7 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: debian/glimpser.deb
+          body_path: release-badges.md
 
   build_windows:
     runs-on: windows-latest

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -6,6 +6,10 @@ The process is split across two runners:
 - **Ubuntu** builds the Debian package and runs the test suite.
 - **Windows** builds the standalone executable using `build_windows.py`.
 
+The Ubuntu job also generates a small `release-badges.md` file that lists
+status badges for the current tag.  This file becomes the body of the GitHub
+release so that each tagged version shows the latest CI status.
+
 Both artifacts are attached to the GitHub release created for the tag. When the
 `PYPI_API_TOKEN` secret is available, Python distributions are also published to
 PyPI.

--- a/scripts/generate_release_badges.py
+++ b/scripts/generate_release_badges.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import os
+
+BADGES = [
+    "[![Python application](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml)",
+    "[![Pylint](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)",
+    "[![Tests](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml)",
+    "[![Coverage](https://codecov.io/gh/KristopherKubicki/glimpser/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/glimpser)",
+    "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kristopherkubicki/glimpser/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kristopherkubicki/glimpser)",
+    "[![CodeQL](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml)",
+    "[![Docs Build](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml)",
+]
+
+
+def main() -> None:
+    version = os.environ.get("GITHUB_REF_NAME", "")
+    lines = [f"# Release {version}", ""] + BADGES
+    Path("release-badges.md").write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate `release-badges.md` during release packaging
- upload the badge file as the body of the GitHub release
- document the new automation step

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f044df32c833398b3dc58ffaebe57