### PR TITLE
Fix slider scaling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -294,6 +294,8 @@ select:hover {
     width: 100%;
     height: 100%;
     object-fit: contain; /* Scale video without cropping */
+    transform-origin: 0 0; /* Prevent viewport from shifting */
+    transform: scale(var(--tile-scale, 1));
 }
 
 /* Maintain aspect ratio without cropping */


### PR DESCRIPTION
## Summary
- adjust video CSS so scale doesn't move the viewport

## Testing
- `black .`
- `flake8`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68418aa18a8c83338c622cf8da1b483f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved video scaling within templates for smoother resizing and better alignment, preventing unwanted viewport shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->