### PR TITLE
Fix nav fetch errors and abort error loops

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -109,6 +109,8 @@ function resetVideo() {
     loopHandler = null;
   }
   video.removeEventListener("ended", handleVideoEnded);
+  video.pause();
+  video.removeAttribute("src");
 }
 
 function showLoadingIndicator() {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -20,7 +20,7 @@ export function initNav() {
       const res = await fetch(url);
       const type = res.headers.get("content-type") || "";
       if (!res.ok || !type.includes("application/json")) {
-        throw new Error(`Unexpected response from ${url}`);
+        return null;
       }
       return res.json();
     };
@@ -29,6 +29,7 @@ export function initNav() {
       if (!healthStatus) return;
       try {
         const data = await fetchJson("/health");
+        if (!data) return;
         if (data.status === "healthy") {
           healthStatus.style.color = "green";
           healthStatus.title = "System Status: Healthy\n\n";
@@ -57,6 +58,7 @@ export function initNav() {
       if (!dangerStatus) return;
       try {
         const data = await fetchJson("/danger_status");
+        if (!data) return;
         if (data.ready) {
           dangerStatus.style.color = "orange";
           dangerStatus.title = "Danger Mode Ready";
@@ -130,6 +132,7 @@ export function initNav() {
       if (!captionsIcon) return;
       try {
         const data = await fetchJson("/captions_status");
+        if (!data) return;
         captionsIcon.title = data.caption || "";
         if (data.timestamp) {
           const ts = new Date(data.timestamp.replace(" ", "T") + "Z");


### PR DESCRIPTION
## Summary
- stop video playback before swapping sources to avoid `AbortError`
- relax nav polling so invalid responses don't log errors

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841afc9408883338eefcfb57cd86936