### PR TITLE
Add jog-shuttle playback widget

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -63,6 +63,37 @@
     row-gap: 5px;
     width: 100%;
 }
+
+#jog-shuttle {
+    width: 60px;
+    height: 60px;
+    border: 2px solid white;
+    border-radius: 50%;
+    position: relative;
+    margin: 0 10px;
+    box-sizing: border-box;
+    cursor: pointer;
+}
+#jog-shuttle::before,
+#jog-shuttle::after {
+    content: "";
+    position: absolute;
+    background: white;
+}
+#jog-shuttle::before {
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    transform: translateY(-50%);
+}
+#jog-shuttle::after {
+    left: 50%;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    transform: translateX(-50%);
+}
 #error-message {
     position: absolute;
     top: 50%;

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -57,6 +57,9 @@ const errorIndicatorMessage = document.getElementById("capture-error-message");
 const streamErrorIndicator = document.getElementById("stream-error-indicator");
 const streamErrorMessage = document.getElementById("stream-error-message");
 const seekBar = document.getElementById("seek-bar");
+const jogShuttle = document.getElementById("jog-shuttle");
+let jogInterval = null;
+let jogging = false;
 let isSeeking = false;
 // Throttle duplicate error messages so the overlay isn't spammed when
 // a camera repeatedly fails. Track the last message and time displayed.
@@ -884,6 +887,61 @@ function stopLiveSwitch() {
   }
 }
 
+function applyJog(speed, direction) {
+  if (jogInterval) {
+    clearInterval(jogInterval);
+    jogInterval = null;
+  }
+  if (direction >= 0) {
+    video.playbackRate = speed;
+    safePlay(video);
+  } else {
+    video.pause();
+    jogInterval = setInterval(() => {
+      video.currentTime = Math.max(0, video.currentTime - 0.05 * speed);
+    }, 50);
+  }
+}
+
+function handleJogMove(e) {
+  if (!jogging) return;
+  const rect = jogShuttle.getBoundingClientRect();
+  const x = e.clientX - rect.left - rect.width / 2;
+  const radius = rect.width / 2;
+  const norm = Math.max(-1, Math.min(1, x / radius));
+  const level = Math.min(4, Math.floor(Math.abs(norm) * 4));
+  const speed = Math.pow(2, level);
+  if (speed === 0) return;
+  applyJog(speed, Math.sign(norm));
+}
+
+function stopJog() {
+  jogging = false;
+  if (jogInterval) {
+    clearInterval(jogInterval);
+    jogInterval = null;
+  }
+  video.pause();
+}
+
+function initJogShuttle() {
+  if (!jogShuttle) return;
+  jogShuttle.addEventListener("mousedown", (e) => {
+    jogging = true;
+    handleJogMove(e);
+  });
+  jogShuttle.addEventListener("touchstart", (e) => {
+    jogging = true;
+    handleJogMove(e.touches[0]);
+  });
+  window.addEventListener("touchmove", (e) => {
+    handleJogMove(e.touches[0]);
+  });
+  window.addEventListener("touchend", stopJog);
+  window.addEventListener("mousemove", handleJogMove);
+  window.addEventListener("mouseup", stopJog);
+}
+
 function updateSpeedContainer() {
   if (!speedContainer) return;
   const source = document.getElementById("video-source").value;
@@ -981,6 +1039,7 @@ updateTemplateDetails();
 updateSpeedContainer();
 updatePlaybackSpeed();
 updateSeekBar();
+initJogShuttle();
 playMJPG();
 startCaptionPolling();
 updateFrameTimestamp();

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -23,8 +23,9 @@
                     <input type="range" id="speed-slider" min="-3" max="4" value="0" step="0.1" oninput="updatePlaybackSpeed()">
                     <label for="speed-slider">Speed: <span id="speed-value">1x</span></label>
                 </div>
+                <div id="jog-shuttle" title="Jog shuttle control"></div>
 
-	<!-- <button id="cast-button">Cast</button> -->
+        <!-- <button id="cast-button">Cast</button> -->
                 <button id="full-screen" title='fullscreen' aria-label="Toggle fullscreen"><i class="fas fa-expand"></i></button>
                 <button id="toggle-details" title="Show details" aria-label="Toggle details"><i class="fas fa-info-circle"></i></button>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Video Archiver](video_archiver.md)
 - [Live All Playback](live_all.md)
 - [Live View Scrubbing](live_scrub.md)
+- [Jog-Shuttle Control](jog_shuttle.md)
 - [Developer Guide](developer_guide.md)
 - [Testing and Coverage](testing.md)
 - [Release Workflow](release_workflow.md)

--- a/docs/jog_shuttle.md
+++ b/docs/jog_shuttle.md
@@ -1,0 +1,3 @@
+# Jog-Shuttle Control
+
+The live viewer offers a jog-shuttle widget for cameras that support video playback. Drag within the circle to scrub forward or backward. The farther you drag from the center the faster playback runs (1x, 2x, 4x and so on). Crossing the center reverses direction. Releasing the control pauses and snaps back to neutral.


### PR DESCRIPTION
## Summary
- add a circular jog-shuttle control to the live view
- style the jog-shuttle in player CSS
- handle jog-shuttle logic in live.js
- document jog-shuttle usage

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b8a2fbac83339c3d67ee9a11b890