### PR TITLE
Add digital/analog clock toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Footer warns when a newer release is available
 - Stream error overlay distinguishes network and unsupported format errors
 - Sortable KPI table on captions page with filtering
+- Switchable digital or analog navigation clock with an option to hide it
 
 ### Changed
 - Improved screenshot reliability

--- a/app/config.py
+++ b/app/config.py
@@ -234,6 +234,8 @@ sync_version(_PKG_VERSION)
 VERSION = get_setting("VERSION", _PKG_VERSION)
 NAME = get_setting("NAME", "glimpser")
 NAV_ICON = get_setting("NAV_ICON", "img/glimpser_small.png")
+NAV_CLOCK_ENABLED = get_setting("NAV_CLOCK_ENABLED", "True") == "True"
+NAV_CLOCK_MODE = get_setting("NAV_CLOCK_MODE", "analog")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))
 DEBUG = get_setting("DEBUG", "False") == "True"

--- a/app/routes.py
+++ b/app/routes.py
@@ -60,6 +60,8 @@ from app.config import (
     SENSITIVE_SETTINGS,
     CHYRON_SPEED,
     NAV_ICON,
+    NAV_CLOCK_ENABLED,
+    NAV_CLOCK_MODE,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -916,6 +918,8 @@ def init_routes(app: Flask) -> None:
             NODE_ENV=NODE_ENV,
             CHYRON_SPEED=CHYRON_SPEED,
             NAV_ICON=NAV_ICON,
+            NAV_CLOCK_ENABLED=NAV_CLOCK_ENABLED,
+            NAV_CLOCK_MODE=NAV_CLOCK_MODE,
         )
 
     # Add a new route for the extended health check

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -821,6 +821,18 @@ button, a {
     background-color: #ff0000;
 }
 
+/* Digital clock mode */
+.cool-clock[data-mode="digital"] .hand {
+    display: none;
+}
+
+.cool-clock[data-mode="digital"] #digitalTime {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+}
+
 /* Template Form Styles */
 #template-form, #edit-template {
     background-color: var(--form-bg-color);

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -281,24 +281,38 @@ export function initNav() {
     };
 
     const updateCoolClock = () => {
-      const secondHand = document.querySelector(".second-hand");
-      const minuteHand = document.querySelector(".minute-hand");
-      const hourHand = document.querySelector(".hour-hand");
+      const clock = document.getElementById("coolClock");
       const digitalTime = document.getElementById("digitalTime");
-      if (!secondHand || !minuteHand || !hourHand || !digitalTime) return;
+      if (!clock || !digitalTime) return;
+
+      const mode = clock.dataset.mode || "analog";
+      const secondHand = clock.querySelector(".second-hand");
+      const minuteHand = clock.querySelector(".minute-hand");
+      const hourHand = clock.querySelector(".hour-hand");
 
       const now = new Date();
-      const secondsDegrees = (now.getSeconds() / 60) * 360;
-      const minutesDegrees =
-        (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6;
-      const hoursDegrees =
-        (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30;
-
-      secondHand.style.transform = `rotate(${secondsDegrees}deg)`;
-      minuteHand.style.transform = `rotate(${minutesDegrees}deg)`;
-      hourHand.style.transform = `rotate(${hoursDegrees}deg)`;
-
       digitalTime.title = `${now.toLocaleTimeString()}\n${Intl.DateTimeFormat().resolvedOptions().timeZone}\n${now.toDateString()}`;
+
+      if (mode === "digital") {
+        digitalTime.textContent = now.toLocaleTimeString();
+        [secondHand, minuteHand, hourHand].forEach((el) => {
+          if (el) el.style.display = "none";
+        });
+      } else {
+        const secondsDegrees = (now.getSeconds() / 60) * 360;
+        const minutesDegrees =
+          (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6;
+        const hoursDegrees =
+          (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30;
+
+        if (secondHand) secondHand.style.transform = `rotate(${secondsDegrees}deg)`;
+        if (minuteHand) minuteHand.style.transform = `rotate(${minutesDegrees}deg)`;
+        if (hourHand) hourHand.style.transform = `rotate(${hoursDegrees}deg)`;
+        [secondHand, minuteHand, hourHand].forEach((el) => {
+          if (el) el.style.display = "";
+        });
+        digitalTime.textContent = "";
+      }
     };
 
     const setupNavFade = () => {

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -44,8 +44,9 @@
         </svg>
       </a>
     </div>
+    {% if NAV_CLOCK_ENABLED %}
     <a href="/live" id="live" aria-label="Open Live page">
-      <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
+      <div id="coolClock" class="cool-clock" data-mode="{{ NAV_CLOCK_MODE }}" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
         <div id="dateDisplay" class="clock-face">
           <div id="digitalTime" class="clock-hands" title="">
             <div class="hand hour-hand"></div>
@@ -55,6 +56,7 @@
         </div>
       </div>
     </a>
+    {% endif %}
       <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
         <svg width="20" height="20">
           <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -16,6 +16,8 @@ SETTINGS_TOOLTIPS = {
     "FFMPEG_THREADS": "Threads for video processing",
     "LIVE_FALLBACK_FPS": "Frame rate for still image streams",
     "LIVE_MAX_FAILURES": "Max retries for live streams",
+    "NAV_CLOCK_ENABLED": "Show or hide the navigation clock",
+    "NAV_CLOCK_MODE": "Display the navigation clock in analog or digital mode",
     "CHYRON_SPEED": "Duration of caption banner in seconds",
     "EMAIL_ENABLED": "Toggle email notifications",
     "EMAIL_SMTP_SERVER": "SMTP server address",
@@ -41,6 +43,8 @@ SETTINGS_GROUPS = {
         "MAX_WORKERS",
         "LOG_LEVEL",
         "FLASK_LOG_LEVEL",
+        "NAV_CLOCK_ENABLED",
+        "NAV_CLOCK_MODE",
     ],
     "Credentials": [
         "USER_NAME",

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -29,6 +29,8 @@ can modify them in the application interface or directly in the database.
 
 - `NAME` – application name (default `glimpser`)
 - `NAV_ICON` – navigation logo path relative to the `static` directory. Set to an empty string to hide the logo (default `img/glimpser_small.png`)
+- `NAV_CLOCK_ENABLED` – set to `False` to hide the navigation clock (default `True`)
+- `NAV_CLOCK_MODE` – choose `analog` or `digital` clock style (default `analog`)
 - `VERSION` – application version (defaults to the installed package version and
   is updated automatically when it changes)
 - `LANG` – default language (default `en-US`)

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -18,7 +18,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
   Clicking the chyron opens the `/captions` page. It stays green for one minute after the
   most recent caption, turns yellow for the next five minutes and becomes red
   when no update has been received for over thirty minutes.
-- **Clock icon** – opens the live page with instructions for real‑time streaming.
+- **Clock icon** – opens the live page with instructions for real‑time streaming. The display can switch between analog and digital or be disabled entirely via settings.
 - **Settings gear icon** – opens the settings page.
 - **Login link** – appears when not authenticated.
 


### PR DESCRIPTION
## Summary
- add NAV_CLOCK_ENABLED and NAV_CLOCK_MODE settings
- update nav template and script to support digital or analog clock
- hide clock via settings
- document new settings and behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e464f4708333a13ef0f4d66f8425