### PR TITLE
Fix ESLint config for ESM

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     files: ["app/static/js/**/*.js"],
     languageOptions: {


### PR DESCRIPTION
## Summary
- convert `eslint.config.js` to ESM

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `npm run lint:js`


------
https://chatgpt.com/codex/tasks/task_e_683f04f1613c8333a9aff26397901655