### PR TITLE
Fix captions table row count

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -138,27 +138,6 @@
                 >{{ template_details[camera]['next_screenshot'] }}</span
               >
             </td>
-            <td data-value="{{ template_details[camera]['screenshot_count'] }}">
-              {{ template_details[camera]['screenshot_count'] }}
-            </td>
-            <td data-value="{{ template_details[camera]['video_count'] }}">
-              {{ template_details[camera]['video_count'] }}
-            </td>
-            <td
-              data-value="{{ template_details[camera]['storage_usage_bytes'] }}"
-            >
-              {{ template_details[camera]['storage_usage'] }}
-            </td>
-            <td
-              data-value="{{ template_details[camera]['llm_response_count'] }}"
-            >
-              {{ template_details[camera]['llm_response_count'] }}
-            </td>
-            <td
-              data-value="{{ template_details[camera]['llm_cost_estimate'] }}"
-            >
-              {{ template_details[camera]['llm_cost_estimate'] }}
-            </td>
             <td>
               <form id="form-{{ camera }}" class="notes-form caption-box">
                 <div class="chat-box">


### PR DESCRIPTION
## Summary
- prune KPI cells from camera rows so headers align

## Testing
- `flake8`
- `pytest -q` *(fails: TestClockRoute::test_clock_page)*

------
https://chatgpt.com/codex/tasks/task_e_684218ba7130833384029e0a3985e1cf