### PR TITLE
Improve log viewer reconnection

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1431,3 +1431,9 @@ details > summary {
 .tab-content.active {
     display: block;
 }
+
+#log-connection-status {
+    text-align: center;
+    padding: 0.5rem;
+    color: var(--accent-color);
+}

--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -14,50 +14,70 @@ export function updateTable(logs) {
   });
 }
 
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.getElementById("log-filter-form");
-  const table = document.getElementById("log-table");
-  const searchInput = document.getElementById("search-input");
-  const levelSelect = document.getElementById("level-select");
+export function initLogs() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("log-filter-form");
+    const table = document.getElementById("log-table");
+    const searchInput = document.getElementById("search-input");
+    const levelSelect = document.getElementById("level-select");
+    const status = document.getElementById("log-connection-status");
 
-  let eventSource;
+    let eventSource;
+    let reconnectTimer;
 
-  function startEventStream() {
-    if (eventSource) {
-      eventSource.close();
+    function startEventStream() {
+      if (eventSource) {
+        eventSource.close();
+      }
+
+      const formData = new FormData(form);
+      const searchParams = new URLSearchParams(formData);
+      eventSource = new EventSource(`/stream_logs?${searchParams.toString()}`);
+      if (status) status.classList.add("hidden");
+
+      eventSource.onopen = () => {
+        if (status) status.classList.add("hidden");
+      };
+
+      eventSource.onmessage = (event) => {
+        const logs = JSON.parse(event.data);
+        updateTable(logs);
+      };
+
+      eventSource.onerror = (error) => {
+        console.error("EventSource failed:", error);
+        if (status) {
+          status.textContent = "Connection lost. Reconnecting...";
+          status.classList.remove("hidden");
+        }
+        eventSource.close();
+        clearTimeout(reconnectTimer);
+        reconnectTimer = setTimeout(startEventStream, 3000);
+      };
     }
 
-    const formData = new FormData(form);
-    const searchParams = new URLSearchParams(formData);
-    eventSource = new EventSource(`/stream_logs?${searchParams.toString()}`);
+    form.addEventListener("submit", (e) => {
+      e.preventDefault();
+      startEventStream();
+    });
 
-    eventSource.onmessage = function (event) {
-      const logs = JSON.parse(event.data);
-      updateTable(logs);
-    };
+    searchInput.addEventListener("input", () => {
+      startEventStream();
+    });
 
-    eventSource.onerror = function (error) {
-      console.error("EventSource failed:", error);
-      eventSource.close();
-    };
-  }
+    levelSelect.addEventListener("change", () => {
+      startEventStream();
+    });
 
-  form.addEventListener("submit", function (e) {
-    e.preventDefault();
+    // Start the initial event stream
     startEventStream();
-  });
 
-  searchInput.addEventListener("input", function () {
-    startEventStream();
+    // expose for tests
+    window.__startLogStream = startEventStream;
   });
+}
 
-  levelSelect.addEventListener("change", function () {
-    startEventStream();
-  });
-
-  // Start the initial event stream
-  startEventStream();
-});
+initLogs();
 
 
 // Expose for legacy scripts that include this file via <script> tag

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -30,4 +30,6 @@
         </tbody>
     </table>
 
-<script src="{{ url_for('static', filename='js/logs.js') }}"></script>
+    <div id="log-connection-status" class="hidden"></div>
+
+    <script src="{{ url_for('static', filename='js/logs.js') }}"></script>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -48,6 +48,7 @@ To filter logs by level and message text, you could request:
 2. Use the search box and dropdowns to filter log output.
 3. Hover over each field for a tooltip explaining the filter.
 4. Results update automatically via `/stream_logs`.
+5. If the connection drops, the viewer automatically reconnects after a few seconds and shows a short notice while retrying.
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 

--- a/tests/js/logs.test.js
+++ b/tests/js/logs.test.js
@@ -7,6 +7,7 @@ document.body.innerHTML = `
   <table id="log-table"><tbody></tbody></table>
   <input id="search-input" />
   <select id="level-select"></select>
+  <div id="log-connection-status" class="hidden"></div>
 `;
 
 let updateTable;
@@ -33,5 +34,28 @@ describe('logs.js', () => {
     expect(rows).toHaveLength(2);
     expect(rows[0].textContent).toContain('INFO');
     expect(rows[1].textContent).toContain('WARN');
+  });
+
+  test('reconnects when the event stream errors', () => {
+    jest.useFakeTimers();
+    const esInstances = [];
+    global.EventSource = jest.fn(() => {
+      const es = { onmessage: null, onerror: null, onopen: null, close: jest.fn() };
+      esInstances.push(es);
+      return es;
+    });
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    expect(EventSource).toHaveBeenCalledTimes(1);
+
+    esInstances[0].onerror(new Event('error'));
+    jest.advanceTimersByTime(3000);
+
+    expect(EventSource).toHaveBeenCalledTimes(2);
+    const status = document.getElementById('log-connection-status');
+    expect(status.classList.contains('hidden')).toBe(false);
+
+    esInstances[1].onopen();
+    expect(status.classList.contains('hidden')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- retry the logs event stream on failures
- show reconnection status message while attempting to reconnect
- add connection status element and styling
- document auto reconnect behaviour
- test reconnection logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f255dff188333ab41b7e62eb7c307