### PR TITLE
Improve danger mode patch feedback

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1000,10 +1000,12 @@ def init_routes(app):
         if request.method == "POST":
             action = request.form.get("action")
             if action == "update_shortcut":
-                if update_chrome_shortcuts():
-                    flash("Chrome shortcuts updated", "success")
+                results = update_chrome_shortcuts()
+                if results:
+                    for path in results:
+                        flash(f"Updated {path}", "success")
                 else:
-                    flash("Failed to update shortcuts", "error")
+                    flash("No Chrome shortcuts updated", "error")
             else:
                 enabled = "enabled" in request.form
                 update_setting("DANGER_MODE", "True" if enabled else "False")
@@ -2408,10 +2410,12 @@ def init_routes(app):
                     else:
                         flash("Invalid file type", "error")
             elif action == "update_shortcut":
-                if update_chrome_shortcuts():
-                    flash("Chrome shortcuts updated", "success")
+                results = update_chrome_shortcuts()
+                if results:
+                    for path in results:
+                        flash(f"Updated {path}", "success")
                 else:
-                    flash("Failed to update shortcuts", "error")
+                    flash("No Chrome shortcuts updated", "error")
             else:
                 for name, value in request.form.items():
                     if (

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -2,6 +2,21 @@
 {% block content %}
 <main class="container danger-page">
   <h2>Danger Mode</h2>
+  <p>
+    Need a refresher? See the
+    <a href="../docs/danger_mode.md" target="_blank" title="Open Danger mode documentation">documentation</a>
+    for setup steps and security notes.
+  </p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      <div class="flash-messages">
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <section>
     <h3>What is it?</h3>

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -42,6 +42,10 @@ that Glimpser attaches to your Chrome session via the debugging port and only
 activates when you are idle. Toggling the option now shows a confirmation modal
 so the feature is not enabled or disabled accidentally.
 
+When you use the **Patch Chrome Shortcuts** button on this page, Glimpser now
+reports each shortcut it updated so you know exactly which `.lnk` files were
+modified.
+
 Below the description, the page lists any cameras flagged as using Danger mode.
 Each item links directly to the camera's template details so you can quickly
 review or disable the setting.

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -21,11 +21,15 @@ def _update_shortcut(shortcut: Path, shell) -> bool:
     return False
 
 
-def update_chrome_shortcuts() -> bool:
-    """Update Chrome .lnk files to include the remote debugging flag."""
+def update_chrome_shortcuts() -> list[str]:
+    """Update Chrome .lnk files to include the remote debugging flag.
+
+    Returns a list of patched shortcut paths. An empty list indicates no
+    shortcuts were modified or the platform does not support updates.
+    """
     if os.name != "nt" or win32com is None:
         print("Shortcut update only supported on Windows with pywin32 installed")
-        return False
+        return []
 
     shell = win32com.client.Dispatch("WScript.Shell")
     locations = [
@@ -42,14 +46,15 @@ def update_chrome_shortcuts() -> bool:
         / "Programs",
     ]
 
-    updated = False
+    updated: list[str] = []
     for loc in locations:
         if loc.exists():
             for shortcut in loc.rglob("*.lnk"):
                 if "chrome" in shortcut.name.lower():
                     if _update_shortcut(shortcut, shell):
-                        print(f"Updated {shortcut}")
-                        updated = True
+                        path = str(shortcut)
+                        print(f"Updated {path}")
+                        updated.append(path)
     return updated
 
 


### PR DESCRIPTION
## Summary
- show flash messages for patched shortcut paths
- link to Danger Mode documentation from the page
- return a list from `update_chrome_shortcuts`
- document the new feedback in Danger Mode docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd9643fa4833392c719fad4689d9c