### PR TITLE
Add progress bars on status metrics

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1419,6 +1419,17 @@ details > summary {
     background-color: red;
 }
 
+.metrics-list li {
+    margin-bottom: 0.25rem;
+}
+
+.metric-bar {
+    width: 8rem;
+    height: 0.6rem;
+    vertical-align: middle;
+    margin: 0 0.25rem;
+}
+
 
 /* simple layout for discovery wizard */
 .wizard-step {

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -14,10 +14,19 @@
 <h1>System Status</h1>
 
 {% call card('System Metrics') %}
-<ul>
-    <li title="Current CPU utilization">CPU Usage: {{ metrics.cpu_usage }}%</li>
-    <li title="Current memory utilization">Memory Usage: {{ metrics.memory_usage }}%</li>
-    <li title="Disk space used">Disk Usage: {{ metrics.disk_usage }}%</li>
+<ul class="metrics-list">
+    <li title="Current CPU utilization">CPU Usage:
+        <progress class="metric-bar" value="{{ metrics.cpu_usage }}" max="100"></progress>
+        {{ metrics.cpu_usage }}%
+    </li>
+    <li title="Current memory utilization">Memory Usage:
+        <progress class="metric-bar" value="{{ metrics.memory_usage }}" max="100"></progress>
+        {{ metrics.memory_usage }}%
+    </li>
+    <li title="Disk space used">Disk Usage:
+        <progress class="metric-bar" value="{{ metrics.disk_usage }}" max="100"></progress>
+        {{ metrics.disk_usage }}%
+    </li>
     <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
     <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
     <li title="System uptime">Uptime: {{ metrics.uptime }}</li>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout.
+The status page shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage now display a small progress bar next to the numeric value for a quick visual indicator.
 
 ### Feed Dashboard
 


### PR DESCRIPTION
## Summary
- show CPU, memory, and disk metrics with progress bars
- style new metric progress bars
- document progress bar display in the system monitoring guide

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bd77ac1c8333bc002bb9cfcc1ae5