### PR TITLE
Fix PyPI token check in release workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -43,10 +43,12 @@ jobs:
         run: |
           python scripts/generate_release_badges.py
       - name: Publish to PyPI
-        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        if: env.PYPI_API_TOKEN != ''
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ env.PYPI_API_TOKEN }}
       - name: Upload Debian package
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- check the PyPI secret via an env variable so the workflow is valid

## Testing
- `flake8`
- `pytest -q` *(fails: TestClockRoute.test_clock_page)*

------
https://chatgpt.com/codex/tasks/task_e_6842163ef974833395fbf2953b6776c2