### PR TITLE
Fix live view fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - N/A
 
 ### Fixed
-- N/A
+- Live video errors now fall back to the last screenshot so the live view never
+  appears blank.
 
 [Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.7...HEAD
 [0.2.7]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.7

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -216,6 +216,7 @@ video.addEventListener("error", (e) => {
     return;
   }
   showError("Error loading video: " + msg);
+  showLastScreenshot();
   setTimeout(() => {
     if (typeof updateFeed === "function") {
       updateFeed();
@@ -349,6 +350,7 @@ function updateFeed() {
     video.pause();
     video.src = "";
     image.src = "";
+    showLastScreenshot();
     updateSeekBar();
     return;
   } else if (details && details.capture_failed) {
@@ -358,6 +360,7 @@ function updateFeed() {
     video.pause();
     video.src = "";
     image.src = "";
+    showLastScreenshot();
     updateSeekBar();
     return;
   } else {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -200,6 +200,8 @@ snapshot image rather than a true video stream.
 - Use the camera's RTSP or HTTP video stream URL when available.
 - Snapshot-only URLs now fall back to an MJPEG feed so the live view
   behaves like a regular video stream.
+- If playback fails entirely, the viewer now shows the last captured
+  screenshot so the page is never blank.
 
 ### Problem: Playback continues in the background after switching types
 


### PR DESCRIPTION
## Summary
- ensure the last screenshot shows when live video errors
- document live view fallback

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_683fc4a624288333ac5580e403f517d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Live video errors now automatically display the last available screenshot, ensuring the live view is never blank when issues occur.

- **Documentation**
  - Updated troubleshooting guide and changelog to reflect the new fallback behavior for live video playback errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->