### PR TITLE
Fix captions history and add chyron toggle

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1071,6 +1071,19 @@ def init_routes(app: Flask) -> None:
         except Exception as e:
             return jsonify({"status": "error", "message": str(e)}), 500
 
+    @app.route("/toggle_chyron", methods=["POST"])
+    @login_required
+    @profile_route("/toggle_chyron")
+    def toggle_chyron():
+        """Enable or disable the caption chyron."""
+        try:
+            current = config.get_setting("CHYRON_SPEED", "0")
+            new_speed = "0" if str(current) != "0" else "240"
+            update_setting("CHYRON_SPEED", new_speed)
+            return jsonify({"speed": int(new_speed)})
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
     @app.route("/danger", methods=["GET", "POST"])
     @login_required
     def danger_mode():
@@ -1833,7 +1846,7 @@ def init_routes(app: Flask) -> None:
     @login_required
     def captions():
 
-        # Load the most recent summaries from the database
+        # Load recent summaries from the database and convert timestamps to ISO
         entries = []
         try:
             session_db = SessionLocal()
@@ -1841,12 +1854,19 @@ def init_routes(app: Flask) -> None:
                 records = (
                     session_db.query(Summary)
                     .order_by(Summary.timestamp.desc())
-                    .limit(5)
+                    .limit(100)
                     .all()
                 )
                 for rec in records:
                     try:
-                        entries.append(json.loads(rec.content))
+                        data = json.loads(rec.content)
+                        for ts, text in data.items():
+                            try:
+                                dt = datetime.utcfromtimestamp(int(ts))
+                                iso_ts = dt.strftime("%Y-%m-%d %H:%M:%S")
+                            except Exception:
+                                iso_ts = ts
+                            entries.append({iso_ts: text})
                     except Exception:
                         pass
             finally:

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -17,7 +17,17 @@
                  error: function(error) {
                      alert('Error updating template: ' + error.responseText);
                  }
-            });
+             });
+         }
+         function toggleChyron() {
+             fetch('/toggle_chyron', {method: 'POST'})
+                 .then(resp => resp.json())
+                 .then(data => {
+                     const btn = document.getElementById('toggle-chyron-btn');
+                     if (data.speed !== undefined && btn) {
+                         btn.textContent = data.speed > 0 ? 'Disable Chyron' : 'Enable Chyron';
+                     }
+                 });
          }
      </script>
 
@@ -126,6 +136,9 @@
         <label for="caption-end">To:</label>
         <input type="date" id="caption-end" title="End date">
         <button id="caption-clear" type="button" title="Clear filters">Clear</button>
+        <button id="toggle-chyron-btn" type="button" onclick="toggleChyron()" title="Toggle caption banner">
+            {% if CHYRON_SPEED|int > 0 %}Disable Chyron{% else %}Enable Chyron{% endif %}
+        </button>
     </div>
     <table id="captions-table" class="captions-table">
             <thead>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -70,6 +70,8 @@ details. The scroll duration comes from the `CHYRON_SPEED` setting which is
 after a caption, changes to
 yellow for the next five minutes and turns red once thirty minutes have passed
 without an update.
+You can toggle the chyron from the **Captions** page using the button in the
+History tab.
 
 ## Danger Mode Indicator
 


### PR DESCRIPTION
## Summary
- show 100 caption entries and convert timestamps to ISO
- add route to toggle caption chyron
- provide chyron toggle button on captions page
- document chyron toggle

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841d3436b888333822c4780148d5ded