### PR TITLE
Shorten e2e timeouts

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,6 +36,9 @@ Ensure that either **ChromeDriver** or **geckodriver** is installed and
 available on your `PATH`. If Selenium cannot create a browser driver the tests
 will be skipped automatically.
 
+All Selenium page and script timeouts are limited to **5 seconds** so that
+failing environments do not hang for long.
+
 Run the end-to-end tests with:
 
 ```sh
@@ -76,3 +79,5 @@ npx playwright test
 
 Playwright is optional, so the Node dependencies are not included in the
 repository. Install them locally to run the tests.
+The Playwright server is configured to start failing after **10 seconds** so
+that end-to-end tests finish quickly when the app fails to launch.

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,7 +6,8 @@ const config = {
   webServer: {
     command: 'python main.py',
     port: 5000,
-    timeout: 120 * 1000,
+    // Short timeout to avoid hanging CI jobs
+    timeout: 10 * 1000,
     reuseExistingServer: true,
   },
   use: {

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -98,10 +98,11 @@ def test_take_screenshot_route(screenshot_server):
         f"{base_url}/login",
         data={"username": "admin", "password": "pw"},
         allow_redirects=False,
+        timeout=5,
     )
     assert resp.status_code == 302
 
-    resp = session.get(f"{base_url}/take_screenshot/cam1")
+    resp = session.get(f"{base_url}/take_screenshot/cam1", timeout=5)
     assert resp.status_code == 200
     assert resp.json()["status"] == "success"
 

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -99,6 +99,9 @@ def browser():
     driver = _create_driver()
     if driver is None:
         pytest.skip("Web driver not available")
+    # Reduce Selenium wait periods to avoid long hangs in CI
+    driver.set_page_load_timeout(5)
+    driver.set_script_timeout(5)
     yield driver
     driver.quit()
 


### PR DESCRIPTION
## Summary
- limit Selenium timeouts to 5 seconds
- add request timeouts in screenshot e2e test
- reduce the Playwright server wait
- document the shorter timeouts

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683f7bc7a88c8333898badb8610708b9