### PR TITLE
Add dropdown navigation for groups

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -513,6 +513,14 @@ nav a {
     transition: background-color 0.2s, color 0.2s; /* Smooth hover transition */
 }
 
+#nav-group-dropdown {
+    background-color: var(--secondary-bg-color);
+    color: var(--text-color);
+    border: 1px solid var(--table-border-color);
+    border-radius: 5px;
+    padding: 4px 8px;
+}
+
 .status-indicator {
     display: flex;
     align-items: center;
@@ -674,6 +682,11 @@ nav a:hover, nav a.active {
     .performance-indicator {
         font-size: 10px;
         padding: 1px 3px;
+    }
+
+    #nav-group-dropdown {
+        width: 100%;
+        margin-bottom: 5px;
     }
 
     /* Enhance touch target sizes for mobile */

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -5,10 +5,43 @@ export function initNav() {
     const discoveryStatus = document.getElementById("discover-status");
     const nav = document.querySelector("nav");
     const menuToggle = document.getElementById("menu-toggle");
+    const groupDropdown = document.getElementById("nav-group-dropdown");
 
     if (nav && menuToggle) {
       menuToggle.addEventListener("click", () => {
         nav.classList.toggle("active");
+      });
+    }
+
+    const loadNavGroups = async () => {
+      if (!groupDropdown) return;
+      groupDropdown.innerHTML = '<option value="">Loading...</option>';
+      groupDropdown.disabled = true;
+      try {
+        const groups = await fetchJson("/groups");
+        groupDropdown.innerHTML = '<option value="">Groups</option>';
+        if (groups && Array.isArray(groups)) {
+          groups.forEach((g) => {
+            const opt = document.createElement("option");
+            opt.value = g;
+            opt.textContent = g;
+            groupDropdown.appendChild(opt);
+          });
+        }
+      } catch (error) {
+        console.error("Error loading groups:", error);
+      } finally {
+        groupDropdown.disabled = false;
+      }
+    };
+
+    if (groupDropdown) {
+      groupDropdown.addEventListener("change", () => {
+        if (groupDropdown.value) {
+          window.location.href = `/group/${encodeURIComponent(
+            groupDropdown.value,
+          )}`;
+        }
       });
     }
 
@@ -233,6 +266,7 @@ export function initNav() {
       showNav();
     };
 
+    loadNavGroups();
     checkHealth();
     setInterval(checkHealth, 5000);
     checkDanger();

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -7,9 +7,7 @@
 <nav>
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
   <div class="nav-left">
-    {% for ag in active_groups %}
-    <a href="/group/{{ ag }}" title="View group {{ ag }}">{{ ag }}</a>
-    {% endfor %}
+    <select id="nav-group-dropdown" title="Jump to group"></select>
     <!-- Discover icon moved to nav-right for consistency -->
   </div>
 

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -6,4 +6,8 @@ The main template view scales thumbnails with the width slider and the page now 
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 
+Group links in the header are now available through a dropdown menu. The list
+populates asynchronously from the `/groups` endpoint and fits neatly inside the
+hamburger layout on small screens.
+
 Offline preview keeps recently viewed pages and assets in the browser cache so the interface remains responsive even on poor connections.


### PR DESCRIPTION
## Summary
- add dropdown select in `nav.html`
- populate navigation groups via `nav.js`
- style the dropdown for hamburger menu
- document the navigation update in the responsive design guide

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d0bd634883339cbea67c0ad7942b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dropdown menu in the navigation bar for selecting groups, replacing individual group links.
  - The dropdown menu dynamically loads available groups and redirects to the selected group.

- **Style**
  - Updated navigation styles to enhance the appearance and responsiveness of the group dropdown, especially on mobile devices.

- **Documentation**
  - Updated responsive design documentation to reflect the new group dropdown navigation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->