### PR TITLE
Fix captions timestamps and add live update

### DIFF
--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -1,3 +1,5 @@
+import { updateHumanizedTimes } from "./templates.js";
+
 export function initCaptions() {
   document.addEventListener("DOMContentLoaded", () => {
     const tabs = document.querySelectorAll(".tab-link");
@@ -82,5 +84,40 @@ export function initCaptions() {
         document.getElementById(target)?.classList.add("active");
       });
     });
+
+    setupLiveHistoryUpdates();
   });
+}
+
+function setupLiveHistoryUpdates() {
+  const tbody = document.querySelector("#captions-table tbody");
+  const header = document.querySelector(
+    "#captions-table th.sortable[data-type='date']",
+  );
+  if (!tbody || !header) return;
+
+  let latest = tbody.querySelector("tr:not(.no-data) span[data-time]")?.dataset
+    .time;
+
+  const fetchLatest = async () => {
+    if (header.dataset.order !== "desc") return;
+    try {
+      const resp = await fetch("/captions_status");
+      const data = await resp.json();
+      if (!data.timestamp || !data.caption) return;
+      if (!latest || new Date(data.timestamp) > new Date(latest)) {
+        const row = document.createElement("tr");
+        row.innerHTML = `<td><span class="humanized-time" data-time="${data.timestamp}">${data.timestamp}</span></td><td>${data.caption}</td>`;
+        tbody.prepend(row);
+        tbody.querySelector(".no-data")?.remove();
+        latest = data.timestamp;
+        updateHumanizedTimes();
+      }
+    } catch (err) {
+      console.error("Error updating captions", err);
+    }
+  };
+
+  fetchLatest();
+  setInterval(fetchLatest, 10000);
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -124,18 +124,22 @@
                 </div>
               </div>
             </td>
-            <td data-value="{{ template_details[camera]['last_screenshot'] }}">
+            <td
+              data-value="{{ template_details[camera]['last_screenshot_time'] }}"
+            >
               <span
                 class="humanized-time"
-                data-time="{{ template_details[camera]['last_screenshot'] }}"
-                >{{ template_details[camera]['last_screenshot'] }}</span
+                data-time="{{ template_details[camera]['last_screenshot_time'] }}"
+                >{{ template_details[camera]['last_screenshot_time'] }}</span
               >
             </td>
-            <td data-value="{{ template_details[camera]['next_screenshot'] }}">
+            <td
+              data-value="{{ template_details[camera]['next_screenshot_time'] }}"
+            >
               <span
                 class="humanized-time"
-                data-time="{{ template_details[camera]['next_screenshot'] }}"
-                >{{ template_details[camera]['next_screenshot'] }}</span
+                data-time="{{ template_details[camera]['next_screenshot_time'] }}"
+                >{{ template_details[camera]['next_screenshot_time'] }}</span
               >
             </td>
             <td>

--- a/docs/captions_live_update.md
+++ b/docs/captions_live_update.md
@@ -1,0 +1,3 @@
+# Captions Live Update
+
+When the **History** table on the Captions page is sorted by Timestamp in descending order, new summaries are automatically inserted at the top. The page checks `/captions_status` every 10&nbsp;seconds and only adds a row when a newer caption exists. Click the Timestamp header again to disable live updates.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,17 +10,20 @@ This guide will walk you through the process of setting up Glimpser and running 
 ## Installation
 
 1. Clone the Glimpser repository:
+
    ```
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    ```
 
 2. Install the required dependencies:
+
    ```
    pip install -r requirements.txt
    ```
 
 3. Run the application:
+
    ```
    python3 main.py
    ```
@@ -55,7 +58,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
+10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the search box in the Prompts tab to quickly find a camera. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. When the table is sorted by Timestamp (↕ shows descending), new captions automatically appear at the top. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- render capture timestamps on captions page
- add live update polling when the History table is sorted by timestamp
- document captions live updates

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684225ee6dd083339d5c98316ff87fcf