### PR TITLE
Move logout option to navigation

### DIFF
--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -18,6 +18,10 @@
     <path d="M10 8l4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
     <path d="M4 4v16h7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
   </symbol>
+  <symbol id="logout" viewBox="0 0 24 24">
+    <path d="M14 8l-4 4 4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M20 4v16h-7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  </symbol>
   <symbol id="check" viewBox="0 0 24 24">
     <polyline points="20 6 9 17 4 12" stroke="currentColor" stroke-width="2" fill="none" />
   </symbol>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -52,12 +52,17 @@
         </div>
       </div>
     </a>
-    <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
-      <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
-      </svg>
-    </a>
-    {% else %}
+      <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
+        <svg width="20" height="20">
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
+        </svg>
+      </a>
+      <a href="{{ url_for('logout') }}" class="settings-icon" title="Logout" aria-label="Logout">
+        <svg width="20" height="20">
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#logout" />
+        </svg>
+      </a>
+      {% else %}
     <a href="{{ url_for('login') }}" class="settings-icon" title="Login" aria-label="Login">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#login" />

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
 <main class="container settings-page">
-    <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
 
     {# Help content now appears directly in the table, so the collapsible menu was removed #}
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -20,3 +20,4 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The delete button text color now meets color contrast guidelines.
 - The live player styles moved to `player.css` and the index page uses
   `<section>` elements for clearer structure.
+- The Logout option now appears in the navigation bar instead of the Settings page for consistent placement.


### PR DESCRIPTION
## Summary
- add logout icon to nav
- remove logout link from settings
- document logout placement

## Testing
- `black --check .`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6841d7b5909c833390271a01cee97a71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a logout link to the main navigation bar for authenticated users, providing easier access to log out.

- **Style**
  - Improved accessibility by including clear labels for navigation icons.

- **Documentation**
  - Updated documentation to reflect the new location of the logout option in the navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->