### PR TITLE
Fix speed container error

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -855,7 +855,8 @@ function updateSpeedContainer() {
         (k) => k !== "All",
       ).length;
     } else {
-      cameraCount = (templateDetails[currentCamera].groupCameras || []).length;
+      const details = templateDetails[currentCamera];
+      cameraCount = details && details.groupCameras ? details.groupCameras.length : 0;
     }
   }
   const show = isGroupView && cameraCount > 1 && source !== "mjpg";


### PR DESCRIPTION
## Summary
- guard against missing group details when showing speed control

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe7d715f08333ace67228d3852f9d