### PR TITLE
Move status legend inline and debounce filtering

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -189,6 +189,19 @@ h1, h2 {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+#template-controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+#template-controls input[type="text"],
+#template-controls select {
+    padding: 5px;
+}
+
 #template-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(50px, var(--grid-item-width, 360px))); /* Use CSS variable */
@@ -208,6 +221,13 @@ h1, h2 {
         padding: 10px; /* Larger padding for a taller dropdown */
         width: 100%; /* Full width on mobile */
         margin-bottom: 10px;
+    }
+    #template-controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    #template-controls input[type="text"] {
+        width: 100%;
     }
     #template-list {
         grid-template-columns: 1fr; /* Single column layout on mobile */
@@ -393,7 +413,7 @@ video:hover + .play-icon {
 #status-legend {
     display: flex;
     gap: 10px;
-    margin: 10px 0;
+    margin-left: 10px;
 }
 
 .status-item {

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -321,6 +321,14 @@ export function generateXPath(inputId) {
   document.querySelector(`#${inputId} + .structured-xpath-input`).remove();
 }
 
+function debounce(fn, delay) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
 export function setupSearch() {
   const searchInput = document.getElementById("search-input");
   const groupDropdown = document.getElementById("group-dropdown");
@@ -364,8 +372,9 @@ export function setupSearch() {
   };
 
   if (templateList) {
-    searchInput.addEventListener("input", loadTemplates);
-    groupDropdown.addEventListener("change", loadTemplates);
+    const debouncedLoad = debounce(loadTemplates, 300);
+    searchInput.addEventListener("input", debouncedLoad);
+    groupDropdown.addEventListener("change", debouncedLoad);
   } else {
     searchInput.addEventListener("input", filterCameras);
     groupDropdown.addEventListener("change", filterCameras);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -103,11 +103,10 @@
 
         <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-</section>
-
-<section id="status-legend">
-    <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent screenshot</span>
-    <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Capture failed</span>
+    <div id="status-legend">
+        <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent screenshot</span>
+        <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Capture failed</span>
+    </div>
 </section>
 
 <section id="template-list-section">

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -1,8 +1,9 @@
 # Dashboard Border Legend
 
 The index page shows each camera tile with a colored border.
-Border thickness is now slimmer (2&nbsp;px) so the legend key no longer 
-dominates the layout.
+Border thickness is now slimmer (2&nbsp;px) so the legend key no longer
+dominates the layout. The legend now sits next to the **Play All** button on the
+dashboard rather than occupying its own row.
 
 - **Accent border** – the last screenshot was captured within the last minute.
 - **Red border** – the most recent capture attempt failed.


### PR DESCRIPTION
## Summary
- inline the dashboard legend beside the Play All button
- tweak styles for responsive filter controls
- smooth search filtering with debounce
- update border legend docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc3849548833386a07328481a86f1