### PR TITLE
Fix tag workflow

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -8,8 +8,9 @@ jobs:
   tag_release:
     permissions:
       contents: write
-      # Allow the push to trigger other workflows (e.g. package release)
-      workflow: write
+      # "workflow" is not a valid permission key.
+      # A writeable contents token is sufficient for creating tags,
+      # which can then trigger other workflows.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove invalid `workflow` permission from tag workflow

## Testing
- `black . --check --exclude node_modules`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684178577b188333ace6868bf7f24c04