### PR TITLE
Fix username handling during credential updates

### DIFF
--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -81,19 +81,18 @@ def generate_credentials(args):
 
     create_users(conn)
 
+    # Determine username early so it is always defined
+    username = app.config.get_setting("USER_NAME", "admin")
+
     # Handle each setting individually
-    if args is None or args.username:
-        username = app.config.get_setting("USER_NAME", "admin")
-        if args:
-            username = args.username
-        else:
-            if sys.stdin.isatty():
-                username = input(
-                    f"Enter the username for login [{app.config.get_setting('USER_NAME', 'admin')}]: "
-                ) or app.config.get_setting("USER_NAME", "admin")
-            else:
-                username = app.config.get_setting("USER_NAME", "admin")
+    if args is None:
+        if sys.stdin.isatty():
+            username = input(f"Enter the username for login [{username}]: ") or username
         upsert_setting("USER_NAME", username.strip(), conn)
+    elif args.username is not None:
+        if args.username:
+            username = args.username
+            upsert_setting("USER_NAME", username.strip(), conn)
 
     if args is None or args.password or args.update_password:
         password = ""  # maybe populate with garbage

--- a/tests/test_generate_credentials.py
+++ b/tests/test_generate_credentials.py
@@ -153,6 +153,50 @@ class TestGenerateCredentials(unittest.TestCase):
         cur.execute("SELECT username, password_hash FROM users WHERE username='bob'")
         self.assertEqual(cur.fetchone(), ("bob", "h"))
 
+    @patch("generate_credentials.generate_password_hash", return_value="pw")
+    @patch(
+        "generate_credentials.app.config.get_setting", side_effect=lambda n, d=None: d
+    )
+    def test_update_password_only(self, mock_get, mock_hash):
+        """Updating only the password should still modify the users table."""
+        generate_credentials.create_settings(self.conn)
+        args = argparse.Namespace(
+            db_path=config.DATABASE_PATH,
+            username=None,
+            password="secret",
+            update_password=True,
+            secret_key=None,
+            update_key=False,
+        )
+        generate_credentials.generate_credentials(args)
+        self.conn.close()
+        self.conn = sqlite3.connect(config.DATABASE_PATH)
+        cur = self.conn.cursor()
+        cur.execute("SELECT username, password_hash FROM users WHERE username='admin'")
+        self.assertEqual(cur.fetchone(), ("admin", "pw"))
+
+    @patch("generate_credentials.generate_password_hash", return_value="h")
+    @patch(
+        "generate_credentials.app.config.get_setting", side_effect=lambda n, d=None: d
+    )
+    def test_update_key_only(self, mock_get, mock_hash):
+        """Updating only the secret key should still update the users table."""
+        generate_credentials.create_settings(self.conn)
+        args = argparse.Namespace(
+            db_path=config.DATABASE_PATH,
+            username=None,
+            password=None,
+            update_password=False,
+            secret_key="new",
+            update_key=True,
+        )
+        generate_credentials.generate_credentials(args)
+        self.conn.close()
+        self.conn = sqlite3.connect(config.DATABASE_PATH)
+        cur = self.conn.cursor()
+        cur.execute("SELECT username FROM users")
+        self.assertEqual(cur.fetchone()[0], "admin")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- default username before user-setting logic in `generate_credentials`
- handle password-only and key-only updates in the user table
- test updating credentials without passing a username

## Testing
- `flake8`
- `pytest -q tests/test_generate_credentials.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406cacbed88333a17eabbc4c616a6c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved and simplified the logic for determining and setting the username during credential generation, reducing redundant steps and streamlining user prompts.

- **Tests**
  - Added tests to verify correct behavior when updating only the password or only the secret key during credential generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->