### PR TITLE
Adjust group page slider to fit thumbnails

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -568,9 +568,17 @@ export async function loadTemplates() {
     if (isIndexPage) {
       window.addEventListener("resize", updateGridLayout);
     }
-    if (window.updateSliderLimits) window.updateSliderLimits();
-    const slider = document.getElementById("grid-width-slider");
-    if (slider) slider.dispatchEvent(new Event("input"));
+    if (window.updateSliderLimits) {
+      window.updateSliderLimits();
+      const slider = document.getElementById("grid-width-slider");
+      if (slider) {
+        slider.value = slider.min;
+        slider.dispatchEvent(new Event("input"));
+      }
+    } else {
+      const slider = document.getElementById("grid-width-slider");
+      if (slider) slider.dispatchEvent(new Event("input"));
+    }
     updateHumanizedTimes();
     window.dispatchEvent(
       new CustomEvent("templatesLoaded", { detail: { count: templateCount } }),

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -2,7 +2,7 @@
 
 Glimpser now adapts to phones and tablets. The navigation menu collapses into a hamburger button on narrow screens and tables reflow vertically to avoid horizontal scrolling. Video grids automatically switch to a single column when viewed on devices without hover capability or small viewports.
 
-The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping.
+The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping. When a group is opened, the slider defaults to the smallest width that keeps all cameras visible without scrolling.
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 


### PR DESCRIPTION
## Summary
- ensure slider resets to min width when templates load so all thumbnails fit on screen
- document new group slider behavior

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e4fd35608333b6df00468274f8e0