### PR TITLE
Fix scheduling functions to run async

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -837,8 +837,8 @@ def update_summary():
 
 
 def schedule_summarization():
+    """Run ``update_summary`` hourly without blocking the caller."""
 
-    # loop through the templates and
     try:
         scheduler.add_job(
             func=update_summary,
@@ -846,9 +846,16 @@ def schedule_summarization():
             id="summary",
             replace_existing=True,
         )
+        # queue an immediate one-off run so startup waits for nothing
+        scheduler.add_job(
+            func=update_summary,
+            trigger="date",
+            id="summary_init",
+            replace_existing=True,
+            run_date=datetime.datetime.now(),
+        )
     except Exception as e:
         logging.error("job schedule error: %s", e)
-    update_summary()
 
 
 def schedule_crawlers():
@@ -1241,9 +1248,16 @@ def schedule_discovery() -> None:
             id="background_discovery",
             replace_existing=True,
         )
+        # kick off an immediate scan in the background
+        scheduler.add_job(
+            func=run_discovery,
+            trigger="date",
+            id="background_discovery_now",
+            replace_existing=True,
+            run_date=datetime.datetime.now(),
+        )
     except Exception as e:
         logging.error("job schedule error: %s", e)
-    run_discovery()
 
 
 def stop_discovery() -> None:

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -29,7 +29,8 @@ This guide provides a high-level look at Glimpser's core components and how they
 
 ## Scheduler Jobs (`app/utils/scheduling.py`)
 - Uses APScheduler to run periodic tasks.
-- Jobs include crawler scheduling, video archiving and summarization.
+- Jobs include crawler scheduling, video archiving, discovery and summarization.
+- Tasks run asynchronously so functions like `schedule_discovery` and `schedule_summarization` never block the caller.
 - Exposes a `GracefulAPScheduler` instance used by the Flask app.
 - Stale crawler jobs are removed when templates are updated.
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -4,6 +4,7 @@ Glimpser includes a simple discovery feature to help find network cameras on you
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
 The page layout now uses card sections and wider progress indicators for a more professional feel while keeping controls grouped logically.
 Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from `/discover`. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run.
+The scheduling call now triggers discovery in a background thread so the UI never hangs when you enable it.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
 discovered camera. The previous hop is stored in the ``upstream`` field so you
 can see which router or switch connects the device. Each progress message now


### PR DESCRIPTION
## Summary
- run summary job in background and launch once on startup
- ensure discovery job schedules async initial run
- document scheduler async behavior in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e9d4ac4c8333b9297337993b74cc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tasks such as summarization and discovery now run immediately upon scheduling, in addition to their regular periodic execution. This ensures faster initial results without blocking the user interface.

- **Documentation**
  - Updated scheduler and camera discovery documentation to clarify that tasks now execute asynchronously in the background, improving responsiveness and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->