### PR TITLE
Rename Discover tab to Add and add shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
   [HTTP Callback Guide](docs/http_callbacks.md) for setup details and payload
   examples.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
-- **Camera Discovery**: Open **Settings** and switch to the **Discover** tab to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address plus manufacturer and model information when available. Glimpser checks common system OUI databases, an online lookup service, and the ONVIF device service to gather these details.
+ - **Camera Discovery**: Open **Settings** and switch to the **Add** tab to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address plus manufacturer and model information when available. Glimpser checks common system OUI databases, an online lookup service, and the ONVIF device service to gather these details.
 - **Camera Fix Suggestions**: Validate a template and discover alternative URLs with `/suggest_fix/<template>`. See [Camera Fix Suggestions](docs/camera_fix.md).
-- **Local Cameras**: The Discover tab also lists any available `/dev/video*` devices for easy webcam integration.
+ - **Local Cameras**: The Add tab also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.
 
@@ -136,7 +136,7 @@ The preferred method for capturing screenshots is through the Glimpser web inter
 
 ### Adding a Camera Source
 
-Open the **Discover** tab under **Settings** to scan your network for ONVIF, RTSP, or local devices and click **Add** next to any result. You can also open **Add Source** in the web interface to manually supply a camera URL and group. See [Camera Discovery](docs/camera_discovery.md) for more details.
+Open the **Add** tab under **Settings** to scan your network for ONVIF, RTSP, or local devices and click **Add** next to any result. You can also open **Add Source** in the web interface to manually supply a camera URL and group. See [Camera Discovery](docs/camera_discovery.md) for more details.
 
 ### Running Tests
 

--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -40,4 +40,8 @@
   <symbol id="moon" viewBox="0 0 24 24">
     <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" stroke="currentColor" stroke-width="2" fill="none" />
   </symbol>
-  </svg>
+  <symbol id="plus" viewBox="0 0 24 24">
+    <line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" stroke-width="2" />
+    <line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" stroke-width="2" />
+  </symbol>
+</svg>

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -552,7 +552,7 @@ export async function loadTemplates() {
       const msg = document.createElement("div");
       msg.className = "no-templates";
       msg.textContent =
-        'No templates found. Use "Add Camera" from the Settings → Discover tab to create one.';
+        'No templates found. Use "Add Camera" from the Settings → Add tab to create one.';
       if (isIndexPage) {
         templateList.appendChild(msg);
       } else if (isCaptionsPage) {

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -1,117 +1,214 @@
+{% extends 'base.html' %} {% block content %}
 
-{% extends 'base.html' %}
-{% block content %}
+<main class="container">
+  <h2 class="page-title">Glimpser Help</h2>
 
-    <main class="container">
-        <h2 class="page-title">Glimpser Help</h2>
+  <section class="help-section">
+    <h3 class="section-title">Getting Started</h3>
+    <p>
+      Glimpser is a powerful tool for monitoring and capturing screenshots from
+      various sources. Here's how to get started:
+    </p>
+    <ol>
+      <li>
+        Open the <strong>Settings</strong> page and switch to the
+        <strong>Add</strong> tab.
+      </li>
+      <li>Fill in the Add Camera form with the name, URL, and frequency.</li>
+      <li>Click "Submit" to create your new camera.</li>
+    </ol>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Getting Started</h3>
-            <p>Glimpser is a powerful tool for monitoring and capturing screenshots from various sources. Here's how to get started:</p>
-            <ol>
-                <li>Open the <strong>Settings</strong> page and switch to the <strong>Discover</strong> tab.</li>
-                <li>Fill in the Add Camera form with the name, URL, and frequency.</li>
-                <li>Click "Submit" to create your new camera.</li>
-            </ol>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Adding a Template: Example with time.gov</h3>
+    <p>Let's walk through the process of adding a template for time.gov:</p>
+    <ol>
+      <li>Open the Add tab to access the Add Camera form.</li>
+      <li>
+        Fill in the following details:
+        <ul class="template-details">
+          <li><strong>Template Name:</strong> Enter "US Official Time"</li>
+          <li><strong>URL:</strong> Enter "https://time.gov"</li>
+          <li>
+            <strong>Frequency (minutes):</strong> Enter "60" to capture once per
+            hour
+          </li>
+          <li>
+            <strong>Timeout (seconds):</strong> Enter "10" for a reasonable load
+            time
+          </li>
+          <li>
+            <strong>Notes:</strong> You can enter "Official US time website" or
+            leave it blank
+          </li>
+          <li>
+            <strong>Object Filter:</strong> Leave blank as we don't need to
+            filter specific objects
+          </li>
+          <li>
+            <strong>Object Confidence:</strong> Leave blank as we're not using
+            object detection
+          </li>
+          <li>
+            <strong>Popup XPath:</strong> Leave blank as time.gov doesn't have
+            popups we need to handle
+          </li>
+          <li>
+            <strong>Dedicated XPath:</strong> Enter "//div[@id='time-display']"
+            to focus on the time display
+          </li>
+          <li>
+            <strong>Callback URL:</strong> Leave blank unless you have a
+            specific callback service
+          </li>
+          <li>
+            <strong>Proxy:</strong> Leave blank unless you need to use a proxy
+          </li>
+          <li>
+            <strong>Groups:</strong> You can enter "Time" or leave it blank
+          </li>
+          <li>
+            <strong>Rollback Frames:</strong> Enter "0" as we don't need to
+            rollback for this static display
+          </li>
+          <li><strong>Invert:</strong> Leave unchecked</li>
+          <li>
+            <strong>Dark Mode:</strong> You can check this if you prefer a dark
+            background
+          </li>
+          <li>
+            <strong>Headless:</strong> Leave checked for background processing
+          </li>
+          <li>
+            <strong>Stealth:</strong> Leave unchecked as time.gov doesn't
+            require stealth mode
+          </li>
+        </ul>
+      </li>
+      <li>Click "Submit" to create your new template.</li>
+      <li>
+        You should now see the "US Official Time" template on your home page,
+        which will update every hour with the current official US time.
+      </li>
+    </ol>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Adding a Template: Example with time.gov</h3>
-            <p>Let's walk through the process of adding a template for time.gov:</p>
-            <ol>
-                <li>Open the Discover tab to access the Add Camera form.</li>
-                <li>Fill in the following details:
-                    <ul class="template-details">
-                        <li><strong>Template Name:</strong> Enter "US Official Time"</li>
-                        <li><strong>URL:</strong> Enter "https://time.gov"</li>
-                        <li><strong>Frequency (minutes):</strong> Enter "60" to capture once per hour</li>
-                        <li><strong>Timeout (seconds):</strong> Enter "10" for a reasonable load time</li>
-                        <li><strong>Notes:</strong> You can enter "Official US time website" or leave it blank</li>
-                        <li><strong>Object Filter:</strong> Leave blank as we don't need to filter specific objects</li>
-                        <li><strong>Object Confidence:</strong> Leave blank as we're not using object detection</li>
-                        <li><strong>Popup XPath:</strong> Leave blank as time.gov doesn't have popups we need to handle</li>
-                        <li><strong>Dedicated XPath:</strong> Enter "//div[@id='time-display']" to focus on the time display</li>
-                        <li><strong>Callback URL:</strong> Leave blank unless you have a specific callback service</li>
-                        <li><strong>Proxy:</strong> Leave blank unless you need to use a proxy</li>
-                        <li><strong>Groups:</strong> You can enter "Time" or leave it blank</li>
-                        <li><strong>Rollback Frames:</strong> Enter "0" as we don't need to rollback for this static display</li>
-                        <li><strong>Invert:</strong> Leave unchecked</li>
-                        <li><strong>Dark Mode:</strong> You can check this if you prefer a dark background</li>
-                        <li><strong>Headless:</strong> Leave checked for background processing</li>
-                        <li><strong>Stealth:</strong> Leave unchecked as time.gov doesn't require stealth mode</li>
-                    </ul>
-                </li>
-                <li>Click "Submit" to create your new template.</li>
-                <li>You should now see the "US Official Time" template on your home page, which will update every hour with the current official US time.</li>
-            </ol>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Managing Templates</h3>
+    <p>You can manage your templates from the home page:</p>
+    <ul>
+      <li>View all templates in a grid layout.</li>
+      <li>Click on a template to view its details and recent captures.</li>
+      <li>Edit a template by clicking "Edit Template" on its details page.</li>
+      <li>
+        Delete a template using the "Delete Template" button on its details
+        page.
+      </li>
+    </ul>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Managing Templates</h3>
-            <p>You can manage your templates from the home page:</p>
-            <ul>
-                <li>View all templates in a grid layout.</li>
-                <li>Click on a template to view its details and recent captures.</li>
-                <li>Edit a template by clicking "Edit Template" on its details page.</li>
-                <li>Delete a template using the "Delete Template" button on its details page.</li>
-            </ul>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Viewing Captures</h3>
+    <p>Glimpser provides several ways to view your captures:</p>
+    <ul>
+      <li>
+        On the home page, you can see the most recent capture for each template.
+      </li>
+      <li>Click on a template to view its recent screenshots and videos.</li>
+      <li>Use the "Live" page to see real-time updates of your captures.</li>
+      <li>
+        The "Captions" page shows AI-generated descriptions of your captures.
+      </li>
+    </ul>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Viewing Captures</h3>
-            <p>Glimpser provides several ways to view your captures:</p>
-            <ul>
-                <li>On the home page, you can see the most recent capture for each template.</li>
-                <li>Click on a template to view its recent screenshots and videos.</li>
-                <li>Use the "Live" page to see real-time updates of your captures.</li>
-                <li>The "Captions" page shows AI-generated descriptions of your captures.</li>
-            </ul>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Offline Access</h3>
+    <p>
+      This help page is available offline once you've visited it while online.
+      You can access it anytime, even without an internet connection.
+    </p>
+  </section>
+  <section class="help-section">
+    <h3 class="section-title">Using the CLI</h3>
+    <p>
+      You can control Glimpser from the command line. Run
+      <code>glimpser --help</code> to see all available commands.
+    </p>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Offline Access</h3>
-            <p>This help page is available offline once you've visited it while online. You can access it anytime, even without an internet connection.</p>
-        </section>
-        <section class="help-section">
-            <h3 class="section-title">Using the CLI</h3>
-            <p>You can control Glimpser from the command line. Run <code>glimpser --help</code> to see all available commands.</p>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Advanced Features</h3>
+    <ul>
+      <li>
+        Schedule automatic archiving with the
+        <a href="../docs/video_archiver.md" target="_blank">video archiver</a>.
+      </li>
+      <li>
+        Track language model usage and cost in the
+        <a href="../docs/cost_tracking.md" target="_blank">cost tracking</a>
+        dashboard.
+      </li>
+      <li>
+        Automatically discover network cameras using the
+        <a href="../docs/camera_discovery.md" target="_blank">discovery tool</a
+        >.
+      </li>
+    </ul>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Advanced Features</h3>
-            <ul>
-                <li>Schedule automatic archiving with the <a href="../docs/video_archiver.md" target="_blank">video archiver</a>.</li>
-                <li>Track language model usage and cost in the <a href="../docs/cost_tracking.md" target="_blank">cost tracking</a> dashboard.</li>
-                <li>Automatically discover network cameras using the <a href="../docs/camera_discovery.md" target="_blank">discovery tool</a>.</li>
-            </ul>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Configuration Files</h3>
+    <p>
+      Settings are stored in <code>app/config.py</code> and the database. Most
+      values can be overridden with environment variables like
+      <code>GLIMPSER_DATABASE_PATH</code>.
+    </p>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Configuration Files</h3>
-            <p>Settings are stored in <code>app/config.py</code> and the database. Most values can be overridden with environment variables like <code>GLIMPSER_DATABASE_PATH</code>.</p>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Documentation</h3>
+    <p>
+      See the <a href="../docs/index.md" target="_blank">docs/</a> directory for
+      detailed guides.
+    </p>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Documentation</h3>
-            <p>See the <a href="../docs/index.md" target="_blank">docs/</a> directory for detailed guides.</p>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Troubleshooting</h3>
+    <p>
+      If you run into problems, check the
+      <a href="../docs/troubleshooting.md" target="_blank"
+        >troubleshooting guide</a
+      >
+      for common solutions. The
+      <a href="../docs/faq.md" target="_blank">FAQ</a> covers additional tips.
+    </p>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Troubleshooting</h3>
-            <p>If you run into problems, check the <a href="../docs/troubleshooting.md" target="_blank">troubleshooting guide</a> for common solutions. The <a href="../docs/faq.md" target="_blank">FAQ</a> covers additional tips.</p>
-        </section>
+  <section class="help-section">
+    <h3 class="section-title">Contributing &amp; Feedback</h3>
+    <p>
+      Glimpser is an open source project. You can view the source code or open
+      issues on
+      <a href="https://github.com/KristopherKubicki/glimpser" target="_blank"
+        >GitHub</a
+      >. Contributions are welcome!
+    </p>
+  </section>
 
-        <section class="help-section">
-            <h3 class="section-title">Contributing &amp; Feedback</h3>
-            <p>Glimpser is an open source project. You can view the source code or open issues on <a href="https://github.com/KristopherKubicki/glimpser" target="_blank">GitHub</a>. Contributions are welcome!</p>
-        </section>
-
-        <section class="help-section">
-            <h3 class="section-title">Need More Help?</h3>
-            <p>If you need further assistance, please visit <a href="https://glimpser.net" target="_blank">glimpser.net</a> or the <a href="https://github.com/KristopherKubicki/glimpser" target="_blank">GitHub repository</a> for updates and to report issues.</p>
-        </section>
-        <p><a href="{{ url_for('index') }}">Back to Glimpser</a></p>
-    </main>
+  <section class="help-section">
+    <h3 class="section-title">Need More Help?</h3>
+    <p>
+      If you need further assistance, please visit
+      <a href="https://glimpser.net" target="_blank">glimpser.net</a> or the
+      <a href="https://github.com/KristopherKubicki/glimpser" target="_blank"
+        >GitHub repository</a
+      >
+      for updates and to report issues.
+    </p>
+  </section>
+  <p><a href="{{ url_for('index') }}">Back to Glimpser</a></p>
+</main>
 
 {% endblock %}
-

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,43 +1,64 @@
 <!-- app/templates/index.html -->
 
-{% extends 'base.html' %}
-{% block content %}
-
+{% extends 'base.html' %} {% block content %}
 
 <section id="template-controls">
-    <input type="text" id="search-input" placeholder="Search cameras" title="Enter search terms">
-    <input type="range" id="grid-width-slider" min="50" max="3840" value="360" title="Adjust the width of the template grid">
-    <span id="status-legend">
-        <span class="status-item"><span class="status-box recent" aria-hidden="true"></span> Recent</span>
-        <span class="status-item"><span class="status-box error" aria-hidden="true"></span> Error</span>
-    </span>
-    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-    <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <input
+    type="text"
+    id="search-input"
+    placeholder="Search cameras"
+    title="Enter search terms"
+  />
+  <input
+    type="range"
+    id="grid-width-slider"
+    min="50"
+    max="3840"
+    value="360"
+    title="Adjust the width of the template grid"
+  />
+  <span id="status-legend">
+    <span class="status-item"
+      ><span class="status-box recent" aria-hidden="true"></span> Recent</span
+    >
+    <span class="status-item"
+      ><span class="status-box error" aria-hidden="true"></span> Error</span
+    >
+  </span>
+  <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+  <button id="live-all-button" title="Live stream all cameras">Live All</button>
 </section>
 
 <section id="template-list-section">
-    <div id="template-list" title="List of all templates" role="region" aria-label="Templates">
-        <!-- Template list will be populated here -->
-    </div>
-
+  <div
+    id="template-list"
+    title="List of all templates"
+    role="region"
+    aria-label="Templates"
+  >
+    <!-- Template list will be populated here -->
+  </div>
 </section>
 
-    <div id="index-time" class="corner-time" title=""></div>
+<div id="index-time" class="corner-time" title=""></div>
 
-    <div id="welcome-modal" class="modal">
-        <div class="modal-content">
-            <span id="welcome-close" class="close-icon" title="Close dialog">&times;</span>
-            <h3>Welcome to Glimpser</h3>
-            <ol>
-                <li>Add a camera from the <strong>Settings → Discover</strong> tab.</li>
-                <li>Configure monitoring options.</li>
-                <li>View live feeds and summaries.</li>
-            </ol>
-            <p>Use the <strong>Discover Cameras</strong> icon in the navigation bar to scan your network.</p>
-            <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
-        </div>
-    </div>
-
+<div id="welcome-modal" class="modal">
+  <div class="modal-content">
+    <span id="welcome-close" class="close-icon" title="Close dialog"
+      >&times;</span
+    >
+    <h3>Welcome to Glimpser</h3>
+    <ol>
+      <li>Add a camera from the <strong>Settings → Add</strong> tab.</li>
+      <li>Configure monitoring options.</li>
+      <li>View live feeds and summaries.</li>
+    </ol>
+    <p>
+      Use the <strong>Discover Cameras</strong> icon in the navigation bar to
+      scan your network.
+    </p>
+    <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
+  </div>
+</div>
 
 {% endblock %}
-

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -1,51 +1,127 @@
 {% if NAV_ICON %}
 <h1>
   <a href="/" title="Home">
-    <img src="{{ url_for('static', filename=NAV_ICON) }}" loading="lazy" alt="Glimpser logo" title="Glimpser" />
+    <img
+      src="{{ url_for('static', filename=NAV_ICON) }}"
+      loading="lazy"
+      alt="Glimpser logo"
+      title="Glimpser"
+    />
   </a>
 </h1>
 {% endif %}
-<div id="caption-chyron" class="caption-chyron" aria-live="polite" data-speed="{{ CHYRON_SPEED }}"></div>
+<div
+  id="caption-chyron"
+  class="caption-chyron"
+  aria-live="polite"
+  data-speed="{{ CHYRON_SPEED }}"
+></div>
 <nav>
-  <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+  <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">
+    ☰
+  </button>
   <div class="nav-left">
     <select id="nav-group-dropdown" title="Jump to group"></select>
-    <select id="nav-camera-dropdown" title="Jump to camera" style="display:none"></select>
+    <select
+      id="nav-camera-dropdown"
+      title="Jump to camera"
+      style="display: none"
+    ></select>
     <!-- Discover icon moved to nav-right for consistency -->
   </div>
 
   <div class="nav-center">
     {% if template_name %}
-    <h1><a href="/templates/{{ template_name }}" title="View template {{ template_name }}">{{ template_name }}</a></h1>
+    <h1>
+      <a
+        href="/templates/{{ template_name }}"
+        title="View template {{ template_name }}"
+        >{{ template_name }}</a
+      >
+    </h1>
     {% endif %}
   </div>
 
   <div class="nav-right">
     {% if session.get('user_id') %}
-    <a id="health-status" href="/status" class="status-indicator" title="System Performance" aria-label="System Performance" data-always-visible="{{ 'true' if HEALTH_STATUS_ALWAYS_VISIBLE else 'false' }}">
+    <a
+      id="health-status"
+      href="/status"
+      class="status-indicator"
+      title="System Performance"
+      aria-label="System Performance"
+      data-always-visible="{{ 'true' if HEALTH_STATUS_ALWAYS_VISIBLE else 'false' }}"
+    >
       <svg width="18" height="18">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#check" />
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#check"
+        />
       </svg>
     </a>
-    <a id="danger-status" href="/danger" class="status-indicator" title="Danger Mode" aria-label="Danger Mode" style="display:none;">
+    <a
+      id="danger-status"
+      href="/danger"
+      class="status-indicator"
+      title="Danger Mode"
+      aria-label="Danger Mode"
+      style="display: none"
+    >
       <svg width="18" height="18">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+        />
       </svg>
     </a>
-    <a id="discover-status" href="/settings?tab=discover-tab" class="status-indicator" title="Discover Cameras" aria-label="Discover Cameras">
+    <a
+      id="discover-status"
+      href="/settings?tab=add-tab"
+      class="status-indicator"
+      title="Discover Cameras"
+      aria-label="Discover Cameras"
+    >
       <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#search" />
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#search"
+        />
       </svg>
     </a>
+    {% if request.path.startswith('/settings') %}
+    <a
+      id="add-shortcut"
+      href="?tab=add-tab"
+      class="settings-icon"
+      title="Add Camera"
+      aria-label="Add Camera"
+    >
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#plus" />
+      </svg>
+    </a>
+    {% endif %}
     <div class="caption-container">
-      <a href="/captions" id="captions" class="settings-icon" title="Read and update camera LLMs" aria-label="Read and update camera LLMs">
+      <a
+        href="/captions"
+        id="captions"
+        class="settings-icon"
+        title="Read and update camera LLMs"
+        aria-label="Read and update camera LLMs"
+      >
         <svg width="20" height="20">
-          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#comment" />
+          <use
+            href="{{ url_for('static', filename='icons/sprite.svg') }}#comment"
+          />
         </svg>
       </a>
     </div>
     <a href="/live" id="live" aria-label="Open Live page">
-      <div id="navClock" class="cool-clock" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}" style="{% if not CLOCK_NAVBAR %}display:none;{% endif %}" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
+      <div
+        id="navClock"
+        class="cool-clock"
+        data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
+        style="{% if not CLOCK_NAVBAR %}display:none;{% endif %}"
+        title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming."
+        aria-label="Open Live page for realtime streaming"
+      >
         <div class="clock-face">
           <div class="clock-hands">
             <div class="hand hour-hand"></div>
@@ -56,15 +132,27 @@
         </div>
       </div>
     </a>
-      <a href="/settings" class="settings-icon" title="Update settings" aria-label="Update settings">
-        <svg width="20" height="20">
-          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
-        </svg>
-      </a>
-      {% else %}
-    <a href="{{ url_for('login') }}" class="settings-icon" title="Login" aria-label="Login">
+    <a
+      href="/settings"
+      class="settings-icon"
+      title="Update settings"
+      aria-label="Update settings"
+    >
       <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#login" />
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
+      </svg>
+    </a>
+    {% else %}
+    <a
+      href="{{ url_for('login') }}"
+      class="settings-icon"
+      title="Login"
+      aria-label="Login"
+    >
+      <svg width="20" height="20">
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#login"
+        />
       </svg>
     </a>
     {% endif %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -19,9 +19,7 @@ content %}
       {{ group }}
     </button>
     {% if loop.first %}
-    <button type="button" class="tab-link" data-tab="discover-tab">
-      Discover
-    </button>
+    <button type="button" class="tab-link" data-tab="add-tab">Add</button>
     {% endif %} {% endfor %}
     <button type="button" class="tab-link" data-tab="management-tab">
       Management
@@ -105,7 +103,13 @@ content %}
                   type="checkbox"
                   name="{{ setting.name }}"
                   value="True"
-                  {% if setting.value == 'True' %}checked{% endif %}
+                  {%
+                  if
+                  setting.value=""
+                  ="True"
+                  %}checked{%
+                  endif
+                  %}
                   data-boolean
                 />
                 <span class="slider round"></span>
@@ -119,14 +123,28 @@ content %}
                 {% for option in choices[setting.name] %}
                 <option
                   value="{{ option }}"
-                  {% if setting.value == option %}selected{% endif %}
+                  {%
+                  if
+                  setting.value=""
+                  ="option"
+                  %}selected{%
+                  endif
+                  %}
                 >
                   {{ option }}
                 </option>
                 {% endfor %}
                 <option
                   value="__other__"
-                  {% if setting.value not in choices[setting.name] %}selected{% endif %}
+                  {%
+                  if
+                  setting.value
+                  not
+                  in
+                  choices[setting.name]
+                  %}selected{%
+                  endif
+                  %}
                 >
                   Other
                 </option>
@@ -177,7 +195,7 @@ content %}
       </table>
     </div>
     {% if loop.first %}
-    <div id="discover-tab" class="tab-content">
+    <div id="add-tab" class="tab-content">
       {% include '_discover_tab.html' %}
     </div>
     {% endif %} {% endfor %}

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -6,7 +6,7 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - The live feed image has both `alt` text and a tooltip.
 - The footer Help link displays a tooltip describing its purpose.
  - The navigation Settings link has a single descriptive `title` attribute.
- - The Discover icon also uses a descriptive `title` attribute and opens the Discover tab.
+ - The Discover icon also uses a descriptive `title` attribute and opens the Add tab.
 - Navigation icons now include matching `aria-label` attributes for screen reader support.
 - When a camera is offline, the player shows an overlay with a clear icon instead of replacing the controls.
 - Deprecated `<center>` tags were removed from templates and replaced with CSS-based centering.

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -1,9 +1,9 @@
 # Camera Discovery
 
-Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The **Discover** tab on the **Settings** page now loads immediately and only scans when you click the **Discover** button. Starting a scan automatically enables hourly background discovery if it isn't already running. Use the **Stop Discovery** button to halt it. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger. Interfaces that are down or using loopback or link-local addresses are ignored so the default scan only targets routable LAN networks.
+Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The **Add** tab on the **Settings** page (formerly **Discover**) now loads immediately and only scans when you click the **Discover** button. Starting a scan automatically enables hourly background discovery if it isn't already running. Use the **Stop Discovery** button to halt it. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger. Interfaces that are down or using loopback or link-local addresses are ignored so the default scan only targets routable LAN networks.
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
 The page layout now uses card sections and wider progress indicators for a more professional feel while keeping controls grouped logically.
-Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from the Discover tab. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run.
+Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from the Add tab. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run.
 The scheduling call now triggers discovery in a background thread so the UI never hangs when you enable it.
 The page now polls `/discovery_status` every 30 seconds so the background state
 is always visible, including the remaining time until the next run.
@@ -175,7 +175,7 @@ contains those keywords. The detected type appears in the ``device_type`` field.
 Discovered entries also include a suggested ``url`` built from the protocol and
 port. This makes the "Add" action work immediately without manual edits.
 
-You can then add a discovered camera to your configuration directly from the Discover tab.
+You can then add a discovered camera to your configuration directly from the Add tab.
 The "Add" button on this page now includes a tooltip (title attribute) for improved accessibility.
 
 The discovery list also shows a **System Status** entry pointing at your local

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -39,7 +39,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 1. Log in to the Glimpser web interface.
 
-2. When no templates exist, the **Add Camera** form automatically opens on the **Settings → Discover** tab.
+2. When no templates exist, the **Add Camera** form automatically opens on the **Settings → Add** tab.
    Otherwise, navigate to that tab to add a new source.
 
 3. Choose a data source type (e.g., camera, dashboard, or video stream).

--- a/docs/guided_setup.md
+++ b/docs/guided_setup.md
@@ -4,7 +4,7 @@ This walkthrough helps you configure Glimpser the first time you log in. Follow 
 
 ## Step 1: Add a Source
 
-After installation, log in to the web interface. If no templates exist, the **Add Camera** form on the **Settings → Discover** tab opens automatically. Enter the camera or dashboard URL, choose a refresh interval, and save.
+After installation, log in to the web interface. If no templates exist, the **Add Camera** form on the **Settings → Add** tab opens automatically. Enter the camera or dashboard URL, choose a refresh interval, and save.
 
 ## Step 2: Configure Summaries
 

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,5 +1,5 @@
 # Offline Preview
 
-A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the `/status`, `/settings`, and `/templates` pages (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
+A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the `/status`, `/settings`, and `/templates` pages (including the Add tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
 
 MJPEG endpoints now fall back to the oldest frame stored on disk if no recent frame is available. This means `/stream.mjpg` and related routes always yield at least one image even when the camera is offline.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -2,7 +2,7 @@
 
 The dashboard now includes a built-in welcome dialog for new users. When no templates are defined, a short guide explains the basic setup steps:
 
-1. **Add a camera from the _Settings → Discover_ tab.**
+1. **Add a camera from the _Settings → Add_ tab.**
 2. **Configure monitoring options.**
 3. **View live feeds and summaries.**
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -59,7 +59,7 @@ To filter logs by level and message text, you could request:
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 
-The `/status` page also appears on the Discover tab as a **System Status**
+The `/status` page also appears on the Add tab as a **System Status**
 camera. Adding it lets Glimpser capture periodic screenshots of its own health
 metrics.
 An accompanying **Internal Caption** camera shows `/internal_caption.mjpg` so you

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -10,7 +10,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **System Performance icon** – shows CPU, memory and other metrics. It hides
   when the system is healthy unless `HEALTH_STATUS_ALWAYS_VISIBLE` is set.
 - **Danger Mode icon** – appears only when Danger mode is available. Hovering over it explains why the feature may be disabled.
- - **Discover Cameras icon** – opens the Settings page to the Discover tab.
+ - **Discover Cameras icon** – opens the Settings page to the Add tab.
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of
   inactivity the newest global summary slowly scrolls across the top in gray text.
@@ -36,7 +36,7 @@ These tooltips aim to make the interface self‑explanatory and easier to naviga
 
 Interactive forms now include additional tooltips:
 
-- **Add Camera** – explains each field on the Discover tab and the "Structured" XPath buttons.
+ - **Add Camera** – explains each field on the Add tab and the "Structured" XPath buttons.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
 - **Captions** – upload and filter controls have descriptive titles.
 - **Danger Mode** – the checkbox, save button and modal controls all include tooltips.

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -49,10 +49,10 @@ class TestClockRoute(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def test_clock_page(self):
-        with patch("app.routes.session", {"user_id": 1}), patch(
-            "app.routes.login_required", lambda x: x
-        ):
-            response = self.client.get("/clock")
+        with self.client.session_transaction() as sess:
+            sess["user_id"] = 1
+
+        response = self.client.get("/clock")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Clock", response.data)
 


### PR DESCRIPTION
## Summary
- rename Discover tab to Add in settings
- add new plus icon and show Add shortcut when on settings
- update docs and links for new Add tab name
- include plus symbol in sprite icon set

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684212fc33648333afbf06c49e636376