### PR TITLE
Implement adjustable chyron speed

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -332,6 +332,11 @@ LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
 # not wasted.
 LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
 
+# Duration of the caption chyron scroll in seconds. Set to 0 to disable
+# the chyron entirely. When enabled, the same value controls how long
+# the banner remains visible after a caption arrives.
+CHYRON_SPEED = int(get_setting("CHYRON_SPEED", 0))
+
 # Watchdog configuration values. These control how aggressively the
 # watchdog restarts the application when health checks fail.
 WATCHDOG_FAILURE_THRESHOLD = int(get_setting("WATCHDOG_FAILURE_THRESHOLD", 3))

--- a/app/routes.py
+++ b/app/routes.py
@@ -57,6 +57,7 @@ from app.config import (
     backup_config,
     restore_config,
     SENSITIVE_SETTINGS,
+    CHYRON_SPEED,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -871,6 +872,7 @@ def init_routes(app: Flask) -> None:
             VERSION_OUTDATED=outdated,
             COMMIT_HASH=COMMIT_HASH,
             NODE_ENV=NODE_ENV,
+            CHYRON_SPEED=CHYRON_SPEED,
         )
 
     # Add a new route for the extended health check

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -353,6 +353,8 @@ video:hover + .play-icon {
     --table-row-alt-bg-color: #1a1a1a;
     --table-hover-bg-color: #333;
     --table-border-color: #444;
+    /* Duration for the chyron scroll animation */
+    --chyron-speed: 240s;
     /* Typography */
     /* stylelint-disable-next-line value-keyword-case */
     --font-family: Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -596,8 +598,8 @@ nav a:hover, nav a.active {
 .caption-chyron.show span {
     display: inline-block;
     padding-left: 100%;
-    /* Slow the chyron scroll to roughly four minutes */
-    animation: chyron-scroll 240s linear infinite;
+    /* Duration comes from the CSS variable; 0 disables animation */
+    animation: chyron-scroll var(--chyron-speed) linear infinite;
 }
 
 @keyframes chyron-scroll {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -75,6 +75,12 @@ export function initNav() {
 
     const captionsIcon = document.getElementById("captions");
     const captionChyron = document.getElementById("caption-chyron");
+    const chyronSpeed = captionChyron
+      ? parseFloat(captionChyron.dataset.speed || "0")
+      : 0;
+    if (captionChyron && chyronSpeed > 0) {
+      captionChyron.style.setProperty("--chyron-speed", `${chyronSpeed}s`);
+    }
     let lastCaptionTime = null;
     let popupTimer;
 
@@ -110,13 +116,13 @@ export function initNav() {
     }
 
     const showCaption = (text) => {
-      if (!captionChyron) return;
+      if (!captionChyron || chyronSpeed <= 0) return;
       captionChyron.innerHTML = `<span>${text}</span>`;
       captionChyron.classList.add("show");
       clearTimeout(popupTimer);
       popupTimer = setTimeout(
         () => captionChyron.classList.remove("show"),
-        240000,
+        chyronSpeed * 1000,
       );
     };
 

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -3,7 +3,7 @@
     <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
   </a>
 </h1>
-<div id="caption-chyron" class="caption-chyron" aria-live="polite"></div>
+<div id="caption-chyron" class="caption-chyron" aria-live="polite" data-speed="{{ CHYRON_SPEED }}"></div>
 <nav>
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
   <div class="nav-left">

--- a/app/templates/settings_help_table.html
+++ b/app/templates/settings_help_table.html
@@ -160,6 +160,15 @@
             </td>
         </tr>
         <tr>
+            <td>CHYRON_SPEED</td>
+            <td>
+                <details>
+                    <summary>Duration of caption chyron</summary>
+                    <p>Controls how long the banner scrolls across the top of the page. Set to 0 to disable.</p>
+                </details>
+            </td>
+        </tr>
+        <tr>
             <td>EMAIL_ENABLED</td>
             <td>
                 <details>

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -16,6 +16,7 @@ SETTINGS_TOOLTIPS = {
     "FFMPEG_THREADS": "Threads for video processing",
     "LIVE_FALLBACK_FPS": "Frame rate for still image streams",
     "LIVE_MAX_FAILURES": "Max retries for live streams",
+    "CHYRON_SPEED": "Duration of caption banner in seconds",
     "EMAIL_ENABLED": "Toggle email notifications",
     "EMAIL_SMTP_SERVER": "SMTP server address",
     "EMAIL_RECIPIENTS": "Notification recipients",

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -116,6 +116,7 @@ Settings controlling how frames are captured from video sources:
 - `ANALYZE_DURATION_OTHER` – analyzeduration for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
+- `CHYRON_SPEED` – seconds the caption chyron scrolls; set to `0` to disable (default `0`)
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
 - `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)
 - `WATCHDOG_MAX_FILE_HANDLES` – open file handle limit before triggering a restart (default `1000`)

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -65,7 +65,9 @@ caption update was. It flashes with the newest caption text when a group message
 arrives. After a few seconds of inactivity the latest global summary slowly
 scrolls across the top in a gray chyron. Clicking this text opens the `/captions`
 page for more
-details. The icon remains green for one minute after a caption, changes to
+details. The scroll duration comes from the `CHYRON_SPEED` setting which is
+`0` by default to disable the banner. The icon remains green for one minute
+after a caption, changes to
 yellow for the next five minutes and turns red once thirty minutes have passed
 without an update.
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -13,6 +13,8 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of
   inactivity the newest global summary slowly scrolls across the top in gray text.
+  The `CHYRON_SPEED` setting controls how long the message scrolls and defaults
+  to `0` so the banner is hidden.
   Clicking the chyron opens the `/captions` page. It stays green for one minute after the
   most recent caption, turns yellow for the next five minutes and becomes red
   when no update has been received for over thirty minutes.


### PR DESCRIPTION
## Summary
- add `CHYRON_SPEED` configuration with default `0`
- expose chyron speed to templates and nav script
- allow disabling the chyron via settings
- document the new option and update help text

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a964ac508333ae49ecd39e6b2cee