### PR TITLE
Implement switch inputs for boolean settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2512,12 +2512,28 @@ def init_routes(app: Flask) -> None:
                 else:
                     flash("Failed to update shortcuts", "error")
             else:
+                current = {s["name"]: s["value"] for s in get_all_settings()}
+                bool_settings = {
+                    n for n, v in current.items() if v in ["True", "False"]
+                }
+                for name in bool_settings:
+                    if name in email_settings:
+                        continue
+                    new_val = (
+                        "True"
+                        if request.form.get(name)
+                        in ["True", "on", "1", "t", "y", "yes"]
+                        else "False"
+                    )
+                    update_setting(name, new_val)
+
                 for name, value in request.form.items():
-                    if (
-                        name
-                        not in ["action", "new_name", "new_value", "name_to_delete"]
-                        + email_settings
-                    ):
+                    if name not in [
+                        "action",
+                        "new_name",
+                        "new_value",
+                        "name_to_delete",
+                    ] + email_settings + list(bool_settings):
                         update_setting(name, value)
             return redirect(url_for("settings"))
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -845,6 +845,55 @@ button, a {
     flex-wrap: wrap;
 }
 
+/* Toggle switch styling for boolean settings */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: #ccc;
+    transition: 0.4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 14px;
+    width: 14px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: 0.4s;
+}
+
+input:checked + .slider {
+    background-color: var(--primary-color);
+}
+
+input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+.slider.round {
+    border-radius: 20px;
+}
+
+.slider.round:before {
+    border-radius: 50%;
+}
+
 .xpath-input-container input {
     width: 70%;
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -46,7 +46,14 @@
                     <tr>
                         <td title="{{ tooltips.get(setting.name, '') }}">{{ setting.name }}</td>
                         <td>
+                            {% if setting.value in ['True', 'False'] %}
+                            <label class="switch">
+                                <input type="checkbox" name="{{ setting.name }}" value="True" {% if setting.value == 'True' %}checked{% endif %} data-boolean>
+                                <span class="slider round"></span>
+                            </label>
+                            {% else %}
                             <input type="text" name="{{ setting.name }}" value="{{ setting.value }}" title="Edit value for {{ setting.name }}">
+                            {% endif %}
                         </td>
                         <td class="setting-explanation">{{ tooltips.get(setting.name, '') }}</td>
                         <td>

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -13,7 +13,8 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Column Search** – click a header to filter rows by that column.
 
 Each row now includes an **Explanation** column so you can read a short
-description without opening the reference table.
+description without opening the reference table. Boolean values are
+displayed as toggle switches to avoid typing errors.
 
 ### Dynamic Feedback
 


### PR DESCRIPTION
## Summary
- use toggle switches for boolean values on the settings page
- validate booleans when saving settings
- add CSS for switch styling
- document the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841be86aa088333815fda4f7140cb71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Boolean settings are now displayed as toggle switches in the settings interface for improved usability.
- **Style**
  - Introduced new styles for toggle switch components to enhance visual clarity.
- **Bug Fixes**
  - Improved handling of boolean settings to ensure consistent updates based on form input.
- **Documentation**
  - Updated documentation to reflect the new toggle switch UI for boolean settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->