### PR TITLE
Fix clock route test

### DIFF
--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,7 +6,9 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
 
 import app
 import app.config as config
@@ -25,6 +27,13 @@ class TestClockRoute(unittest.TestCase):
 
         importlib.reload(config)
         importlib.reload(routes)
+
+        # Disable authentication before the routes are registered so the
+        # patched ``login_required`` decorator is used when the application
+        # creates its route handlers.
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+
         importlib.reload(app)
         conn = sqlite3.connect(self.db_path)
         conn.execute(
@@ -42,6 +51,7 @@ class TestClockRoute(unittest.TestCase):
     def tearDown(self):
         self.restart_patch.stop()
         self.app_context.pop()
+        self.login_patch.stop()
         self.env_patch.stop()
         importlib.reload(config)
         importlib.reload(routes)
@@ -49,9 +59,7 @@ class TestClockRoute(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def test_clock_page(self):
-        with patch("app.routes.session", {"user_id": 1}), patch(
-            "app.routes.login_required", lambda x: x
-        ):
+        with patch("app.routes.session", {"user_id": 1}):
             response = self.client.get("/clock")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Clock", response.data)


### PR DESCRIPTION
## Summary
- ensure authentication is disabled before initializing routes in clock test

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421f46d5848333b5b80088c7ee2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test setup to ensure authentication is consistently disabled during testing, resulting in more reliable and isolated test cases.
  - Simplified test methods by removing redundant patching steps.
  - Minor formatting improvements for better code clarity within tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->