### PR TITLE
Fix partial PNGs during direct downloads

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -791,11 +791,18 @@ def download_image(
             image = remove_background(image)
             if dark:
                 apply_dark_mode(image)
-            # Save the image in PNG format
-            image.save(output_path, "PNG")
-            if os.path.exists(output_path) and _is_valid_png(output_path):
-                add_timestamp(output_path, name=name, invert=invert)
+
+            os.makedirs(os.path.dirname(output_path), exist_ok=True)
+            tmp_path = output_path + ".tmp"
+
+            # Save to a temporary file first so readers don't see partial data
+            image.save(tmp_path, "PNG")
+            if os.path.exists(tmp_path) and _is_valid_png(tmp_path):
+                add_timestamp(tmp_path, name=name, invert=invert)
+                os.replace(tmp_path, output_path)
                 return True
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
         else:
             response.close()
             logging.warning(f"Error downloading image: HTTP status code {status} {url}")
@@ -890,12 +897,19 @@ def download_pdf(
         image = remove_background(image)
         if dark:
             image = apply_dark_mode(image)
-        image.save(output_path, "PNG")
 
-        if os.path.exists(output_path) and _is_valid_png(output_path):
-            add_timestamp(output_path, name=name, invert=invert)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        tmp_path = output_path + ".tmp"
+        image.save(tmp_path, "PNG")
+
+        if os.path.exists(tmp_path) and _is_valid_png(tmp_path):
+            add_timestamp(tmp_path, name=name, invert=invert)
+            os.replace(tmp_path, output_path)
             logging.debug(f"Successfully saved PDF page to {output_path}")
             lsuccess = True
+        else:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
         return lsuccess
 
     except Exception as e:

--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -84,6 +84,7 @@ After capturing the content, Glimpser applies several post-processing steps:
 5. **Micro QR Overlay**: A tiny QR-style code containing the camera name is placed in the lower-right corner so screenshots can be tracked within the system.
 6. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
 7. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.
+8. **Atomic Writes**: Direct downloads first save to a `.tmp` file and move it into place only after validation so live streams never read a partially written PNG.
 
 ## Status Code Caching
 


### PR DESCRIPTION
## Summary
- avoid partial PNGs by writing to a temporary file then renaming
- document atomic PNG writes in capture process docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b4ac0eb08333890b07920d6f881d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image saving process to prevent partially written or corrupted files from appearing in the output.

- **Documentation**
  - Updated documentation to describe the new atomic file-saving process for enhanced image integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->