### PR TITLE
Add explanations and search to settings page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1176,6 +1176,14 @@ input[type=submit]:hover {
     margin-top: 0.5rem;
 }
 
+#settings-search {
+    margin: 10px 0;
+}
+
+#settings-search input {
+    padding: 4px;
+}
+
 .captions-table,
 .camera-table,
 .settings-table {

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -11,6 +11,7 @@ import { initIndexTime } from "./time.js";
 import { initWelcome } from "./welcome.js";
 import { initTooltips } from "./tooltips.js";
 import { initCaptions } from "./captions.js";
+import { initSettingsSearch } from "./settings.js";
 
 initTemplates();
 initVideoControls();
@@ -26,3 +27,4 @@ initIndexTime();
 initWelcome();
 initTooltips();
 initCaptions();
+initSettingsSearch();

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -1,0 +1,32 @@
+export function initSettingsSearch() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const headers = document.querySelectorAll(".settings-table th.searchable");
+    const container = document.getElementById("settings-search");
+    const input = document.getElementById("search-input");
+    if (!headers.length || !container || !input) return;
+
+    let column = 0;
+
+    const filterRows = () => {
+      const term = input.value.toLowerCase();
+      const rows = document.querySelectorAll(".settings-table tbody tr");
+      rows.forEach((row) => {
+        const cell = row.cells[column];
+        const text = cell.textContent.toLowerCase();
+        row.style.display = text.includes(term) ? "" : "none";
+      });
+    };
+
+    headers.forEach((th, idx) => {
+      th.addEventListener("click", () => {
+        column = idx;
+        input.value = "";
+        filterRows();
+        container.classList.remove("hidden");
+        input.focus();
+      });
+    });
+
+    input.addEventListener("input", filterRows);
+  });
+}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -20,12 +20,17 @@
         <button type="submit" title="Add setting">Add Setting</button>
     </form>
 
+    <div id="settings-search" class="hidden">
+        <label for="search-input" title="Filter the selected column">Search:</label>
+        <input type="text" id="search-input" title="Type to filter settings">
+    </div>
     <form method="POST" action="{{ url_for('settings') }}">
         <table class="settings-table">
             <thead>
                 <tr>
-                    <th>Setting</th>
-                    <th>Value</th>
+                    <th class="searchable">Setting</th>
+                    <th class="searchable">Value</th>
+                    <th class="searchable">Explanation</th>
                     <th>Action</th>
                 </tr>
             </thead>
@@ -36,6 +41,7 @@
                     <td>
                         <input type="text" name="{{ setting.name }}" value="{{ setting.value }}" title="Edit value for {{ setting.name }}">
                     </td>
+                    <td class="setting-explanation">{{ tooltips.get(setting.name, '') }}</td>
                     <td>
                         <button type="submit" name="action" value="delete" title="Delete {{ setting.name }}" onclick="return confirmDeleteSetting('{{ setting.name }}')">Delete</button>
                     </td>

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -10,6 +10,10 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Danger Mode** – update Chrome shortcuts with the required flags.
 - **Offline Preview** – toggle a Service Worker that caches recent images.
 - **Settings Reference** – expand the table to read explanations for each setting.
+- **Column Search** – click a header to filter rows by that column.
+
+Each row now includes an **Explanation** column so you can read a short
+description without opening the reference table.
 
 ### Dynamic Feedback
 


### PR DESCRIPTION
## Summary
- show explanation for each setting directly in the table
- allow filtering a column by clicking its header
- style the new search input
- document settings search feature

## Testing
- `black --check .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc4eaf04483338f9571949cb7f826