### PR TITLE
Add theme toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -374,6 +374,18 @@ video:hover + .play-icon {
     }
 }
 
+body.light-mode {
+    --bg-color: #ffffff;
+    --secondary-bg-color: #f2f2f2;
+    --text-color: #222;
+    --form-bg-color: #ffffff;
+    --form-text-color: #222;
+    --table-header-bg-color: #f2f2f2;
+    --table-row-alt-bg-color: #fafafa;
+    --table-hover-bg-color: #e0e0e0;
+    --table-border-color: #ddd;
+}
+
 .camera-name, .timestamp {
     position: absolute;
     color: white;

--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -26,4 +26,18 @@
     <line x1="12" y1="8" x2="12" y2="14" stroke="currentColor" stroke-width="2" />
     <circle cx="12" cy="18" r="1" fill="currentColor" />
   </symbol>
+  <symbol id="sun" viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2" fill="none" />
+    <line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" stroke-width="2" />
+    <line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" stroke-width="2" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2" />
+    <line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="2" />
+    <line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" stroke-width="2" />
+  </symbol>
+  <symbol id="moon" viewBox="0 0 24 24">
+    <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" stroke="currentColor" stroke-width="2" fill="none" />
+  </symbol>
   </svg>

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -13,6 +13,7 @@ import { initTooltips } from "./tooltips.js";
 import { initCaptions } from "./captions.js";
 import { initSettingsSearch } from "./settings.js";
 import { initTabs } from "./tabs.js";
+import { initThemeToggle } from "./theme.js";
 
 initTemplates();
 initVideoControls();
@@ -30,3 +31,4 @@ initTooltips();
 initCaptions();
 initSettingsSearch();
 initTabs();
+initThemeToggle();

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -9,10 +9,17 @@ export function initThemeToggle() {
 
     const applyTheme = (theme) => {
       document.body.classList.toggle("light-mode", theme === "light");
-      useEl.setAttribute("href", `${sprite}#${theme === "light" ? "moon" : "sun"}`);
+      useEl.setAttribute(
+        "href",
+        `${sprite}#${theme === "light" ? "moon" : "sun"}`,
+      );
     };
 
-    let current = localStorage.getItem("theme") || (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+    let current =
+      localStorage.getItem("theme") ||
+      (window.matchMedia("(prefers-color-scheme: light)").matches
+        ? "light"
+        : "dark");
     applyTheme(current);
 
     toggle.addEventListener("click", (e) => {

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -1,0 +1,25 @@
+export function initThemeToggle() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggle = document.getElementById("theme-toggle");
+    if (!toggle) return;
+
+    const useEl = toggle.querySelector("use");
+    if (!useEl) return;
+    const sprite = useEl.getAttribute("href").split("#")[0];
+
+    const applyTheme = (theme) => {
+      document.body.classList.toggle("light-mode", theme === "light");
+      useEl.setAttribute("href", `${sprite}#${theme === "light" ? "moon" : "sun"}`);
+    };
+
+    let current = localStorage.getItem("theme") || (window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark");
+    applyTheme(current);
+
+    toggle.addEventListener("click", (e) => {
+      e.preventDefault();
+      current = current === "light" ? "dark" : "light";
+      localStorage.setItem("theme", current);
+      applyTheme(current);
+    });
+  });
+}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -52,12 +52,17 @@
         </div>
       </div>
     </a>
-    <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
-      <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
-      </svg>
-    </a>
-    {% else %}
+      <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
+        <svg width="20" height="20">
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
+        </svg>
+      </a>
+      <a id="theme-toggle" href="#" class="status-indicator" title="Toggle light or dark theme" aria-label="Toggle theme">
+        <svg width="18" height="18">
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
+        </svg>
+      </a>
+      {% else %}
     <a href="{{ url_for('login') }}" class="settings-icon" title="Login" aria-label="Login">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#login" />

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -5,6 +5,10 @@ The CSS defines variables for background and text colors with light and dark
 variants. Forms and tables use these variables so elements remain readable in
 both themes.
 
+You can force the interface into light or dark mode using the new toggle in the
+navigation bar. The switch stores your choice in `localStorage` so your
+preference persists across visits.
+
 A new `--table-border-color` variable controls table outlines. Dark mode
 defaults to a subtle `#444` while the light theme overrides it to `#ddd`.
 The settings page now uses this variable for its forms and tables so fields


### PR DESCRIPTION
## Summary
- support switching between light and dark UI themes
- document how to force dark or light mode

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d36dbaa48333be301fd2b16bfc18