### PR TITLE
Improve shutdown handling for background threads

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,6 +17,9 @@ from app.utils.scheduling import (
     schedule_discovery,
     scheduler,
     start_log_caching,
+    start_metrics_collection,
+    stop_background_tasks,
+    stop_event,
 )
 from app.utils.video_archiver import archive_screenshots, compile_to_teaser
 from app.config import (
@@ -183,7 +186,7 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         failure_count = 0
         failure_threshold = WATCHDOG_FAILURE_THRESHOLD
 
-        while True:
+        while not stop_event.is_set():
             time.sleep(10)  # Check every 10 seconds
             if not app.debug:
                 try:
@@ -242,8 +245,6 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         app.watchdog_thread = watchdog_thread
 
     # Start collecting metrics
-    from .utils.scheduling import start_metrics_collection
-
     start_metrics_collection()
 
     start_log_caching()

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -974,8 +974,13 @@ system_metrics = {
 }
 
 
+stop_event = threading.Event()
+metrics_thread = None
+log_caching_thread = None
+
+
 def collect_system_metrics():
-    while True:
+    while not stop_event.is_set():
         system_metrics["cpu_usage"] = psutil.cpu_percent(interval=1)
         system_metrics["memory_usage"] = psutil.virtual_memory().percent
         system_metrics["thread_count"] = threading.active_count()
@@ -983,6 +988,7 @@ def collect_system_metrics():
 
 
 def start_metrics_collection():
+    global metrics_thread
     metrics_thread = threading.Thread(target=collect_system_metrics, daemon=True)
     metrics_thread.start()
 
@@ -1013,7 +1019,7 @@ def cache_logs():
     try:
         with open(log_file_path, "r") as file:
             file.seek(0, os.SEEK_END)  # Start at end of file
-            while True:
+            while not stop_event.is_set():
                 new_log = file.readline()
                 if new_log:
                     with log_cache_lock:
@@ -1046,12 +1052,21 @@ def cache_logs():
 
 
 def start_log_caching():
+    global log_caching_thread
     log_caching_thread = threading.Thread(target=cache_logs, daemon=True)
     log_caching_thread.start()
 
     # No longer schedule cache_logs via the APScheduler.  The background thread
     # itself handles continuous log caching and avoids spawning additional
     # threads on scheduler restarts.
+
+
+def stop_background_tasks() -> None:
+    """Signal background threads to exit and wait for them."""
+    stop_event.set()
+    for t in (metrics_thread, log_caching_thread):
+        if t is not None:
+            t.join(timeout=1)
 
 
 def get_feed_status():

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -256,3 +256,5 @@ If shutdown is interrupted it can leave background threads running.
 **Solution:**
 - Glimpser now manages cleanup through `CleanupManager`, ensuring shutdown only runs once.
 - Calling `main.shutdown_manager.cleanup()` manually will join any remaining threads.
+- If threads still refuse to exit, call `app.utils.scheduling.stop_background_tasks()` to signal the
+  metrics and logging loops to terminate.

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ import socket
 import app.config as config
 from app import create_app
 from app import scheduler
-from app.utils.scheduling import get_system_metrics
+from app.utils.scheduling import get_system_metrics, stop_background_tasks
 
 banner = """
           ____  _  _
@@ -255,6 +255,8 @@ class CleanupManager:
             scheduler.shutdown(wait=True)
         except Exception as e:
             logging.error("Error shutting down scheduler: %s", e)
+
+        stop_background_tasks()
 
         time.sleep(0.01)
         for thread in threading.enumerate():


### PR DESCRIPTION
## Summary
- stop `collect_system_metrics` and log caching loops on shutdown
- expose `stop_background_tasks()` and use it in `CleanupManager`
- watchdog thread checks for shutdown event
- document new helper in troubleshooting guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841791965588333821372b7191803d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown process to ensure background tasks and threads terminate cleanly, preventing issues with lingering processes.

- **Documentation**
  - Updated troubleshooting guide with new steps for handling background threads that do not exit during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->