### PR TITLE
Fix duplicate tabs on settings page

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -22,6 +22,9 @@ content %}
     <button type="button" class="tab-link" data-tab="discover-tab">
       Discover
     </button>
+    <button type="button" class="tab-link" data-tab="status-tab">
+      System Status
+    </button>
     {% endif %} {% endfor %}
     <button type="button" class="tab-link" data-tab="management-tab">
       Management
@@ -44,24 +47,6 @@ content %}
       </svg>
     </a>
   </div>
-
-
-    <div class="tabs">
-        {% for group in grouped_settings.keys() %}
-        <button type="button" class="tab-link{% if loop.first %} active{% endif %}" data-tab="{{ group|replace(' ', '-') }}-tab">{{ group }}</button>
-        {% if loop.first %}
-        <button type="button" class="tab-link" data-tab="discover-tab">Discover</button>
-        <button type="button" class="tab-link" data-tab="status-tab">System Status</button>
-        {% endif %}
-        {% endfor %}
-        <button type="button" class="tab-link" data-tab="management-tab">Management</button>
-        <a href="{{ url_for('logout') }}" class="tab-link logout-link" title="Log out of the interface">Logout</a>
-        <a id="theme-toggle" href="#" class="tab-link" title="Toggle light or dark theme" aria-label="Toggle theme">
-            <svg width="18" height="18">
-                <use href="{{ url_for('static', filename='icons/sprite.svg') }}#sun" />
-            </svg>
-        </a>
-    </div>
 
 
   <form method="POST" action="{{ url_for('settings') }}" id="settings-form">


### PR DESCRIPTION
## Summary
- remove redundant tabs bar on settings.html
- add missing **System Status** tab to the main navigation bar

## Testing
- `flake8`
- `pytest tests/test_settings_route.py`


------
https://chatgpt.com/codex/tasks/task_e_684216e1d9188333b5626603939d0342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "System Status" tab and content area to the settings page.

- **Bug Fixes**
  - Removed duplicate tab navigation buttons for a cleaner and more consistent user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->