### PR TITLE
Fix video tile scaling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -287,15 +287,14 @@ select:hover {
     display: block;
 }
 
+
 .templateDiv video {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: contain; /* Scale video without cropping */
-    transform-origin: 0 0; /* Prevent viewport from shifting */
-    transform: scale(var(--tile-scale, 1));
+    object-fit: contain; /* Show entire frame */
 }
 
 /* Maintain aspect ratio without cropping */

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining 
 ### How do I enable SMS alerts?
 Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
 ### Why is the thumbnail size slider so narrow?
-The slider automatically adjusts to the current browser width and now scales thumbnails vertically as well as horizontally. Images are resized using `object-fit: contain` so nothing gets clipped. Sizes are capped around 1080&nbsp;px high so oversized previews don't bog down the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
+The slider automatically adjusts to the current browser width and scales thumbnails vertically as well as horizontally. Thumbnails now resize by changing their width and height directly, so the entire frame stays visible. Sizes are capped around 1080&nbsp;px high to keep previews from slowing the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 
 
 ### Why is the live feed slightly cropped on small screens?

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -2,7 +2,7 @@
 
 Glimpser now adapts to phones and tablets. The navigation menu collapses into a hamburger button on narrow screens and tables reflow vertically to avoid horizontal scrolling. Video grids automatically switch to a single column when viewed on devices without hover capability or small viewports.
 
-The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews shrink or grow using `object-fit: contain` so the entire image stays visible at any size.
+The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping.
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 


### PR DESCRIPTION
## Summary
- prevent viewport shift by removing video scaling transform
- clarify resizing details in responsive design and FAQ docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d5614e2c8333b49b495abd77b5e1