### PR TITLE
Fix prettier formatting for JS

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -851,10 +851,13 @@ function updateSpeedContainer() {
   let cameraCount = 0;
   if (isGroupView) {
     if (currentCamera === "All") {
-      cameraCount = Object.keys(templateDetails).filter((k) => k !== "All").length;
+      cameraCount = Object.keys(templateDetails).filter(
+        (k) => k !== "All",
+      ).length;
     } else {
       const details = templateDetails[currentCamera];
-      cameraCount = details && details.groupCameras ? details.groupCameras.length : 0;
+      cameraCount =
+        details && details.groupCameras ? details.groupCameras.length : 0;
     }
   }
   const show = isGroupView && cameraCount > 1 && source !== "mjpg";

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -209,11 +209,12 @@ export async function loadGroups() {
 export function timeAgo(utcDateString) {
   if (!utcDateString) return "just now";
   const now = new Date();
-  const iso = utcDateString instanceof Date
-    ? utcDateString.toISOString()
-    : utcDateString.includes("T")
-      ? utcDateString
-      : `${utcDateString.replace(" ", "T")}Z`;
+  const iso =
+    utcDateString instanceof Date
+      ? utcDateString.toISOString()
+      : utcDateString.includes("T")
+        ? utcDateString
+        : `${utcDateString.replace(" ", "T")}Z`;
   const utcDate = new Date(iso);
   if (Number.isNaN(utcDate.getTime())) return "just now";
   const diffInSeconds = Math.floor((now - utcDate) / 1000);


### PR DESCRIPTION
## Summary
- run Prettier in write mode on `app/static/js`
- fix code style issues in `live.js` and `templates.js`

## Testing
- `npm run format:js`
- `black .`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68402d1f78308333a16bfa5e125ad3f8