### PR TITLE
Move theme toggle to settings page

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -60,11 +60,6 @@
           <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
         </svg>
       </a>
-      <a id="theme-toggle" href="#" class="status-indicator" title="Toggle light or dark theme" aria-label="Toggle theme">
-        <svg width="18" height="18">
-          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
-        </svg>
-      </a>
       {% else %}
     <a href="{{ url_for('login') }}" class="settings-icon" title="Login" aria-label="Login">
       <svg width="20" height="20">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3,6 +3,11 @@
 {% block content %}
 <main class="container settings-page">
     <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
+    <a id="theme-toggle" href="#" class="status-indicator" title="Toggle light or dark theme" aria-label="Toggle theme">
+        <svg width="18" height="18">
+            <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
+        </svg>
+    </a>
 
     {# Help content now appears directly in the table, so the collapsible menu was removed #}
 

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -5,8 +5,8 @@ The CSS defines variables for background and text colors with light and dark
 variants. Forms and tables use these variables so elements remain readable in
 both themes.
 
-You can force the interface into light or dark mode using the new toggle in the
-navigation bar. The switch stores your choice in `localStorage` so your
+You can force the interface into light or dark mode using the toggle on the
+settings page. The switch stores your choice in `localStorage` so your
 preference persists across visits.
 
 A new `--table-border-color` variable controls table outlines. Dark mode


### PR DESCRIPTION
## Summary
- move dark/light toggle from nav bar into the settings page
- update dark mode documentation

## Testing
- `black --check app`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ff4e686c8333b3cd39811d99ad41