### PR TITLE
Fix missing brace in templates.js

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -191,6 +191,9 @@ export async function loadGroups() {
     groupDropdown.disabled = false;
   }
 
+  // Close the loadGroups function
+}
+
 export function getSelectedGroup() {
   const dropdown = document.getElementById("group-dropdown");
   if (dropdown && dropdown.value) return dropdown.value;
@@ -347,7 +350,9 @@ export function setupSearch() {
 
   const filterCameras = () => {
     const searchTerm = searchInput.value.toLowerCase();
-    const selectedGroup = groupDropdown ? groupDropdown.value : getSelectedGroup();
+    const selectedGroup = groupDropdown
+      ? groupDropdown.value
+      : getSelectedGroup();
     const column = filterColumn ? filterColumn.value : "";
     const filterVal = filterValue ? filterValue.value.trim().toLowerCase() : "";
     cameraRows.forEach((row) => {


### PR DESCRIPTION
## Summary
- close `loadGroups` function in `templates.js`
- format script with Prettier

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841edcad1408333a7d9c751461c4340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a missing closing brace in a function to ensure proper functionality.

- **Style**
  - Improved code formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->