### PR TITLE
Fix slider scaling of tiles

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -70,7 +70,7 @@ html {
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 .camera-list .thumbnail-video video.hover-video {
@@ -293,13 +293,13 @@ select:hover {
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover; /* This will cover the area of the .templateDiv, potentially clipping the video */
+    object-fit: contain; /* Scale video without cropping */
 }
 
-/* If you need to maintain the aspect ratio without clipping, use object-fit: contain; */
+/* Maintain aspect ratio without cropping */
 .templateDiv video {
-    object-fit: cover;
-    /*object-position: center; */ /* Aligns the video to the top, so the empty space, if any, will be at the bottom */
+    object-fit: contain;
+    /*object-position: center;*/
 }
 
 .play-icon {
@@ -896,7 +896,7 @@ button, a {
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
 }
 
 .camera-name, .timestamp, .next-capture {
@@ -1170,7 +1170,7 @@ input[type=submit]:hover {
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
     filter: grayscale(40%);
     transition: filter 0.3s;
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The slider automatically adjusts to the current browser width and now scales thumbnails vertically as well as horizontally. Sizes are capped around 1080&nbsp;px high so oversized images don't bog down the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The slider automatically adjusts to the current browser width and now scales thumbnails vertically as well as horizontally. Images are resized using `object-fit: contain` so nothing gets clipped. Sizes are capped around 1080&nbsp;px high so oversized previews don't bog down the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 
 ### Why is the live feed slightly cropped on small screens?

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -2,7 +2,7 @@
 
 Glimpser now adapts to phones and tablets. The navigation menu collapses into a hamburger button on narrow screens and tables reflow vertically to avoid horizontal scrolling. Video grids automatically switch to a single column when viewed on devices without hover capability or small viewports.
 
-The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists.
+The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews shrink or grow using `object-fit: contain` so the entire image stays visible at any size.
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 


### PR DESCRIPTION
## Summary
- avoid cropping when grid width slider resizes tiles
- mention new scaling behavior in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840eac1dc1083339ad06ffae3f59fcc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated video and image display to use aspect ratio-preserving scaling, ensuring full content is visible without cropping.

- **Documentation**
  - Clarified FAQ and responsive design documentation to explain the new image and video scaling behavior using aspect ratio-preserving methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->