### PR TITLE
Implement fading borders for recent/error tiles

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -242,6 +242,16 @@ export function isMobile() {
   return window.matchMedia("(hover: none)").matches;
 }
 
+export function computeBorderColor(ageMinutes, isError) {
+  const base = isError ? [255, 0, 0] : [26, 115, 232];
+  let step = 0;
+  if (ageMinutes >= 1) {
+    step = Math.floor(Math.log10(ageMinutes)) + 1;
+  }
+  const alpha = Math.pow(0.5, step);
+  return `rgba(${base[0]}, ${base[1]}, ${base[2]}, ${alpha})`;
+}
+
 export function updateGridLayout() {
   const templateList = document.getElementById("template-list");
   if (!templateList) return;
@@ -480,12 +490,14 @@ export async function loadTemplates() {
         const nextCaptureTime = timeAgo(template.next_screenshot_time);
 
         const lastScreenshotDate = new Date(lastScreenshotTime);
-        const oneMinuteAgo = new Date(Date.now() - 60000);
-        const isRecent = lastScreenshotDate > oneMinuteAgo;
-        const videoContainerClass = isRecent
-          ? "video-container recent-screenshot"
-          : "video-container";
-        const errorClass = template.capture_failed ? "template-error" : "";
+        const ageMinutes =
+          (Date.now() - lastScreenshotDate.getTime()) / 60000;
+        const videoContainerClass = "video-container";
+        const errorClass = template.capture_failed ? "template-error" : "recent-screenshot";
+        const borderColor = computeBorderColor(
+          ageMinutes,
+          template.capture_failed,
+        );
 
         if (isIndexPage) {
           const templateDiv = document.createElement("div");
@@ -497,7 +509,7 @@ export async function loadTemplates() {
 
           templateDiv.innerHTML = `
             <a href='/templates/${name}'>
-              <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}">
+              <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                 <div class="camera-name">${name}</div>
                 <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none">
                   <source src="/last_video/${name}" type="video/mp4">

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -6,5 +6,7 @@ dominates the layout. The legend now sits next to the **Play All** button on the
 dashboard rather than occupying its own row. A single legend element is rendered
 to avoid duplication when the page loads.
 
-- **Accent border** – the last screenshot was captured within the last minute.
-- **Red border** – the most recent capture attempt failed.
+- **Accent border** – blue for recent captures. The color intensity fades by half after one minute,
+  again after ten minutes, and so on.
+- **Red border** – indicates the most recent capture attempt failed. The red border fades using the
+  same logarithmic scale. A successful capture clears the error state.

--- a/tests/js/border_color.test.js
+++ b/tests/js/border_color.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+
+let computeBorderColor;
+
+beforeAll(async () => {
+  const mod = await import('../../app/static/js/templates.js');
+  computeBorderColor = mod.computeBorderColor;
+});
+
+describe('computeBorderColor', () => {
+  test('recent capture is full blue', () => {
+    expect(computeBorderColor(0.5, false)).toBe('rgba(26, 115, 232, 1)');
+  });
+  test('after five minutes color halves', () => {
+    expect(computeBorderColor(5, false)).toBe('rgba(26, 115, 232, 0.5)');
+  });
+  test('after fifty minutes color quarters', () => {
+    expect(computeBorderColor(50, false)).toBe('rgba(26, 115, 232, 0.25)');
+  });
+  test('error uses red base', () => {
+    expect(computeBorderColor(0, true)).toBe('rgba(255, 0, 0, 1)');
+  });
+});


### PR DESCRIPTION
## Summary
- fade dashboard borders using logarithmic opacity
- update border legend docs
- add unit test for `computeBorderColor`

## Testing
- `flake8`
- `pytest -q`
- ❌ `npm` commands *(failed: node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684211dfaa308333b800d9cb4a6df75c