### PR TITLE
Improve live view group navigation

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -73,6 +73,7 @@ function loadSavedPreferences() {
   if (!requestedCamera) {
     const savedCam = localStorage.getItem("liveCamera");
     const camSelect = document.getElementById("camera-selector");
+    const navGroup = document.getElementById("nav-group-dropdown");
     if (
       savedCam &&
       camSelect &&
@@ -80,6 +81,13 @@ function loadSavedPreferences() {
     ) {
       currentCamera = savedCam;
       camSelect.value = savedCam;
+    }
+    if (navGroup) {
+      if (currentCamera === "All") {
+        navGroup.value = "all";
+      } else if (currentCamera.startsWith("group-")) {
+        navGroup.value = currentCamera.split("group-")[1];
+      }
     }
   }
 
@@ -325,6 +333,17 @@ function changeCamera() {
     // Individual camera is selected
     currentCamera = selectedValue;
     isConnected = checkCameraConnection(currentCamera);
+  }
+
+  const navGroup = document.getElementById("nav-group-dropdown");
+  if (navGroup) {
+    if (selectedValue === "All") {
+      navGroup.value = "all";
+    } else if (selectedValue.startsWith("group-")) {
+      navGroup.value = selectedValue.split("group-")[1];
+    } else {
+      navGroup.value = "";
+    }
   }
 
   // Persist the chosen camera so the selection sticks across sessions

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -83,6 +83,21 @@ export function initNav() {
     if (groupDropdown) {
       groupDropdown.addEventListener("change", () => {
         if (!groupDropdown.value) return;
+        if (
+          window.location.pathname.startsWith("/live") &&
+          typeof window.changeCamera === "function"
+        ) {
+          const camSelector = document.getElementById("camera-selector");
+          if (camSelector) {
+            camSelector.value =
+              groupDropdown.value === "all"
+                ? "All"
+                : `group-${groupDropdown.value}`;
+            window.changeCamera();
+            loadNavCameras(groupDropdown.value);
+            return;
+          }
+        }
         if (groupDropdown.value === "all") {
           window.location.href = "/";
         } else {

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -10,4 +10,8 @@ Group links in the header are now available through a dropdown menu. The list
 populates asynchronously from the `/groups` endpoint and fits neatly inside the
 hamburger layout on small screens.
 
+Selecting a group from that dropdown while on the **Live** page now updates the
+camera selector immediately without reloading the page, keeping navigation
+seamless.
+
 Offline preview keeps recently viewed pages and assets in the browser cache so the interface remains responsive even on poor connections. This feature is enabled automatically.


### PR DESCRIPTION
## Summary
- sync the top navigation group dropdown with the live view selector
- note new behavior in responsive design docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841feb5ee00833380382c81d4ddbed4