### PR TITLE
Add startup tips to console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ scratch/*
 *.tsv
 .env
 output.txt
+
+# Node artifacts
+node_modules/
+package-lock.json

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [HTTP Callback Guide](http_callbacks.md)
 - [Recommendations](recommendations.md)
 - [Troubleshooting](troubleshooting.md)
+- [Startup Tips](startup_tips.md)
 - [Architecture Overview](architecture_overview.md)
 - [UI Accessibility Improvements](accessibility.md)
 - [Dark Mode Support](dark_mode.md)

--- a/docs/startup_tips.md
+++ b/docs/startup_tips.md
@@ -1,0 +1,14 @@
+# Startup Tips and Gotchas
+
+This page lists quick reminders that appear when Glimpser starts.
+
+- **Running without HTTPS?** Set `SESSION_COOKIE_SECURE=False` in your environment so the login cookie works over plain HTTP:
+
+  ```bash
+  export SESSION_COOKIE_SECURE=False
+  python main.py
+  ```
+- **Port already in use?** Make sure another process isn't bound to the configured port before starting Glimpser.
+- **Need more logging?** Start the app with `--console-log` to mirror log output to your terminal.
+
+Refer to this file any time you hit a startup issue.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -97,7 +97,8 @@ This guide addresses common issues that users might encounter while using Glimps
 - If you land back on the login page without errors, check that cookies are
   enabled. The page shows a "Login requires cookies" warning when the session
   cookie is missing. Running without HTTPS? Disable `SESSION_COOKIE_SECURE` so
-  your browser accepts the cookie.
+  your browser accepts the cookie. See [Startup Tips](startup_tips.md) for a
+  quick reminder of this and other common gotchas.
 
 
 ## Getting Further Help

--- a/main.py
+++ b/main.py
@@ -301,6 +301,28 @@ def clear_console_cli():
     clear_console()
 
 
+STARTUP_TIPS = [
+    "Set SESSION_COOKIE_SECURE=False when running without HTTPS.",
+    "Use --console-log to mirror logs to your terminal.",
+    "See docs/startup_tips.md for more tips.",
+]
+
+
+def display_startup_tips():
+    """Log common setup reminders."""
+    border = "-" * 60
+    logging.info(border)
+    logging.info("Startup Tips")
+    logging.info(border)
+    for tip in STARTUP_TIPS:
+        logging.info("* %s", tip)
+    logging.info(border)
+    if config.SESSION_COOKIE_SECURE:
+        logging.warning(
+            "SESSION_COOKIE_SECURE is enabled; browsers only send the login cookie over HTTPS."
+        )
+
+
 def is_port_in_use(port):
     # Skip the check if running in Docker
     if os.environ.get("IN_DOCKER"):
@@ -316,6 +338,7 @@ def main(argv=None):
     clear_console()
 
     logging.info(banner)
+    display_startup_tips()
 
     atexit.register(cleanup_resources)
     signal.signal(signal.SIGTERM, graceful_shutdown)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -149,6 +149,11 @@ class TestMain(unittest.TestCase):
             enable_watchdog=False, schedule=False, crawlers=False
         )
 
+    @patch("logging.info")
+    def test_display_startup_tips(self, mock_info):
+        main.display_startup_tips()
+        mock_info.assert_any_call("Startup Tips")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show startup tips when launching Glimpser
- document reminders in `startup_tips.md`
- link to the new doc from the docs index and troubleshooting guide
- ignore node build artifacts

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841867c468883338775fc34561e8988