### PR TITLE
Add ffmpeg and GPU info to status

### DIFF
--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -30,6 +30,10 @@
     <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
     <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
     <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+    <li title="Installed ffmpeg version">FFmpeg Version: {{ metrics.ffmpeg_version }}</li>
+    <li title="Hardware acceleration devices present">Machine HW Accel: {{ metrics.machine_hwaccel }}</li>
+    <li title="ffmpeg has hardware acceleration support">FFmpeg HW Accel: {{ metrics.ffmpeg_hwaccel }}</li>
+    <li title="Hardware acceleration enabled via config">HW Accel Enabled: {{ metrics.hwaccel_enabled }}</li>
 </ul>
 {% endcall %}
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -11,6 +11,8 @@ import threading
 import time
 import multiprocessing
 from collections import deque
+import subprocess
+import shutil
 import textwrap
 
 from apscheduler.triggers.cron import CronTrigger
@@ -26,6 +28,8 @@ from app.config import (
     VIDEO_DIRECTORY,
     CLIP_MODEL_NAME,
     LOGGING_PATH,
+    FFMPEG_PATH,
+    FFMPEG_HWACCEL,
 )
 from app.utils.db import SessionLocal
 from app.models import Summary
@@ -979,6 +983,36 @@ metrics_thread = None
 log_caching_thread = None
 
 
+def ffmpeg_version() -> str:
+    """Return the installed FFmpeg version or 'unavailable'."""
+    try:
+        output = subprocess.check_output(
+            [FFMPEG_PATH, "-version"], stderr=subprocess.STDOUT, timeout=2
+        ).decode()
+        first = output.splitlines()[0]
+        match = re.search(r"ffmpeg version\s+([^\s]+)", first)
+        return match.group(1) if match else first
+    except Exception:
+        return "unavailable"
+
+
+def machine_supports_hwaccel() -> bool:
+    """Return ``True`` if GPU devices appear to be available."""
+    return os.path.exists("/dev/dri") or shutil.which("nvidia-smi") is not None
+
+
+def ffmpeg_supports_hwaccel() -> bool:
+    """Return ``True`` if ``ffmpeg`` reports any hardware acceleration methods."""
+    try:
+        output = subprocess.check_output(
+            [FFMPEG_PATH, "-hwaccels"], stderr=subprocess.STDOUT, timeout=2
+        ).decode()
+        lines = [l.strip() for l in output.splitlines() if l.strip()]
+        return len(lines) > 1
+    except Exception:
+        return False
+
+
 def collect_system_metrics():
     while not stop_event.is_set():
         system_metrics["cpu_usage"] = psutil.cpu_percent(interval=1)
@@ -1004,6 +1038,10 @@ def get_system_metrics():
         "open_files": open_files,
         "thread_count": system_metrics["thread_count"],
         "uptime": f"{int(uptime // 3600)}h {int((uptime % 3600) // 60)}m {int(uptime % 60)}s",
+        "ffmpeg_version": ffmpeg_version(),
+        "machine_hwaccel": machine_supports_hwaccel(),
+        "ffmpeg_hwaccel": ffmpeg_supports_hwaccel(),
+        "hwaccel_enabled": bool(FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false"),
     }
 
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -29,6 +29,10 @@ name, last image time, last caption time, or status.
 - **Open Files** – number of file descriptors opened by the process
 - **Thread Count** – active thread count for the application
 - **Uptime** – elapsed time since the app started
+- **FFmpeg Version** – version string reported by the ffmpeg binary
+- **Machine HW Accel** – whether GPU devices are detected
+- **FFmpeg HW Accel** – whether ffmpeg supports hardware acceleration
+- **HW Accel Enabled** – if hardware acceleration is configured
 
 ## Streaming Logs
 

--- a/main.py
+++ b/main.py
@@ -233,6 +233,10 @@ def output_shutdown_stats():
     logging.info("Open Files: %s", metrics["open_files"])
     logging.info("Thread Count: %s", metrics["thread_count"])
     logging.info("Uptime: %s", metrics["uptime"])
+    logging.info("FFmpeg Version: %s", metrics["ffmpeg_version"])
+    logging.info("Machine HW Accel: %s", metrics["machine_hwaccel"])
+    logging.info("FFmpeg HW Accel: %s", metrics["ffmpeg_hwaccel"])
+    logging.info("HW Accel Enabled: %s", metrics["hwaccel_enabled"])
     logging.info("Thank you for running Glimpser. Goodbye!")
 
 

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -20,6 +20,10 @@ class TestMainUtilities(unittest.TestCase):
             "open_files": 40,
             "thread_count": 5,
             "uptime": "1h",
+            "ffmpeg_version": "6.0",
+            "machine_hwaccel": True,
+            "ffmpeg_hwaccel": True,
+            "hwaccel_enabled": True,
         }
         mock_metrics.return_value = metrics
 
@@ -33,6 +37,10 @@ class TestMainUtilities(unittest.TestCase):
             ("Open Files: %s", metrics["open_files"]),
             ("Thread Count: %s", metrics["thread_count"]),
             ("Uptime: %s", metrics["uptime"]),
+            ("FFmpeg Version: %s", metrics["ffmpeg_version"]),
+            ("Machine HW Accel: %s", metrics["machine_hwaccel"]),
+            ("FFmpeg HW Accel: %s", metrics["ffmpeg_hwaccel"]),
+            ("HW Accel Enabled: %s", metrics["hwaccel_enabled"]),
             ("Thank you for running Glimpser. Goodbye!",),
         ]
         self.assertEqual([c.args for c in mock_log.call_args_list], expected)

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -58,7 +58,17 @@ class TestAddMotionAndCaption(unittest.TestCase):
 
 class TestGetSystemMetrics(unittest.TestCase):
     @patch("app.utils.scheduling.psutil")
-    def test_metrics_fields(self, mock_psutil):
+    @patch("app.utils.scheduling.ffmpeg_version", return_value="6.0")
+    @patch("app.utils.scheduling.machine_supports_hwaccel", return_value=True)
+    @patch("app.utils.scheduling.ffmpeg_supports_hwaccel", return_value=True)
+    @patch.object(scheduling, "FFMPEG_HWACCEL", "cuda")
+    def test_metrics_fields(
+        self,
+        mock_ffmpeg_hwaccel,
+        mock_machine,
+        mock_version,
+        mock_psutil,
+    ):
         scheduling.system_metrics.update(
             {
                 "cpu_usage": 1.234,
@@ -76,6 +86,10 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertEqual(metrics["open_files"], 3)
         self.assertEqual(metrics["thread_count"], 5)
         self.assertTrue(metrics["uptime"].startswith("1h 1m"))
+        self.assertEqual(metrics["ffmpeg_version"], "6.0")
+        self.assertTrue(metrics["machine_hwaccel"])
+        self.assertTrue(metrics["ffmpeg_hwaccel"])
+        self.assertTrue(metrics["hwaccel_enabled"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display ffmpeg version and hwaccel information on `/status`
- expose same details from `get_system_metrics`
- log ffmpeg/gpu metrics on shutdown
- document the new metrics
- update unit tests for additional metrics

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684205a8698c83338a18f314347130ba