### PR TITLE
Add configurable clock settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -258,6 +258,11 @@ SESSION_COOKIE_SECURE = get_setting("SESSION_COOKIE_SECURE", "True") == "True"
 SESSION_COOKIE_HTTPONLY = get_setting("SESSION_COOKIE_HTTPONLY", "True") == "True"
 SESSION_TIMEOUT_MINUTES = int(get_setting("SESSION_TIMEOUT_MINUTES", 30))
 
+# Clock configuration
+CLOCK_OVERLAY = get_setting("CLOCK_OVERLAY", "False") == "True"
+CLOCK_DIGITAL = get_setting("CLOCK_DIGITAL", "False") == "True"
+CLOCK_NAVBAR = get_setting("CLOCK_NAVBAR", "True") == "True"
+
 # Load settings from the database
 SECRET_KEY = get_setting("SECRET_KEY", "default_secret_key")
 USER_NAME = get_setting("USER_NAME", "admin")

--- a/app/routes.py
+++ b/app/routes.py
@@ -61,6 +61,9 @@ from app.config import (
     CHYRON_SPEED,
     NAV_ICON,
     HEALTH_STATUS_ALWAYS_VISIBLE,
+    CLOCK_OVERLAY,
+    CLOCK_DIGITAL,
+    CLOCK_NAVBAR,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -923,6 +926,9 @@ def init_routes(app: Flask) -> None:
             CHYRON_SPEED=CHYRON_SPEED,
             NAV_ICON=NAV_ICON,
             HEALTH_STATUS_ALWAYS_VISIBLE=HEALTH_STATUS_ALWAYS_VISIBLE,
+            CLOCK_OVERLAY=CLOCK_OVERLAY,
+            CLOCK_DIGITAL=CLOCK_DIGITAL,
+            CLOCK_NAVBAR=CLOCK_NAVBAR,
         )
 
     # Add a new route for the extended health check
@@ -2047,6 +2053,13 @@ def init_routes(app: Flask) -> None:
         return render_template(
             "live.html", template_details=templates, page_title="Live View"
         )
+
+    @app.route("/clock")
+    @login_required
+    def clock_page():
+        """Render a standalone clock page."""
+
+        return render_template("clock.html", page_title="Clock")
 
     @app.route("/latest_frame/<string:template_name>")
     @login_required

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -787,6 +787,20 @@ button, a {
     margin-left: 20px;
 }
 
+.clock-overlay {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: 10;
+}
+
+.digital-clock {
+    font-size: 14px;
+    line-height: 25px;
+    text-align: center;
+    color: var(--text-color);
+}
+
 .clock-face {
     width: 100%;
     height: 100%;

--- a/app/static/js/clock.js
+++ b/app/static/js/clock.js
@@ -1,0 +1,49 @@
+export function initClocks() {
+  const clocks = document.querySelectorAll('.cool-clock');
+  if (!clocks.length) return;
+
+  const update = () => {
+    const now = new Date();
+    clocks.forEach((clock) => {
+      const digital = clock.dataset.digital === 'true';
+      const secondHand = clock.querySelector('.second-hand');
+      const minuteHand = clock.querySelector('.minute-hand');
+      const hourHand = clock.querySelector('.hour-hand');
+      const digitalDisp = clock.querySelector('.digital-clock');
+      if (digital) {
+        if (digitalDisp) {
+          digitalDisp.textContent = now.toLocaleTimeString();
+        }
+        if (secondHand) secondHand.style.display = 'none';
+        if (minuteHand) minuteHand.style.display = 'none';
+        if (hourHand) hourHand.style.display = 'none';
+      } else {
+        const secDeg = (now.getSeconds() / 60) * 360;
+        const minDeg = (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6;
+        const hourDeg = (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30;
+        if (secondHand) {
+          secondHand.style.display = '';
+          secondHand.style.transform = `rotate(${secDeg}deg)`;
+        }
+        if (minuteHand) {
+          minuteHand.style.display = '';
+          minuteHand.style.transform = `rotate(${minDeg}deg)`;
+        }
+        if (hourHand) {
+          hourHand.style.display = '';
+          hourHand.style.transform = `rotate(${hourDeg}deg)`;
+        }
+        if (digitalDisp) digitalDisp.textContent = '';
+      }
+    });
+  };
+
+  update();
+  setInterval(update, 1000);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initClocks);
+} else {
+  initClocks();
+}

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -1,3 +1,5 @@
+import { initClocks } from "./clock.js";
+
 export function initNav() {
   document.addEventListener("DOMContentLoaded", () => {
     const healthStatus = document.getElementById("health-status");
@@ -304,26 +306,6 @@ export function initNav() {
       }
     };
 
-    const updateCoolClock = () => {
-      const secondHand = document.querySelector(".second-hand");
-      const minuteHand = document.querySelector(".minute-hand");
-      const hourHand = document.querySelector(".hour-hand");
-      const digitalTime = document.getElementById("digitalTime");
-      if (!secondHand || !minuteHand || !hourHand || !digitalTime) return;
-
-      const now = new Date();
-      const secondsDegrees = (now.getSeconds() / 60) * 360;
-      const minutesDegrees =
-        (now.getMinutes() / 60) * 360 + (now.getSeconds() / 60) * 6;
-      const hoursDegrees =
-        (now.getHours() / 12) * 360 + (now.getMinutes() / 60) * 30;
-
-      secondHand.style.transform = `rotate(${secondsDegrees}deg)`;
-      minuteHand.style.transform = `rotate(${minutesDegrees}deg)`;
-      hourHand.style.transform = `rotate(${hoursDegrees}deg)`;
-
-      digitalTime.title = `${now.toLocaleTimeString()}\n${Intl.DateTimeFormat().resolvedOptions().timeZone}\n${now.toDateString()}`;
-    };
 
     const setupNavFade = () => {
       const header = document.querySelector("header");
@@ -353,8 +335,7 @@ export function initNav() {
     setInterval(checkCaptions, 10000);
     checkDiscovery();
     setInterval(checkDiscovery, 60000);
-    updateCoolClock();
-    setInterval(updateCoolClock, 1000);
+    initClocks();
     setupNavFade();
   });
 }

--- a/app/templates/clock.html
+++ b/app/templates/clock.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="clock-page">
+  <div class="cool-clock" id="pageClock" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}">
+    <div class="clock-face">
+      <div class="clock-hands">
+        <div class="hand hour-hand"></div>
+        <div class="hand minute-hand"></div>
+        <div class="hand second-hand"></div>
+      </div>
+      <div class="digital-clock"></div>
+    </div>
+  </div>
+</div>
+<script type="module" src="{{ url_for('static', filename='js/clock.js') }}"></script>
+{% endblock %}

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -81,6 +81,18 @@
                 <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
                 <p id="stream-error-message"></p>
             </div>
+            {% if CLOCK_OVERLAY %}
+            <div id="overlayClock" class="cool-clock clock-overlay" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}">
+                <div class="clock-face">
+                    <div class="clock-hands">
+                        <div class="hand hour-hand"></div>
+                        <div class="hand minute-hand"></div>
+                        <div class="hand second-hand"></div>
+                    </div>
+                    <div class="digital-clock"></div>
+                </div>
+            </div>
+            {% endif %}
         </div>
         <div id="error-message" role="alert"></div>
     </div>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -45,13 +45,14 @@
       </a>
     </div>
     <a href="/live" id="live" aria-label="Open Live page">
-      <div id="coolClock" class="cool-clock" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
-        <div id="dateDisplay" class="clock-face">
-          <div id="digitalTime" class="clock-hands" title="">
+      <div id="navClock" class="cool-clock" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}" style="{% if not CLOCK_NAVBAR %}display:none;{% endif %}" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
+        <div class="clock-face">
+          <div class="clock-hands">
             <div class="hand hour-hand"></div>
             <div class="hand minute-hand"></div>
             <div class="hand second-hand"></div>
           </div>
+          <div class="digital-clock"></div>
         </div>
       </div>
     </a>

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -56,6 +56,18 @@
             <i class="fas fa-times-circle video-icon"></i>
             <p id="stream-error-message"></p>
         </div>
+        {% if CLOCK_OVERLAY %}
+        <div id="overlayClock" class="cool-clock clock-overlay" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}">
+            <div class="clock-face">
+                <div class="clock-hands">
+                    <div class="hand hour-hand"></div>
+                    <div class="hand minute-hand"></div>
+                    <div class="hand second-hand"></div>
+                </div>
+                <div class="digital-clock"></div>
+            </div>
+        </div>
+        {% endif %}
     </div>
     <div id="error-message"></div>
 </div>

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -23,6 +23,9 @@ SETTINGS_TOOLTIPS = {
     "TWILIO_SID": "Twilio account SID",
     "TWILIO_TOKEN": "Twilio authentication token",
     "TWILIO_NUMBER": "Sending phone number",
+    "CLOCK_OVERLAY": "Show clock on video overlay",
+    "CLOCK_DIGITAL": "Display clock as digital text",
+    "CLOCK_NAVBAR": "Show clock in the navigation bar",
 }
 
 # Settings categories used to group configuration values on the settings page.
@@ -97,4 +100,5 @@ SETTINGS_GROUPS = {
     "SMS": ["TWILIO_SID", "TWILIO_TOKEN", "TWILIO_NUMBER"],
     "CAP": ["CAP_ENDPOINT", "CAP_SENDER"],
     "MCP": ["MCP_SERVER_COMMAND", "MCP_SERVER_URL"],
+    "Clock": ["CLOCK_OVERLAY", "CLOCK_DIGITAL", "CLOCK_NAVBAR"],
 }

--- a/docs/clock_settings.md
+++ b/docs/clock_settings.md
@@ -1,0 +1,9 @@
+# Clock Settings
+
+The application includes a configurable clock that can appear in multiple places. Open the **Settings** page and switch to the **Clock** tab to adjust its behaviour.
+
+* **CLOCK_OVERLAY** – display the clock on video overlays.
+* **CLOCK_DIGITAL** – show the clock as digital text rather than an analogue face.
+* **CLOCK_NAVBAR** – show or hide the navigation bar clock.
+
+The standalone `/clock` page presents a large clock which reflects these settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Recommendations: recommendations.md
       - Release Workflow: release_workflow.md
       - Settings Page: settings_page.md
+      - Clock Settings: clock_settings.md
       - Configuration Management: config_management.md
       - System Monitoring: system_monitoring.md
       - Testing: testing.md

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -1,0 +1,61 @@
+import os
+import sqlite3
+import importlib
+import unittest
+import tempfile
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app
+import app.config as config
+import app.routes as routes
+
+
+class TestClockRoute(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+
+        self.env_patch = patch.dict(
+            os.environ, {"GLIMPSER_DATABASE_PATH": self.db_path}
+        )
+        self.env_patch.start()
+
+        importlib.reload(config)
+        importlib.reload(routes)
+        importlib.reload(app)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS settings (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.commit()
+        conn.close()
+        self.app = app.create_app(enable_watchdog=False, schedule=False)
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        self.restart_patch = patch("app.routes.restart_server")
+        self.restart_patch.start()
+
+    def tearDown(self):
+        self.restart_patch.stop()
+        self.app_context.pop()
+        self.env_patch.stop()
+        importlib.reload(config)
+        importlib.reload(routes)
+        importlib.reload(app)
+        self.temp_dir.cleanup()
+
+    def test_clock_page(self):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
+            response = self.client.get("/clock")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Clock", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow toggling clock overlay, digital mode and nav bar display
- add standalone clock page and update navigation
- document new clock settings
- test new clock route

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68420e4ef29c833393f77c60b8a14331