### PR TITLE
Fix loader after screenshot change

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -609,7 +609,9 @@ function showLastScreenshot() {
   const pre = new Image();
   pre.onload = () => {
     image.src = pre.src;
+    hideLoadingIndicator();
   };
+  pre.onerror = hideLoadingIndicator;
   pre.src = url;
   image.style.display = "block";
   updateFrameTimestamp();


### PR DESCRIPTION
## Summary
- ensure loading overlay hides once the screenshot preload finishes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684204c8ad04833392e0ef39a98210a4