### PR TITLE
Hide healthy nav status

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -338,6 +338,14 @@ LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
 # the banner remains visible after a caption arrives.
 CHYRON_SPEED = int(get_setting("CHYRON_SPEED", 0))
 
+# Whether the System Performance icon in the navigation bar should remain
+# visible even when the application reports healthy status. When set to
+# ``False`` the icon hides itself if all metrics look nominal to reduce
+# clutter. Set ``True`` to keep it visible at all times.
+HEALTH_STATUS_ALWAYS_VISIBLE = (
+    get_setting("HEALTH_STATUS_ALWAYS_VISIBLE", "False") == "True"
+)
+
 # Watchdog configuration values. These control how aggressively the
 # watchdog restarts the application when health checks fail.
 WATCHDOG_FAILURE_THRESHOLD = int(get_setting("WATCHDOG_FAILURE_THRESHOLD", 3))

--- a/app/routes.py
+++ b/app/routes.py
@@ -60,6 +60,7 @@ from app.config import (
     SENSITIVE_SETTINGS,
     CHYRON_SPEED,
     NAV_ICON,
+    HEALTH_STATUS_ALWAYS_VISIBLE,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -916,6 +917,7 @@ def init_routes(app: Flask) -> None:
             NODE_ENV=NODE_ENV,
             CHYRON_SPEED=CHYRON_SPEED,
             NAV_ICON=NAV_ICON,
+            HEALTH_STATUS_ALWAYS_VISIBLE=HEALTH_STATUS_ALWAYS_VISIBLE,
         )
 
     # Add a new route for the extended health check

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,6 +1,11 @@
 export function initNav() {
   document.addEventListener("DOMContentLoaded", () => {
     const healthStatus = document.getElementById("health-status");
+    const healthAlwaysVisible =
+      healthStatus && healthStatus.dataset.alwaysVisible === "true";
+    if (healthStatus && !healthAlwaysVisible) {
+      healthStatus.style.display = "none";
+    }
     const dangerStatus = document.getElementById("danger-status");
     const discoveryStatus = document.getElementById("discover-status");
     const nav = document.querySelector("nav");
@@ -119,7 +124,13 @@ export function initNav() {
         if (data.status === "healthy") {
           healthStatus.style.color = "green";
           healthStatus.title = "System Status: Healthy\n\n";
+          if (!healthAlwaysVisible) {
+            healthStatus.style.display = "none";
+          } else {
+            healthStatus.style.display = "flex";
+          }
         } else {
+          healthStatus.style.display = "flex";
           healthStatus.style.color = "red";
           healthStatus.title = "System Status: Degraded\n\n";
         }

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -60,7 +60,9 @@ export function initNav() {
       cameraDropdown.innerHTML = '<option value="">Cameras</option>';
       cameraDropdown.disabled = true;
       try {
-        const cams = await fetchJson(`/templates?group=${encodeURIComponent(group)}`);
+        const cams = await fetchJson(
+          `/templates?group=${encodeURIComponent(group)}`,
+        );
         if (cams) {
           Object.keys(cams)
             .sort()

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -22,7 +22,7 @@
 
   <div class="nav-right">
     {% if session.get('user_id') %}
-    <a id="health-status" href="/status" class="status-indicator" title="System Performance" aria-label="System Performance">
+    <a id="health-status" href="/status" class="status-indicator" title="System Performance" aria-label="System Performance" data-always-visible="{{ 'true' if HEALTH_STATUS_ALWAYS_VISIBLE else 'false' }}">
       <svg width="18" height="18">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#check" />
       </svg>

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -118,6 +118,7 @@ Settings controlling how frames are captured from video sources:
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
 - `CHYRON_SPEED` – seconds the caption chyron scrolls; set to `0` to disable (default `0`)
+- `HEALTH_STATUS_ALWAYS_VISIBLE` – keep the System Performance icon visible even when the system is healthy (default `False`)
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
 - `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)
 - `WATCHDOG_MAX_FILE_HANDLES` – open file handle limit before triggering a restart (default `1000`)

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -73,6 +73,13 @@ without an update.
 You can toggle the chyron from the **Captions** page using the button in the
 History tab.
 
+## System Performance Icon
+
+The System Performance icon in the navigation bar provides quick access to the
+`/status` page. When all metrics look healthy the icon now hides to reduce
+clutter. Set the `HEALTH_STATUS_ALWAYS_VISIBLE` option to `True` if you prefer
+to keep it shown at all times.
+
 ## Danger Mode Indicator
 
 When Chrome's remote debugging port is open and no user input has been detected for a short time, an orange icon appears in the navigation bar. The icon hides again when Danger mode is unavailable. Hovering over it explains why Danger mode may be disabled. See [Danger Mode](danger_mode.md) for setup instructions.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -7,7 +7,8 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **Home** – returns to the dashboard.
 - **Group links** – open the page listing cameras in that group.
 - **Template title** – links to the template details page.
-- **System Performance icon** – shows CPU, memory and other metrics.
+- **System Performance icon** – shows CPU, memory and other metrics. It hides
+  when the system is healthy unless `HEALTH_STATUS_ALWAYS_VISIBLE` is set.
 - **Danger Mode icon** – appears only when Danger mode is available. Hovering over it explains why the feature may be disabled.
 - **Discover Cameras icon** – opens the camera discovery page.
 - **Captions icon** – reads and updates camera language models. The icon flashes


### PR DESCRIPTION
## Summary
- add `HEALTH_STATUS_ALWAYS_VISIBLE` option
- hide the system performance icon when healthy unless option is set
- document the new behavior

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841e4d0c66c8333af3d8a0f8cffb425