### PR TITLE
Add ensure_column tests

### DIFF
--- a/tests/test_db_ensure_column.py
+++ b/tests/test_db_ensure_column.py
@@ -1,0 +1,38 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+from unittest.mock import patch
+from sqlalchemy import create_engine, text
+
+from app.utils.db import ensure_column
+
+
+class TestEnsureColumn(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine(
+            "sqlite:///:memory:", connect_args={"check_same_thread": False}
+        )
+        with self.engine.begin() as conn:
+            conn.execute(text("CREATE TABLE test_table (id INTEGER PRIMARY KEY)"))
+
+    def get_columns(self):
+        with self.engine.connect() as conn:
+            return [
+                row[1] for row in conn.execute(text("PRAGMA table_info(test_table)"))
+            ]
+
+    def test_adds_missing_column(self):
+        with patch("app.utils.db.engine", self.engine):
+            ensure_column("test_table", "name", "TEXT", "''")
+        self.assertIn("name", self.get_columns())
+
+    def test_existing_column_unchanged(self):
+        with patch("app.utils.db.engine", self.engine):
+            before = self.get_columns()
+            ensure_column("test_table", "id", "INTEGER", "0")
+        self.assertEqual(before, self.get_columns())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for `ensure_column` utility in `app.utils.db`

## Testing
- `flake8`
- `pytest tests/test_db_ensure_column.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684174488030833387ff64602e3964f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify that missing columns can be added to database tables and that existing columns remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->