### PR TITLE
Add arrow controls for live view media type

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -972,6 +972,26 @@ function selectPreviousCamera() {
   changeCamera();
 }
 
+function selectNextSource() {
+  const selector = document.getElementById("video-source");
+  if (!selector) return;
+  const options = Array.from(selector.options);
+  const currentIndex = options.findIndex((opt) => opt.value === selector.value);
+  const nextIndex = (currentIndex + 1) % options.length;
+  selector.value = options[nextIndex].value;
+  changeVideoSource();
+}
+
+function selectPreviousSource() {
+  const selector = document.getElementById("video-source");
+  if (!selector) return;
+  const options = Array.from(selector.options);
+  const currentIndex = options.findIndex((opt) => opt.value === selector.value);
+  const prevIndex = (currentIndex - 1 + options.length) % options.length;
+  selector.value = options[prevIndex].value;
+  changeVideoSource();
+}
+
 document.addEventListener("keydown", (event) => {
   if (
     event.target.tagName === "INPUT" ||
@@ -997,6 +1017,14 @@ document.addEventListener("keydown", (event) => {
       selectPreviousCamera();
       event.preventDefault();
       break;
+    case "ArrowUp":
+      selectPreviousSource();
+      event.preventDefault();
+      break;
+    case "ArrowDown":
+      selectNextSource();
+      event.preventDefault();
+      break;
   }
 });
 
@@ -1006,6 +1034,8 @@ window.changeVideoSource = changeVideoSource;
 window.updatePlaybackSpeed = updatePlaybackSpeed;
 window.selectNextCamera = selectNextCamera;
 window.selectPreviousCamera = selectPreviousCamera;
+window.selectNextSource = selectNextSource;
+window.selectPreviousSource = selectPreviousSource;
 window.togglePlayback = togglePlayback;
 
 // --- Mobile swipe handling ---
@@ -1027,12 +1057,19 @@ function handleTouchEnd(event) {
   const diffX = touchEndX - touchStartX;
   const diffY = touchEndY - touchStartY;
 
-  // Only trigger if the gesture is mostly horizontal and long enough
+  // Horizontal swipe changes the camera
   if (Math.abs(diffX) > 50 && Math.abs(diffX) > Math.abs(diffY)) {
     if (diffX > 0) {
       selectPreviousCamera();
     } else {
       selectNextCamera();
+    }
+  } else if (Math.abs(diffY) > 50 && Math.abs(diffY) > Math.abs(diffX)) {
+    // Vertical swipe changes the media source
+    if (diffY > 0) {
+      selectNextSource();
+    } else {
+      selectPreviousSource();
     }
   }
 

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -22,9 +22,11 @@ Key topics covered include:
 On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** if you want a direct real-time feed. Glimpser remembers your last selected camera, video source, and playback speed to streamline future visits.
 
 When watching a live stream, you can use keyboard shortcuts:
-`Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen,
-Left/Right arrows change the selected camera, and `[`/`]` adjust playback speed.
-On phones and tablets, swipe left or right on the video to switch cameras quickly.
+`Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen.
+Left/Right arrows change the selected camera, Up/Down arrows cycle through the
+available media types, and `[`/`]` adjust playback speed. On phones and tablets,
+swipe left or right on the video to switch cameras or swipe up or down to change
+the media type quickly.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the
 bottom of the help page.


### PR DESCRIPTION
## Summary
- add next/previous media type handlers in live view
- allow arrow up/down keys to switch media type
- support vertical swipe on mobile for media switching
- document new shortcuts

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe010563483338d2922d9b6b63fce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability to change media source using Up/Down arrow keys and vertical swipe gestures on mobile devices.

- **Documentation**
  - Updated help page to include new keyboard shortcuts and swipe gestures for changing media sources.
  - Improved formatting of the shortcut list for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->