### PR TITLE
Fix settings tab navigation and add-setting placement

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1541,6 +1541,10 @@ details > summary {
     margin-bottom: 1rem;
 }
 
+#add-setting-container {
+    margin-bottom: 1rem;
+}
+
 .tab-link {
     padding: 0.5rem 1rem;
     background-color: var(--secondary-bg-color);

--- a/app/static/js/tabs.js
+++ b/app/static/js/tabs.js
@@ -2,6 +2,7 @@ export function initTabs() {
   document.addEventListener("DOMContentLoaded", () => {
     const tabs = document.querySelectorAll(".tab-link");
     const contents = document.querySelectorAll(".tab-content");
+    const addContainer = document.getElementById("add-setting-container");
     if (!tabs.length) return;
 
     tabs.forEach((tab) => {
@@ -11,6 +12,13 @@ export function initTabs() {
         contents.forEach((c) => c.classList.remove("active"));
         tab.classList.add("active");
         document.getElementById(target)?.classList.add("active");
+        if (addContainer) {
+          if (target === "Other-tab") {
+            addContainer.classList.remove("hidden");
+          } else {
+            addContainer.classList.add("hidden");
+          }
+        }
       });
     });
   });

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3,35 +3,32 @@
 <main class="container settings-page">
     <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
 
-    <details class="settings-help">
-        <summary>What does each setting do?</summary>
-        {% include 'settings_help_table.html' %}
-    </details>
-
-    <h3>Add New Setting</h3>
-    <form id="add-setting-form" method="POST" action="{{ url_for('settings') }}">
-        <input type="hidden" name="action" value="add" title="Add setting action">
-        <label for="new_name" title="Name of the new setting">Name:</label>
-        <input type="text" id="new_name" name="new_name" required title="Enter setting name">
-        <label for="new_value" title="Initial value for the setting">Value:</label>
-        <input type="text" id="new_value" name="new_value" required title="Enter setting value">
-        <div id="setting-error" class="form-error hidden"></div>
-        <button type="submit" title="Add setting">Add Setting</button>
-    </form>
+    {# Help content now appears directly in the table, so the collapsible menu was removed #}
 
     <div id="settings-search" class="hidden">
         <label for="search-input" title="Filter the selected column">Search:</label>
         <input type="text" id="search-input" title="Type to filter settings">
     </div>
 
-    <form method="POST" action="{{ url_for('settings') }}">
-        <div class="tabs">
-            {% for group in grouped_settings.keys() %}
-            <button class="tab-link{% if loop.first %} active{% endif %}" data-tab="{{ group|replace(' ', '-') }}-tab">{{ group }}</button>
-            {% endfor %}
-            <button class="tab-link" data-tab="management-tab">Management</button>
-        </div>
+    <div class="tabs">
+        {% for group in grouped_settings.keys() %}
+        <button type="button" class="tab-link{% if loop.first %} active{% endif %}" data-tab="{{ group|replace(' ', '-') }}-tab">{{ group }}</button>
+        {% endfor %}
+        <button type="button" class="tab-link" data-tab="management-tab">Management</button>
+    </div>
 
+    <div id="add-setting-container" class="hidden">
+        <form id="add-setting-form" method="POST" action="{{ url_for('settings') }}">
+            <label for="new_name" title="Name of the new setting">Name:</label>
+            <input type="text" id="new_name" name="new_name" required title="Enter setting name">
+            <label for="new_value" title="Initial value for the setting">Value:</label>
+            <input type="text" id="new_value" name="new_value" required title="Enter setting value">
+            <div id="setting-error" class="form-error hidden"></div>
+            <button type="submit" name="action" value="add" title="Add setting">Add Setting</button>
+        </form>
+    </div>
+
+    <form method="POST" action="{{ url_for('settings') }}" id="settings-form">
         {% for group, items in grouped_settings.items() %}
         <div id="{{ group|replace(' ', '-') }}-tab" class="tab-content{% if loop.first %} active{% endif %}">
             <h3>{{ group }} Settings</h3>


### PR DESCRIPTION
## Summary
- remove legacy help accordion from settings page
- move Add Setting controls below the tabs
- show/hide Add Setting when Other tab is active
- prevent tab buttons from submitting the form

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b486387083338a563fe01edbf01d