### PR TITLE
Fix collapsed bulk tools menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped scikit-image to 0.25.0
 - Bumped numpy to 1.26.0
 - Updated default VERSION to 0.2.7 for footer display
+- Bulk tools menu is expanded by default on the captions page
 
 ### Fixed
 - Addressed Python build issues and string concatenation errors

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -156,8 +156,8 @@
 </div>
 
 <div id="bulk-tab" class="tab-content">
-    <details class="tsv-controls">
-        <summary>Bulk Caption Management</summary>
+    <div class="tsv-controls">
+        <h3>Bulk Caption Management</h3>
         <div class="tsv-buttons">
             <a href="/download_captions_tsv" class="btn btn-primary" title="Download captions as TSV file">Download Captions as TSV</a>
 
@@ -167,7 +167,7 @@
             </form>
         </div>
         <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
-    </details>
+    </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}


### PR DESCRIPTION
## Summary
- expand the captions bulk tools menu
- document the UI tweak in the changelog

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841af268f2c8333ad356428d8f4dbc6