### PR TITLE
Show caption chyron

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -545,30 +545,19 @@ nav a:hover, nav a.active {
     position: relative;
 }
 
-.caption-popup {
-    position: absolute;
-    top: 24px;
-    right: 0;
-    background: rgba(0, 0, 0, 0.8);
+.caption-chyron {
+    background: rgba(0, 0, 0, 0.9);
     color: #fff;
     padding: 4px 8px;
-    border-radius: 4px;
     font-size: 14px;
     line-height: 1.2;
-    max-width: 200px;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    opacity: 0;
-    pointer-events: none;
     white-space: pre-line;
-    transition: opacity 0.5s;
-    z-index: 1000;
+    display: none;
+    text-align: center;
 }
 
-.caption-popup.show {
-    opacity: 1;
+.caption-chyron.show {
+    display: block;
 }
 
 .performance-indicator {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -63,7 +63,7 @@ export function initNav() {
     };
 
     const captionsIcon = document.getElementById("captions");
-    const captionPopup = document.getElementById("caption-popup");
+    const captionChyron = document.getElementById("caption-chyron");
     let lastCaptionTime = null;
     let popupTimer;
 
@@ -75,7 +75,7 @@ export function initNav() {
     const markIdle = () => {
       idle = true;
       if (pendingCaption) {
-        showCaptionPopup(pendingCaption);
+        showCaption(pendingCaption);
         pendingCaption = null;
       }
     };
@@ -92,13 +92,13 @@ export function initNav() {
 
     resetIdleTimer();
 
-    const showCaptionPopup = (text) => {
-      if (!captionPopup) return;
-      captionPopup.textContent = text;
-      captionPopup.classList.add("show");
+    const showCaption = (text) => {
+      if (!captionChyron) return;
+      captionChyron.textContent = text;
+      captionChyron.classList.add("show");
       clearTimeout(popupTimer);
       popupTimer = setTimeout(
-        () => captionPopup.classList.remove("show"),
+        () => captionChyron.classList.remove("show"),
         60000,
       );
     };
@@ -117,7 +117,7 @@ export function initNav() {
               () => captionsIcon.classList.remove("flash-caption"),
               5000,
             );
-            showCaptionPopup(data.caption);
+            showCaption(data.caption);
             lastCaptionTime = ts;
           }
           const ageSec = (Date.now() - ts.getTime()) / 1000;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,6 +2,7 @@
 <body>
     <a href="#main-content" class="skip-link" title="Jump to main area">Skip to main content</a>
     <header>
+        <div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
         {% include 'nav.html' %}
     </header>
 

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -41,7 +41,6 @@
           <use href="{{ url_for('static', filename='icons/sprite.svg') }}#comment" />
         </svg>
       </a>
-      <div id="caption-popup" class="caption-popup" aria-live="polite"></div>
     </div>
     <a href="/live" id="live" aria-label="Open Live page">
       <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -62,8 +62,8 @@ can monitor recent caption text without leaving the dashboard.
 
 The navigation bar shows a captions icon that reflects how recent the last
 caption update was. It flashes with the newest caption text when a group message
-arrives. A condensed popup with the latest caption appears in the top-right
-corner after the user has been idle for a few seconds. The icon remains green
+arrives. The most recent caption now appears in a chyron across the top of the
+page after the screen has been idle for a few seconds. The icon remains green
 for one minute after a caption, changes to yellow for the next five minutes and
 turns red once thirty minutes have passed without an update.
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -11,11 +11,11 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Danger Mode icon** – explains why danger mode may be disabled.
 - **Discover Cameras icon** – opens the camera discovery page.
 - **Captions icon** – reads and updates camera language models. The icon flashes
-  with the latest caption when group messages arrive. A condensed popup with the
-  text appears in the top-right corner after the screen has been idle for a few
-  seconds. It stays green for one minute after the most recent caption, turns
-  yellow for the next five minutes and becomes red when no update has been
-  received for over thirty minutes.
+  with the latest caption when group messages arrive. The full caption appears
+  in a chyron across the top after the screen has been idle for a few seconds.
+  It stays green for one minute after the most recent caption, turns yellow for
+  the next five minutes and becomes red when no update has been received for
+  over thirty minutes.
 - **Clock icon** – opens the live page with instructions for real‑time streaming.
 - **Settings gear icon** – opens the settings page.
 - **Login link** – appears when not authenticated.


### PR DESCRIPTION
## Summary
- replace caption popup with a full-width chyron at the top of the header
- adjust JS logic to populate the chyron
- update styles
- document the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc3c4e1a08333a442c58b4045d2a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a chyron banner at the top of the page to display the latest caption after user inactivity.

- **Style**
  - Updated caption display styling with improved background opacity, centered text, and revised visibility logic.

- **Documentation**
  - Updated documentation and tooltips to reflect the new caption chyron behavior and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->