### PR TITLE
Fix video play errors and adjust sprite preload

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1,6 +1,17 @@
 import { timeAgo, formatExactTime } from "./templates.js";
 
 const video = document.getElementById("live-video");
+
+function safePlay(el) {
+  const promise = el.play();
+  if (promise && typeof promise.catch === "function") {
+    promise.catch((err) => {
+      if (err.name !== "AbortError") {
+        console.error("Error playing video:", err);
+      }
+    });
+  }
+}
 const image = document.getElementById("live-image");
 const templateDetailsContainer = document.getElementById("template-details");
 const templateDetails = window.templateDetails || {};
@@ -457,7 +468,7 @@ function playM3U8() {
     hlsInstance.loadSource(m3u8Url);
     hlsInstance.attachMedia(video);
     hlsInstance.on(Hls.Events.MANIFEST_PARSED, function () {
-      video.play().catch((e) => console.error("Error playing video:", e));
+      safePlay(video);
     });
     hlsInstance.on(Hls.Events.ERROR, function (event, data) {
       console.error("HLS error:", data);
@@ -486,7 +497,7 @@ function playM3U8() {
   } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
     video.src = m3u8Url;
     video.addEventListener("canplay", function () {
-      video.play().catch((e) => console.error("Error playing video:", e));
+      safePlay(video);
     });
     video.addEventListener("error", function (e) {
       console.error("Video error:", video.error);
@@ -528,7 +539,7 @@ function playLoop() {
       const cameraName = groupCameras[cameraIndex];
       video.src = `/last_video/${cameraName}`; // Update the video source with the current camera
       video.load();
-      video.play();
+      safePlay(video);
       cameraIndex++; // Move to the next camera
     };
 
@@ -538,7 +549,7 @@ function playLoop() {
     // Handling for individual cameras
     video.src = `/last_video/${currentCamera}`;
     video.load();
-    video.play();
+    safePlay(video);
   }
 }
 
@@ -609,7 +620,7 @@ function playMP4() {
     video.src = `/stream.mp4?camera=${encodeURIComponent(currentCamera)}`;
   }
   video.load();
-  video.play();
+  safePlay(video);
 
   // Remove any existing 'ended' event listeners
   video.removeEventListener("ended", handleVideoEnded);
@@ -629,7 +640,7 @@ function handleVideoEnded() {
     video.dataset.currentCamera = nextCamera;
   }
   video.load();
-  video.play();
+  safePlay(video);
 }
 
 function playLive() {
@@ -672,7 +683,7 @@ function playLive() {
       const cameraName = groupCameras[cameraIndex];
       video.src = "/live_video?camera=" + encodeURIComponent(cameraName);
       video.load();
-      video.play();
+      safePlay(video);
       cameraIndex++;
     };
 
@@ -683,7 +694,7 @@ function playLive() {
   } else {
     video.src = "/live_video?camera=" + encodeURIComponent(currentCamera);
     video.load();
-    video.play();
+    safePlay(video);
   }
 }
 
@@ -975,7 +986,7 @@ if (seekBar) {
   const stopSeek = () => {
     if (isSeeking) {
       isSeeking = false;
-      video.play();
+      safePlay(video);
     }
   };
 
@@ -1000,7 +1011,7 @@ if (toggleDetailsButton) {
 
 function togglePlayback() {
   if (video.paused) {
-    video.play();
+    safePlay(video);
   } else {
     video.pause();
   }

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -1,3 +1,14 @@
+function safePlay(el) {
+  const promise = el.play();
+  if (promise && typeof promise.catch === "function") {
+    promise.catch((err) => {
+      if (err.name !== "AbortError") {
+        console.error("Error playing video:", err);
+      }
+    });
+  }
+}
+
 export function initVideoControls() {
   document.addEventListener("DOMContentLoaded", () => {
     setupStatusPageVideoHover();
@@ -13,9 +24,7 @@ export function initVideoControls() {
       entries.forEach((entry) => {
         if (!playAllActive) return;
         if (entry.isIntersecting) {
-          entry.target
-            .play()
-            .catch((e) => console.error("Error playing video:", e));
+          safePlay(entry.target);
         } else {
           entry.target.pause();
         }
@@ -45,7 +54,7 @@ export function initVideoControls() {
           });
           videos.forEach((video) => {
             playAllObserver.observe(video);
-            video.play().catch((e) => console.error("Error playing video:", e));
+            safePlay(video);
           });
           playAllButton.textContent = "Stop";
         }
@@ -69,7 +78,7 @@ export function initVideoControls() {
             source.src = `/live_video?camera=${encodeURIComponent(name)}`;
             video.poster = "";
             video.load();
-            video.play().catch((e) => console.error("Error playing video:", e));
+            safePlay(video);
           }
         });
         liveAllButton.textContent = liveAllActive ? "Live All" : "Stop Live";
@@ -108,7 +117,11 @@ export function setupVideoControls() {
 
   if (playPauseButton) {
     playPauseButton.addEventListener("click", () => {
-      video.paused ? video.play() : video.pause();
+      if (video.paused) {
+        safePlay(video);
+      } else {
+        video.pause();
+      }
     });
   }
   if (muteButton) {
@@ -148,7 +161,11 @@ export function setupVideoControls() {
       case " ": // Spacebar
       case "k":
         e.preventDefault();
-        video.paused ? video.play() : video.pause();
+        if (video.paused) {
+          safePlay(video);
+        } else {
+          video.pause();
+        }
         break;
       case "m":
         video.muted = !video.muted;
@@ -200,7 +217,7 @@ export function setupStatusPageVideoHover() {
       cell.addEventListener("mouseenter", () => {
         img.style.display = "none";
         video.style.display = "block";
-        video.play();
+        safePlay(video);
       });
       cell.addEventListener("mouseleave", () => {
         video.pause();

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/player.css') }}">
-    <link rel="preload" as="image" href="{{ url_for('static', filename='icons/sprite.svg') }}">
+    <link rel="preload" as="fetch" crossorigin href="{{ url_for('static', filename='icons/sprite.svg') }}">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>

--- a/docs/nginx_http2_push.md
+++ b/docs/nginx_http2_push.md
@@ -10,4 +10,4 @@ location / {
 }
 ```
 
-Combined with the `<link rel="preload" as="image" href="/static/icons/sprite.svg">` tag in `header.html`, pushing the sprite saves roughly 120&nbsp;ms on a 4G connection.
+Combined with the `<link rel="preload" as="fetch" crossorigin href="/static/icons/sprite.svg">` tag in `header.html`, pushing the sprite saves roughly 120&nbsp;ms on a 4G connection.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -76,7 +76,8 @@ class TestHtmlTemplates(unittest.TestCase):
         for attrs in parser.link_tags:
             if (
                 attrs.get("rel") == "preload"
-                and attrs.get("as") == "image"
+                and attrs.get("as") == "fetch"
+                and "crossorigin" in attrs
                 and attrs.get("href") == expected_href
             ):
                 break


### PR DESCRIPTION
## Summary
- guard all `play()` calls to ignore AbortError
- preload sprite.svg using `as=fetch` and update documentation
- adjust test for sprite preload

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a10abe1883338e071c2e37171406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved video playback reliability by centralizing error handling, reducing unexpected playback errors and suppressing harmless abort errors.
- **Documentation**
	- Updated documentation to reflect changes in resource preloading attributes and usage.
- **Tests**
	- Adjusted tests to verify the updated preload link attributes in templates.
- **Style**
	- Modified preload link in the header to use more appropriate attributes for SVG sprite loading, enhancing browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->