### PR TITLE
Add host domain enforcement option

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -236,6 +236,7 @@ NAME = get_setting("NAME", "glimpser")
 NAV_ICON = get_setting("NAV_ICON", "img/glimpser_small.png")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))
+ENFORCE_DOMAIN_IN_HOST = get_setting("ENFORCE_DOMAIN_IN_HOST", "False") == "True"
 DEBUG = get_setting("DEBUG", "False") == "True"
 # Provide a separate attribute for runtime checks
 DEBUG_MODE = DEBUG

--- a/app/routes.py
+++ b/app/routes.py
@@ -66,6 +66,7 @@ from app.config import (
     CLOCK_OVERLAY,
     CLOCK_DIGITAL,
     CLOCK_NAVBAR,
+    ENFORCE_DOMAIN_IN_HOST,
 )
 from app.models import User, Summary
 from app.utils import (
@@ -934,6 +935,14 @@ def init_routes(app: Flask) -> None:
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["Cache-Control"] = "no-store"
         return response
+
+    @app.before_request
+    def enforce_host_domain():
+        """Block requests missing a domain when enforcement is enabled."""
+        if config.ENFORCE_DOMAIN_IN_HOST:
+            host = request.headers.get("Host", "")
+            if "." not in host:
+                abort(403)
 
     @app.context_processor
     def inject_footer_data():

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -34,6 +34,7 @@ can modify them in the application interface or directly in the database.
 - `LANG` – default language (default `en-US`)
 - `TZ` – timezone used for logs (default `UTC`)
 - `HOST` – address to bind the server (default `0.0.0.0`)
+- `ENFORCE_DOMAIN_IN_HOST` – require a domain in the `Host` header (default `False`)
 - `PORT` – port for the web interface (default `8082`)
 - `DEBUG` – enable debug mode (default `False`)
 - `DEBUG_MODE` – runtime alias of `DEBUG` used by the command-line interface

--- a/main.py
+++ b/main.py
@@ -125,6 +125,10 @@ def setup_config(args=None):
     # Update variables based on command-line arguments
     config.DATABASE_PATH = args.db_path
     config.HOST = args.host
+    if config.ENFORCE_DOMAIN_IN_HOST and "." not in config.HOST:
+        raise ValueError(
+            "HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled"
+        )
     config.PORT = args.port
     config.LOGGING_PATH = args.log_path
     config.DEBUG_MODE = args.debug
@@ -210,6 +214,11 @@ def create_application(args=None):
     else:
         setup_config()
         setup_logging()
+
+    if config.ENFORCE_DOMAIN_IN_HOST and "." not in config.HOST:
+        raise ValueError(
+            "HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled"
+        )
 
     ensure_directories()
     generate_credentials_if_needed()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,6 +154,50 @@ class TestMain(unittest.TestCase):
         main.display_startup_tips()
         mock_info.assert_any_call("Startup Tips")
 
+    def test_enforce_domain_host_setup_config(self):
+        args = MagicMock()
+        args.db_path = os.path.join(self.temp_dir, "db.sqlite")
+        args.host = "localhost"
+        args.port = 8080
+        args.log_path = os.path.join(self.temp_dir, "log.txt")
+        args.debug = False
+        args.screenshot_dir = os.path.join(self.temp_dir, "screenshots")
+        args.video_dir = os.path.join(self.temp_dir, "videos")
+        args.summaries_dir = os.path.join(self.temp_dir, "summaries")
+
+        old_enforce = config.ENFORCE_DOMAIN_IN_HOST
+        config.ENFORCE_DOMAIN_IN_HOST = True
+        with self.assertRaises(ValueError):
+            main.setup_config(args)
+        config.ENFORCE_DOMAIN_IN_HOST = old_enforce
+
+    @patch("main.create_app")
+    @patch("main.ensure_directories")
+    @patch("main.generate_credentials_if_needed")
+    def test_enforce_domain_host_create_application(
+        self, mock_generate, mock_ensure, mock_create_app
+    ):
+        args = MagicMock()
+        args.db_path = os.path.join(self.temp_dir, "db.sqlite")
+        args.host = "localhost"
+        args.port = 8080
+        args.log_path = os.path.join(self.temp_dir, "log.txt")
+        args.log_level = "INFO"
+        args.console_log = False
+        args.debug = False
+        args.screenshot_dir = os.path.join(self.temp_dir, "screenshots")
+        args.video_dir = os.path.join(self.temp_dir, "videos")
+        args.summaries_dir = os.path.join(self.temp_dir, "summaries")
+        args.no_scheduler = True
+        args.no_watchdog = True
+        args.no_crawlers = True
+
+        old_enforce = config.ENFORCE_DOMAIN_IN_HOST
+        config.ENFORCE_DOMAIN_IN_HOST = True
+        with self.assertRaises(ValueError):
+            main.create_application(args)
+        config.ENFORCE_DOMAIN_IN_HOST = old_enforce
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- introduce `ENFORCE_DOMAIN_IN_HOST` setting
- reject requests without a domain in the Host header when enforcement is enabled
- validate the host at startup when enforcement is enabled
- document the new setting
- test host domain enforcement logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684226beebd883338fed08c5ca793dc0