### PR TITLE
Fix PNG All rotation

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -738,8 +738,18 @@ function playPNG() {
     pngInterval = setInterval(refreshGroupPNG, 10000 / speed);
   } else if (currentCamera === "All") {
     // Special handling for the "All" option
+    let cameraIndex = 0;
+    const allCameras = Object.keys(templateDetails).filter(
+      (key) => key !== "All",
+    );
     const refreshAllPNG = () => {
-      image.src = "/stream.png?time=" + new Date().getTime();
+      if (cameraIndex >= allCameras.length) {
+        cameraIndex = 0;
+      }
+      const cameraName = allCameras[cameraIndex];
+      image.src =
+        "/last_screenshot/" + cameraName + "?time=" + new Date().getTime();
+      cameraIndex++;
     };
     refreshAllPNG();
     clearInterval(pngInterval);

--- a/docs/live_all.md
+++ b/docs/live_all.md
@@ -1,3 +1,5 @@
 # Live All Playback
 
 The dashboard now offers a **Live All** button next to **Play All**. When clicked every video tile switches to a real-time stream for its camera. Click again to stop the streams and revert to the latest screenshot. Similarly, **Play All** starts playback of the most recent archived videos. Stopping returns the tiles to their latest screenshots.
+
+When selecting **PNG Stream** with the **All** camera option, the viewer now cycles through all cameras one by one instead of remaining on the first camera.


### PR DESCRIPTION
## Summary
- rotate through every camera when using PNG stream with the `All` option
- document PNG rotation in **Live All Playback** docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841a9a654588333af1aa7b4097d37e6