### PR TITLE
Fix duplicate tooltips

### DIFF
--- a/app/static/js/tooltips.js
+++ b/app/static/js/tooltips.js
@@ -14,6 +14,8 @@ export function initTooltips() {
       if (!target) return;
       const text = target.getAttribute("title");
       if (!text) return;
+      target.setAttribute("data-title", text);
+      target.removeAttribute("title");
       tooltip.textContent = text;
       moveTooltip(e);
       tooltip.classList.remove("hidden");
@@ -23,6 +25,11 @@ export function initTooltips() {
     const hideTooltip = (e) => {
       tooltip.classList.add("hidden");
       e.target.removeEventListener("mousemove", moveTooltip);
+      const orig = e.target.getAttribute("data-title");
+      if (orig) {
+        e.target.setAttribute("title", orig);
+        e.target.removeAttribute("data-title");
+      }
     };
 
     document.addEventListener("mouseover", showTooltip);

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -46,3 +46,5 @@ Interactive forms now include additional tooltips:
 ## Dynamic Tooltips
 
 A small JavaScript helper now displays a custom tooltip when hovering or focusing on any element with a `title` attribute. These tooltips track the mouse cursor and update automatically when the `title` text changes, giving live feedback across the interface.
+
+To avoid the browser's default tooltip from also appearing, the script now temporarily removes the `title` attribute while showing the custom tooltip and restores it on mouseout.


### PR DESCRIPTION
## Summary
- prevent native browser tooltips from showing
- document the tooltip change

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d4c408488333b222b4d889900674