### PR TITLE
Improve build script speed

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -22,9 +22,9 @@ fi
 # Build Debian package
 echo "Building Debian package..."
 mkdir -p debian/glimpser/opt/glimpser || { echo "Failed to create directory"; exit 1; }
-cp -R app debian/glimpser/opt/glimpser/ || { echo "Failed to copy app directory"; exit 1; }
+rsync -a app/ debian/glimpser/opt/glimpser/app/ || { echo "Failed to sync app directory"; exit 1; }
 cp requirements.txt debian/glimpser/opt/glimpser/ || { echo "Failed to copy requirements.txt"; exit 1; }
-cp -R data debian/glimpser/opt/glimpser/ || { echo "Failed to copy data directory"; exit 1; }
+rsync -a data/ debian/glimpser/opt/glimpser/data/ || { echo "Failed to sync data directory"; exit 1; }
 mkdir -p debian/glimpser/etc/systemd/system || { echo "Failed to create systemd directory"; exit 1; }
 cat > debian/glimpser/etc/systemd/system/glimpser.service << EOL || { echo "Failed to create service file"; exit 1; }
 [Unit]

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -3,7 +3,9 @@
 Glimpser packages are generated automatically when a version tag is pushed to the repository.
 The process is split across two runners:
 
-- **Ubuntu** builds the Debian package and runs the test suite.
+- **Ubuntu** builds the Debian package and runs the test suite. The packaging
+  script now uses `rsync` to copy directories so unchanged files are skipped,
+  speeding up repeated builds.
 - **Windows** builds the standalone executable using `build_windows.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists


### PR DESCRIPTION
## Summary
- speed up Debian packaging by copying files with `rsync`
- document rsync usage in release workflow

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402eb06cdc8333896462ccdb67340c