### PR TITLE
Hide discovery icon on non-settings pages

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -8,6 +8,10 @@ export function initNav() {
     }
     const dangerStatus = document.getElementById("danger-status");
     const discoveryStatus = document.getElementById("discover-status");
+    const onSettingsPage = window.location.pathname.startsWith("/settings");
+    if (discoveryStatus) {
+      discoveryStatus.style.display = onSettingsPage ? "flex" : "none";
+    }
     const nav = document.querySelector("nav");
     const menuToggle = document.getElementById("menu-toggle");
     const groupDropdown = document.getElementById("nav-group-dropdown");
@@ -351,8 +355,10 @@ export function initNav() {
     setInterval(checkDanger, 5000);
     checkCaptions();
     setInterval(checkCaptions, 10000);
-    checkDiscovery();
-    setInterval(checkDiscovery, 60000);
+    if (discoveryStatus && onSettingsPage) {
+      checkDiscovery();
+      setInterval(checkDiscovery, 60000);
+    }
     updateCoolClock();
     setInterval(updateCoolClock, 1000);
     setupNavFade();

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -32,7 +32,7 @@
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
       </svg>
     </a>
-    <a id="discover-status" href="/settings?tab=discover-tab" class="status-indicator" title="Discover Cameras" aria-label="Discover Cameras">
+    <a id="discover-status" href="/settings?tab=discover-tab" class="status-indicator" title="Discover Cameras" aria-label="Discover Cameras" style="display:none;">
       <svg width="20" height="20">
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#search" />
       </svg>


### PR DESCRIPTION
## Summary
- hide the discovery (search) icon unless the current page is the settings page
- skip discovery status polling when the icon is hidden

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684210170ca0833395ab64f8585f5bcb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The "Discover Cameras" status indicator in the navigation bar is now only visible when viewing the settings page.
	- Discovery status checks and updates are now performed exclusively on the settings page, improving performance and reducing unnecessary UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->