### PR TITLE
Add Magic Map Utility scaffolding

### DIFF
--- a/.github/workflows/magic-map.yml
+++ b/.github/workflows/magic-map.yml
@@ -1,0 +1,30 @@
+name: Magic Map CI
+
+on:
+  push:
+    paths:
+      - 'magic_map/**'
+  pull_request:
+    paths:
+      - 'magic_map/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest black
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Check formatting
+        run: black --check magic_map
+      - name: Lint
+        run: flake8 magic_map
+      - name: Test
+        run: pytest magic_map/tests

--- a/docs/magic_map_utility.md
+++ b/docs/magic_map_utility.md
@@ -1,0 +1,4 @@
+# Magic Map Utility
+
+Initial scaffolding for a tool that will help update Google Maps data.
+Currently provides a placeholder entry point and basic test setup.

--- a/magic_map/AGENTS.md
+++ b/magic_map/AGENTS.md
@@ -1,0 +1,4 @@
+1. Keep commits small and follow conventional messages.
+2. Format with `black` and lint with `flake8`.
+3. Run `pytest` for tests in this directory.
+4. Document decisions in `docs/` when adding features.

--- a/magic_map/LICENSE
+++ b/magic_map/LICENSE
@@ -1,0 +1,1 @@
+Kristopher Kubicki All Rights Reserved.

--- a/magic_map/README.md
+++ b/magic_map/README.md
@@ -1,0 +1,5 @@
+# Magic Map Utility
+
+This subproject aims to automate Google Maps updates using a local browser
+session. The implementation is currently a placeholder and will be expanded in
+future commits.

--- a/magic_map/TODO.md
+++ b/magic_map/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+- [ ] Implement browser automation
+- [ ] Integrate OpenAI classification
+- [ ] Add persistent storage for screenshots

--- a/magic_map/main.py
+++ b/magic_map/main.py
@@ -1,0 +1,10 @@
+"""Entry point for the Magic Map Utility."""
+
+
+def main() -> None:
+    """Run the utility."""
+    print("Magic Map Utility placeholder")
+
+
+if __name__ == "__main__":
+    main()

--- a/magic_map/tests/test_placeholder.py
+++ b/magic_map/tests/test_placeholder.py
@@ -1,0 +1,16 @@
+"""Simple placeholder test for Magic Map Utility."""
+
+import os
+import sys
+
+# Ensure repository root is on the import path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from magic_map import main
+
+
+def test_main(capsys):
+    """Verify placeholder entry point prints output."""
+    main.main()
+    captured = capsys.readouterr()
+    assert "Magic Map Utility" in captured.out


### PR DESCRIPTION
## Summary
- scaffold Magic Map Utility module with placeholder code
- document the new utility
- add TODO list and project-specific AGENTS guidelines
- introduce CI workflow for Magic Map
- include initial license for the new tool

## Testing
- `flake8 magic_map`
- `pytest magic_map/tests -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b402c41483339e9b09b1e165ac5c