### PR TITLE
Handle missing screenshot timestamps

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -1,3 +1,5 @@
+export const NO_TIMESTAMP_PLACEHOLDER = "no timestamp";
+
 export function initTemplates() {
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.querySelector("#template-form form");
@@ -282,9 +284,12 @@ export function updateHumanizedTimes() {
       if (!element.dataset.originalTimestamp) {
         element.dataset.originalTimestamp = original;
       }
-      if (original) {
+      if (original && original !== NO_TIMESTAMP_PLACEHOLDER) {
         element.setAttribute("data-timestamp", timeAgo(original));
         element.setAttribute("title", formatExactTime(original));
+      } else if (original === NO_TIMESTAMP_PLACEHOLDER) {
+        element.setAttribute("data-timestamp", NO_TIMESTAMP_PLACEHOLDER);
+        element.removeAttribute("title");
       }
     });
 }
@@ -470,8 +475,12 @@ export async function loadTemplates() {
       ) {
         hasTemplates = true;
         templateCount += 1;
-        const lastScreenshotTime = template.last_screenshot_time;
-        const humanizedTimestamp = timeAgo(lastScreenshotTime);
+        const lastScreenshotTime =
+          template.last_screenshot_time || NO_TIMESTAMP_PLACEHOLDER;
+        const humanizedTimestamp =
+          lastScreenshotTime === NO_TIMESTAMP_PLACEHOLDER
+            ? NO_TIMESTAMP_PLACEHOLDER
+            : timeAgo(lastScreenshotTime);
         const nextCaptureTime = timeAgo(template.next_screenshot_time);
 
         const lastScreenshotDate = new Date(lastScreenshotTime);
@@ -529,7 +538,11 @@ export async function loadTemplates() {
           templateDiv.innerHTML = `
             <img src="/last_screenshot/${name}" alt="${name}" style="width:100%">
             <div class="camera-name">${name}</div>
-            <div class="timestamp" title="${formatExactTime(lastScreenshotTime)}">Last: ${humanizedTimestamp}</div>
+            <div class="timestamp" title="${
+              lastScreenshotTime === NO_TIMESTAMP_PLACEHOLDER
+                ? ""
+                : formatExactTime(lastScreenshotTime)
+            }">Last: ${humanizedTimestamp}</div>
             <div class="next-capture">Next: ${nextCaptureTime}</div>
             <textarea class="notes-textarea" id="notes-${name}" name="notes">${template.notes}</textarea>
             <button class="update-button" type="button" onclick="updateTemplate('${name}')">Update</button>

--- a/tests/js/placeholder.test.js
+++ b/tests/js/placeholder.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+
+document.body.innerHTML = `
+  <div id="template-list"></div>
+  <select id="group-dropdown"></select>
+  <input id="grid-width-slider" type="range">
+`;
+
+let loadTemplates;
+let NO_TIMESTAMP_PLACEHOLDER;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/templates.js');
+  loadTemplates = mod.loadTemplates;
+  NO_TIMESTAMP_PLACEHOLDER = mod.NO_TIMESTAMP_PLACEHOLDER;
+});
+
+global.fetch = jest.fn();
+
+describe('loadTemplates placeholder timestamp', () => {
+  test('inserts placeholder when timestamp missing', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () =>
+        Promise.resolve({
+          cam1: { url: '#', capture_failed: false, last_caption: '' },
+        }),
+    });
+
+    await loadTemplates();
+    const container = document.querySelector('.video-container');
+    expect(container.getAttribute('data-timestamp')).toBe(NO_TIMESTAMP_PLACEHOLDER);
+  });
+});


### PR DESCRIPTION
## Summary
- insert `NO_TIMESTAMP_PLACEHOLDER` when a template lacks a timestamp
- keep placeholder visible through `updateHumanizedTimes`
- avoid invalid titles for missing timestamps
- add unit test for placeholder logic

## Testing
- `flake8 app/static/js/templates.js tests/js/*.js`
- `pytest -q`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841b9fb7a748333880a9ba36a1033e0