### PR TITLE
Improve blank screenshot handling

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -532,7 +532,7 @@ def is_similar_color(color1, color2, threshold):
 
 def is_mostly_blank(
     image: Image.Image,
-    threshold: float = 0.92,
+    threshold: float = 0.98,
     blank_color=(255, 255, 255),
     text_std_threshold: int = 20,
     dark_threshold: int = 10,
@@ -705,6 +705,18 @@ def add_timestamp(image_path, name="unknown", invert=False):
             add_micro_barcode(image_path, name)
         except Exception as e:  # pragma: no cover - overlay failures are non-critical
             logging.debug(f"Micro barcode overlay failed: {e}")
+
+
+def create_placeholder(image_path, name="unknown"):
+    """Generate a simple placeholder image with a timestamp."""
+    img = Image.new("RGB", (640, 360), color="black")
+    draw = ImageDraw.Draw(img)
+    font = load_font(20)
+    zone = tz.gettz(TZ) or tz.UTC
+    timestamp = datetime.datetime.now(zone).strftime("%Y-%m-%d %H:%M:%S")
+    text = f"{name}\n{timestamp}"
+    draw.multiline_text((10, 10), text, fill=(255, 255, 255), font=font)
+    img.save(image_path, "PNG")
 
 
 def download_image(
@@ -2612,21 +2624,25 @@ def _finalize_screenshot(tmp_path, final_path, name, invert, dark):
         with Image.open(tmp_path) as img:
             img = img.convert("RGB")
 
-            if is_mostly_blank(img):
+            blank = is_mostly_blank(img)
+            if blank:
                 logging.warning(f"[{name}] The captured screenshot looks mostly blank.")
-                os.remove(tmp_path)
-                return False
+                orig_path = final_path + ".orig.png"
+                os.rename(tmp_path, orig_path)
+                create_placeholder(tmp_path, name)
+                success = False
+            else:
+                # Optional background removal
+                img = remove_background(img)
 
-            # Optional background removal
-            img = remove_background(img)
+                # If you want to do naive “darkening” or inverting more thoroughly,
+                # you can do that here. For example:
+                # if dark:
+                #    img = apply_dark_mode(img)
 
-            # If you want to do naive “darkening” or inverting more thoroughly,
-            # you can do that here. For example:
-            # if dark:
-            #    img = apply_dark_mode(img)
-
-            # Save back
-            img.save(tmp_path, "PNG")
+                # Save back
+                img.save(tmp_path, "PNG")
+                success = True
 
         # Now add a timestamp overlay
         add_timestamp(tmp_path, name=name, invert=invert)
@@ -2636,7 +2652,7 @@ def _finalize_screenshot(tmp_path, final_path, name, invert, dark):
         os.rename(tmp_path, final_path)
 
         logging.debug(f"SAVED screenshot -> {final_path}")
-        return True
+        return success
 
     except Exception as e:
         logging.error(f"Screenshot finalization error: {e}")

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,35 @@
+import unittest
+import tempfile
+import os
+from PIL import Image
+from unittest.mock import patch
+
+from app.utils.screenshots import create_placeholder, _finalize_screenshot
+
+
+class TestPlaceholderGeneration(unittest.TestCase):
+    def test_create_placeholder(self):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            path = tmp.name
+        try:
+            create_placeholder(path, "Test")
+            self.assertTrue(os.path.exists(path))
+            with Image.open(path) as img:
+                self.assertEqual(img.size, (640, 360))
+        finally:
+            os.remove(path)
+
+    def test_finalize_blank_keeps_original(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = os.path.join(tmpdir, "tmp.png")
+            final = os.path.join(tmpdir, "final.png")
+            Image.new("RGB", (10, 10), color="black").save(tmp)
+            with patch("app.utils.screenshots.is_mostly_blank", return_value=True):
+                result = _finalize_screenshot(tmp, final, "Cam", False, False)
+            self.assertFalse(result)
+            self.assertTrue(os.path.exists(final))
+            self.assertTrue(os.path.exists(final + ".orig.png"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -22,6 +22,9 @@ class TestScreenshotCapture(unittest.TestCase):
     def tearDown(self):
         if os.path.exists(self.output_path):
             os.remove(self.output_path)
+        orig = self.output_path + ".orig.png"
+        if os.path.exists(orig):
+            os.remove(orig)
         os.rmdir(self.temp_dir)
 
     @patch("app.utils.screenshots._finalize_screenshot", return_value=True)
@@ -81,9 +84,10 @@ class TestScreenshotCapture(unittest.TestCase):
     @patch("app.utils.screenshots.launch_headless_chrome")
     @patch("app.utils.screenshots.get_chrome_version", return_value=120)
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.create_placeholder")
     @patch("app.utils.screenshots.is_mostly_blank", return_value=True)
     def test_capture_screenshot_blank_image(
-        self, mock_blank, mock_get_path, mock_get_version, mock_launch
+        self, mock_blank, mock_placeholder, mock_get_path, mock_get_version, mock_launch
     ):
         mock_driver = MagicMock()
         mock_launch.return_value = mock_driver
@@ -96,13 +100,18 @@ class TestScreenshotCapture(unittest.TestCase):
             return True
 
         mock_driver.save_screenshot.side_effect = fake_save
+        mock_placeholder.side_effect = lambda path, name: Image.new("RGB", (1, 1)).save(
+            path
+        )
 
         result = capture_screenshot_and_har("http://example.com", self.output_path)
 
         self.assertFalse(result)
-        self.assertFalse(os.path.exists(self.output_path))
+        self.assertTrue(os.path.exists(self.output_path))
+        self.assertTrue(os.path.exists(self.output_path + ".orig.png"))
         self.assertFalse(os.path.exists(partial))
         mock_blank.assert_called()
+        mock_placeholder.assert_called_once()
 
     @patch("app.utils.screenshots._finalize_screenshot", return_value=True)
     @patch("app.utils.screenshots.launch_headless_chrome")


### PR DESCRIPTION
## Summary
- relax `is_mostly_blank` threshold
- generate placeholder images when captures look blank
- keep original capture for debugging
- test blank frame handling and placeholder creation

## Testing
- `flake8 app/utils/screenshots.py tests/test_screenshot_capture.py tests/test_placeholder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b9f857948333bb4085f0a6f98ba7