### PR TITLE
Clarify dark mode guidance

### DIFF
--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -1,6 +1,19 @@
 # Dark Mode Support
 
-Glimpser's interface now adapts to your system's preferred color scheme.
-The CSS defines variables for background and text colors with light and dark
-variants. Forms and tables use these variables so elements remain readable in
-both themes.
+Glimpser's interface now adapts to your system's preferred color scheme and
+defaults to dark mode. The CSS defines variables for background and text colors
+with light and dark variants. Forms and tables use these variables so elements
+remain readable in both themes.
+
+Dark mode is the recommended scheme. You can customize the look by overriding
+the provided CSS variables:
+
+```css
+:root {
+    --bg-color: #1a1a1a;
+    --text-color: #eaeaea;
+}
+```
+
+Ensure that contrast ratios stay above accessibility guidelines when adjusting
+colors.

--- a/docs/design_guidelines.md
+++ b/docs/design_guidelines.md
@@ -2,7 +2,7 @@
 
 These guidelines help maintain a consistent look and feel across Glimpser's interface.
 
-- Use a cohesive color scheme. Pick a default light or dark theme—or provide a toggle—but keep buttons and alerts styled consistently.
+- Use a cohesive color scheme. Dark mode is the default and recommended theme. Provide a toggle for light mode if desired, but keep buttons and alerts styled consistently.
 - Apply uniform spacing and padding around form fields, buttons, and table rows.
 - Establish a clear typography scale so headings and labels stand out.
 - Group related controls with consistent margins to improve readability.


### PR DESCRIPTION
## Summary
- expand `docs/dark_mode.md` with customization examples
- note in `docs/design_guidelines.md` that dark mode is the recommended theme

## Testing
- `black . --quiet`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683fe53a855883338a1b13d7972f271b