### PR TITLE
Add feed status tooltips

### DIFF
--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -55,7 +55,7 @@
                 N/A
                 {% endif %}
             </td>
-            <td data-label="Status" data-value="{{ feed.status }}"><span class="status-dot {{ feed.status }}" title="{{ feed.status }}"></span></td>
+            <td data-label="Status" data-value="{{ feed.status }}"><span class="status-dot {{ feed.status }}" title="{{ feed.tooltip }}"></span></td>
         </tr>
     {% endfor %}
     </tbody>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1097,6 +1097,7 @@ def get_feed_status():
         offline_since = template.get("offline_since")
 
         status = "ok"
+        tooltip_parts: list[str] = []
         if capture_failed or offline_since:
             status = "error"
         elif last_shot:
@@ -1110,6 +1111,32 @@ def get_feed_status():
         else:
             status = "error"
 
+        if capture_failed:
+            tooltip_parts.append("Capture failed")
+        if offline_since:
+            tooltip_parts.append(f"Offline since {offline_since}")
+        if status == "slow" and last_shot and frequency:
+            try:
+                shot_time = datetime.datetime.strptime(last_shot, "%Y-%m-%d %H:%M:%S")
+                diff = int((now - shot_time).total_seconds())
+                tooltip_parts.append(
+                    f"Last shot {diff // 60}m ago; expected every {frequency}s"
+                )
+            except Exception:
+                pass
+
+        last_log = None
+        if status != "ok":
+            with log_cache_lock:
+                for log in reversed(log_cache):
+                    if name in log.get("message", ""):
+                        last_log = f"{log['level']}: {log['message']}"
+                        break
+        if last_log:
+            tooltip_parts.append(f"Last log: {last_log[:120]}")
+
+        tooltip = " | ".join(tooltip_parts) if tooltip_parts else "OK"
+
         feeds.append(
             {
                 "name": name,
@@ -1118,6 +1145,7 @@ def get_feed_status():
                 "last_caption_time": _iso(last_caption),
                 "last_caption_display": _humanize(last_caption),
                 "status": status,
+                "tooltip": tooltip,
             }
         )
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -10,7 +10,7 @@ The status page shows current system metrics and includes the live log viewer. M
 
 ### Feed Dashboard
 
-Below the system metrics the page lists each configured feed with a color-coded indicator.
+Below the system metrics the page lists each configured feed with a color-coded indicator. Hovering over a red or yellow dot now shows a short tooltip describing the issue, including when the feed went offline and the most recent related log entry if available.
 
 - **Green** – the feed is updating on schedule.
 - **Yellow** – the last capture is behind its configured frequency.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -39,6 +39,7 @@ Interactive forms now include additional tooltips:
 - **Danger Mode** – the checkbox, save button and modal controls all include tooltips.
 - **Live video player** – tooltip now refreshes with the full caption as it updates.
 - **Info icon** – toggles camera metadata on the live page.
+- **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
 
 ## Dynamic Tooltips
 

--- a/tests/test_feed_status_tooltip.py
+++ b/tests/test_feed_status_tooltip.py
@@ -1,0 +1,51 @@
+import unittest
+import sys
+import os
+import datetime
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import scheduling
+
+
+class DummyLock:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class TestFeedStatusTooltip(unittest.TestCase):
+    def test_tooltip_includes_log_and_offline(self):
+        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        templates = {
+            "cam1": {
+                "last_screenshot_time": now,
+                "last_caption_time": now,
+                "frequency": 60,
+                "capture_failed": False,
+                "offline_since": now,
+            }
+        }
+        logs = [
+            {
+                "level": "ERROR",
+                "source": "cam1",
+                "timestamp": datetime.datetime.utcnow(),
+                "message": "cam1 failed",
+            }
+        ]
+        with patch("app.utils.scheduling.get_templates", return_value=templates), patch(
+            "app.utils.scheduling.log_cache",
+            logs,
+        ), patch("app.utils.scheduling.log_cache_lock", DummyLock()):
+            feeds = scheduling.get_feed_status()
+        tooltip = feeds[0]["tooltip"]
+        self.assertIn("Offline since", tooltip)
+        self.assertIn("Last log:", tooltip)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- show details for offline or slow feeds on the System Status page
- document new tooltips
- test tooltip generation

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fc5acd4cc833393fc39ec7553892c