### PR TITLE
Allow customizing nav logo

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -233,6 +233,7 @@ sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)
 NAME = get_setting("NAME", "glimpser")
+NAV_ICON = get_setting("NAV_ICON", "img/glimpser_small.png")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))
 DEBUG = get_setting("DEBUG", "False") == "True"

--- a/app/routes.py
+++ b/app/routes.py
@@ -59,6 +59,7 @@ from app.config import (
     restore_config,
     SENSITIVE_SETTINGS,
     CHYRON_SPEED,
+    NAV_ICON,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -911,6 +912,7 @@ def init_routes(app: Flask) -> None:
             COMMIT_HASH=COMMIT_HASH,
             NODE_ENV=NODE_ENV,
             CHYRON_SPEED=CHYRON_SPEED,
+            NAV_ICON=NAV_ICON,
         )
 
     # Add a new route for the extended health check

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,8 +1,10 @@
+{% if NAV_ICON %}
 <h1>
   <a href="/" title="Home">
-    <img src="{{ url_for('static', filename='img/glimpser_small.png') }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
+    <img src="{{ url_for('static', filename=NAV_ICON) }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
   </a>
 </h1>
+{% endif %}
 <div id="caption-chyron" class="caption-chyron" aria-live="polite" data-speed="{{ CHYRON_SPEED }}"></div>
 <nav>
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -28,6 +28,7 @@ Below are key settings loaded from the database with their default values. You
 can modify them in the application interface or directly in the database.
 
 - `NAME` – application name (default `glimpser`)
+- `NAV_ICON` – navigation logo path relative to the `static` directory. Set to an empty string to hide the logo (default `img/glimpser_small.png`)
 - `VERSION` – application version (defaults to the installed package version and
   is updated automatically when it changes)
 - `LANG` – default language (default `en-US`)


### PR DESCRIPTION
## Summary
- make navigation logo configurable with `NAV_ICON`
- inject `NAV_ICON` into templates
- show logo only if configured
- document the setting in the configuration guide

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d7dee9748333986f43178ad5743e