### PR TITLE
Fix unsafe command execution

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1871,11 +1871,12 @@ def get_chrome_version(chrome_path):
     ):
         return int(chrome_version[chrome_path][0])
 
-    command = "%s --version" % chrome_path
-
     try:
         result = subprocess.run(
-            command.split(), capture_output=True, text=True, timeout=3
+            [chrome_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         version = result.stdout.strip().split()[-1]
         version = int(version.split(".")[0])  # Return the major version

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import subprocess
 import argparse
 import random
 import time
@@ -288,12 +289,9 @@ def graceful_shutdown(signum, frame):
 
 
 def clear_console():
-    # For Windows
-    if os.name == "nt":
-        _ = os.system("cls")
-    # For macOS and Linux
-    else:
-        _ = os.system("clear")
+    """Clear the terminal in a platform agnostic way."""
+    command = ["cls"] if os.name == "nt" else ["clear"]
+    subprocess.run(command, check=False)
 
 
 def clear_console_cli():

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -68,17 +68,17 @@ class TestMainUtilities(unittest.TestCase):
         mock_cleanup.assert_called_once()
         mock_exit.assert_called_once_with(0)
 
-    @patch("main.os.system")
-    def test_clear_console_windows(self, mock_system):
+    @patch("main.subprocess.run")
+    def test_clear_console_windows(self, mock_run):
         with patch.object(main.os, "name", "nt"):
             main.clear_console()
-            mock_system.assert_called_once_with("cls")
+            mock_run.assert_called_once_with(["cls"], check=False)
 
-    @patch("main.os.system")
-    def test_clear_console_posix(self, mock_system):
+    @patch("main.subprocess.run")
+    def test_clear_console_posix(self, mock_run):
         with patch.object(main.os, "name", "posix"):
             main.clear_console()
-            mock_system.assert_called_once_with("clear")
+            mock_run.assert_called_once_with(["clear"], check=False)
 
     @patch("main.clear_console")
     def test_clear_console_cli_calls_clear(self, mock_clear):


### PR DESCRIPTION
## Summary
- sanitize Chrome version check by avoiding string split commands
- avoid `os.system` in `clear_console`
- update tests for new `clear_console` behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc3094f088333bd661ef90bd89fa5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved subprocess handling for retrieving the Chrome version and clearing the console, replacing older command execution methods with a more robust approach.
- **Tests**
  - Updated tests to mock the new subprocess behavior for console clearing on different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->