### PR TITLE
Add placeholder screenshot when none available

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -539,6 +539,23 @@ def resize_and_pad(
     return background
 
 
+def _placeholder_screenshot() -> io.BytesIO:
+    """Return a simple PNG stating that no screenshot is available."""
+
+    text = "No screenshot available"
+    img = Image.new("RGB", (320, 240), "black")
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.load_default()
+    bbox = draw.textbbox((0, 0), text, font=font)
+    w = bbox[2] - bbox[0]
+    h = bbox[3] - bbox[1]
+    draw.text(((320 - w) / 2, (240 - h) / 2), text, fill="white", font=font)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
 lock = Lock()
 
 
@@ -1305,9 +1322,13 @@ def init_routes(app: Flask) -> None:
         """
         Endpoint to receive and process an image submitted by a remote service or camera.
         """
+        raw_name = template_name
         template_name = validate_template_name(template_name)
         if template_name is None:
-            abort(404)
+            logging.warning("Unable to serve screenshot for %s", raw_name)
+            resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+            resp.status_code = 404
+            return resp
 
         # Check if the template exists and get the canonical name stored
         # in the database. ``get_template`` returns an attribute dictionary
@@ -1976,9 +1997,13 @@ def init_routes(app: Flask) -> None:
         """
         Serve the latest frame for a specific camera.
         """
+        raw_name = template_name
         template_name = validate_template_name(template_name)
         if template_name is None:
-            abort(404)
+            logging.warning("Unable to serve screenshot for %s", raw_name)
+            resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+            resp.status_code = 404
+            return resp
 
         path = os.path.join(
             os.path.dirname(os.path.join(__file__)),
@@ -2053,9 +2078,13 @@ def init_routes(app: Flask) -> None:
         Serve a specific screenshot by template name.
         """
 
+        raw_name = template_name
         template_name = validate_template_name(template_name)
         if template_name is None:
-            abort(404)
+            logging.warning("Unable to serve screenshot for %s", raw_name)
+            resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+            resp.status_code = 404
+            return resp
 
         for group_camera in re.findall(r"^group-(.+?)$", template_name):
             path = os.path.join(
@@ -2066,7 +2095,10 @@ def init_routes(app: Flask) -> None:
             )
             if os.path.exists(path):
                 return send_file(path)
-            abort(404)
+            logging.warning("Unable to serve screenshot for %s", template_name)
+            resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+            resp.status_code = 404
+            return resp
 
         # Placeholder logic to serve the screenshot
         path = os.path.join(
@@ -2076,7 +2108,10 @@ def init_routes(app: Flask) -> None:
             template_name,
         )
         if not os.path.exists(path):
-            abort(404)
+            logging.warning("Unable to serve screenshot for %s", template_name)
+            resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+            resp.status_code = 404
+            return resp
 
         lfiles = [f for f in glob.glob(path + "/*.png") if os.path.isfile(f)]
         lfiles.sort(key=os.path.getmtime, reverse=True)
@@ -2087,7 +2122,10 @@ def init_routes(app: Flask) -> None:
             except OSError:
                 continue
 
-        abort(404)
+        logging.warning("Unable to serve screenshot for %s", template_name)
+        resp = send_file(_placeholder_screenshot(), mimetype="image/png")
+        resp.status_code = 404
+        return resp
 
     @app.route("/compile_teaser", methods=["POST"])
     @login_required

--- a/tests/test_serve_screenshot.py
+++ b/tests/test_serve_screenshot.py
@@ -1,3 +1,4 @@
+import io
 import os
 import sys
 import shutil
@@ -30,17 +31,30 @@ class TestServeScreenshot(unittest.TestCase):
         self.sc_patch.stop()
         shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
 
-    def test_empty_screenshot_returns_404(self):
+    @patch("app.routes.logging.warning")
+    def test_empty_screenshot_returns_placeholder(self, mock_warn):
         path = os.path.join(self.full_base, "cam1_20200101.png")
         open(path, "wb").close()
         resp = self.client.get("/last_screenshot/cam1")
         self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.mimetype, "image/png")
+        Image.open(io.BytesIO(resp.data))
+        mock_warn.assert_called_once()
 
     def test_valid_screenshot_served(self):
         path = os.path.join(self.full_base, "cam1_20200102.png")
         Image.new("RGB", (1, 1)).save(path)
         resp = self.client.get("/last_screenshot/cam1")
         self.assertEqual(resp.status_code, 200)
+
+    @patch("app.routes.logging.warning")
+    def test_missing_directory_returns_placeholder(self, mock_warn):
+        shutil.rmtree(self.full_base)
+        resp = self.client.get("/last_screenshot/cam1")
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.mimetype, "image/png")
+        Image.open(io.BytesIO(resp.data))
+        mock_warn.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log a warning when a screenshot cannot be served
- return a small PNG placeholder instead of a blank 404
- cover missing screenshot behaviour with regression tests

## Testing
- `flake8`
- `pytest tests/test_serve_screenshot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b9fd512c8333b993563c477bddf3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When a requested screenshot is missing or invalid, users now receive a placeholder image indicating "No screenshot available" instead of an error page.

- **Bug Fixes**
  - Improved error handling for missing or invalid screenshots by providing a consistent placeholder image response.

- **Tests**
  - Enhanced tests to verify that the placeholder image is returned with the correct status and format when screenshots are missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->