### PR TITLE
Improve startup log messages

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -81,6 +81,7 @@ This guide addresses common issues that users might encounter while using Glimps
 **Solution:**
 - Check if the Glimpser server is running
 - Verify you're using the correct port (default is 8082)
+- Ensure the `HOST` setting is `0.0.0.0` so the server is reachable from other devices
 - Clear your browser cache and cookies
 - Confirm that WebSocket connections are allowed on your network
 

--- a/main.py
+++ b/main.py
@@ -331,7 +331,11 @@ def main(argv=None):
         sys.exit(1)
 
     try:
-        logging.info("Starting web...")
+        logging.info(
+            "Starting web interface at http://%s:%s",
+            config.HOST,
+            config.PORT,
+        )
         app.run(
             host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
         )


### PR DESCRIPTION
## Summary
- log the full URL when the server starts
- mention the HOST setting in the troubleshooting guide

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840dabd1540833389863abcaf6b658a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the troubleshooting guide with an additional step to check the HOST setting for server accessibility from other devices.

- **Style**
  - Improved the startup log message to display the web interface URL, including host and port information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->