### PR TITLE
Fix dashboard layout and playback controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -575,6 +575,8 @@ nav a:hover, nav a.active {
     white-space: pre-line;
     display: none;
     text-align: center;
+    margin-left: auto;
+    flex-grow: 1;
 }
 
 .caption-chyron.show {

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -28,8 +28,11 @@ export function initVideoControls() {
         if (playAllActive) {
           if (playAllObserver) playAllObserver.disconnect();
           videos.forEach((video) => {
+            const name = video.getAttribute("data-name");
             video.pause();
             video.currentTime = 0;
+            video.poster = `/last_screenshot/${name}?t=${Date.now()}`;
+            video.load();
           });
           playAllButton.textContent = "Play All";
         } else {
@@ -51,13 +54,15 @@ export function initVideoControls() {
           const source = video.querySelector("source");
           if (liveAllActive) {
             source.src = `/last_video/${name}`;
-            video.poster = `/last_screenshot/${name}`;
+            video.poster = `/last_screenshot/${name}?t=${Date.now()}`;
+            video.pause();
+            video.load();
           } else {
             source.src = `/live_video?camera=${encodeURIComponent(name)}`;
             video.poster = "";
+            video.load();
+            video.play().catch((e) => console.error("Error playing video:", e));
           }
-          video.load();
-          video.play().catch((e) => console.error("Error playing video:", e));
         });
         liveAllButton.textContent = liveAllActive ? "Live All" : "Stop Live";
         liveAllActive = !liveAllActive;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,8 +2,8 @@
 <body>
     <a href="#main-content" class="skip-link" title="Jump to main area">Skip to main content</a>
     <header>
-        <div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
         {% include 'nav.html' %}
+        <div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
     </header>
 
     <main id="main-content" tabindex="-1">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -109,10 +109,6 @@
 <section id="status-legend">
     <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent screenshot</span>
     <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Capture failed</span>
-    <div id="status-legend">
-        <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent screenshot</span>
-        <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Capture failed</span>
-    </div>
 </section>
 
 <section id="template-list-section">

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -3,7 +3,8 @@
 The index page shows each camera tile with a colored border.
 Border thickness is now slimmer (2&nbsp;px) so the legend key no longer
 dominates the layout. The legend now sits next to the **Play All** button on the
-dashboard rather than occupying its own row.
+dashboard rather than occupying its own row. A single legend element is rendered
+to avoid duplication when the page loads.
 
 - **Accent border** – the last screenshot was captured within the last minute.
 - **Red border** – the most recent capture attempt failed.

--- a/docs/live_all.md
+++ b/docs/live_all.md
@@ -1,3 +1,3 @@
 # Live All Playback
 
-The dashboard now offers a **Live All** button next to **Play All**. When clicked every video tile switches to a real-time stream for its camera. Click again to stop the streams and revert to the latest recording.
+The dashboard now offers a **Live All** button next to **Play All**. When clicked every video tile switches to a real-time stream for its camera. Click again to stop the streams and revert to the latest screenshot. Similarly, **Play All** starts playback of the most recent archived videos. Stopping returns the tiles to their latest screenshots.


### PR DESCRIPTION
## Summary
- keep chyron to the right of the Glimpser logo
- deduplicate dashboard legend
- revert to screenshots when stopping Play All or Live All
- document playback and legend changes

## Testing
- `black . --check`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fd4e4ab508333a5f04de5de5873d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved duplication in the status legend on the dashboard.
  - Improved video playback controls to ensure updated thumbnails and smoother transitions between live and recorded videos.

- **Style**
  - Adjusted caption display to better align within the header.

- **Documentation**
  - Updated guides to clarify dashboard legend rendering and playback button behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->