### PR TITLE
Remove extra group filter controls

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -206,6 +206,14 @@ export async function loadGroups() {
   } finally {
     groupDropdown.disabled = false;
   }
+
+export function getSelectedGroup() {
+  const dropdown = document.getElementById("group-dropdown");
+  if (dropdown && dropdown.value) return dropdown.value;
+  const navDropdown = document.getElementById("nav-group-dropdown");
+  if (navDropdown && navDropdown.value) return navDropdown.value;
+  if (window.currentGroup) return window.currentGroup;
+  return "all";
 }
 
 export function timeAgo(utcDateString) {
@@ -351,11 +359,11 @@ export function setupSearch() {
   const filterValue = document.getElementById("filter-value");
   const applyFilter = document.getElementById("apply-filter");
   const templateList = document.getElementById("template-list");
-  if (!searchInput || !groupDropdown) return;
+  if (!searchInput) return;
 
   const filterCameras = () => {
     const searchTerm = searchInput.value.toLowerCase();
-    const selectedGroup = groupDropdown.value;
+    const selectedGroup = groupDropdown ? groupDropdown.value : getSelectedGroup();
     const column = filterColumn ? filterColumn.value : "";
     const filterVal = filterValue ? filterValue.value.trim().toLowerCase() : "";
     cameraRows.forEach((row) => {
@@ -388,10 +396,10 @@ export function setupSearch() {
   if (templateList) {
     const debouncedLoad = debounce(loadTemplates, 300);
     searchInput.addEventListener("input", debouncedLoad);
-    groupDropdown.addEventListener("change", debouncedLoad);
+    if (groupDropdown) groupDropdown.addEventListener("change", debouncedLoad);
   } else {
     searchInput.addEventListener("input", filterCameras);
-    groupDropdown.addEventListener("change", filterCameras);
+    if (groupDropdown) groupDropdown.addEventListener("change", filterCameras);
     if (applyFilter) applyFilter.addEventListener("click", filterCameras);
   }
 }
@@ -404,9 +412,8 @@ export function templateMatchesSearch(template, searchQuery) {
 }
 
 export async function loadTemplates() {
-  const groupDropdown = document.getElementById("group-dropdown");
   const searchInput = document.getElementById("search-input");
-  const selectedGroup = groupDropdown ? groupDropdown.value || "all" : "all";
+  const selectedGroup = getSelectedGroup();
   const searchQuery = searchInput ? searchInput.value.toLowerCase() : "";
   const url = `/templates?group=${selectedGroup}&search=${searchQuery}&t=${new Date().getTime()}`;
 

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -41,11 +41,6 @@
         <details class="filter-controls">
             <summary>Search &amp; Filters</summary>
             <div class="controls-inner">
-                <label for="group-dropdown" title="Filter templates by group">Group:</label>
-                <select id="group-dropdown" title="Select a group to filter templates">
-                    <!-- Options will be populated here -->
-                </select>
-
                 <label for="search-input" title="Search for cameras or groups">Search:</label>
                 <input type="search" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
 

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -2,8 +2,6 @@
 {% block content %}
 <h2>Group {{ group_name }}</h2>
 <div>
-    <label for="group-dropdown" title="Filter templates by group">Filter by Group:</label>
-    <select id="group-dropdown" title="Select a group to filter templates"></select>
     <label for="search-input" title="Search for cameras or groups">Search:</label>
     <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
     <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
@@ -13,16 +11,10 @@
 <div id="template-list" title="List of all templates" role="region" aria-label="Templates"></div>
 <div id="index-time" class="corner-time" title=""></div>
 <script type="module">
-    import { loadGroups, loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
+    import { loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
     window.currentGroup = '{{ group_name }}';
     document.addEventListener('DOMContentLoaded', () => {
-        loadGroups().then(() => {
-            const dropdown = document.getElementById('group-dropdown');
-            if (dropdown) {
-                dropdown.value = '{{ group_name }}';
-            }
-            loadTemplates();
-        });
+        loadTemplates();
     });
 </script>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -91,17 +91,10 @@
 
 
 <section id="template-controls">
-    <label for="group-dropdown" title="Filter templates by group">Filter by Group:</label>
-
-    <select id="group-dropdown" title="Select a group to filter templates">
-        <!-- Options will be populated here -->
-    </select>
-
     <label for="search-input" title="Search for cameras or groups">Search:</label>
     <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
 
-
-        <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
+    <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
     <button id="live-all-button" title="Live stream all cameras">Live All</button>
 </section>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -55,7 +55,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the group filter and search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
+10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- drop page-level group dropdowns
- use `getSelectedGroup` helper when filtering templates
- update instructions about captions search box

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e314d3b083338ab71dc6edfba4bd