### PR TITLE
Enhance discovery status feedback

### DIFF
--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -38,16 +38,20 @@ export function initDiscoveryToggle() {
       });
     }
 
-    fetchJson("/discovery_status")
-      .then((data) => {
-        statusSpan.textContent = formatStatus(data);
-        if (stopBtn) {
-          stopBtn.style.display =
-            data.status === "running" ? "inline-block" : "none";
-        }
-      })
-      .catch(() => {
-        statusSpan.textContent = "error";
-      });
+    const refreshStatus = () =>
+      fetchJson("/discovery_status")
+        .then((data) => {
+          statusSpan.textContent = formatStatus(data);
+          if (stopBtn) {
+            stopBtn.style.display =
+              data.status === "running" ? "inline-block" : "none";
+          }
+        })
+        .catch(() => {
+          statusSpan.textContent = "error";
+        });
+
+    refreshStatus();
+    setInterval(refreshStatus, 30000);
   });
 }

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -5,6 +5,8 @@ The subnet list is now deduplicated so machines with multiple addresses per inte
 The page layout now uses card sections and wider progress indicators for a more professional feel while keeping controls grouped logically.
 Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from `/discover`. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run.
 The scheduling call now triggers discovery in a background thread so the UI never hangs when you enable it.
+The page now polls `/discovery_status` every 30 seconds so the background state
+is always visible, including the remaining time until the next run.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
 discovered camera. The previous hop is stored in the ``upstream`` field so you
 can see which router or switch connects the device. Each progress message now


### PR DESCRIPTION
## Summary
- poll `/discovery_status` every 30s so the discovery page always shows the latest state
- document the new polling feature in the discovery guide

## Testing
- `black app --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f2618cdc8333a5f71f7f4fc518dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The discovery status on the camera discovery page now updates automatically every 30 seconds, ensuring real-time visibility of the discovery state and stop button without requiring manual refresh.

- **Documentation**
  - Updated documentation to reflect the new automatic polling behavior for the discovery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->