### PR TITLE
Remove redundant group heading

### DIFF
--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Group {{ group_name }}</h2>
 <div>
     <label for="search-input" title="Search for cameras or groups">Search:</label>
     <input type="text" id="search-input" placeholder="Search cameras or groups" title="Enter search terms">


### PR DESCRIPTION
## Summary
- drop the `<h2>` title from the group page

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684215570e1483338733ab1f183d5145