### PR TITLE
Add note on HTTPS requirement for login

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,12 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 5. Open your web browser and navigate to `http://127.0.0.1:8082` to complete the setup.
 
+   **Note:** Glimpser sets the `SESSION_COOKIE_SECURE` flag by default, so
+   browsers only send the login cookie over HTTPS. If you're running locally
+   without HTTPS, set `SESSION_COOKIE_SECURE=False` in your environment before
+   starting the app to allow non-HTTPS logins. See the
+   [Configuration Guide](configuration_guide.md#user-credentials) for details.
+
 ## Your First Monitoring Task
 
 1. Log in to the Glimpser web interface.


### PR DESCRIPTION
## Summary
- clarify that session cookies only work over HTTPS by default
- mention how to allow HTTP logins in docs

## Testing
- `black app tests scripts generate_credentials.py main.py wsgi.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdd689b6c8333b02e2038672536c8