### PR TITLE
Fix live view aspect ratio

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -14,6 +14,8 @@
     top: 0;
     left: 0;
     width: 100%;
+    height: 100%;
+    object-fit: contain;
     max-width: 100vw;
     max-height: 92vh;
 }


### PR DESCRIPTION
## Summary
- preserve element aspect ratio for live views

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ed9fdd5c8333bdf8d6a790ed96a1