### PR TITLE
Expand MCP integration

### DIFF
--- a/app/utils/mcp.py
+++ b/app/utils/mcp.py
@@ -22,20 +22,31 @@ except Exception:  # pragma: no cover - openai-agents may not be installed
 class _StubMCPServer:
     """Fallback server used when ``openai-agents`` is unavailable."""
 
+    def __init__(self) -> None:
+        self._tools: Dict[str, Dict[str, Any]] = {}
+        self.register_tool(
+            "echo",
+            "Return the provided text",
+            lambda params=None: {"text": (params or {}).get("text", "")},
+        )
+
+    def register_tool(self, name: str, description: str, func) -> None:
+        """Register a callable as a stub MCP tool."""
+        self._tools[name] = {"description": description, "func": func}
+
     async def list_tools(self) -> List[Dict[str, Any]]:
         return [
-            {
-                "name": "echo",
-                "description": "Return the provided text",
-            }
+            {"name": name, "description": info["description"]}
+            for name, info in self._tools.items()
         ]
 
     async def call_tool(
         self, name: str, params: Dict[str, Any] | None = None
     ) -> Dict[str, Any]:
-        if name != "echo":
+        info = self._tools.get(name)
+        if not info:
             return {"error": f"Unknown tool: {name}"}
-        return {"text": (params or {}).get("text", "")}
+        return info["func"](params)
 
 
 class MCPClient:
@@ -92,6 +103,14 @@ def _get_default_client() -> MCPClient:
             url=config.MCP_SERVER_URL,
         )
     return _default_client
+
+
+def register_local_tool(name: str, description: str, func) -> None:
+    """Register a stub MCP tool when no server is available."""
+    client = _get_default_client()
+    asyncio.run(client._ensure_server())
+    if isinstance(client._server, _StubMCPServer):  # type: ignore[attr-defined]
+        client._server.register_tool(name, description, func)
 
 
 def list_tools_sync() -> List[Dict[str, Any]]:

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Help Page Overview](help_page.md)
 - [Camera Fix Suggestions](camera_fix.md)
 - [HTTP Callback Guide](http_callbacks.md)
+- [MCP Integration](mcp_integration.md)
 - [Recommendations](recommendations.md)
 - [Troubleshooting](troubleshooting.md)
 - [Startup Tips](startup_tips.md)

--- a/docs/mcp_integration.md
+++ b/docs/mcp_integration.md
@@ -1,0 +1,27 @@
+# MCP Integration
+
+Glimpser can delegate actions to an external **Model Control Plane (MCP)**. The
+MCP server exposes a list of tools that can be invoked from the web interface or
+through the `/mcp/tool/<name>` endpoint.
+
+## Configuration
+Set `MCP_SERVER_COMMAND` or `MCP_SERVER_URL` in `app/config.py` to point to the
+MCP server. When neither is configured, Glimpser falls back to a lightweight
+stub implementation.
+
+## Registering Local Tools
+When running without `openai-agents` installed, you can register custom tools
+for the stub server using `register_local_tool`:
+
+```python
+from app.utils import mcp
+
+def upper(params=None):
+    text = (params or {}).get("text", "")
+    return {"text": text.upper()}
+
+mcp.register_local_tool("upper", "Uppercase text", upper)
+```
+
+The new tool immediately becomes available via `mcp.call_tool_sync("upper")` and
+through the HTTP API.

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -24,6 +24,15 @@ class TestMCPClient(unittest.TestCase):
         result = asyncio.run(client.call_tool("bad"))
         self.assertEqual(result, {"error": "Unknown tool: bad"})
 
+    def test_register_local_tool(self):
+        def upper(params=None):
+            text = (params or {}).get("text", "")
+            return {"text": text.upper()}
+
+        mcp.register_local_tool("upper", "Uppercase text", upper)
+        result = mcp.call_tool_sync("upper", {"text": "hi"})
+        self.assertEqual(result, {"text": "HI"})
+
     def test_sync_helpers_use_config(self):
         with (
             patch("app.config.MCP_SERVER_COMMAND", "cmd"),


### PR DESCRIPTION
## Summary
- allow registration of local MCP tools when not using openai-agents
- test registering a custom tool
- document MCP integration and add index link

## Testing
- `flake8 app/utils/mcp.py tests/test_mcp_client.py`
- `pytest tests/test_mcp_client.py tests/test_mcp_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d5c57cc0833387639dee24b92c83