### PR TITLE
Autodiscover ONVIF endpoints on camera add

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2282,6 +2282,16 @@ def init_routes(app: Flask) -> None:
             template_name = validate_template_name(data["name"])
             if template_name is None:
                 abort(404)
+            url = data.get("url", "")
+            if url and ("onvif" in url or urlparse(url).path in {"", "/"}):
+                try:
+                    endpoints = camera_discovery.autodetect_onvif_endpoints(url)
+                    if endpoints.get("snapshot"):
+                        data["url"] = endpoints["snapshot"]
+                    elif endpoints.get("stream"):
+                        data["url"] = endpoints["stream"]
+                except Exception:
+                    pass
             if template_manager.save_template(template_name, data):
                 return jsonify({"status": "success", "message": "Template saved"})
 

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -170,6 +170,125 @@ def _onvif_get_device_info(xaddr: str, timeout: int = 2) -> dict[str, str]:
     return info
 
 
+def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
+    """Return stream and snapshot URLs derived from an ONVIF device service.
+
+    Parameters
+    ----------
+    url : str
+        Base camera URL or ONVIF device service address.
+    timeout : int
+        Request timeout in seconds.
+
+    Returns
+    -------
+    dict
+        Dictionary with optional ``stream`` and ``snapshot`` keys.
+    """
+
+    parsed = urlparse(url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    xaddr = url if "device_service" in parsed.path else f"{base}/onvif/device_service"
+
+    # Step 1: locate the media service address via GetCapabilities
+    cap_body = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope'>"
+        "<s:Body>"
+        "<GetCapabilities xmlns='http://www.onvif.org/ver10/device/wsdl'>"
+        "<Category>All</Category>"
+        "</GetCapabilities>"
+        "</s:Body>"
+        "</s:Envelope>"
+    )
+    media_addr = None
+    try:
+        resp = requests.post(xaddr, data=cap_body, timeout=timeout)
+        if resp.ok:
+            xml = ET.fromstring(resp.content)
+            ns = {"tt": "http://www.onvif.org/ver10/schema"}
+            node = xml.find(".//tt:Capabilities/tt:Media/tt:XAddr", ns)
+            if node is not None and node.text:
+                media_addr = node.text
+    except Exception:
+        media_addr = None
+    if not media_addr:
+        media_addr = f"{base}/onvif/media_service"
+
+    # Step 2: fetch the first profile token
+    prof_body = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope'>"
+        "<s:Body>"
+        "<GetProfiles xmlns='http://www.onvif.org/ver10/media/wsdl'/>"
+        "</s:Body>"
+        "</s:Envelope>"
+    )
+    token = None
+    try:
+        resp = requests.post(media_addr, data=prof_body, timeout=timeout)
+        if resp.ok:
+            xml = ET.fromstring(resp.content)
+            ns = {"trt": "http://www.onvif.org/ver10/media/wsdl"}
+            prof = xml.find(".//trt:Profiles", ns)
+            if prof is not None:
+                token = prof.attrib.get("token")
+    except Exception:
+        token = None
+    if not token:
+        return {}
+
+    # Step 3: fetch stream URI and snapshot URI
+    result: dict[str, str] = {}
+    stream_body = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:trt='http://www.onvif.org/ver10/media/wsdl' xmlns:tt='http://www.onvif.org/ver10/schema'>"
+        "<s:Body>"
+        "<trt:GetStreamUri>"
+        "<trt:StreamSetup>"
+        "<tt:Stream>RTP-Unicast</tt:Stream>"
+        "<tt:Transport><tt:Protocol>RTSP</tt:Protocol></tt:Transport>"
+        "</trt:StreamSetup>"
+        f"<trt:ProfileToken>{token}</trt:ProfileToken>"
+        "</trt:GetStreamUri>"
+        "</s:Body>"
+        "</s:Envelope>"
+    )
+    try:
+        resp = requests.post(media_addr, data=stream_body, timeout=timeout)
+        if resp.ok:
+            xml = ET.fromstring(resp.content)
+            ns = {"tt": "http://www.onvif.org/ver10/schema"}
+            uri = xml.find(".//tt:Uri", ns)
+            if uri is not None and uri.text:
+                result["stream"] = uri.text
+    except Exception:
+        pass
+
+    snap_body = (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:trt='http://www.onvif.org/ver10/media/wsdl' xmlns:tt='http://www.onvif.org/ver10/schema'>"
+        "<s:Body>"
+        "<trt:GetSnapshotUri>"
+        f"<trt:ProfileToken>{token}</trt:ProfileToken>"
+        "</trt:GetSnapshotUri>"
+        "</s:Body>"
+        "</s:Envelope>"
+    )
+    try:
+        resp = requests.post(media_addr, data=snap_body, timeout=timeout)
+        if resp.ok:
+            xml = ET.fromstring(resp.content)
+            ns = {"tt": "http://www.onvif.org/ver10/schema"}
+            uri = xml.find(".//tt:Uri", ns)
+            if uri is not None and uri.text:
+                result["snapshot"] = uri.text
+    except Exception:
+        pass
+
+    return result
+
+
 def _mac_manufacturer(mac: str | None) -> str | None:
     """Return the vendor name for ``mac`` using known mappings or remote lookup."""
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -204,6 +204,12 @@ Remote sources such as **GOES16**, **ZoomEarth**, and **Dopler** can be added
 manually, but they are not discovered automatically because they are hosted
 outside the local network.
 
+When creating a new template you can now supply just the camera's base
+address (for example `http://192.168.1.10`). If the device speaks ONVIF,
+Glimpser queries it for the recommended snapshot and stream URIs and
+updates the template URL automatically. This makes initial setup similar to
+tools like Blue Iris.
+
 ## Future improvements
 
 Discovering cameras on remote networks remains on the roadmap. Authentication for protected feeds has been enhanced – you can now store a username and password with each template, and the capture routines will automatically supply these credentials.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -4,6 +4,7 @@ import os
 import sys
 from ipaddress import ip_network
 from unittest.mock import patch
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -536,6 +537,24 @@ class TestCameraDiscovery(unittest.TestCase):
         cam = cams[0]
         self.assertEqual(cam.get("url"), "rtsp://1.2.3.4:554/")
         self.assertEqual(cam["info"].get("device_type"), "camera")
+
+    @patch("app.utils.camera_discovery.requests.post")
+    def test_autodetect_onvif_endpoints(self, mock_post):
+        def _side_effect(url, data, timeout=3):
+            if "GetCapabilities" in data:
+                xml = "<Envelope><Body><Capabilities><Media><XAddr>http://1.2.3.4/onvif/media_service</XAddr></Media></Capabilities></Body></Envelope>"
+            elif "GetProfiles" in data:
+                xml = "<Envelope><Body><trt:GetProfilesResponse xmlns:trt='http://www.onvif.org/ver10/media/wsdl'><trt:Profiles token='p0'/></trt:GetProfilesResponse></Body></Envelope>"
+            elif "GetStreamUri" in data:
+                xml = "<Envelope><Body><tt:Uri xmlns:tt='http://www.onvif.org/ver10/schema'>rtsp://1.2.3.4/stream</tt:Uri></Body></Envelope>"
+            else:
+                xml = "<Envelope><Body><tt:Uri xmlns:tt='http://www.onvif.org/ver10/schema'>http://1.2.3.4/snap.jpg</tt:Uri></Body></Envelope>"
+            return SimpleNamespace(ok=True, content=xml.encode())
+
+        mock_post.side_effect = _side_effect
+        res = camera_discovery.autodetect_onvif_endpoints("http://1.2.3.4")
+        self.assertEqual(res["stream"], "rtsp://1.2.3.4/stream")
+        self.assertEqual(res["snapshot"], "http://1.2.3.4/snap.jpg")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- autodetect stream and snapshot URLs via ONVIF
- replace camera URL on template creation when possible
- document new autodiscovery behavior
- test autodetection helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d5acb58c83339b4a68536d537d3c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - When creating a new camera template, users can now provide only the camera's base address. If the device supports ONVIF, the system will automatically detect and use recommended snapshot or stream URLs.

- **Documentation**
  - Updated camera discovery documentation to reflect the new ONVIF autodetection feature for camera templates.

- **Tests**
  - Added tests to ensure the ONVIF endpoint autodetection works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->