### PR TITLE
Enable offline preview by default

### DIFF
--- a/app/static/js/offline.js
+++ b/app/static/js/offline.js
@@ -1,38 +1,5 @@
 export function initOffline() {
-  const checkbox = document.getElementById("offline-preview");
-  if (!checkbox) return;
-
-  checkbox.checked = localStorage.getItem("offlinePreviewEnabled") === "true";
-
-  checkbox.addEventListener("change", () => {
-    if (checkbox.checked) {
-      localStorage.setItem("offlinePreviewEnabled", "true");
-      registerSW();
-    } else {
-      localStorage.removeItem("offlinePreviewEnabled");
-      unregisterSW();
-    }
-  });
-
-  if (checkbox.checked) {
-    registerSW();
-  }
-}
-
-function registerSW() {
   if ("serviceWorker" in navigator) {
     navigator.serviceWorker.register("/sw.js").catch(console.error);
-  }
-}
-
-function unregisterSW() {
-  if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.getRegistrations().then((regs) => {
-      regs.forEach((reg) => {
-        if (reg.active && reg.active.scriptURL.includes("sw.js")) {
-          reg.unregister();
-        }
-      });
-    });
   }
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -76,11 +76,6 @@
             <h3>Danger Mode</h3>
             <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
 
-            <h3>Offline Preview</h3>
-            <label>
-                <input type="checkbox" id="offline-preview" title="Cache snapshots for offline viewing">
-                Enable offline preview
-            </label>
         </div>
 
         <input type="hidden" id="name_to_delete" name="name_to_delete" value="" title="Name of setting to delete">

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,5 +1,5 @@
 # Offline Preview
 
-A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. When **Enable offline preview** is checked on the Settings page, the browser registers `/sw.js` which caches the `/status`, `/discover`, `/settings`, and `/templates` pages. Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
+A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the `/status`, `/discover`, `/settings`, and `/templates` pages. Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
 
 MJPEG endpoints now fall back to the oldest frame stored on disk if no recent frame is available. This means `/stream.mjpg` and related routes always yield at least one image even when the camera is offline.

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -10,4 +10,4 @@ Group links in the header are now available through a dropdown menu. The list
 populates asynchronously from the `/groups` endpoint and fits neatly inside the
 hamburger layout on small screens.
 
-Offline preview keeps recently viewed pages and assets in the browser cache so the interface remains responsive even on poor connections.
+Offline preview keeps recently viewed pages and assets in the browser cache so the interface remains responsive even on poor connections. This feature is enabled automatically.

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -8,7 +8,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Current Settings** – edit existing values or delete them. Tabs switch between setting groups and the **Management** tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Danger Mode** – update Chrome shortcuts with the required flags.
-- **Offline Preview** – toggle a Service Worker that caches recent images.
+- **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ npm test -- --coverage
 Jest runs in ESM mode because `package.json` declares `"type": "module"`.
 Dynamic imports work without additional configuration.
 
-New tests cover the offline service‑worker toggle and template helpers.
+New tests cover automatic Service Worker registration and template helpers.
 
 ## Playwright End‑to‑End Tests
 

--- a/tests/js/offline.test.js
+++ b/tests/js/offline.test.js
@@ -1,20 +1,8 @@
 import { jest } from '@jest/globals';
-// tests/js/offline.test.js
 
-// Mock DOM element
-document.body.innerHTML = `
-  <input type="checkbox" id="offline-preview" />
-`;
-
-// Provide mock serviceWorker APIs
 Object.defineProperty(global.navigator, 'serviceWorker', {
   value: {
     register: jest.fn(() => Promise.resolve()),
-    getRegistrations: jest.fn(() =>
-      Promise.resolve([
-        { active: { scriptURL: '/sw.js' }, unregister: jest.fn() },
-      ]),
-    ),
   },
   configurable: true,
 });
@@ -29,31 +17,10 @@ beforeAll(async () => {
 describe('offline.js', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    localStorage.clear();
   });
 
-  test('checking the box registers the service worker', () => {
+  test('registers the service worker automatically', () => {
     initOffline();
-    const checkbox = document.getElementById('offline-preview');
-    checkbox.checked = true;
-    checkbox.dispatchEvent(new Event('change'));
-
-    expect(localStorage.getItem('offlinePreviewEnabled')).toBe('true');
     expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js');
-  });
-
-  test('unchecking the box unregisters the service worker', async () => {
-    initOffline();
-    const checkbox = document.getElementById('offline-preview');
-
-    // enable then disable
-    checkbox.checked = true;
-    checkbox.dispatchEvent(new Event('change'));
-
-    checkbox.checked = false;
-    checkbox.dispatchEvent(new Event('change'));
-
-    expect(localStorage.getItem('offlinePreviewEnabled')).toBeNull();
-    expect(navigator.serviceWorker.getRegistrations).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- always register the service worker in `offline.js`
- remove the Offline Preview checkbox from Settings
- update docs for automatic offline preview
- adjust unit tests for new behavior

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d375792c8333bf09ad45cdeac708