### PR TITLE
Fix sprite preload tag

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -10,7 +10,7 @@
     <meta property="og:description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/player.css') }}">
-    <link rel="preload" as="fetch" crossorigin href="{{ url_for('static', filename='icons/sprite.svg') }}">
+    <link rel="preload" href="{{ url_for('static', filename='icons/sprite.svg') }}" as="image" type="image/svg+xml" crossorigin>
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
 </head>

--- a/docs/nginx_http2_push.md
+++ b/docs/nginx_http2_push.md
@@ -10,4 +10,4 @@ location / {
 }
 ```
 
-Combined with the `<link rel="preload" as="fetch" crossorigin href="/static/icons/sprite.svg">` tag in `header.html`, pushing the sprite saves roughly 120&nbsp;ms on a 4G connection.
+Combined with the `<link rel="preload" href="/static/icons/sprite.svg" as="image" type="image/svg+xml" crossorigin>` tag in `header.html`, pushing the sprite saves roughly 120&nbsp;ms on a 4G connection.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -76,7 +76,8 @@ class TestHtmlTemplates(unittest.TestCase):
         for attrs in parser.link_tags:
             if (
                 attrs.get("rel") == "preload"
-                and attrs.get("as") == "fetch"
+                and attrs.get("as") == "image"
+                and attrs.get("type") == "image/svg+xml"
                 and "crossorigin" in attrs
                 and attrs.get("href") == expected_href
             ):


### PR DESCRIPTION
## Summary
- correct `as` value in sprite preload link
- update docs to match new preload link
- adjust HTML template test

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a96cbe0883338015af23cc3e6e8d