### PR TITLE
Add caption overlay toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -432,6 +432,10 @@ body.light-mode {
     overflow-y: auto;
 }
 
+.hide-captions .caption-overlay {
+    display: none;
+}
+
 #status-legend {
     display: flex;
     gap: 5px;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -10,6 +10,18 @@ export function initTemplates() {
       ?.closest("details");
     const slider = document.getElementById("grid-width-slider");
     const templateList = document.getElementById("template-list");
+    const captionToggle = document.getElementById("toggle-captions");
+    let captionsVisible = localStorage.getItem("showCaptions") !== "false";
+
+    const applyCaptionVisibility = (width) => {
+      const show = captionsVisible && (!width || width >= 150);
+      document.documentElement.classList.toggle("hide-captions", !show);
+      templateList
+        ?.querySelectorAll(".caption-overlay")
+        .forEach((o) => (o.style.display = show ? "block" : "none"));
+      if (captionToggle)
+        captionToggle.textContent = show ? "Hide Captions" : "Show Captions";
+    };
     const MAX_THUMBNAIL_HEIGHT = 1080;
     const ASPECT_RATIO = 9 / 16;
     const MAX_THUMBNAIL_WIDTH = Math.round(MAX_THUMBNAIL_HEIGHT / ASPECT_RATIO);
@@ -54,6 +66,14 @@ export function initTemplates() {
       window.addEventListener("resize", updateSliderLimits);
       window.updateSliderLimits = updateSliderLimits;
       slider.dispatchEvent(new Event("input"));
+    }
+
+    if (captionToggle) {
+      captionToggle.addEventListener("click", () => {
+        captionsVisible = !captionsVisible;
+        localStorage.setItem("showCaptions", captionsVisible.toString());
+        applyCaptionVisibility(parseFloat(slider?.value || "0"));
+      });
     }
 
     function autofillGroup() {
@@ -107,6 +127,7 @@ export function initTemplates() {
           "--timestamp-font-size",
           `${timestampFontSize}px`,
         );
+        applyCaptionVisibility(value);
       };
 
       slider.addEventListener("input", handleSlider);
@@ -162,6 +183,7 @@ export function initTemplates() {
     setupCaptionsFilter();
     updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
+    applyCaptionVisibility(parseFloat(slider?.value || "0"));
   });
 
   window.showStructuredInput = showStructuredInput;
@@ -579,6 +601,7 @@ export async function loadTemplates() {
     window.dispatchEvent(
       new CustomEvent("templatesLoaded", { detail: { count: templateCount } }),
     );
+    applyCaptionVisibility(parseFloat(slider?.value || "0"));
   } catch (error) {
     console.error("Error loading templates:", error);
     const errorMsg =

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,20 +1,43 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <h2>Group {{ group_name }}</h2>
 <div>
-    <label for="search-input" title="Search for cameras or groups">Search:</label>
-    <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">
-    <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
-    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-    <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <label for="search-input" title="Search for cameras or groups">Search:</label>
+  <input
+    type="text"
+    id="search-input"
+    placeholder="Search cameras or groups"
+    title="Enter search terms"
+  />
+  <input
+    type="range"
+    id="grid-width-slider"
+    min="50"
+    max="3840"
+    value="360"
+    title="Adjust the width of the template grid"
+  />
+  <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+  <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <button
+    id="toggle-captions"
+    title="Toggle caption overlays"
+    aria-label="Toggle caption overlays"
+  >
+    Hide Captions
+  </button>
 </div>
-<div id="template-list" title="List of all templates" role="region" aria-label="Templates"></div>
+<div
+  id="template-list"
+  title="List of all templates"
+  role="region"
+  aria-label="Templates"
+></div>
 <div id="index-time" class="corner-time" title=""></div>
 <script type="module">
-    import { loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
-    window.currentGroup = '{{ group_name }}';
-    document.addEventListener('DOMContentLoaded', () => {
-        loadTemplates();
-    });
+  import { loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
+  window.currentGroup = '{{ group_name }}';
+  document.addEventListener('DOMContentLoaded', () => {
+      loadTemplates();
+  });
 </script>
 {% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,43 +1,71 @@
 <!-- app/templates/index.html -->
 
-{% extends 'base.html' %}
-{% block content %}
-
+{% extends 'base.html' %} {% block content %}
 
 <section id="template-controls">
-    <input type="text" id="search-input" placeholder="Search cameras" title="Enter search terms">
-    <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
-    <span id="status-legend">
-        <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent</span>
-        <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Error</span>
-    </span>
-    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-    <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <input
+    type="text"
+    id="search-input"
+    placeholder="Search cameras"
+    title="Enter search terms"
+  />
+  <input
+    type="range"
+    id="grid-width-slider"
+    min="50"
+    max="3840"
+    value="360"
+    title="Adjust the width of the template grid"
+  />
+  <span id="status-legend">
+    <span class="status-item"
+      ><span class="status-box recent" aria-hidden="true"></span> Recent</span
+    >
+    <span class="status-item"
+      ><span class="status-box error" aria-hidden="true"></span> Error</span
+    >
+  </span>
+  <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+  <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <button
+    id="toggle-captions"
+    title="Toggle caption overlays"
+    aria-label="Toggle caption overlays"
+  >
+    Hide Captions
+  </button>
 </section>
 
 <section id="template-list-section">
-    <div id="template-list" title="List of all templates" role="region" aria-label="Templates">
-        <!-- Template list will be populated here -->
-    </div>
-
+  <div
+    id="template-list"
+    title="List of all templates"
+    role="region"
+    aria-label="Templates"
+  >
+    <!-- Template list will be populated here -->
+  </div>
 </section>
 
-    <div id="index-time" class="corner-time" title=""></div>
+<div id="index-time" class="corner-time" title=""></div>
 
-    <div id="welcome-modal" class="modal">
-        <div class="modal-content">
-            <span id="welcome-close" class="close-icon" title="Close dialog">&times;</span>
-            <h3>Welcome to Glimpser</h3>
-            <ol>
-                <li>Add a camera from the <strong>Settings → Discover</strong> tab.</li>
-                <li>Configure monitoring options.</li>
-                <li>View live feeds and summaries.</li>
-            </ol>
-            <p>Use the <strong>Discover Cameras</strong> icon in the navigation bar to scan your network.</p>
-            <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
-        </div>
-    </div>
-
+<div id="welcome-modal" class="modal">
+  <div class="modal-content">
+    <span id="welcome-close" class="close-icon" title="Close dialog"
+      >&times;</span
+    >
+    <h3>Welcome to Glimpser</h3>
+    <ol>
+      <li>Add a camera from the <strong>Settings → Discover</strong> tab.</li>
+      <li>Configure monitoring options.</li>
+      <li>View live feeds and summaries.</li>
+    </ol>
+    <p>
+      Use the <strong>Discover Cameras</strong> icon in the navigation bar to
+      scan your network.
+    </p>
+    <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
+  </div>
+</div>
 
 {% endblock %}
-

--- a/docs/caption_overlay_toggle.md
+++ b/docs/caption_overlay_toggle.md
@@ -1,0 +1,3 @@
+# Caption Overlay Toggle
+
+Each thumbnail shows the latest caption text at the bottom. A **Hide Captions** button next to the width slider toggles these overlays. Your preference is stored in `localStorage` so it persists between visits. Captions automatically hide when thumbnails are under 150&nbsp;px wide.


### PR DESCRIPTION
## Summary
- add Hide Captions button to dashboard and group pages
- hide caption overlays below 150px tile width
- store toggle preference in localStorage
- document caption overlay toggle

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420de2e0b083338298b1affbc211be