### PR TITLE
Hide inactive danger icon

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -93,10 +93,11 @@ export function initNav() {
         const data = await fetchJson("/danger_status");
         if (!data) return;
         if (data.ready) {
+          dangerStatus.style.display = "flex";
           dangerStatus.style.color = "orange";
           dangerStatus.title = "Danger Mode Ready";
         } else {
-          dangerStatus.style.color = "grey";
+          dangerStatus.style.display = "none";
           const reason = [];
           if (!data.port_open) reason.push("Debug port closed");
           if (!data.idle) reason.push("User active");

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -24,7 +24,7 @@
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#check" />
       </svg>
     </a>
-    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode" aria-label="Danger Mode">
+    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode" aria-label="Danger Mode" style="display:none;">
       <svg width="18" height="18">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
       </svg>

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -26,7 +26,7 @@ For now, you can store the launch command in a script and double-click it instea
 
 ## Using Danger Mode in Glimpser
 
-When Chrome's debug port is open and no user input has been detected for a short period, Glimpser shows an orange indicator in the navigation bar. A `!` appears in the icon when ready and an `×` explains why it's disabled when you hover over it.
+When Chrome's debug port is open and no user input has been detected for a short period, Glimpser shows an orange indicator in the navigation bar. The icon hides again when Danger mode is unavailable. A `!` appears when ready and an `×` in the tooltip explains why it's disabled.
 
 Captures marked as "Danger" in the template editor will use your running Chrome session. Glimpser opens a new tab, performs the capture, and closes the tab when finished. It skips the operation if you become active while the capture is pending.
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -73,7 +73,7 @@ without an update.
 
 ## Danger Mode Indicator
 
-When Chrome's remote debugging port is open and no user input has been detected for a short time, Danger mode becomes available. An orange icon in the navigation bar shows this state. Hovering over the icon explains why Danger mode may be unavailable. See [Danger Mode](danger_mode.md) for setup instructions.
+When Chrome's remote debugging port is open and no user input has been detected for a short time, an orange icon appears in the navigation bar. The icon hides again when Danger mode is unavailable. Hovering over it explains why Danger mode may be disabled. See [Danger Mode](danger_mode.md) for setup instructions.
 
 ## Profiling
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -8,7 +8,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Group links** – open the page listing cameras in that group.
 - **Template title** – links to the template details page.
 - **System Performance icon** – shows CPU, memory and other metrics.
-- **Danger Mode icon** – explains why danger mode may be disabled.
+- **Danger Mode icon** – appears only when Danger mode is available. Hovering over it explains why the feature may be disabled.
 - **Discover Cameras icon** – opens the camera discovery page.
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of


### PR DESCRIPTION
## Summary
- hide the danger icon unless danger mode is ready
- document the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d7cbea1c8333b1d9779c9e473e49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Danger Mode" status indicator in the navigation bar is now hidden when Danger mode is unavailable, improving visual feedback.

- **Documentation**
  - Updated documentation to clarify when the "Danger Mode" indicator appears and how its tooltip behaves, providing clearer guidance on its visibility and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->