### PR TITLE
Increase OpenAI timeout

### DIFF
--- a/app/utils/api_utils.py
+++ b/app/utils/api_utils.py
@@ -10,7 +10,7 @@ def request_with_retry(
     url: str,
     *,
     retries: int = 2,
-    timeout: int = 10,
+    timeout: int = 30,
     backoff_factor: float = 1.0,
     **kwargs: Any,
 ) -> requests.Response:

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -1,6 +1,6 @@
 # API Resilience
 
-Glimpser interacts with external services such as camera endpoints and language models. Network issues or rate limits can cause these APIs to become temporarily unavailable. To avoid blocking the user interface, Glimpser now sends API requests with a timeout and retries using exponential backoff.
+Glimpser interacts with external services such as camera endpoints and language models. Network issues or rate limits can cause these APIs to become temporarily unavailable. To avoid blocking the user interface, Glimpser now sends API requests with a timeout and retries using exponential backoff. The default timeout for these requests is **30 seconds**.
 
 The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.request` and will retry failed requests a few times, waiting longer between attempts. When the LLM summarization call fails after retries, the last cached summary is returned if available. Otherwise a short message such as "Summarization delayed" is provided so the UI continues to load.
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -12,7 +12,7 @@ class TestRequestWithRetry(unittest.TestCase):
         ) as mock_req:
             result = request_with_retry("get", "http://ex")
             self.assertIs(result, resp)
-            mock_req.assert_called_once_with("get", "http://ex", timeout=10)
+            mock_req.assert_called_once_with("get", "http://ex", timeout=30)
 
     def test_retry_then_success(self):
         resp = MagicMock()


### PR DESCRIPTION
## Summary
- bump default timeout for `request_with_retry`
- adjust tests
- document new default timeout

## Testing
- `flake8`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bf4f0568833390d4475f2debe39b