### PR TITLE
Fix jog shuttle visibility

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -389,6 +389,7 @@ function updateFeed() {
     image.src = "";
     showLastScreenshot();
     updateSeekBar();
+    updateJogShuttle();
     return;
   } else if (details && details.capture_failed) {
     hideOfflineIndicator();
@@ -399,6 +400,7 @@ function updateFeed() {
     image.src = "";
     showLastScreenshot();
     updateSeekBar();
+    updateJogShuttle();
     return;
   } else {
     hideOfflineIndicator();
@@ -440,6 +442,7 @@ function updateFeed() {
   }
 
   updateSeekBar();
+  updateJogShuttle();
 }
 
 function playM3U8() {
@@ -990,6 +993,17 @@ function updateSeekBar() {
   }
 }
 
+function updateJogShuttle() {
+  if (!jogShuttle) return;
+  const source = document.getElementById("video-source").value;
+  const isSingleCamera = !(
+    currentCamera === "All" || currentCamera.startsWith("group-")
+  );
+  const show = isSingleCamera && (source === "mp4" || source === "loop");
+  jogShuttle.style.visibility = show ? "visible" : "hidden";
+  jogShuttle.style.pointerEvents = show ? "auto" : "none";
+}
+
 function checkCameraConnection(cameraName) {
   if (cameraName === "All" || cameraName.startsWith("group-")) {
     return true;
@@ -1046,6 +1060,7 @@ updateTemplateDetails();
 updateSpeedContainer();
 updatePlaybackSpeed();
 updateSeekBar();
+updateJogShuttle();
 initJogShuttle();
 playMJPG();
 startCaptionPolling();

--- a/docs/jog_shuttle.md
+++ b/docs/jog_shuttle.md
@@ -1,3 +1,5 @@
 # Jog-Shuttle Control
 
 The live viewer offers a jog-shuttle widget for cameras that support video playback. Drag within the circle to scrub forward or backward. The farther you drag from the center the faster playback runs (1x, 2x, 4x and so on). Crossing the center reverses direction. Releasing the control pauses and snaps back to neutral.
+
+The jog-shuttle appears only when an individual camera is selected and the **MP4** or **Loop** source is active. Other sources like MJPG or live streams are not seekable, so the control is hidden.


### PR DESCRIPTION
## Summary
- hide jog control when media is not seekable
- document jog-shuttle requirements

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841fe91bf9483338afc370322d32fe6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The jog-shuttle control now appears only when a single camera is selected and the video source is MP4 or Loop, ensuring consistent visibility with other playback controls.

- **Documentation**
  - Updated documentation to clarify when the jog-shuttle widget is displayed and which video sources support it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->