### PR TITLE
Implement idle-based session timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <center>
 
-  
   <source srcset="app/static/img/glimpser.png" media="(prefers-color-scheme: dark)">
   <img src="https://github.com/user-attachments/assets/6113370d-f15d-4195-8ae5-2cb748afbf46" alt="Use dark mode!">
-
 
 </center>
 
@@ -25,6 +23,7 @@
 [![Docs Build](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml)
 
 ## Introduction
+
 Glimpser is a straightforward yet powerful real-time monitoring application designed to capture, analyze, and summarize live data from various sources such as cameras, dashboards, and video streams. Utilizing advanced image processing techniques and AI models, Glimpser provides insightful summaries and alerts. It’s highly configurable, allowing users to tailor it to their specific monitoring needs through an easy-to-use interface.
 
 For more documentation, see the [documentation index](docs/index.md).
@@ -35,6 +34,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 ![Glimpser August 2024](https://github.com/user-attachments/assets/44ddcbd5-31f1-4ff9-954a-954a85479dc0)
 
 ## Features
+
 - **Real-time Monitoring**: Continuously captures data from multiple sources. Whether it's a traffic camera or a weather dashboard, Glimpser ensures you’re always up-to-date with the latest information.
 
 - **Image Processing**: Employs advanced techniques to compare images and detect even subtle changes, making it ideal for monitoring evolving situations effectively.
@@ -56,24 +56,28 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
   [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
- - **Camera Discovery**: Open **Settings** and switch to the **Discover** tab to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address plus manufacturer and model information when available. Glimpser checks common system OUI databases, an online lookup service, and the ONVIF device service to gather these details.
+- **Camera Discovery**: Open **Settings** and switch to the **Discover** tab to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address plus manufacturer and model information when available. Glimpser checks common system OUI databases, an online lookup service, and the ONVIF device service to gather these details.
 - **Camera Fix Suggestions**: Validate a template and discover alternative URLs with `/suggest_fix/<template>`. See [Camera Fix Suggestions](docs/camera_fix.md).
- - **Local Cameras**: The Discover tab also lists any available `/dev/video*` devices for easy webcam integration.
+- **Local Cameras**: The Discover tab also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.
 
 ## Installation
 
 ### Prerequisites
+
 - Python 3.8 to 3.12
 
 ### Steps
+
 1. **Install the Package**
+
    ```sh
    pip install glimpser
    ```
 
    Or, if you want to install from source:
+
    ```sh
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
@@ -81,6 +85,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
    ```
 
 2. **Run the Application**
+
 ```sh
 glimpser
 ```
@@ -103,11 +108,11 @@ Run `glimpser --help` to see all available options.
 
 For a full description of every command-line flag, including the separate credentials utility, see [docs/command_line.md](docs/command_line.md).
 
-   You will be prompted to create a secret key to initialize the local sqlite database. Follow the rest of the guided setup and then direct your browser to http://127.0.0.1:8082 to finish the rest of the setup.
+You will be prompted to create a secret key to initialize the local sqlite database. Follow the rest of the guided setup and then direct your browser to http://127.0.0.1:8082 to finish the rest of the setup.
 
 ### Docker Quick Start
 
-If you prefer to run Glimpser in Docker, copy `.env.example` to `.env` and set at least `SECRET_KEY` and `API_KEY`. You may also adjust `SESSION_TIMEOUT_MINUTES` and related cookie settings. Then build and start the container using Gunicorn:
+If you prefer to run Glimpser in Docker, copy `.env.example` to `.env` and set at least `SECRET_KEY` and `API_KEY`. You may also adjust `SESSION_TIMEOUT_MINUTES` and related cookie settings. The timeout resets after each request, so active use keeps the session alive. Then build and start the container using Gunicorn:
 
 ```sh
 docker-compose up --build
@@ -116,38 +121,49 @@ docker-compose up --build
 The web interface will be available at [http://localhost:8082](http://localhost:8082).
 
 ### Common Setup Issues
+
 If you cannot log in or see video feeds, double-check that your `.env` file matches the configuration values in the database. Missing `SECRET_KEY` or API credentials often cause startup failures. Refer to [Troubleshooting](docs/troubleshooting.md) for more solutions.
 
 ## Usage
 
 ### Configuration
+
 Glimpser uses a database-driven configuration to manage data sources and processing rules. Users can easily add, update, or remove configurations through the web interface. SMS alerts can be enabled by setting `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration.
 
 ### Capturing Screenshots
+
 The preferred method for capturing screenshots is through the Glimpser web interface. Simply navigate to the capture section, select your desired source, and click the capture button. This ensures a seamless and user-friendly experience.
 
 ### Adding a Camera Source
+
 Open the **Discover** tab under **Settings** to scan your network for ONVIF, RTSP, or local devices and click **Add** next to any result. You can also open **Add Source** in the web interface to manually supply a camera URL and group. See [Camera Discovery](docs/camera_discovery.md) for more details.
 
 ### Running Tests
+
 To ensure everything works as expected, you can run the included unit tests:
+
 ```sh
 python -m coverage run -m pytest
 ```
 
 ### Troubleshooting Quick Tips
+
 If the summarizer stops working, ensure the scheduler is running and check `/jobs` for a `summary` entry. Review `logs/glimpser.log` for errors. More solutions are listed in [Troubleshooting](docs/troubleshooting.md).
 
 ### Motion Detection
+
 Glimpser automatically detects motion in the captured images and videos. When motion is detected, the system can trigger alerts, capture additional data, and generate relevant summaries and captions.
 
 ### Auto-captioning
+
 Using advanced AI models, Glimpser generates concise and informative captions for images and videos. This feature helps users quickly understand the content and context of the captured data.
 
 ### Auto-summarization
+
 Glimpser can summarize data from multiple sources into a coherent and concise format. The summaries highlight the most important information, making it easier for users to stay informed.
 
 ### RTSP Streaming
+
 Glimpser exposes a simple RTSP endpoint at `/test.rtsp`. When a client issues the standard RTSP verbs, the `/rtsp_stream` route serves MJPEG frames packetized with RTP headers.
 
 Typical sequence:
@@ -167,18 +183,21 @@ This allows external NVR software to ingest the stream as a basic camera source.
 To set up the project for development:
 
 1. Clone the repository:
+
    ```sh
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    ```
 
 2. Create a virtual environment and activate it:
+
    ```sh
    python -m venv env
    source env/bin/activate  # On Windows, use `env\Scripts\activate`
    ```
 
 3. Install the package in editable mode with development dependencies:
+
    ```sh
    pip install -e ".[dev]"
    ```
@@ -189,6 +208,7 @@ To set up the project for development:
    ```
 
 ## Releases
+
 Release packages are built automatically when a version tag is pushed.
 The workflow runs tests and creates the Debian package on an Ubuntu runner.
 The Windows executable is built separately on a Windows runner using
@@ -203,29 +223,34 @@ version tag was pushed. You can run `scripts/auto_tag_release.py` to create
 and push the tag manually.
 
 ## Contributing
+
 Contributions are always welcome. If you have an idea to improve Glimpser, feel free to fork the repository and submit a pull request. Please read our [Code of Conduct](CODE_OF_CONDUCT.md) to understand the expectations for participants and how to report issues.
 
 ### Steps to Contribute
+
 1. Fork the repository.
 2. Create a feature branch.
-    ```sh
-    git checkout -b feature-branch
-    ```
+   ```sh
+   git checkout -b feature-branch
+   ```
 3. Commit your changes.
-    ```sh
-    git commit -m "Description of changes"
-    ```
+   ```sh
+   git commit -m "Description of changes"
+   ```
 4. Push to the branch.
-    ```sh
-    git push origin feature-branch
-    ```
+   ```sh
+   git push origin feature-branch
+   ```
 5. Open a pull request.
 
 ## Recommendations
+
 For detailed suggestions on how to use Glimpser effectively, please check out our [Recommendations](docs/recommendations.md) guide.
 
 ## License
+
 This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.
 
 ## Acknowledgements
+
 We are grateful to the contributors and the open-source community. Special thanks to OpenAI for their powerful models that enable Glimpser's advanced features.

--- a/app/routes.py
+++ b/app/routes.py
@@ -205,6 +205,11 @@ def login_required(f: Callable) -> Callable:
                 flash("Session expired. Please log in again.")
                 return redirect(url_for("login", next=request.url))
 
+            # Refresh expiry so the timeout is based on inactivity
+            session["expiry"] = (
+                datetime.now() + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
+            ).strftime("%Y-%m-%d %H:%M:%S")
+
             db_session = SessionLocal()
             try:
                 inspector = sa_inspect(engine)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -10,16 +10,16 @@ The following environment variables are read in `app/config.py` and allow you to
 change where runtime data is stored. If not provided, the defaults shown below
 are used.
 
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `GLIMPSER_DATABASE_PATH` | `data/glimpser.db` | Location of the SQLite database file |
-| `GLIMPSER_LOGGING_PATH` | `logs/glimpser.log` | Path to the main log file |
-| `GLIMPSER_BACKUP_PATH` | `data/config_backup.json` | File used when backing up configuration |
+| Variable                 | Default                   | Purpose                                 |
+| ------------------------ | ------------------------- | --------------------------------------- |
+| `GLIMPSER_DATABASE_PATH` | `data/glimpser.db`        | Location of the SQLite database file    |
+| `GLIMPSER_LOGGING_PATH`  | `logs/glimpser.log`       | Path to the main log file               |
+| `GLIMPSER_BACKUP_PATH`   | `data/config_backup.json` | File used when backing up configuration |
 
 Relative paths are resolved from the application's root directory. Use an
 absolute path if the backup file should reside elsewhere.
 
-`app.config` parses the `.env` file only once when it is first imported.  Later
+`app.config` parses the `.env` file only once when it is first imported. Later
 imports reuse the existing values instead of re-reading the file.
 
 ## Core Settings
@@ -59,7 +59,8 @@ updated with `generate_credentials.py` or through the web interface.
   (default `True`)
 - `SESSION_COOKIE_HTTPONLY` – set `True` to prevent JavaScript access to the
   session cookie (default `True`)
-- `SESSION_TIMEOUT_MINUTES` – session lifetime in minutes (default `30`)
+- `SESSION_TIMEOUT_MINUTES` – session timeout after this many minutes of
+  inactivity (default `30`)
 
 User accounts are stored in the `users` table. Each record contains the
 `username`, `password_hash`, and an optional `role` that can be used for future

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -237,6 +237,41 @@ class TestAuthentication(unittest.TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertIn("/login", response.headers["Location"])
 
+    def test_login_required_refreshes_expiry(self):
+        login_attempts = {}  # reset
+        initial_expiry = (
+            datetime.datetime.now() + datetime.timedelta(minutes=5)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        session_data = {"user_id": 1, "expiry": initial_expiry}
+        dummy_user = SimpleNamespace(id=1, username=USER_NAME)
+
+        class DummyQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return dummy_user
+
+        class DummySession:
+            def query(self, model):
+                return DummyQuery()
+
+            def close(self):
+                pass
+
+        with patch("app.routes.session", session_data), patch(
+            "app.routes.SessionLocal", return_value=DummySession()
+        ):
+            response = self.client.get("/protected")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b"Protected Content", response.data)
+            self.assertNotEqual(session_data["expiry"], initial_expiry)
+            new_ts = datetime.datetime.strptime(
+                session_data["expiry"], "%Y-%m-%d %H:%M:%S"
+            )
+            old_ts = datetime.datetime.strptime(initial_expiry, "%Y-%m-%d %H:%M:%S")
+            self.assertGreater(new_ts, old_ts)
+
     def test_login_required_with_api_key(self):
         login_attempts = {}  # reset
         mock_api_key = "mock_api_key_for_testing"


### PR DESCRIPTION
## Summary
- expire sessions only after inactivity
- mention new timeout behavior in configuration docs and README
- test refreshed expiry timestamps

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684206dc0cf88333a1d9a847873de22c