### PR TITLE
Improve caption status by group

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1069,7 +1069,40 @@ def init_routes(app: Flask) -> None:
     @app.route("/captions_status")
     @login_required
     def captions_status():
-        """Return the newest global summary and its timestamp."""
+        """Return the most recent caption and timestamp.
+
+        If a ``group`` query parameter is provided, the newest caption from
+        templates in that group is returned. Otherwise the latest global summary
+        is used.
+        """
+
+        group = request.args.get("group")
+        if group and group != "all":
+            templates = template_manager.get_templates()
+            latest_time = None
+            caption = ""
+            for name, tmpl in templates.items():
+                groups = [g.strip() for g in tmpl.get("groups", "").split(",")]
+                if group not in groups:
+                    continue
+                t = tmpl.get("last_caption_time")
+                if not t:
+                    continue
+                try:
+                    dt = datetime.strptime(t, "%Y-%m-%d %H:%M:%S")
+                except Exception:
+                    continue
+                if not latest_time or dt > latest_time:
+                    latest_time = dt
+                    caption = tmpl.get("last_caption", "")
+            if latest_time:
+                return jsonify(
+                    {
+                        "caption": caption,
+                        "timestamp": latest_time.strftime("%Y-%m-%d %H:%M:%S"),
+                    }
+                )
+
         caption = ""
         timestamp = ""
         session_db = SessionLocal()

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -442,7 +442,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +825,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {
@@ -1458,6 +1458,15 @@ details > summary {
 #camera-metadata {
   margin: 10px 0;
   color: #ccc;
+}
+
+#camera-metadata ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#camera-metadata li {
+  margin-bottom: 0.25em;
 }
 
 .modal {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -248,7 +248,12 @@ export function initNav() {
     const checkCaptions = async () => {
       if (!captionsIcon) return;
       try {
-        const data = await fetchJson("/captions_status");
+        const group = window.currentGroup;
+        const url =
+          group && group !== "all"
+            ? `/captions_status?group=${encodeURIComponent(group)}`
+            : "/captions_status";
+        const data = await fetchJson(url);
         if (!data) return;
         captionsIcon.title = data.caption || "";
         if (data.timestamp) {

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-This endpoint now redirects to the *System Status* tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator.
+This endpoint now redirects to the _System Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator.
 
 ### Feed Dashboard
 
@@ -41,7 +41,7 @@ name, last image time, last caption time, any KPI column, or status.
 
 **GET /stream_logs**
 
-This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the *System Status* tab consume this endpoint to display updates in real time.
+This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the _System Status_ tab consume this endpoint to display updates in real time.
 
 To filter logs by level and message text, you could request:
 
@@ -51,7 +51,7 @@ To filter logs by level and message text, you could request:
 
 ## Using the Live Log Viewer
 
-1. Open the *System Status* tab under Settings or navigate to `/logs` after logging in.
+1. Open the _System Status_ tab under Settings or navigate to `/logs` after logging in.
 2. Use the search box and dropdowns to filter log output.
 3. Hover over each field for a tooltip explaining the filter.
 4. Results update automatically via `/stream_logs`.
@@ -59,7 +59,7 @@ To filter logs by level and message text, you could request:
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 
-The *System Status* tab also appears as a **System Status** camera under Discover.
+The _System Status_ tab also appears as a **System Status** camera under Discover.
 Adding it lets Glimpser capture periodic screenshots of its own health metrics.
 An accompanying **Internal Caption** camera shows `/internal_caption.mjpg` so you
 can monitor recent caption text without leaving the dashboard.
@@ -67,8 +67,9 @@ can monitor recent caption text without leaving the dashboard.
 ## Caption Activity Indicator
 
 The navigation bar shows a captions icon that reflects how recent the last
-caption update was. It flashes with the newest caption text when a group message
-arrives. After a few seconds of inactivity the latest global summary slowly
+caption update was. When viewing a group or individual camera page the icon uses
+the newest caption from that group. It flashes with the newest caption text when
+a group message arrives. After a few seconds of inactivity the latest global summary slowly
 scrolls across the top in a gray chyron. Clicking this text opens the `/captions`
 page for more
 details. The scroll duration comes from the `CHYRON_SPEED` setting which is
@@ -82,7 +83,7 @@ History tab.
 ## System Performance Icon
 
 The System Performance icon in the navigation bar provides quick access to the
-*System Status* tab. When all metrics look healthy the icon now hides to reduce
+_System Status_ tab. When all metrics look healthy the icon now hides to reduce
 clutter. Set the `HEALTH_STATUS_ALWAYS_VISIBLE` option to `True` if you prefer
 to keep it shown at all times.
 


### PR DESCRIPTION
## Summary
- fetch group-specific caption status and display via nav icon
- remove bullets from camera metadata
- clarify caption icon docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842256125f48333ba3a5404023eb90e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying the latest caption specific to a selected group, if applicable.
- **Bug Fixes**
  - Improved handling of caption timestamps, ignoring invalid or missing data.
- **Style**
  - Standardized CSS indentation and added styling for camera metadata lists.
- **Documentation**
  - Updated documentation to clarify caption activity behavior for groups and improved formatting for system status references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->