### PR TITLE
Fix group handling in live view JS

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -849,11 +849,10 @@ function updateSpeedContainer() {
   let cameraCount = 0;
   if (isGroupView) {
     if (currentCamera === "All") {
-      cameraCount = Object.keys(templateDetails).filter(
-        (k) => k !== "All",
-      ).length;
+      cameraCount = Object.keys(templateDetails).filter((k) => k !== "All").length;
     } else {
-      cameraCount = (templateDetails[currentCamera].groupCameras || []).length;
+      const details = templateDetails[currentCamera];
+      cameraCount = details && details.groupCameras ? details.groupCameras.length : 0;
     }
   }
   const show = isGroupView && cameraCount > 1 && source !== "mjpg";

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -275,8 +275,11 @@
                 if (cameraName.startsWith('group-') || cameraName === 'All') {
                     const groupCams = cameraName === 'All'
                         ? Object.keys(templateDetails).filter(key => key !== 'All')
-                        : templateDetails[cameraName].groupCameras;
-                    return '/live_video?camera=' + encodeURIComponent(groupCams[0]);
+                        : (templateDetails[cameraName]?.groupCameras || []);
+                    if (groupCams.length > 0) {
+                        return '/live_video?camera=' + encodeURIComponent(groupCams[0]);
+                    }
+                    return null;
                 }
                 return '/live_video?camera=' + encodeURIComponent(cameraName);
             }
@@ -439,7 +442,7 @@ function changeCamera() {
                 video.src = '';
                 image.src = '';
                 return;
-            } else if (templateDetails[currentCamera].capture_failed) {
+            } else if (templateDetails[currentCamera] && templateDetails[currentCamera].capture_failed) {
                 hideOfflineIndicator();
                 showCaptureErrorIndicator(currentCamera);
                 hideLoadingIndicator();


### PR DESCRIPTION
## Summary
- handle missing group details when updating playback speed
- avoid errors for groups not yet in `templateDetails`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe680c4748333b222376848e8321b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent issues when camera group details are missing or incomplete.
  - Enhanced stability by adding checks to avoid runtime errors when accessing camera information.

- **Refactor**
  - Streamlined logic for counting cameras and generating video URLs for groups, improving code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->