### PR TITLE
Improve danger mode page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -93,7 +93,10 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 from app.utils.scheduling import log_cache, log_cache_lock
 from app.utils.validators import validate_template_name, validate_update_data
 from app.utils.profiling import profile_route, get_latency_stats
-from scripts.update_chrome_shortcut import update_chrome_shortcuts
+from scripts.update_chrome_shortcut import (
+    update_chrome_shortcuts,
+    update_chrome_shortcuts_info,
+)
 
 
 def restart_server() -> None:
@@ -1077,7 +1080,7 @@ def init_routes(app: Flask) -> None:
         if request.method == "POST":
             action = request.form.get("action")
             if action == "update_shortcut":
-                paths = update_chrome_shortcuts()
+                paths, msg = update_chrome_shortcuts_info()
                 if paths:
                     joined = ", ".join(str(p) for p in paths)
                     flash(
@@ -1085,7 +1088,7 @@ def init_routes(app: Flask) -> None:
                         "success",
                     )
                 else:
-                    flash("Failed to update shortcuts", "error")
+                    flash(f"Failed to update shortcuts: {msg}", "error")
             else:
                 enabled = "enabled" in request.form
                 update_setting("DANGER_MODE", "True" if enabled else "False")

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -3,7 +3,8 @@
 <main class="container danger-page">
   <h2>Danger Mode</h2>
   <p class="page-tip">
-    For a full walkthrough see the <code>docs/danger_mode.md</code> guide.
+    For a full walkthrough see the
+    <a href="../docs/danger_mode.md" target="_blank">Danger Mode documentation</a>.
     Use the button below if Chrome was not launched with the debugging flag.
   </p>
   {% with messages = get_flashed_messages(with_categories=true) %}
@@ -56,8 +57,9 @@
   </section>
   {% endif %}
 
-  <form id="danger-form" method="post">
-    <label for="danger-checkbox" title="Toggle danger mode">
+  <form id="danger-form" method="post" class="checkbox-row">
+    <span>Enable Danger Mode</span>
+    <label class="switch" title="Toggle danger mode">
       <input
         id="danger-checkbox"
         type="checkbox"
@@ -65,7 +67,7 @@
         {% if enabled %}checked{% endif %}
         title="Enable or disable danger mode"
       />
-      Enable Danger Mode
+      <span class="slider round"></span>
     </label>
     <button type="submit" title="Save danger mode setting">Save</button>
   </form>

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -53,6 +53,19 @@ def update_chrome_shortcuts() -> list[Path]:
     return updated
 
 
+def update_chrome_shortcuts_info() -> tuple[list[Path], str]:
+    """Return updated paths and a message describing the result."""
+    if os.name != "nt" or win32com is None:
+        return [], "Shortcut update only supported on Windows with pywin32 installed"
+
+    paths = update_chrome_shortcuts()
+    if paths:
+        return paths, ""
+    if not shortcuts_need_patch():
+        return [], "Chrome shortcuts already include the debugging flag"
+    return [], "No Chrome shortcuts were updated. Check your permissions"
+
+
 def shortcuts_need_patch() -> bool:
     """Return True if any Chrome shortcuts are missing the debug flag."""
     if os.name != "nt" or win32com is None:


### PR DESCRIPTION
## Summary
- show an in-app docs link on the Danger Mode page
- use toggle switch with confirmation for enabling danger mode
- provide detailed messages when patching Chrome shortcuts

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d6600ebc83339f3848947b090792