### PR TITLE
Fix loop video error handling

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -215,6 +215,14 @@ video.addEventListener("error", (e) => {
     // Ignore errors from blank or cleared sources when switching cameras
     return;
   }
+  if (
+    (currentCamera === "All" || currentCamera.startsWith("group-")) &&
+    typeof loopHandler === "function"
+  ) {
+    // Skip to the next camera when a clip fails to load
+    loopHandler();
+    return;
+  }
   showError("Error loading video: " + msg);
   setTimeout(() => {
     if (typeof updateFeed === "function") {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -211,6 +211,17 @@ source. That could cause extra network requests and confusing behavior.
 - The player now destroys any active HLS or looping handlers before starting the
   new stream, so switching sources cleanly stops the old one.
 
+### Problem: Loop video or the "All" camera shows `Format error`
+
+This typically happens when Glimpser cannot locate a recent MP4 clip for a
+camera. The player attempts to load the file and the browser reports a *Format
+error* because the response is missing or invalid.
+
+**Solution:**
+- Ensure the `compile_to_teaser` job is running so group videos are generated.
+- When a clip fails to load, the live player now skips to the next camera
+  instead of stalling on the error message.
+
 ## 12. Layout Issues
 
 ### Problem: Buttons at the bottom of the Templates page are hidden


### PR DESCRIPTION
## Summary
- skip to next camera when loop videos fail to load
- document solution for "Format error" in loop video mode

## Testing
- `black .`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fc5c659cc8333beb8f5e32da234d4