### PR TITLE
Improve status page layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1372,6 +1372,13 @@ details > summary {
     margin-bottom: 0.5rem;
 }
 
+.scheduler-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
 /* Status dashboard */
 .feed-status {
     width: 100%;

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,6 +1,7 @@
 
 
 {% extends 'base.html' %}
+{% from 'components.html' import card %}
 {% block content %}
 
 <div class="scheduler-controls">
@@ -12,8 +13,7 @@
 
 <h1>System Status</h1>
 
-<!-- Display system metrics -->
-<h2>System Metrics</h2>
+{% call card('System Metrics') %}
 <ul>
     <li title="Current CPU utilization">CPU Usage: {{ metrics.cpu_usage }}%</li>
     <li title="Current memory utilization">Memory Usage: {{ metrics.memory_usage }}%</li>
@@ -22,8 +22,9 @@
     <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
     <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
 </ul>
+{% endcall %}
 
-<h2>Feed Status</h2>
+{% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">
     <thead>
         <tr>
@@ -62,7 +63,7 @@
 </table>
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
-
+{% endcall %}
 
 {% include 'logs.html' %}
 {% endblock %}

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint.
+The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout.
 
 ### Feed Dashboard
 


### PR DESCRIPTION
## Summary
- wrap metrics and feed table in reusable `card` component
- style scheduler controls for better spacing
- document status page cards

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f8c78ff48333a623eccbf8e0a968

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Introduced a new layout style for scheduler controls using a flexbox-based CSS class.
  - Updated the status page to display "System Metrics" and "Feed Status" within consistent card layouts for improved visual organization.

- **Documentation**
  - Clarified that the status page now groups metrics and feed dashboard into separate cards for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->