### PR TITLE
fix: guard against null timestamps in timeAgo

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -207,10 +207,13 @@ export async function loadGroups() {
 }
 
 export function timeAgo(utcDateString) {
+  if (!utcDateString) return "just now";
   const now = new Date();
-  const iso = utcDateString.includes("T")
-    ? utcDateString
-    : `${utcDateString.replace(" ", "T")}Z`;
+  const iso = utcDateString instanceof Date
+    ? utcDateString.toISOString()
+    : utcDateString.includes("T")
+      ? utcDateString
+      : `${utcDateString.replace(" ", "T")}Z`;
   const utcDate = new Date(iso);
   if (Number.isNaN(utcDate.getTime())) return "just now";
   const diffInSeconds = Math.floor((now - utcDate) / 1000);

--- a/tests/js/script.test.js
+++ b/tests/js/script.test.js
@@ -87,4 +87,9 @@ describe('script.js', () => {
     expect(timeAgo(oneHourAgo)).toBe('1 hour ago');
     expect(timeAgo(oneDayAgo)).toBe('1 day ago');
   });
+
+  test('timeAgo handles null and undefined', () => {
+    expect(timeAgo(null)).toBe('just now');
+    expect(timeAgo(undefined)).toBe('just now');
+  });
 });


### PR DESCRIPTION
## Summary
- handle null or Date inputs in `timeAgo`
- test that `timeAgo` tolerates null or undefined values

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe4627a6883339266488bcd74708d