### PR TITLE
Relax Codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -7,6 +7,7 @@ following tasks:
 - Formats Python code with `black` and lints with `flake8`.
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites and uploads coverage.
+- Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
 - Scans dependencies using `pip safety` and `npm audit`.
 - Caches Python and Node dependencies to speed up builds.
 


### PR DESCRIPTION
## Summary
- add Codecov config so coverage drop <0.5% doesn't fail
- document new Codecov behavior

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bbccc77c8333aeb4fc58e0a15d6c