### PR TITLE
Move theme toggle and add logout tab

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1653,6 +1653,11 @@ details > summary {
     color: #fff;
 }
 
+.logout-link {
+    background-color: #e74c3c;
+    color: #fff;
+}
+
 .tab-content {
     display: none;
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -2,12 +2,6 @@
 {% from 'components.html' import card %}
 {% block content %}
 <main class="container settings-page">
-    <a href="{{ url_for('logout') }}" class="settings-icon btn btn-danger" title="Log out of the interface">Logout</a>
-    <a id="theme-toggle" href="#" class="status-indicator" title="Toggle light or dark theme" aria-label="Toggle theme">
-        <svg width="18" height="18">
-            <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
-        </svg>
-    </a>
 
     {# Help content now appears directly in the table, so the collapsible menu was removed #}
 
@@ -24,6 +18,12 @@
         {% endif %}
         {% endfor %}
         <button type="button" class="tab-link" data-tab="management-tab">Management</button>
+        <a href="{{ url_for('logout') }}" class="tab-link logout-link" title="Log out of the interface">Logout</a>
+        <a id="theme-toggle" href="#" class="tab-link" title="Toggle light or dark theme" aria-label="Toggle theme">
+            <svg width="18" height="18">
+                <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
+            </svg>
+        </a>
     </div>
 
     <div id="add-setting-container" class="hidden">


### PR DESCRIPTION
## Summary
- reposition Dark Mode toggle inside the Settings tabs
- add red Logout button styled like a tab

## Testing
- `black -q .`
- `npm run format:js`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842075a80b4833388918394df540575