### PR TITLE
Fix e2e login test session setup

### DIFF
--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -90,6 +90,9 @@ def live_server_with_user(tmp_path_factory):
     patcher = patch.dict(os.environ, env)
     patcher.start()
 
+    secure_patch = patch("app.config.SESSION_COOKIE_SECURE", False)
+    secure_patch.start()
+
     import generate_credentials
     import app.config as config
     import app.utils.db as db
@@ -119,6 +122,7 @@ def live_server_with_user(tmp_path_factory):
     server.shutdown()
     os.chdir(prev_cwd)
 
+    secure_patch.stop()
     patcher.stop()
     importlib.reload(config)
     importlib.reload(db)


### PR DESCRIPTION
## Summary
- disable secure cookies in the e2e web server fixture so the test can authenticate over HTTP

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f0f0713d08333b919647a7187c208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test setup to temporarily disable secure session cookies during end-to-end tests, improving test reliability in non-secure environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->