### PR TITLE
Improve caption history usability

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1281,6 +1281,20 @@ details > summary {
     width: 12rem;
 }
 
+.caption-filters {
+    margin-bottom: 1rem;
+}
+
+.caption-filters input[type="search"],
+.caption-filters input[type="date"] {
+    margin-right: 0.5rem;
+    padding: 4px;
+}
+
+.caption-filters button {
+    padding: 4px 8px;
+}
+
 /* Utility classes for modals and embedded media */
 .live-embed {
     margin-bottom: 20px;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -173,6 +173,7 @@ export function initTemplates() {
     }
     setupSearch();
     setupSorting();
+    setupCaptionsFilter();
     updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
   });
@@ -207,7 +208,11 @@ export async function loadGroups() {
 
 export function timeAgo(utcDateString) {
   const now = new Date();
-  const utcDate = new Date(utcDateString);
+  const iso = utcDateString.includes("T")
+    ? utcDateString
+    : `${utcDateString.replace(" ", "T")}Z`;
+  const utcDate = new Date(iso);
+  if (Number.isNaN(utcDate.getTime())) return "just now";
   const diffInSeconds = Math.floor((now - utcDate) / 1000);
   if (diffInSeconds < 0) return "in the future";
 
@@ -399,7 +404,7 @@ export async function loadTemplates() {
   updateGridLayout();
 
   const templateList = document.getElementById("template-list");
-  const captionsTable = document.querySelector("details table");
+  const captionsTable = document.getElementById("captions-table");
   const templateContainer = document.querySelector(".template-container");
 
   const isIndexPage = Boolean(templateList);
@@ -599,4 +604,49 @@ export function setupSorting() {
   setupTableSorting("camera-table");
   setupTableSorting("feed-status");
   setupTableSorting("captions-table");
+}
+
+export function setupCaptionsFilter() {
+  const searchInput = document.getElementById("captions-search");
+  const startInput = document.getElementById("caption-start");
+  const endInput = document.getElementById("caption-end");
+  const clearBtn = document.getElementById("caption-clear");
+  const rows = document.querySelectorAll("#captions-table tbody tr");
+
+  if (!searchInput || rows.length === 0) return;
+
+  const parseDate = (str) => {
+    if (!str) return null;
+    const iso = str.includes("T") ? str : str.replace(" ", "T") + "Z";
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime()) ? null : d;
+  };
+
+  const filter = () => {
+    const term = searchInput.value.toLowerCase();
+    const start = startInput && startInput.value ? new Date(startInput.value) : null;
+    const end = endInput && endInput.value ? new Date(endInput.value) : null;
+
+    rows.forEach((row) => {
+      const timeElem = row.querySelector("td:first-child span");
+      const rowDate = timeElem ? parseDate(timeElem.dataset.time) : null;
+      const text = row.textContent.toLowerCase();
+      let show = true;
+      if (term && !text.includes(term)) show = false;
+      if (start && rowDate && rowDate < start) show = false;
+      if (end && rowDate && rowDate > new Date(end.getTime() + 86400000 - 1)) show = false;
+      row.style.display = show ? "" : "none";
+    });
+  };
+
+  searchInput.addEventListener("input", filter);
+  if (startInput) startInput.addEventListener("change", filter);
+  if (endInput) endInput.addEventListener("change", filter);
+  if (clearBtn)
+    clearBtn.addEventListener("click", () => {
+      searchInput.value = "";
+      if (startInput) startInput.value = "";
+      if (endInput) endInput.value = "";
+      filter();
+    });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -118,8 +118,16 @@
 </div>
 
 <div id="history-tab" class="tab-content">
-    <details><summary>Captions</summary>
-        <table id="captions-table" class="captions-table">
+    <h2>Captions</h2>
+    <div class="caption-filters">
+        <input type="search" id="captions-search" placeholder="Search captions or time" title="Filter captions">
+        <label for="caption-start">From:</label>
+        <input type="date" id="caption-start" title="Start date">
+        <label for="caption-end">To:</label>
+        <input type="date" id="caption-end" title="End date">
+        <button id="caption-clear" type="button" title="Clear filters">Clear</button>
+    </div>
+    <table id="captions-table" class="captions-table">
             <thead>
             <tr>
                 <th class="sortable" data-type="date">Timestamp</th>
@@ -145,7 +153,6 @@
             {% endif %}
             </tbody>
         </table>
-    </details>
 </div>
 
 <div id="bulk-tab" class="tab-content">

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -55,7 +55,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. Use the group filter and search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
+10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the group filter and search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,4 +49,6 @@ The main dashboard now displays the current time in the lower right corner. Hove
 Thumbnails also now show the last capture time in a human readable
 "X ago" format, matching the tables on the Captions page.
 The Live View page displays the time of the latest frame in the
-lower-right corner using the same format.
+lower-right corner using the same format. Timestamp parsing was improved so
+times display correctly across time zones instead of always showing
+"just now".


### PR DESCRIPTION
## Summary
- keep caption history expanded with new search and date filters
- style new caption filters
- fix timestamp parsing so times show correct relative values
- document updated history tab and timestamp behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe1bc95808333a57facb87e1d761b