### PR TITLE
Add Live All playback button

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -4,7 +4,9 @@ export function initVideoControls() {
     setupVideoControls();
 
     const playAllButton = document.getElementById("play-all-button");
+    const liveAllButton = document.getElementById("live-all-button");
     let playAllActive = false;
+    let liveAllActive = false;
     let playAllObserver;
 
     function handlePlayAll(entries) {
@@ -38,6 +40,27 @@ export function initVideoControls() {
           playAllButton.textContent = "Stop All";
         }
         playAllActive = !playAllActive;
+      });
+    }
+
+    if (liveAllButton) {
+      liveAllButton.addEventListener("click", () => {
+        const videos = document.querySelectorAll(".templateDiv video");
+        videos.forEach((video) => {
+          const name = video.getAttribute("data-name");
+          const source = video.querySelector("source");
+          if (liveAllActive) {
+            source.src = `/last_video/${name}`;
+            video.poster = `/last_screenshot/${name}`;
+          } else {
+            source.src = `/live_video?camera=${encodeURIComponent(name)}`;
+            video.poster = "";
+          }
+          video.load();
+          video.play().catch((e) => console.error("Error playing video:", e));
+        });
+        liveAllButton.textContent = liveAllActive ? "Live All" : "Stop Live";
+        liveAllActive = !liveAllActive;
       });
     }
 

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -8,6 +8,7 @@
     <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
     <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+    <button id="live-all-button" title="Live stream all cameras">Live All</button>
 </div>
 <div id="template-list" title="List of all templates" role="region" aria-label="Templates"></div>
 <div id="index-time" class="corner-time" title=""></div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -103,6 +103,7 @@
 
         <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+    <button id="live-all-button" title="Live stream all cameras">Live All</button>
 </section>
 
 <section id="status-legend">

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Configuration Guide](configuration_guide.md)
 - [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)
+- [Live All Playback](live_all.md)
 - [Developer Guide](developer_guide.md)
 - [Testing and Coverage](testing.md)
 - [Release Workflow](release_workflow.md)

--- a/docs/live_all.md
+++ b/docs/live_all.md
@@ -1,0 +1,3 @@
+# Live All Playback
+
+The dashboard now offers a **Live All** button next to **Play All**. When clicked every video tile switches to a real-time stream for its camera. Click again to stop the streams and revert to the latest recording.


### PR DESCRIPTION
## Summary
- add **Live All** doc
- link new doc from the docs index
- add Live All button to dashboard templates
- support Live All streaming in `video.js`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc637f4b88333b46267cb64e37cdd