### PR TITLE
Add tests for llm cache

### DIFF
--- a/tests/test_llm_cache_module.py
+++ b/tests/test_llm_cache_module.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import llm_cache
+
+
+class TestLLMCacheModule(unittest.TestCase):
+    def test_key_uniqueness(self):
+        first = llm_cache._key("p", ["a.png", "b.png"])
+        second = llm_cache._key("p", ["b.png", "a.png"])
+        self.assertEqual(first, llm_cache._key("p", ["a.png", "b.png"]))
+        self.assertNotEqual(first, second)
+
+    def test_persist_and_load(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = os.path.join(tmpdir, "cache.json")
+            with patch.dict(os.environ, {"PYTEST_CURRENT_TEST": ""}):
+                with patch("app.utils.llm_cache.CACHE_PATH", cache_path):
+                    llm_cache._cache.clear()
+                    llm_cache.store("p", "r", 1, ["x.png"])
+                    self.assertTrue(os.path.exists(cache_path))
+                    llm_cache._cache.clear()
+                    llm_cache._load_cache()
+                    entry = llm_cache.get("p", ["x.png"])
+                    self.assertEqual(entry["response"], "r")
+                    self.assertEqual(entry["tokens"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover unique key generation and cache persistence

## Testing
- `flake8`
- `black --check --exclude node_modules .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840f7a138488333895114d3d2a3054a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive tests for cache key uniqueness and cache persistence to ensure correct caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->