### PR TITLE
Add all-group navigation and camera menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with Blue Iris, Home Assistant and Hubitat
 - Custom video controls including Play All/Pause All
 - Automatic group loading for cameras
+- Navigation dropdown now includes an "all" group and per-group camera menu
 - Live view tooltip refreshes with the latest caption
 - Add Template form auto-fills selected group
 - API discovery and paginated log view

--- a/app/routes.py
+++ b/app/routes.py
@@ -1317,6 +1317,8 @@ def init_routes(app: Flask) -> None:
         """Render a page listing all cameras in a group."""
         group_name = secure_filename(group_name)
         groups = get_active_groups()
+        if group_name == "all":
+            return redirect(url_for("index"))
         if group_name not in groups:
             abort(404)
         return render_template(
@@ -1827,6 +1829,8 @@ def init_routes(app: Flask) -> None:
     def get_groups():
         # Assuming you have a function that returns a list of unique groups
         groups = get_active_groups()
+        if "all" not in groups:
+            groups = ["all"] + groups
         return jsonify(groups)
 
     @app.route("/captions")

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -6,6 +6,9 @@ export function initNav() {
     const nav = document.querySelector("nav");
     const menuToggle = document.getElementById("menu-toggle");
     const groupDropdown = document.getElementById("nav-group-dropdown");
+    const cameraDropdown = document.getElementById("nav-camera-dropdown");
+    const currentGroup = window.currentGroup || null;
+    const currentCamera = window.currentCamera || null;
 
     if (nav && menuToggle) {
       menuToggle.addEventListener("click", () => {
@@ -24,9 +27,16 @@ export function initNav() {
           groups.forEach((g) => {
             const opt = document.createElement("option");
             opt.value = g;
-            opt.textContent = g;
+            opt.textContent = g === "all" ? "All" : g;
             groupDropdown.appendChild(opt);
           });
+        }
+        if (currentGroup) {
+          groupDropdown.value = currentGroup;
+          await loadNavCameras(currentGroup);
+          if (cameraDropdown && currentCamera) {
+            cameraDropdown.value = currentCamera;
+          }
         }
       } catch (error) {
         console.error("Error loading groups:", error);
@@ -35,11 +45,54 @@ export function initNav() {
       }
     };
 
+    const loadNavCameras = async (group) => {
+      if (!cameraDropdown) return;
+      if (!group || group === "all") {
+        cameraDropdown.style.display = "none";
+        return;
+      }
+      cameraDropdown.style.display = "";
+      cameraDropdown.innerHTML = '<option value="">Cameras</option>';
+      cameraDropdown.disabled = true;
+      try {
+        const cams = await fetchJson(`/templates?group=${encodeURIComponent(group)}`);
+        if (cams) {
+          Object.keys(cams)
+            .sort()
+            .forEach((c) => {
+              const opt = document.createElement("option");
+              opt.value = c;
+              opt.textContent = c;
+              cameraDropdown.appendChild(opt);
+            });
+        }
+      } catch (error) {
+        console.error("Error loading cameras:", error);
+      } finally {
+        cameraDropdown.disabled = false;
+      }
+    };
+
     if (groupDropdown) {
       groupDropdown.addEventListener("change", () => {
-        if (groupDropdown.value) {
+        if (!groupDropdown.value) return;
+        if (groupDropdown.value === "all") {
+          window.location.href = "/";
+        } else {
           window.location.href = `/group/${encodeURIComponent(
             groupDropdown.value,
+          )}`;
+        }
+        loadNavCameras(groupDropdown.value);
+      });
+      if (currentGroup) loadNavCameras(currentGroup);
+    }
+
+    if (cameraDropdown) {
+      cameraDropdown.addEventListener("change", () => {
+        if (cameraDropdown.value) {
+          window.location.href = `/templates/${encodeURIComponent(
+            cameraDropdown.value,
           )}`;
         }
       });

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -14,6 +14,7 @@
 <div id="index-time" class="corner-time" title=""></div>
 <script type="module">
     import { loadGroups, loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
+    window.currentGroup = '{{ group_name }}';
     document.addEventListener('DOMContentLoaded', () => {
         loadGroups().then(() => {
             const dropdown = document.getElementById('group-dropdown');

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -8,6 +8,7 @@
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
   <div class="nav-left">
     <select id="nav-group-dropdown" title="Jump to group"></select>
+    <select id="nav-camera-dropdown" title="Jump to camera" style="display:none"></select>
     <!-- Discover icon moved to nav-right for consistency -->
   </div>
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -5,6 +5,10 @@
 <script>
     const cameraMeta = {{ template_details|tojson }};
     window.templateDetails = { "{{ template_name }}": cameraMeta };
+    window.currentCamera = '{{ template_name }}';
+    {% if template_details.get('groups') %}
+    window.currentGroup = "{{ template_details.get('groups').split(',')[0].strip() }}";
+    {% endif %}
 </script>
 
 <link rel="stylesheet" href="{{ url_for('static', filename='css/player.css') }}">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -575,6 +575,23 @@ class TestRoutes(unittest.TestCase):
         response = self.client.get("/group/unknown")
         self.assertEqual(response.status_code, 404)
 
+    @patch("app.routes.get_active_groups")
+    @patch("app.routes.session", {"user_id": 1})
+    def test_group_page_all_redirect(self, mock_groups):
+        mock_groups.return_value = ["group1"]
+        response = self.client.get("/group/all")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/", response.headers["Location"])
+
+    @patch("app.routes.get_active_groups")
+    @patch("app.routes.session", {"user_id": 1})
+    def test_groups_endpoint_includes_all(self, mock_groups):
+        mock_groups.return_value = ["group1"]
+        response = self.client.get("/groups")
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn("all", data)
+
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
     def test_captions_status(self, mock_session_local):


### PR DESCRIPTION
## Summary
- add `all` option in group navigation
- show camera dropdown when viewing a group or camera
- redirect `/group/all` to the dashboard
- expose all groups via `/groups`
- document navigation update
- test the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d8069b808333ae1cecaf52a8797b