### PR TITLE
Improve danger mode help and shortcut feedback

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1000,8 +1000,13 @@ def init_routes(app):
         if request.method == "POST":
             action = request.form.get("action")
             if action == "update_shortcut":
-                if update_chrome_shortcuts():
-                    flash("Chrome shortcuts updated", "success")
+                paths = update_chrome_shortcuts()
+                if paths:
+                    joined = ", ".join(str(p) for p in paths)
+                    flash(
+                        f"Updated {len(paths)} shortcut{'s' if len(paths) != 1 else ''}: {joined}",
+                        "success",
+                    )
                 else:
                     flash("Failed to update shortcuts", "error")
             else:
@@ -2408,8 +2413,13 @@ def init_routes(app):
                     else:
                         flash("Invalid file type", "error")
             elif action == "update_shortcut":
-                if update_chrome_shortcuts():
-                    flash("Chrome shortcuts updated", "success")
+                paths = update_chrome_shortcuts()
+                if paths:
+                    joined = ", ".join(str(p) for p in paths)
+                    flash(
+                        f"Updated {len(paths)} shortcut{'s' if len(paths) != 1 else ''}: {joined}",
+                        "success",
+                    )
                 else:
                     flash("Failed to update shortcuts", "error")
             else:

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -2,6 +2,19 @@
 {% block content %}
 <main class="container danger-page">
   <h2>Danger Mode</h2>
+  <p class="page-tip">
+    For a full walkthrough see the <code>docs/danger_mode.md</code> guide.
+    Use the button below if Chrome was not launched with the debugging flag.
+  </p>
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="flash-messages">
+      {% for category, message in messages %}
+      <div class="alert alert-{{ category }}">{{ message }}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  {% endwith %}
 
   <section>
     <h3>What is it?</h3>

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -17,7 +17,7 @@ If Chrome is not started with this flag, Danger mode will be unavailable.
 After Chrome updates, shortcuts may revert to their original command line. Two approaches can help keep the debug port enabled:
 
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
-- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page.
+ - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
 
 After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 
@@ -37,8 +37,9 @@ Visit `/danger` to toggle the feature on or off. When disabled, captures marked 
 
 ## Danger Page Overview
 
-The `/danger` page explains what the feature does and when to use it. It notes
-that Glimpser attaches to your Chrome session via the debugging port and only
+The `/danger` page explains what the feature does and when to use it. A short
+help section near the top links back to this document. The page notes that
+Glimpser attaches to your Chrome session via the debugging port and only
 activates when you are idle. Toggling the option now shows a confirmation modal
 so the feature is not enabled or disabled accidentally.
 

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -21,11 +21,11 @@ def _update_shortcut(shortcut: Path, shell) -> bool:
     return False
 
 
-def update_chrome_shortcuts() -> bool:
-    """Update Chrome .lnk files to include the remote debugging flag."""
+def update_chrome_shortcuts() -> list[Path]:
+    """Update Chrome .lnk files and return paths that were modified."""
     if os.name != "nt" or win32com is None:
         print("Shortcut update only supported on Windows with pywin32 installed")
-        return False
+        return []
 
     shell = win32com.client.Dispatch("WScript.Shell")
     locations = [
@@ -42,14 +42,14 @@ def update_chrome_shortcuts() -> bool:
         / "Programs",
     ]
 
-    updated = False
+    updated: list[Path] = []
     for loc in locations:
         if loc.exists():
             for shortcut in loc.rglob("*.lnk"):
                 if "chrome" in shortcut.name.lower():
                     if _update_shortcut(shortcut, shell):
                         print(f"Updated {shortcut}")
-                        updated = True
+                        updated.append(shortcut)
     return updated
 
 


### PR DESCRIPTION
## Summary
- display which Chrome shortcuts were updated when patching
- show flash messages on the Danger Mode page
- link to docs and explain Danger mode in docs
- clarify Danger mode page in docs

## Testing
- `flake8 scripts/update_chrome_shortcut.py app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd94d4a3c83339abd8f95b3b3fcd4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Success messages now display the number and paths of updated Chrome shortcuts after running the update action, providing more detailed feedback.
	- The Danger page includes a new help section with a link to detailed documentation and improved guidance for users.

- **Bug Fixes**
	- Error messages are shown if no Chrome shortcuts are updated, improving clarity for failed actions.

- **Documentation**
	- Updated documentation to reflect new user feedback behavior and the addition of the help section on the Danger page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->