### PR TITLE
Fix broken image when switching cameras

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -876,7 +876,10 @@ function stopPNG() {
     clearInterval(pngInterval);
     pngInterval = null;
   }
-  image.src = "";
+  // Hide the image and clear the source so browsers don't briefly
+  // display the broken image icon when switching cameras.
+  image.style.display = "none";
+  image.removeAttribute("src");
 }
 
 function stopLiveSwitch() {


### PR DESCRIPTION
## Summary
- prevent broken frame icon when switching between camera groups

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e5d6bf608333ab1c40dc30fb8d16