### PR TITLE
Enable click-to-pause video playback

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1122,6 +1122,9 @@ window.selectNextSource = selectNextSource;
 window.selectPreviousSource = selectPreviousSource;
 window.togglePlayback = togglePlayback;
 
+// Allow pausing/resuming the video by clicking anywhere on the player
+video.addEventListener("click", togglePlayback);
+
 // --- Mobile swipe handling ---
 // Allow quick camera changes on touch devices by swiping left or right
 let touchStartX = null;

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -21,7 +21,7 @@ Key topics covered include:
 
 On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** if you want a direct real-time feed. Glimpser remembers your last selected camera, video source, and playback speed to streamline future visits.
 
-When watching a live stream, you can use keyboard shortcuts:
+When watching a live stream, you can click directly on the video to pause or resume playback. Keyboard shortcuts also work:
 `Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen.
 Left/Right arrows change the selected camera, Up/Down arrows cycle through the
 available media types, and `[`/`]` adjust playback speed. On phones and tablets,

--- a/docs/live_scrub.md
+++ b/docs/live_scrub.md
@@ -1,3 +1,3 @@
 # Live View Scrubbing
 
-The live viewer now exposes a time slider whenever MP4 or Loop playback is selected. Drag the slider to seek within the current clip. The video pauses while scrubbing and resumes once released. Scrubbing is available only for individual cameras.
+The live viewer now exposes a time slider whenever MP4 or Loop playback is selected. Drag the slider to seek within the current clip. The video pauses while scrubbing and resumes once released. You can also click the video itself to toggle play or pause. Scrubbing is available only for individual cameras.


### PR DESCRIPTION
## Summary
- allow pausing/resuming the player by clicking on the video
- document click playback toggle

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b69d11f88333926b283c55174bfe