### PR TITLE
Move KPI columns to status page

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -1,193 +1,264 @@
-
-
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <div class="captions-page">
+  <script>
+    function updateTemplate(templateName) {
+      var notes = $("#notes-" + templateName).val();
+      $.ajax({
+        url: "/update_template/" + templateName,
+        type: "POST",
+        data: { notes: notes },
+        success: function (response) {
+          alert("Template updated successfully!");
+        },
+        error: function (error) {
+          alert("Error updating template: " + error.responseText);
+        },
+      });
+    }
+    function toggleChyron() {
+      fetch("/toggle_chyron", { method: "POST" })
+        .then((resp) => resp.json())
+        .then((data) => {
+          const btn = document.getElementById("toggle-chyron-btn");
+          if (data.speed !== undefined && btn) {
+            btn.textContent =
+              data.speed > 0 ? "Disable Chyron" : "Enable Chyron";
+          }
+        });
+    }
+  </script>
 
-     <script>
-         function updateTemplate(templateName) {
-             var notes = $('#notes-' + templateName).val();
-             $.ajax({
-                 url: '/update_template/' + templateName,
-                 type: 'POST',
-                 data: {notes: notes},
-                success: function(response) {
-                     alert('Template updated successfully!');
-                 },
-                 error: function(error) {
-                     alert('Error updating template: ' + error.responseText);
-                 }
-             });
-         }
-         function toggleChyron() {
-             fetch('/toggle_chyron', {method: 'POST'})
-                 .then(resp => resp.json())
-                 .then(data => {
-                     const btn = document.getElementById('toggle-chyron-btn');
-                     if (data.speed !== undefined && btn) {
-                         btn.textContent = data.speed > 0 ? 'Disable Chyron' : 'Enable Chyron';
-                     }
-                 });
-         }
-     </script>
+  <div class="tabs">
+    <button class="tab-link active" data-tab="prompts-tab">Prompts</button>
+    <button class="tab-link" data-tab="history-tab">History</button>
+    <button class="tab-link" data-tab="bulk-tab">Bulk Tools</button>
+  </div>
 
-    <div class="tabs">
-        <button class="tab-link active" data-tab="prompts-tab">Prompts</button>
-        <button class="tab-link" data-tab="history-tab">History</button>
-        <button class="tab-link" data-tab="bulk-tab">Bulk Tools</button>
-    </div>
+  <div id="prompts-tab" class="tab-content active">
+    <details class="filter-controls">
+      <summary>Search &amp; Filters</summary>
+      <div class="controls-inner">
+        <label for="search-input" title="Search for cameras or groups"
+          >Search:</label
+        >
+        <input
+          type="search"
+          id="search-input"
+          placeholder="Search cameras or groups"
+          title="Enter search terms"
+        />
 
-    <div id="prompts-tab" class="tab-content active">
-        <details class="filter-controls">
-            <summary>Search &amp; Filters</summary>
-            <div class="controls-inner">
-                <label for="search-input" title="Search for cameras or groups">Search:</label>
-                <input type="search" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
+        <label for="filter-column" title="KPI to filter">KPI:</label>
+        <select id="filter-column" title="Select KPI">
+          <option value="">All</option>
+        </select>
+        <input
+          type="text"
+          id="filter-value"
+          placeholder="Value"
+          title="Filter value"
+        />
+        <button id="apply-filter" type="button" title="Filter table rows">
+          Apply
+        </button>
+        <input
+          type="range"
+          id="grid-width-slider"
+          min="50"
+          max="3840"
+          value="360"
+          title="Adjust thumbnail width"
+        />
+      </div>
+    </details>
 
-                <label for="filter-column" title="KPI to filter">KPI:</label>
-                <select id="filter-column" title="Select KPI">
-                    <option value="">All</option>
-                    <option value="screenshot_count">Shots</option>
-                    <option value="video_count">Videos</option>
-                    <option value="storage_usage">Storage</option>
-                    <option value="llm_response_count">LLM Resp</option>
-                    <option value="llm_cost_estimate">LLM Cost</option>
-                </select>
-                <input type="text" id="filter-value" placeholder="Value" title="Filter value">
-                <button id="apply-filter" type="button" title="Filter table rows">Apply</button>
-                <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust thumbnail width">
-            </div>
-        </details>
-
-        <h2>Camera Notes</h2>
-        <div id="template-list">
-        <table id="camera-table" class="camera-table">
-    <thead>
-        <tr>
+    <h2>Camera Notes</h2>
+    <div id="template-list">
+      <table id="camera-table" class="camera-table">
+        <thead>
+          <tr>
             <th class="sortable" data-type="string">Camera</th>
             <th class="sortable" data-type="date">Last</th>
             <th class="sortable" data-type="date">Next</th>
-            <th class="sortable" data-type="number">Shots</th>
-            <th class="sortable" data-type="number">Videos</th>
-            <th class="sortable" data-type="number">Storage</th>
-            <th class="sortable" data-type="number">LLM Resp</th>
-            <th class="sortable" data-type="number">LLM Cost</th>
             <th>Caption</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for camera in template_details %}
-        <tr class="camera-row" data-groups="{{ template_details[camera]['groups'] }}" data-screenshot_count="{{ template_details[camera]['screenshot_count'] }}" data-video_count="{{ template_details[camera]['video_count'] }}" data-storage_usage="{{ template_details[camera]['storage_usage_bytes'] }}" data-llm_response_count="{{ template_details[camera]['llm_response_count'] }}" data-llm_cost_estimate="{{ template_details[camera]['llm_cost_estimate'] }}">
+          </tr>
+        </thead>
+        <tbody>
+          {% for camera in template_details %}
+          <tr
+            class="camera-row"
+            data-groups="{{ template_details[camera]['groups'] }}"
+          >
             <td>
-                <div class="templateDiv">
-                    <div class="video-container" data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}">
-                        <div class="camera-name"><a href='/templates/{{camera}}' title="Open {{ camera }} details">{{camera}}</a></div>
-                        <video class="hover-video" loop muted poster="/last_screenshot/{{ camera }}">
-                            <source src="/last_video/{{ camera }}" type="video/mp4">
-                            Your browser does not support the video tag.
-                        </video>
-                    </div>
+              <div class="templateDiv">
+                <div
+                  class="video-container"
+                  data-timestamp="{{ template_details[camera]['last_screenshot_time'] }}"
+                >
+                  <div class="camera-name">
+                    <a
+                      href="/templates/{{camera}}"
+                      title="Open {{ camera }} details"
+                      >{{camera}}</a
+                    >
+                  </div>
+                  <video
+                    class="hover-video"
+                    loop
+                    muted
+                    poster="/last_screenshot/{{ camera }}"
+                  >
+                    <source src="/last_video/{{ camera }}" type="video/mp4" />
+                    Your browser does not support the video tag.
+                  </video>
                 </div>
+              </div>
             </td>
-            <td data-value="{{ template_details[camera]['last_screenshot'] }}"><span class="humanized-time" data-time="{{ template_details[camera]['last_screenshot'] }}">{{ template_details[camera]['last_screenshot'] }}</span></td>
-            <td data-value="{{ template_details[camera]['next_screenshot'] }}"><span class="humanized-time" data-time="{{ template_details[camera]['next_screenshot'] }}">{{ template_details[camera]['next_screenshot'] }}</span></td>
-            <td data-value="{{ template_details[camera]['screenshot_count'] }}">{{ template_details[camera]['screenshot_count'] }}</td>
-            <td data-value="{{ template_details[camera]['video_count'] }}">{{ template_details[camera]['video_count'] }}</td>
-            <td data-value="{{ template_details[camera]['storage_usage_bytes'] }}">{{ template_details[camera]['storage_usage'] }}</td>
-            <td data-value="{{ template_details[camera]['llm_response_count'] }}">{{ template_details[camera]['llm_response_count'] }}</td>
-            <td data-value="{{ template_details[camera]['llm_cost_estimate'] }}">{{ template_details[camera]['llm_cost_estimate'] }}</td>
+            <td data-value="{{ template_details[camera]['last_screenshot'] }}">
+              <span
+                class="humanized-time"
+                data-time="{{ template_details[camera]['last_screenshot'] }}"
+                >{{ template_details[camera]['last_screenshot'] }}</span
+              >
+            </td>
+            <td data-value="{{ template_details[camera]['next_screenshot'] }}">
+              <span
+                class="humanized-time"
+                data-time="{{ template_details[camera]['next_screenshot'] }}"
+                >{{ template_details[camera]['next_screenshot'] }}</span
+              >
+            </td>
             <td>
-                <form id="form-{{ camera }}" class="notes-form caption-box">
-                        <div class="chat-box">
-                            <div class="chat-prompt">
-                                <label for="notes-{{ camera }}">Prompt:</label>
-                                <textarea id="notes-{{ camera }}" class="notes-textarea">{{ template_details[camera]['notes'] }}</textarea>
-                            </div>
-                            <div class="chat-response">
-                                <label>Response:</label>
-                                <div class="last-caption">
-                                    {{ template_details[camera]['last_caption'] }}
-                                </div>
-                            </div>
-                        </div>
-                        <button class="update-button" data-template="{{ camera }}" title="Send updated prompt">
-                            Send
-                        </button>
-                </form>
+              <form id="form-{{ camera }}" class="notes-form caption-box">
+                <div class="chat-box">
+                  <div class="chat-prompt">
+                    <label for="notes-{{ camera }}">Prompt:</label>
+                    <textarea id="notes-{{ camera }}" class="notes-textarea">
+{{ template_details[camera]['notes'] }}</textarea
+                    >
+                  </div>
+                  <div class="chat-response">
+                    <label>Response:</label>
+                    <div class="last-caption">
+                      {{ template_details[camera]['last_caption'] }}
+                    </div>
+                  </div>
+                </div>
+                <button
+                  class="update-button"
+                  data-template="{{ camera }}"
+                  title="Send updated prompt"
+                >
+                  Send
+                </button>
+              </form>
             </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-</div>
-</div>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
 
-<div id="history-tab" class="tab-content">
+  <div id="history-tab" class="tab-content">
     <h2>Captions</h2>
     <div class="caption-filters">
-        <input type="search" id="captions-search" placeholder="Search captions or time" title="Filter captions">
-        <label for="caption-start">From:</label>
-        <input type="date" id="caption-start" title="Start date">
-        <label for="caption-end">To:</label>
-        <input type="date" id="caption-end" title="End date">
-        <button id="caption-clear" type="button" title="Clear filters">Clear</button>
-        <button id="toggle-chyron-btn" type="button" onclick="toggleChyron()" title="Toggle caption banner">
-            {% if CHYRON_SPEED|int > 0 %}Disable Chyron{% else %}Enable Chyron{% endif %}
-        </button>
+      <input
+        type="search"
+        id="captions-search"
+        placeholder="Search captions or time"
+        title="Filter captions"
+      />
+      <label for="caption-start">From:</label>
+      <input type="date" id="caption-start" title="Start date" />
+      <label for="caption-end">To:</label>
+      <input type="date" id="caption-end" title="End date" />
+      <button id="caption-clear" type="button" title="Clear filters">
+        Clear
+      </button>
+      <button
+        id="toggle-chyron-btn"
+        type="button"
+        onclick="toggleChyron()"
+        title="Toggle caption banner"
+      >
+        {% if CHYRON_SPEED|int > 0 %}Disable Chyron{% else %}Enable Chyron{%
+        endif %}
+      </button>
     </div>
     <table id="captions-table" class="captions-table">
-            <thead>
-            <tr>
-                <th class="sortable" data-type="date">Timestamp</th>
-                <th class="sortable" data-type="string">Caption</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% if not lcaptions %}
-            <tr class="no-data">
-                <td colspan="2">No captions available</td>
-            </tr>
-            {% else %}
-            {% for caption in lcaptions %}
-            {% for lc in caption %}
-            {% if caption[lc] != "" %}
-            <tr>
-                <td><span class="humanized-time" data-time="{{ lc }}">{{ lc }}</span></td>
-                <td>{{ caption[lc] }}</td>
-            </tr>
-            {% endif %}
-            {% endfor %}
-            {% endfor %}
-            {% endif %}
-            </tbody>
-        </table>
-</div>
+      <thead>
+        <tr>
+          <th class="sortable" data-type="date">Timestamp</th>
+          <th class="sortable" data-type="string">Caption</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% if not lcaptions %}
+        <tr class="no-data">
+          <td colspan="2">No captions available</td>
+        </tr>
+        {% else %} {% for caption in lcaptions %} {% for lc in caption %} {% if
+        caption[lc] != "" %}
+        <tr>
+          <td>
+            <span class="humanized-time" data-time="{{ lc }}">{{ lc }}</span>
+          </td>
+          <td>{{ caption[lc] }}</td>
+        </tr>
+        {% endif %} {% endfor %} {% endfor %} {% endif %}
+      </tbody>
+    </table>
+  </div>
 
-<div id="bulk-tab" class="tab-content">
+  <div id="bulk-tab" class="tab-content">
     <div class="tsv-controls">
-        <h3>Bulk Caption Management</h3>
-        <div class="tsv-buttons">
-            <a href="/download_captions_tsv" class="btn btn-primary" title="Download captions as TSV file">Download Captions as TSV</a>
+      <h3>Bulk Caption Management</h3>
+      <div class="tsv-buttons">
+        <a
+          href="/download_captions_tsv"
+          class="btn btn-primary"
+          title="Download captions as TSV file"
+          >Download Captions as TSV</a
+        >
 
-            <form action="/upload_captions_tsv" method="post" enctype="multipart/form-data" class="tsv-upload-form">
-                <input type="file" name="tsv_file" id="tsv_file" accept=".tsv" title="Select TSV file to upload">
-                <button type="submit" class="btn btn-success" title="Upload caption TSV file">Upload TSV</button>
-            </form>
-        </div>
-        <p class="tsv-help">Download the TSV file, edit in a spreadsheet application, then upload to update captions.</p>
+        <form
+          action="/upload_captions_tsv"
+          method="post"
+          enctype="multipart/form-data"
+          class="tsv-upload-form"
+        >
+          <input
+            type="file"
+            name="tsv_file"
+            id="tsv_file"
+            accept=".tsv"
+            title="Select TSV file to upload"
+          />
+          <button
+            type="submit"
+            class="btn btn-success"
+            title="Upload caption TSV file"
+          >
+            Upload TSV
+          </button>
+        </form>
+      </div>
+      <p class="tsv-help">
+        Download the TSV file, edit in a spreadsheet application, then upload to
+        update captions.
+      </p>
     </div>
 
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        <div class="flash-messages">
-        {% for category, message in messages %}
-          <div class="alert alert-{{ category }}">{{ message }}</div>
-        {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
-  {% from 'components.html' import confirm_modal %}
-  {{ confirm_modal('update', 'Send updated prompt?', 'Send', 'Cancel') }}
+    {% with messages = get_flashed_messages(with_categories=true) %} {% if
+    messages %}
+    <div class="flash-messages">
+      {% for category, message in messages %}
+      <div class="alert alert-{{ category }}">{{ message }}</div>
+      {% endfor %}
+    </div>
+    {% endif %} {% endwith %} {% from 'components.html' import confirm_modal %}
+    {{ confirm_modal('update', 'Send updated prompt?', 'Send', 'Cancel') }}
+  </div>
+  {% endblock %}
 </div>
-{% endblock %}
-

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,82 +1,144 @@
-
-
-{% extends 'base.html' %}
-{% from 'components.html' import card %}
-{% block content %}
+{% extends 'base.html' %} {% from 'components.html' import card %} {% block
+content %}
 
 <div class="scheduler-controls">
-    <button id="toggle-scheduler" class="btn btn-primary" title="Start or stop the scheduler">
-        Loading...
-    </button>
-    <span id="scheduler-status" title="Current scheduler status">Checking status...</span>
+  <button
+    id="toggle-scheduler"
+    class="btn btn-primary"
+    title="Start or stop the scheduler"
+  >
+    Loading...
+  </button>
+  <span id="scheduler-status" title="Current scheduler status"
+    >Checking status...</span
+  >
 </div>
 
 <h1>System Status</h1>
 
 {% call card('System Metrics') %}
 <ul class="metrics-list">
-    <li title="Current CPU utilization">CPU Usage:
-        <progress class="metric-bar" value="{{ metrics.cpu_usage }}" max="100"></progress>
-        {{ metrics.cpu_usage }}%
-    </li>
-    <li title="Current memory utilization">Memory Usage:
-        <progress class="metric-bar" value="{{ metrics.memory_usage }}" max="100"></progress>
-        {{ metrics.memory_usage }}%
-    </li>
-    <li title="Disk space used">Disk Usage:
-        <progress class="metric-bar" value="{{ metrics.disk_usage }}" max="100"></progress>
-        {{ metrics.disk_usage }}%
-    </li>
-    <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
-    <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
-    <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
-    <li title="Installed ffmpeg version">FFmpeg Version: {{ metrics.ffmpeg_version }}</li>
-    <li title="Hardware acceleration devices present">Machine HW Accel: {{ metrics.machine_hwaccel }}</li>
-    <li title="ffmpeg has hardware acceleration support">FFmpeg HW Accel: {{ metrics.ffmpeg_hwaccel }}</li>
-    <li title="Hardware acceleration enabled via config">HW Accel Enabled: {{ metrics.hwaccel_enabled }}</li>
+  <li title="Current CPU utilization">
+    CPU Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.cpu_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.cpu_usage }}%
+  </li>
+  <li title="Current memory utilization">
+    Memory Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.memory_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.memory_usage }}%
+  </li>
+  <li title="Disk space used">
+    Disk Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.disk_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.disk_usage }}%
+  </li>
+  <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
+  <li title="Number of active threads">
+    Thread Count: {{ metrics.thread_count }}
+  </li>
+  <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+  <li title="Installed ffmpeg version">
+    FFmpeg Version: {{ metrics.ffmpeg_version }}
+  </li>
+  <li title="Hardware acceleration devices present">
+    Machine HW Accel: {{ metrics.machine_hwaccel }}
+  </li>
+  <li title="ffmpeg has hardware acceleration support">
+    FFmpeg HW Accel: {{ metrics.ffmpeg_hwaccel }}
+  </li>
+  <li title="Hardware acceleration enabled via config">
+    HW Accel Enabled: {{ metrics.hwaccel_enabled }}
+  </li>
 </ul>
-{% endcall %}
-
-{% call card('Feed Status') %}
+{% endcall %} {% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">
-    <thead>
-        <tr>
-            <th class="sortable" data-type="string">Feed</th>
-            <th class="sortable" data-type="date">Last Image</th>
-            <th class="sortable" data-type="date">Last Caption</th>
-            <th class="sortable" data-type="string">Status</th>
-        </tr>
-    </thead>
-    <tbody>
+  <thead>
+    <tr>
+      <th class="sortable" data-type="string">Feed</th>
+      <th class="sortable" data-type="date">Last Image</th>
+      <th class="sortable" data-type="date">Last Caption</th>
+      <th class="sortable" data-type="number">Shots</th>
+      <th class="sortable" data-type="number">Videos</th>
+      <th class="sortable" data-type="number">Storage</th>
+      <th class="sortable" data-type="number">LLM Resp</th>
+      <th class="sortable" data-type="number">LLM Cost</th>
+      <th class="sortable" data-type="string">Status</th>
+    </tr>
+  </thead>
+  <tbody>
     {% for feed in feeds %}
-        <tr class="{{ feed.status }}">
-            <td data-label="Feed" data-value="{{ feed.name }}"><a href="{{ url_for('template_details', template_name=feed.name) }}">{{ feed.name }}</a></td>
-            <td data-label="Last Image" data-value="{{ feed.last_screenshot_time or '' }}">
-                {% if feed.last_screenshot_display %}
-                <span class="humanized-time" data-time="{{ feed.last_screenshot_time }}" title="{{ feed.last_screenshot_time }}">
-                    {{ feed.last_screenshot_display }}
-                </span>
-                {% else %}
-                N/A
-                {% endif %}
-            </td>
-            <td data-label="Last Caption" data-value="{{ feed.last_caption_time or '' }}">
-                {% if feed.last_caption_display %}
-                <span class="humanized-time" data-time="{{ feed.last_caption_time }}" title="{{ feed.last_caption_time }}">
-                    {{ feed.last_caption_display }}
-                </span>
-                {% else %}
-                N/A
-                {% endif %}
-            </td>
-            <td data-label="Status" data-value="{{ feed.status }}"><span class="status-dot {{ feed.status }}" title="{{ feed.tooltip }}"></span></td>
-        </tr>
+    <tr class="{{ feed.status }}">
+      <td data-label="Feed" data-value="{{ feed.name }}">
+        <a href="{{ url_for('template_details', template_name=feed.name) }}"
+          >{{ feed.name }}</a
+        >
+      </td>
+      <td
+        data-label="Last Image"
+        data-value="{{ feed.last_screenshot_time or '' }}"
+      >
+        {% if feed.last_screenshot_display %}
+        <span
+          class="humanized-time"
+          data-time="{{ feed.last_screenshot_time }}"
+          title="{{ feed.last_screenshot_time }}"
+        >
+          {{ feed.last_screenshot_display }}
+        </span>
+        {% else %} N/A {% endif %}
+      </td>
+      <td
+        data-label="Last Caption"
+        data-value="{{ feed.last_caption_time or '' }}"
+      >
+        {% if feed.last_caption_display %}
+        <span
+          class="humanized-time"
+          data-time="{{ feed.last_caption_time }}"
+          title="{{ feed.last_caption_time }}"
+        >
+          {{ feed.last_caption_display }}
+        </span>
+        {% else %} N/A {% endif %}
+      </td>
+      <td data-label="Shots" data-value="{{ feed.screenshot_count }}">
+        {{ feed.screenshot_count }}
+      </td>
+      <td data-label="Videos" data-value="{{ feed.video_count }}">
+        {{ feed.video_count }}
+      </td>
+      <td data-label="Storage" data-value="{{ feed.storage_usage_bytes }}">
+        {{ feed.storage_usage }}
+      </td>
+      <td data-label="LLM Resp" data-value="{{ feed.llm_response_count }}">
+        {{ feed.llm_response_count }}
+      </td>
+      <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
+        {{ feed.llm_cost_estimate }}
+      </td>
+      <td data-label="Status" data-value="{{ feed.status }}">
+        <span
+          class="status-dot {{ feed.status }}"
+          title="{{ feed.tooltip }}"
+        ></span>
+      </td>
+    </tr>
     {% endfor %}
-    </tbody>
+  </tbody>
 </table>
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
-{% endcall %}
-
-{% include 'logs.html' %}
-{% endblock %}
+{% endcall %} {% include 'logs.html' %} {% endblock %}

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -54,6 +54,12 @@ from .template_manager import (
     update_last_screenshot_time,
     mark_offline,
     set_capture_failed,
+    get_screenshot_count,
+    get_video_count,
+    get_storage_usage,
+    get_storage_usage_bytes,
+    get_llm_response_count,
+    get_llm_cost_estimate,
 )
 from .email_alerts import email_alert
 from .sms_alerts import sms_alert
@@ -1155,6 +1161,12 @@ def get_feed_status():
         frequency = int(template.get("frequency", 0) or 0)
         capture_failed = template.get("capture_failed", False)
         offline_since = template.get("offline_since")
+        shot_count = get_screenshot_count(name)
+        video_count = get_video_count(name)
+        storage = get_storage_usage(name)
+        storage_bytes = get_storage_usage_bytes(name)
+        llm_responses = get_llm_response_count(name)
+        llm_cost = get_llm_cost_estimate(name)
 
         status = "ok"
         tooltip_parts: list[str] = []
@@ -1206,6 +1218,12 @@ def get_feed_status():
                 "last_caption_display": _humanize(last_caption),
                 "status": status,
                 "tooltip": tooltip,
+                "screenshot_count": shot_count,
+                "video_count": video_count,
+                "storage_usage": storage,
+                "storage_usage_bytes": storage_bytes,
+                "llm_response_count": llm_responses,
+                "llm_cost_estimate": llm_cost,
             }
         )
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -18,8 +18,11 @@ Below the system metrics the page lists each configured feed with a color-coded 
 
 The dashboard also shows when the most recent system summary was generated.
 
+Additional KPI columns track the number of screenshots, videos, total storage
+used, LLM responses, and estimated LLM cost for each feed.
+
 The table headers are sortable. Click a column name to reorder feeds by feed
-name, last image time, last caption time, or status.
+name, last image time, last caption time, any KPI column, or status.
 
 ### Metrics
 
@@ -99,7 +102,6 @@ curl /profiling
 
 Use this information to identify slow endpoints and monitor performance.
 
-
 Baseline metrics from the main branch are stored in
 `docs/latency_baseline.json`. Run the helper script to refresh this file after
 tests:
@@ -110,4 +112,3 @@ python scripts/update_latency_baseline.py
 
 CI bots can compare the latest profiling results against this baseline to detect
 latency regressions.
-


### PR DESCRIPTION
## Summary
- show feed KPIs on the status dashboard
- remove KPI columns from captions
- expose KPI metrics in `get_feed_status`
- document new dashboard columns

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420c503e688333a4617f81bb370140