### PR TITLE
Fix API discovery listing

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1043,6 +1043,9 @@ def init_routes(app):
                     "path": "/captions_status",
                     "method": "GET",
                     "description": "Get the most recent caption and timestamp",
+                    "authentication_required": False,
+                },
+                {
                     "path": "/discovery_status",
                     "method": "GET",
                     "description": "Check background discovery status",

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -195,6 +195,30 @@ Example response:
 Trigger compilation of recent footage into a teaser video. Requires authentication.
 GET requests to this endpoint return `405 Method Not Allowed`.
 
+### 13. API Discovery and Status
+
+These utility endpoints expose basic information about the server.
+
+**GET /api/discover**
+
+Returns a JSON list of available endpoints with method and description.
+
+**GET /health**
+
+Checks the overall health of the application and returns system metrics.
+
+**GET /danger_status**
+
+Indicates whether Danger mode is ready for use.
+
+**GET /captions_status**
+
+Returns the latest caption text and timestamp.
+
+**GET /discovery_status**
+
+Reports the status of background camera discovery.
+
 ## Error Handling
 
 All endpoints may return the following error responses:


### PR DESCRIPTION
## Summary
- correct discovery endpoint listing in `/api/discover`
- document status-related endpoints

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f09f1d324833390c6f1cf3f024888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated API discovery information to clearly indicate which endpoints do not require authentication.
  - Added API discovery and status endpoints to the documentation, providing details on server status and utility endpoints.

- **Documentation**
  - Introduced a new section outlining API discovery and status endpoints, with descriptions and usage details for each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->