### PR TITLE
Use datalist for enum settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped numpy to 1.26.0
 - Updated default VERSION to 0.2.7 for footer display
 - Bulk tools menu is expanded by default on the captions page
+- Enumerated settings use a single autocomplete field instead of a dropdown and separate text box
 
 ### Fixed
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -2642,14 +2642,7 @@ def init_routes(app: Flask) -> None:
                         continue
 
                     if name in SETTINGS_CHOICES:
-                        # When "Other" is selected use the companion text field.
-                        if value == "__other__":
-                            value = request.form.get(f"{name}_other", "")
                         update_setting(name, value)
-                        continue
-
-                    if name.endswith("_other"):
-                        # Companion fields are handled above
                         continue
 
                     update_setting(name, value)

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -11,7 +11,7 @@ import { initIndexTime } from "./time.js";
 import { initWelcome } from "./welcome.js";
 import { initTooltips } from "./tooltips.js";
 import { initCaptions } from "./captions.js";
-import { initSettingsSearch, initEnumFields } from "./settings.js";
+import { initSettingsSearch } from "./settings.js";
 import { initTabs } from "./tabs.js";
 import { initThemeToggle } from "./theme.js";
 
@@ -30,6 +30,5 @@ initWelcome();
 initTooltips();
 initCaptions();
 initSettingsSearch();
-initEnumFields();
 initTabs();
 initThemeToggle();

--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -30,23 +30,3 @@ export function initSettingsSearch() {
     input.addEventListener("input", filterRows);
   });
 }
-
-export function initEnumFields() {
-  document.addEventListener("DOMContentLoaded", () => {
-    const selects = document.querySelectorAll("select[data-other-target]");
-    selects.forEach((sel) => {
-      const targetId = sel.getAttribute("data-other-target");
-      const input = document.getElementById(targetId);
-      if (!input) return;
-      const toggle = () => {
-        if (sel.value === "__other__") {
-          input.classList.remove("hidden");
-        } else {
-          input.classList.add("hidden");
-        }
-      };
-      sel.addEventListener("change", toggle);
-      toggle();
-    });
-  });
-}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -111,34 +111,18 @@ content %}
                 <span class="slider round"></span>
               </label>
               {% elif setting.name in choices %}
-              <select
-                name="{{ setting.name }}"
-                data-other-target="{{ setting.name }}-other"
-                title="Select value for {{ setting.name }}"
-              >
-                {% for option in choices[setting.name] %}
-                <option
-                  value="{{ option }}"
-                  {% if setting.value == option %}selected{% endif %}
-                >
-                  {{ option }}
-                </option>
-                {% endfor %}
-                <option
-                  value="__other__"
-                  {% if setting.value not in choices[setting.name] %}selected{% endif %}
-                >
-                  Other
-                </option>
-              </select>
               <input
                 type="text"
-                id="{{ setting.name }}-other"
-                name="{{ setting.name }}_other"
-                value="{% if setting.value not in choices[setting.name] %}{{ setting.value }}{% endif %}"
-                class="{% if setting.value in choices[setting.name] %}hidden{% endif %}"
-                placeholder="Custom value"
+                name="{{ setting.name }}"
+                list="{{ setting.name }}-options"
+                value="{{ setting.value }}"
+                title="Select or enter value for {{ setting.name }}"
               />
+              <datalist id="{{ setting.name }}-options">
+                {% for option in choices[setting.name] %}
+                <option value="{{ option }}"></option>
+                {% endfor %}
+              </datalist>
               {% elif setting.name == 'PORT' %}
               <input
                 type="number"

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -22,4 +22,4 @@ Focusing any input field shows a tooltip on screen with a description pulled fro
 
 ### Selectable Options
 
-Common settings like `HOST`, `LANG`, `LOG_LEVEL`, and `TZ` now use dropdowns with popular values. Choosing **Other** reveals a text field so you can enter a custom option. The `PORT` field enforces non‑privileged ports (1024–65535) to avoid permission errors.
+Common settings like `HOST`, `LANG`, `LOG_LEVEL`, and `TZ` now use a single autocomplete field. Typing shows suggestions for common values, but any text can be entered. The `PORT` field enforces non‑privileged ports (1024–65535) to avoid permission errors.


### PR DESCRIPTION
## Summary
- implement datalist instead of select+other input on settings page
- remove enum toggle JS and related import
- update settings route for simplified enum handling
- document new single-field UI

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842132cccfc8333abeb3c43c88458d3