### PR TITLE
fix(live): send headers for ffmpeg

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -42,6 +42,7 @@ from werkzeug.security import check_password_hash
 from werkzeug.utils import secure_filename
 from ipaddress import ip_network
 import subprocess
+from urllib.parse import urlparse
 import struct
 import random
 
@@ -424,6 +425,14 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
     command = [config.FFMPEG_PATH]
     if config.FFMPEG_HWACCEL and config.FFMPEG_HWACCEL.lower() != "false":
         command.extend(["-hwaccel", config.FFMPEG_HWACCEL])
+
+    parsed = urlparse(url)
+    if parsed.scheme in ("http", "https"):
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        command.extend(["-headers", f"User-Agent: {config.UA}\r\n"])
+        command.extend(["-headers", f"referer: {base_url}\r\n"])
+        command.extend(["-headers", f"origin: {base_url}\r\n"])
+        command.extend(["-seekable", "0"])
     command.extend(
         [
             "-reconnect",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -204,6 +204,12 @@ snapshot image rather than a true video stream.
   behaves like a regular video stream.
 - If playback fails entirely, the viewer now shows the last captured
   screenshot so the page is never blank.
+- HTTP errors like `403 Forbidden` or repeated ffmpeg timeouts typically mean
+  the stream is blocked. Verify the URL is accessible from the host running
+  Glimpser and check for required credentials or firewall rules.
+- Some cameras reject ffmpeg if it does not send browser-style headers. The
+  live stream now includes the configured `UA`, `referer` and `origin` headers.
+  Adjust these settings if your camera expects a specific user agent.
 
 ### Problem: Playback continues in the background after switching types
 


### PR DESCRIPTION
## Summary
- include browser-style headers when streaming live video
- note requirement in troubleshooting docs

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bcadd8908333a5dcb5d0a633af3c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sending configurable browser-style headers (User-Agent, referer, and origin) when streaming from HTTP/HTTPS sources to improve compatibility with certain cameras.
- **Documentation**
  - Updated troubleshooting guide with advice on handling HTTP errors and stream playback failures, including information about header configuration for live streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->