### PR TITLE
Fix JS tests with matchMedia polyfill

### DIFF
--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -2,7 +2,7 @@ let cpuData = [];
 const maxDataPoints = 60;
 
 export function updatePerformanceMetrics() {
-  fetch("/health")
+  return fetch("/health")
     .then((response) => response.json())
     .then((data) => {
       const cpuVal = document.getElementById("cpu-value");

--- a/app/static/js/time.js
+++ b/app/static/js/time.js
@@ -1,5 +1,5 @@
 export function initIndexTime() {
-  document.addEventListener("DOMContentLoaded", () => {
+  const setup = () => {
     const elem = document.getElementById("index-time");
     if (!elem) return;
     const update = () => {
@@ -9,5 +9,11 @@ export function initIndexTime() {
     };
     update();
     setInterval(update, 1000);
-  });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup);
+  } else {
+    setup();
+  }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@
 export default {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: ['/node_modules/', 'tests/playwright/'],
+  setupFiles: ['<rootDir>/tests/js/setup.js'],
 };

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -13,13 +13,14 @@ document.body.innerHTML = `
 
 // Provide a mock canvas context
 const canvas = document.getElementById('cpu-sparkline');
-canvas.getContext = jest.fn(() => ({
+const ctx = {
   clearRect: jest.fn(),
   beginPath: jest.fn(),
   moveTo: jest.fn(),
   lineTo: jest.fn(),
   stroke: jest.fn(),
-}));
+};
+canvas.getContext = jest.fn(() => ctx);
 
 let performanceModule;
 let updatePerformanceMetrics;
@@ -42,14 +43,17 @@ describe('performance.js', () => {
     const mockData = { cpu_usage: 50, memory_usage: 40, uptime: '1h' };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(mockData) }));
 
+    const sparkSpy = jest.spyOn(performanceModule, 'updateCPUSparkline');
+
     await updatePerformanceMetrics();
 
     expect(fetch).toHaveBeenCalledWith('/health');
     expect(document.getElementById('cpu-value').textContent).toBe('50%');
     expect(document.getElementById('memory-value').textContent).toBe('40%');
     expect(document.getElementById('uptime-value').textContent).toBe('1h');
-    const ctx = canvas.getContext();
-    expect(ctx.clearRect).toHaveBeenCalled();
+    expect(sparkSpy).toHaveBeenCalledWith(50);
+    const ctxCalled = canvas.getContext();
+    expect(ctxCalled.clearRect).toHaveBeenCalled();
   });
 
   test('updateCPUSparkline draws on the canvas', () => {

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -21,15 +21,16 @@ canvas.getContext = jest.fn(() => ({
   stroke: jest.fn(),
 }));
 
+let performanceModule;
 let updatePerformanceMetrics;
 let updateCPUSparkline;
 
 beforeAll(async () => {
   global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
   global.setInterval = jest.fn();
-  const mod = await import('../../app/static/js/performance.js');
-  updatePerformanceMetrics = mod.updatePerformanceMetrics;
-  updateCPUSparkline = mod.updateCPUSparkline;
+  performanceModule = await import('../../app/static/js/performance.js');
+  updatePerformanceMetrics = performanceModule.updatePerformanceMetrics;
+  updateCPUSparkline = performanceModule.updateCPUSparkline;
 });
 
 describe('performance.js', () => {
@@ -40,7 +41,7 @@ describe('performance.js', () => {
   test('updatePerformanceMetrics fetches metrics and updates DOM', async () => {
     const mockData = { cpu_usage: 50, memory_usage: 40, uptime: '1h' };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(mockData) }));
-    const sparkSpy = jest.spyOn(module, 'updateCPUSparkline');
+    const sparkSpy = jest.spyOn(performanceModule, 'updateCPUSparkline');
 
     await updatePerformanceMetrics();
 

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -41,7 +41,6 @@ describe('performance.js', () => {
   test('updatePerformanceMetrics fetches metrics and updates DOM', async () => {
     const mockData = { cpu_usage: 50, memory_usage: 40, uptime: '1h' };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(mockData) }));
-    const sparkSpy = jest.spyOn(performanceModule, 'updateCPUSparkline');
 
     await updatePerformanceMetrics();
 
@@ -49,7 +48,8 @@ describe('performance.js', () => {
     expect(document.getElementById('cpu-value').textContent).toBe('50%');
     expect(document.getElementById('memory-value').textContent).toBe('40%');
     expect(document.getElementById('uptime-value').textContent).toBe('1h');
-    expect(sparkSpy).toHaveBeenCalledWith(50);
+    const ctx = canvas.getContext();
+    expect(ctx.clearRect).toHaveBeenCalled();
   });
 
   test('updateCPUSparkline draws on the canvas', () => {

--- a/tests/js/script.test.js
+++ b/tests/js/script.test.js
@@ -34,15 +34,21 @@ describe('script.js', () => {
   test('loadTemplates fetches data and updates the DOM', async () => {
     // Mock the fetch response
     global.fetch.mockResolvedValueOnce({
-      json: () => Promise.resolve({
-        template1: { last_screenshot_time: new Date().toISOString() },
-        template2: { last_screenshot_time: new Date().toISOString() },
-      }),
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () =>
+        Promise.resolve({
+          template1: { last_screenshot_time: new Date().toISOString() },
+          template2: { last_screenshot_time: new Date().toISOString() },
+        }),
     });
 
     await loadTemplates();
 
-    expect(fetch).toHaveBeenCalledWith('/templates');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringMatching(/\/templates\?group=all&search=&t=\d+/),
+    );
     expect(document.getElementById('template-list').children.length).toBe(2);
   });
 

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -8,3 +8,12 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     dispatchEvent: () => false,
   });
 }
+
+if (typeof window !== 'undefined' && !window.IntersectionObserver) {
+  window.IntersectionObserver = class {
+    constructor() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,10 @@
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}

--- a/tests/js/slider_height.test.js
+++ b/tests/js/slider_height.test.js
@@ -20,6 +20,13 @@ describe('grid width slider', () => {
   });
 
   test('adjusts height variable on input', () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      }),
+    );
     initTemplates();
     document.dispatchEvent(new Event('DOMContentLoaded'));
     const slider = document.getElementById('grid-width-slider');


### PR DESCRIPTION
## Summary
- add global `matchMedia` polyfill for jsdom
- update performance tests to use module object
- run `initIndexTime` immediately when DOM is ready
- configure Jest to use the setup file

## Testing
- `flake8`
- `pytest -q`
- ❌ `npm test -- --coverage` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_683f26e8e13c83338eefd0b870eb37c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved page load handling for time updates to ensure faster initialization.
	- Updated test configuration to include a global setup file for JavaScript tests.
	- Added polyfills for window.matchMedia and IntersectionObserver to enhance test reliability.
- **Tests**
	- Refactored performance metrics tests for improved module handling without changing test behavior.
	- Enhanced template loading and slider height tests with improved fetch mocking and response simulation.
- **Bug Fixes**
	- Ensured asynchronous performance metric updates return promises for better handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->