### PR TITLE
Fix module loading in settings page

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -96,8 +96,8 @@
         <button type="submit" title="Save all changes">Save Changes</button>
     </form>
 </main>
-<script src="{{ url_for('static', filename='js/performance.js') }}"></script>
-<script src="{{ url_for('static', filename='js/tabs.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/performance.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/tabs.js') }}"></script>
 <script>
     function confirmDeleteSetting(name) {
         if (confirm('Are you sure you want to delete ' + name + '?')) {


### PR DESCRIPTION
## Summary
- ensure JavaScript modules in `settings.html` are loaded as ES modules

## Testing
- `npm run format`
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684208600fec83338bbd1c379c2039b8