### PR TITLE
Fix chyron to show global summary

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -957,17 +957,27 @@ def init_routes(app):
     @app.route("/captions_status")
     @login_required
     def captions_status():
-        """Return the newest caption and its timestamp."""
+        """Return the newest global summary and its timestamp."""
         caption = ""
         timestamp = ""
+        session_db = SessionLocal()
         try:
-            templates = template_manager.get_templates_sorted_by_last_caption_time()
-            if templates:
-                _, info = templates[0]
-                caption = info.get("last_caption", "")
-                timestamp = info.get("last_caption_time", "")
+            rec = session_db.query(Summary).order_by(Summary.timestamp.desc()).first()
+            if rec:
+                try:
+                    data = json.loads(rec.content)
+                    if data:
+                        caption = next(iter(data.values()))
+                except Exception:
+                    caption = rec.content
+                timestamp = datetime.utcfromtimestamp(rec.timestamp).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
         except Exception as e:  # pragma: no cover - unexpected DB errors
             logging.error("error retrieving captions status: %s", e)
+        finally:
+            session_db.close()
+
         return jsonify({"caption": caption, "timestamp": timestamp})
 
     @app.route("/discovery_status")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -592,7 +592,7 @@ nav a:hover, nav a.active {
 .caption-chyron.show span {
     display: inline-block;
     padding-left: 100%;
-    animation: chyron-scroll 15s linear infinite;
+    animation: chyron-scroll 60s linear infinite;
 }
 
 @keyframes chyron-scroll {

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -62,8 +62,9 @@ can monitor recent caption text without leaving the dashboard.
 
 The navigation bar shows a captions icon that reflects how recent the last
 caption update was. It flashes with the newest caption text when a group message
-arrives. After a few seconds of inactivity the latest summary scrolls across the
-top in a gray chyron. Clicking this text opens the `/captions` page for more
+arrives. After a few seconds of inactivity the latest global summary slowly
+scrolls across the top in a gray chyron. Clicking this text opens the `/captions`
+page for more
 details. The icon remains green for one minute after a caption, changes to
 yellow for the next five minutes and turns red once thirty minutes have passed
 without an update.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -12,8 +12,8 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Discover Cameras icon** – opens the camera discovery page.
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of
-  inactivity the newest summary scrolls across the top in gray text. Clicking
-  the chyron opens the `/captions` page. It stays green for one minute after the
+  inactivity the newest global summary slowly scrolls across the top in gray text.
+  Clicking the chyron opens the `/captions` page. It stays green for one minute after the
   most recent caption, turns yellow for the next five minutes and becomes red
   when no update has been received for over thirty minutes.
 - **Clock icon** – opens the live page with instructions for real‑time streaming.

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,6 +9,7 @@ from flask import Flask
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.routes import init_routes
+from app.models import Summary
 from types import SimpleNamespace
 
 
@@ -574,20 +575,43 @@ class TestRoutes(unittest.TestCase):
         response = self.client.get("/group/unknown")
         self.assertEqual(response.status_code, 404)
 
-    @patch("app.routes.template_manager.get_templates_sorted_by_last_caption_time")
+    @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
-    def test_captions_status(self, mock_sorted):
-        mock_sorted.return_value = [
-            (
-                "cam1",
-                {"last_caption": "hello", "last_caption_time": "2024-01-01 00:00:00"},
-            )
-        ]
+    def test_captions_status(self, mock_session_local):
+        dummy_user = SimpleNamespace(id=1)
+
+        class DummyQuery:
+            def __init__(self, model):
+                self.model = model
+                self.order_called = False
+
+            def filter_by(self, **kwargs):
+                self.filter_kwargs = kwargs
+                return self
+
+            def order_by(self, *args, **kwargs):
+                self.order_called = True
+                return self
+
+            def first(self):
+                if self.model is Summary:
+                    return SimpleNamespace(timestamp=0, content='{"summary":"hello"}')
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery(model)
+
+            def close(self):
+                pass
+
+        mock_session_local.return_value = DummySession()
+
         response = self.client.get("/captions_status")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.get_json(),
-            {"caption": "hello", "timestamp": "2024-01-01 00:00:00"},
+            {"caption": "hello", "timestamp": "1970-01-01 00:00:00"},
         )
 
 


### PR DESCRIPTION
## Summary
- make `/captions_status` return the newest summary
- slow down chyron scroll animation
- update docs about slower global summary chyron
- adjust test for new summary behaviour

## Testing
- `flake8 app/routes.py tests/test_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe0df910883339e29d6f17cea8900