### PR TITLE
Add danger mode detection tests

### DIFF
--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -17,7 +17,8 @@ If Chrome is not started with this flag, Danger mode will be unavailable.
 After Chrome updates, shortcuts may revert to their original command line. Two approaches can help keep the debug port enabled:
 
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
- - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
+- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
+- **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
 
 After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 

--- a/scripts/check_danger_mode.py
+++ b/scripts/check_danger_mode.py
@@ -1,0 +1,21 @@
+from app.utils.screenshots import is_chrome_debug_port_open
+from scripts.update_chrome_shortcut import shortcuts_need_patch
+
+
+def main() -> int:
+    ready = is_chrome_debug_port_open("127.0.0.1", 9222)
+    if ready:
+        print("Danger mode detected.")
+    else:
+        print("Danger mode not detected.")
+
+    patched = not shortcuts_need_patch()
+    if patched:
+        print("Chrome shortcuts are patched.")
+    else:
+        print("Chrome shortcuts need patching.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -53,5 +53,36 @@ def update_chrome_shortcuts() -> list[Path]:
     return updated
 
 
+def shortcuts_need_patch() -> bool:
+    """Return True if any Chrome shortcuts are missing the debug flag."""
+    if os.name != "nt" or win32com is None:
+        return False
+
+    shell = win32com.client.Dispatch("WScript.Shell")
+    locations = [
+        Path(os.environ.get("USERPROFILE", "")) / "Desktop",
+        Path(os.environ.get("APPDATA", ""))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs",
+        Path(os.environ.get("ProgramData", ""))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs",
+    ]
+
+    for loc in locations:
+        if loc.exists():
+            for shortcut in loc.rglob("*.lnk"):
+                if "chrome" in shortcut.name.lower():
+                    sc = shell.CreateShortcut(str(shortcut))
+                    args = sc.Arguments or ""
+                    if FLAG not in args:
+                        return True
+    return False
+
+
 if __name__ == "__main__":  # pragma: no cover - manual usage
     sys.exit(0 if update_chrome_shortcuts() else 1)

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -35,6 +35,38 @@ class TestDangerStatusEndpoint(unittest.TestCase):
             },
         )
 
+    @patch("app.routes.is_chrome_debug_port_open", return_value=False)
+    @patch("app.routes.check_user_activity", return_value=False)
+    def test_danger_port_closed(self, mock_idle, mock_port):
+        """Should report not ready when the debug port is closed."""
+        resp = self.client.get("/danger_status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.get_json(),
+            {
+                "port_open": False,
+                "idle": True,
+                "enabled": True,
+                "ready": False,
+            },
+        )
+
+    @patch("app.routes.is_chrome_debug_port_open", return_value=True)
+    @patch("app.routes.check_user_activity", return_value=True)
+    def test_danger_user_active(self, mock_idle, mock_port):
+        """Should report not ready when user activity is detected."""
+        resp = self.client.get("/danger_status")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.get_json(),
+            {
+                "port_open": True,
+                "idle": False,
+                "enabled": True,
+                "ready": False,
+            },
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_shortcuts_need_patch.py
+++ b/tests/test_shortcuts_need_patch.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts import update_chrome_shortcut  # noqa: E402
+
+
+class TestShortcutsNeedPatch(unittest.TestCase):
+    def _setup_env(self, tmpdir: str):
+        env = {"USERPROFILE": tmpdir, "APPDATA": tmpdir, "ProgramData": tmpdir}
+        patcher = patch.dict(os.environ, env)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        desktop = Path(tmpdir) / "Desktop"
+        desktop.mkdir()
+        return desktop
+
+    def _win32_stub(self, arg: str):
+        class Shell:
+            def CreateShortcut(self, _):
+                return SimpleNamespace(Arguments=arg)
+
+        return SimpleNamespace(client=SimpleNamespace(Dispatch=lambda *_: Shell()))
+
+    def _patch_os(self):
+        fake_os = SimpleNamespace(name="nt", environ=os.environ)
+        return patch.object(update_chrome_shortcut, "os", fake_os)
+
+    def test_needs_patch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            desktop = self._setup_env(tmpdir)
+            (desktop / "Chrome.lnk").touch()
+            stub = self._win32_stub("")
+            with self._patch_os(), patch.object(
+                update_chrome_shortcut, "win32com", stub
+            ):
+                self.assertTrue(update_chrome_shortcut.shortcuts_need_patch())
+
+    def test_no_patch_needed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            desktop = self._setup_env(tmpdir)
+            (desktop / "Chrome.lnk").touch()
+            stub = self._win32_stub(update_chrome_shortcut.FLAG)
+            with self._patch_os(), patch.object(
+                update_chrome_shortcut, "win32com", stub
+            ):
+                self.assertFalse(update_chrome_shortcut.shortcuts_need_patch())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test danger mode status for port closed and user activity
- add helper script to check danger mode status
- expose function `shortcuts_need_patch` to detect missing Chrome flags
- document check_danger_mode script

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fde36543883339f56ed9311424129