### PR TITLE
Add costs tab in settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -77,6 +77,7 @@ from app.utils import (
     prompt_optimizer,
     camera_fix,
 )
+from app.utils.template_manager import LLM_COST_PER_TOKEN
 
 from app.utils.llm import ask_question
 from app.utils.settings_tooltips import SETTINGS_TOOLTIPS, SETTINGS_GROUPS
@@ -2728,6 +2729,21 @@ def init_routes(app: Flask) -> None:
         metrics = scheduling.get_system_metrics()
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
+
+        cost_data = []
+        templates = template_manager.get_templates()
+        for name, tmpl in templates.items():
+            tokens = template_manager.get_llm_token_usage(name)
+            group = tmpl.get("groups") or "Ungrouped"
+            cost_data.append(
+                {
+                    "name": name,
+                    "group": group,
+                    "tokens": tokens,
+                    "cost": round(tokens * LLM_COST_PER_TOKEN, 2),
+                }
+            )
+        cost_groups = sorted({c["group"] for c in cost_data})
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
@@ -2736,6 +2752,8 @@ def init_routes(app: Flask) -> None:
             feeds=feeds,
             last_summary=last_summary,
             choices=SETTINGS_CHOICES,
+            cost_data=cost_data,
+            cost_groups=cost_groups,
             page_title="Settings",
         )
 

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -1,0 +1,62 @@
+export function initCosts() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const dataEl = document.getElementById("cost-data");
+    if (!dataEl) return;
+    const data = JSON.parse(dataEl.textContent);
+    const groupSel = document.getElementById("cost-group");
+    const camSel = document.getElementById("cost-camera");
+    const tbody = document.querySelector("#cost-table tbody");
+    const ctx = document.getElementById("costChart");
+    let chart;
+
+    const filterData = () => {
+      const g = groupSel.value;
+      const c = camSel.value;
+      return data.filter((d) => (!g || d.group === g) && (!c || d.name === c));
+    };
+
+    const renderTable = () => {
+      tbody.innerHTML = "";
+      for (const row of filterData()) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `<td>${row.name}</td><td>${row.tokens}</td><td>$${row.cost.toFixed(2)}</td>`;
+        tbody.appendChild(tr);
+      }
+    };
+
+    const renderChart = () => {
+      if (!ctx) return;
+      const rows = filterData();
+      const labels = rows.map((r) => r.name);
+      const values = rows.map((r) => r.cost);
+      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360}, 70%, 60%)`);
+      const chartData = {
+        labels,
+        datasets: [
+          {
+            data: values,
+            backgroundColor: bg,
+          },
+        ],
+      };
+      if (chart) {
+        chart.data = chartData;
+        chart.update();
+      } else {
+        chart = new Chart(ctx, { type: "pie", data: chartData });
+      }
+    };
+
+    groupSel.addEventListener("change", () => {
+      renderTable();
+      renderChart();
+    });
+    camSel.addEventListener("change", () => {
+      renderTable();
+      renderChart();
+    });
+
+    renderTable();
+    renderChart();
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -14,6 +14,7 @@ import { initCaptions } from "./captions.js";
 import { initSettingsSearch } from "./settings.js";
 import { initTabs } from "./tabs.js";
 import { initThemeToggle } from "./theme.js";
+import { initCosts } from "./costs.js";
 
 initTemplates();
 initVideoControls();
@@ -32,3 +33,4 @@ initCaptions();
 initSettingsSearch();
 initTabs();
 initThemeToggle();
+initCosts();

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -1,0 +1,47 @@
+<div class="costs-page">
+  {% call card('LLM Cost Summary') %}
+  <div class="cost-controls">
+    <label for="cost-group">Group:</label>
+    <select id="cost-group">
+      <option value="">All</option>
+      {% for g in cost_groups %}
+      <option value="{{ g }}">{{ g }}</option>
+      {% endfor %}
+    </select>
+    <label for="cost-camera">Camera:</label>
+    <select id="cost-camera">
+      <option value="">All</option>
+      {% for item in cost_data %}
+      <option value="{{ item.name }}">{{ item.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <canvas id="costChart"></canvas>
+  <table id="cost-table" class="cost-table">
+    <thead>
+      <tr>
+        <th>Camera</th>
+        <th>Tokens</th>
+        <th>Cost</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in cost_data %}
+      <tr data-group="{{ item.group }}" data-name="{{ item.name }}">
+        <td>{{ item.name }}</td>
+        <td>{{ item.tokens }}</td>
+        <td>${{ '%.2f'|format(item.cost) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endcall %}
+</div>
+<script id="cost-data" type="application/json">
+  {{ cost_data|tojson }}
+</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/costs.js') }}"
+></script>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -25,6 +25,9 @@ content %}
     <button type="button" class="tab-link" data-tab="status-tab">
       System Status
     </button>
+    <button type="button" class="tab-link" data-tab="costs-tab">
+      Costs
+    </button>
     {% endif %} {% endfor %}
     <button type="button" class="tab-link" data-tab="management-tab">
       Management
@@ -182,6 +185,9 @@ content %}
         </div>
         <div id="status-tab" class="tab-content">
             {% include '_status_tab.html' %}
+        </div>
+        <div id="costs-tab" class="tab-content">
+            {% include '_costs_tab.html' %}
         </div>
         {% endif %}
         {% endfor %}

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -749,6 +749,39 @@ def get_llm_cost_estimate(name: str) -> str:
     return f"${cost:.2f}"
 
 
+def get_llm_token_usage(name: str) -> int:
+    """Return the total tokens recorded for ``name``."""
+
+    name = validate_template_name(name)
+    if name is None:
+        return 0
+
+    if not os.path.exists(LLM_USAGE_PATH):
+        return 0
+
+    try:
+        with open(LLM_USAGE_PATH, "r") as f:
+            data = json.load(f)
+    except Exception:
+        return 0
+
+    entry = data.get(name, 0)
+    if isinstance(entry, list):
+        total = 0
+        for val in entry:
+            if isinstance(val, int):
+                total += val
+            elif isinstance(val, dict) and "tokens" in val:
+                try:
+                    total += int(val["tokens"])
+                except Exception:
+                    continue
+        return total
+    if isinstance(entry, int):
+        return entry
+    return 0
+
+
 def update_last_screenshot_time(name: str) -> None:
     """Set ``last_screenshot_time`` to now and clear ``offline_since``."""
     name = validate_template_name(name)

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -4,6 +4,8 @@ Glimpser now records the number of tokens used when generating captions.
 Token counts are stored in `data/llm_usage.json` keyed by template name.
 Costs are calculated at `$0.005` per thousand tokens.
 Use the captions page to view each template's estimated cost.
+The Settings page now includes a **Costs** tab with a summary table and pie
+chart. Filter by group or camera to see usage for specific feeds.
 
 ## LLM Response Cache
 


### PR DESCRIPTION
## Summary
- add new costs tab for settings page
- compute LLM token usage and cost data
- render new tab with pie chart and filtering
- document cost tab in docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422470964c83339bebed12d70f1747