### PR TITLE
Improve live view error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed unclosed `.form-error` block in `style.css` causing CSS lint failures
 - Timestamp and caption overlays now align correctly with their tinted
   backgrounds
+- Repeated stream errors on the `/live` page are now throttled to prevent
+  frequent popups.
 
 ## [0.2.7] - 2025-06-02
 

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -47,6 +47,10 @@ const streamErrorIndicator = document.getElementById("stream-error-indicator");
 const streamErrorMessage = document.getElementById("stream-error-message");
 const seekBar = document.getElementById("seek-bar");
 let isSeeking = false;
+// Throttle duplicate error messages so the overlay isn't spammed when
+// a camera repeatedly fails. Track the last message and time displayed.
+let lastErrorMessage = "";
+let lastErrorTime = 0;
 
 // Restore previously selected camera, source and speed from localStorage so
 // reloading the page keeps user preferences. If the user specified a camera in
@@ -126,6 +130,13 @@ function showPlayPauseIndicator(isPaused) {
 }
 
 function showError(message) {
+  const now = Date.now();
+  if (message === lastErrorMessage && now - lastErrorTime < 10000) {
+    return;
+  }
+  lastErrorMessage = message;
+  lastErrorTime = now;
+
   errorMessage.textContent = message;
   errorMessage.style.display = "block";
   showStreamErrorIndicator(message);


### PR DESCRIPTION
## Summary
- throttle repeated error overlays on the live view
- document error popup throttling in the changelog

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840eb1223848333b6404c6efefa517f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stream errors on the live page are now throttled, reducing repeated error popups within a short period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->