### PR TITLE
Fix camera dropdown style

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -524,7 +524,8 @@ nav a {
     transition: background-color 0.2s, color 0.2s; /* Smooth hover transition */
 }
 
-#nav-group-dropdown {
+#nav-group-dropdown,
+#nav-camera-dropdown {
     background-color: var(--secondary-bg-color);
     color: var(--text-color);
     border: 1px solid var(--table-border-color);
@@ -695,7 +696,8 @@ nav a:hover, nav a.active {
         padding: 1px 3px;
     }
 
-    #nav-group-dropdown {
+    #nav-group-dropdown,
+    #nav-camera-dropdown {
         width: 100%;
         margin-bottom: 5px;
     }


### PR DESCRIPTION
## Summary
- style camera dropdown like the group dropdown

## Testing
- `black .`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841e42574848333af2243503ddf88a2