### PR TITLE
Fix loop playback with empty groups

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -530,6 +530,13 @@ function playLoop() {
       groupCameras = templateDetails["group-" + groupName].groupCameras;
     }
 
+    if (!groupCameras || groupCameras.length === 0) {
+      console.warn("playLoop: no cameras available for", currentCamera);
+      showError("No cameras available for loop");
+      showLastScreenshot();
+      return;
+    }
+
     let cameraIndex = 0;
 
     loopHandler = () => {


### PR DESCRIPTION
## Summary
- prevent invalid requests when looping through groups with no cameras

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841ae51e11883339db89d3b915baeb1