### PR TITLE
Improve caption chyron placement

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -568,19 +568,31 @@ nav a:hover, nav a.active {
 
 .caption-chyron {
     background: rgba(0, 0, 0, 0.9);
-    color: #fff;
+    color: #ccc;
     padding: 4px 8px;
     font-size: 14px;
     line-height: 1.2;
-    white-space: pre-line;
+    white-space: nowrap;
+    overflow: hidden;
     display: none;
-    text-align: center;
-    margin-left: auto;
+    margin-left: 10px;
     flex-grow: 1;
+    cursor: pointer;
 }
 
 .caption-chyron.show {
     display: block;
+}
+
+.caption-chyron.show span {
+    display: inline-block;
+    padding-left: 100%;
+    animation: chyron-scroll 15s linear infinite;
+}
+
+@keyframes chyron-scroll {
+    0% { transform: translateX(100%); }
+    100% { transform: translateX(-100%); }
 }
 
 .performance-indicator {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -92,9 +92,15 @@ export function initNav() {
 
     resetIdleTimer();
 
+    if (captionChyron) {
+      captionChyron.addEventListener("click", () => {
+        window.location.href = "/captions";
+      });
+    }
+
     const showCaption = (text) => {
       if (!captionChyron) return;
-      captionChyron.textContent = text;
+      captionChyron.innerHTML = `<span>${text}</span>`;
       captionChyron.classList.add("show");
       clearTimeout(popupTimer);
       popupTimer = setTimeout(

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,7 +3,6 @@
     <a href="#main-content" class="skip-link" title="Jump to main area">Skip to main content</a>
     <header>
         {% include 'nav.html' %}
-        <div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
     </header>
 
     <main id="main-content" tabindex="-1">

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -3,6 +3,7 @@
     <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
   </a>
 </h1>
+<div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
 <nav>
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
   <div class="nav-left">

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -62,10 +62,11 @@ can monitor recent caption text without leaving the dashboard.
 
 The navigation bar shows a captions icon that reflects how recent the last
 caption update was. It flashes with the newest caption text when a group message
-arrives. The most recent caption now appears in a chyron across the top of the
-page after the screen has been idle for a few seconds. The icon remains green
-for one minute after a caption, changes to yellow for the next five minutes and
-turns red once thirty minutes have passed without an update.
+arrives. After a few seconds of inactivity the latest summary scrolls across the
+top in a gray chyron. Clicking this text opens the `/captions` page for more
+details. The icon remains green for one minute after a caption, changes to
+yellow for the next five minutes and turns red once thirty minutes have passed
+without an update.
 
 ## Danger Mode Indicator
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -11,11 +11,11 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Danger Mode icon** – explains why danger mode may be disabled.
 - **Discover Cameras icon** – opens the camera discovery page.
 - **Captions icon** – reads and updates camera language models. The icon flashes
-  with the latest caption when group messages arrive. The full caption appears
-  in a chyron across the top after the screen has been idle for a few seconds.
-  It stays green for one minute after the most recent caption, turns yellow for
-  the next five minutes and becomes red when no update has been received for
-  over thirty minutes.
+  with the latest caption when group messages arrive. After a short period of
+  inactivity the newest summary scrolls across the top in gray text. Clicking
+  the chyron opens the `/captions` page. It stays green for one minute after the
+  most recent caption, turns yellow for the next five minutes and becomes red
+  when no update has been received for over thirty minutes.
 - **Clock icon** – opens the live page with instructions for real‑time streaming.
 - **Settings gear icon** – opens the settings page.
 - **Login link** – appears when not authenticated.


### PR DESCRIPTION
## Summary
- reorder caption chyron between logo and nav buttons
- animate chyron text and make it open `/captions`
- style chyron in gray and add scrolling effect
- update docs for new behavior

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fdea63810833396a1ca8e79b626ba