### PR TITLE
Disable e2e tests by default

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,13 +36,13 @@ Ensure that either **ChromeDriver** or **geckodriver** is installed and
 available on your `PATH`. If Selenium cannot create a browser driver the tests
 will be skipped automatically.
 
-Run the end-to-end tests with:
+End-to-end tests are skipped by default. To run them set `SKIP_E2E=0` and use:
 
 ```sh
 pytest tests/test_e2e_web.py
 ```
 
-Running the full suite with coverage (including the end-to-end tests) looks
+Running the full suite with coverage, including the end-to-end tests, looks
 like:
 
 ```sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+# Skip end-to-end tests unless explicitly enabled
+os.environ.setdefault("SKIP_E2E", "1")


### PR DESCRIPTION
## Summary
- skip e2e tests by default via `tests/conftest.py`
- document how to enable e2e tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb58925bc8333a16c7f240113f791

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to clarify how to enable or skip end-to-end tests using an environment variable.
- **Chores**
  - Introduced default behavior to skip end-to-end tests unless explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->