### PR TITLE
Add server-side validation for settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -109,7 +109,11 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
-from app.utils.validators import validate_template_name, validate_update_data
+from app.utils.validators import (
+    validate_template_name,
+    validate_update_data,
+    validate_setting,
+)
 from app.utils.profiling import profile_route, get_latency_stats
 from scripts.update_chrome_shortcut import (
     update_chrome_shortcuts,
@@ -2628,7 +2632,11 @@ def init_routes(app: Flask) -> None:
                         "error",
                     )
                     return redirect(url_for("settings")), 400
-                update_setting(new_name, new_value)
+                sanitized = validate_setting(new_name, new_value)
+                if sanitized is None:
+                    flash(f"Invalid value for {new_name}", "error")
+                    return redirect(url_for("settings")), 400
+                update_setting(new_name, sanitized)
             elif action == "delete":
                 name_to_delete = request.form.get("name_to_delete")
                 if name_to_delete:
@@ -2637,7 +2645,11 @@ def init_routes(app: Flask) -> None:
                 for setting in email_settings:
                     value = request.form.get(setting)
                     if value is not None:
-                        update_setting(setting, value)
+                        sanitized = validate_setting(setting, value)
+                        if sanitized is None:
+                            flash(f"Invalid value for {setting}", "error")
+                            return redirect(url_for("settings")), 400
+                        update_setting(setting, sanitized)
             elif action == "backup":
                 if backup_config():
                     flash("Configuration backed up successfully", "success")
@@ -2705,11 +2717,16 @@ def init_routes(app: Flask) -> None:
                     ):
                         continue
 
-                    if name in SETTINGS_CHOICES:
-                        update_setting(name, value)
+                    sanitized = validate_setting(name, value)
+                    if sanitized is None:
+                        flash(f"Invalid value for {name}", "error")
                         continue
 
-                    update_setting(name, value)
+                    if name in SETTINGS_CHOICES:
+                        update_setting(name, sanitized)
+                        continue
+
+                    update_setting(name, sanitized)
             return redirect(url_for("settings"))
 
         settings = get_all_settings()

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -199,3 +199,69 @@ def validate_update_data(data: dict) -> dict:
         sanitized[key] = _to_bool(data.get(key, False))
 
     return sanitized
+
+
+INTEGER_RANGES = {
+    "PORT": (1024, 65535),
+    "EMAIL_SMTP_PORT": (1, 65535),
+    "MAX_WORKERS": (1, None),
+    "FFMPEG_THREADS": (1, None),
+    "NUM_FRAMES": (1, None),
+    "CAPTURE_TIMEOUT": (1, None),
+    "LIVE_FALLBACK_FPS": (1, None),
+    "LIVE_MAX_FAILURES": (1, None),
+    "CHYRON_SPEED": (0, None),
+    "WATCHDOG_FAILURE_THRESHOLD": (1, None),
+    "WATCHDOG_RESTART_COOLDOWN": (1, None),
+    "WATCHDOG_MAX_FILE_HANDLES": (1, None),
+    "SESSION_TIMEOUT_MINUTES": (1, None),
+}
+
+BOOLEAN_SETTINGS = {
+    "DEBUG",
+    "DEBUG_MODE",
+    "SESSION_COOKIE_SECURE",
+    "SESSION_COOKIE_HTTPONLY",
+    "CLOCK_OVERLAY",
+    "CLOCK_DIGITAL",
+    "CLOCK_NAVBAR",
+    "HEALTH_STATUS_ALWAYS_VISIBLE",
+    "DISCOVERY_AUTOSTART",
+    "EMAIL_ENABLED",
+    "EMAIL_USE_TLS",
+}
+
+
+def validate_setting(name: str, value: str) -> str | None:
+    """Return sanitized ``value`` for the given setting ``name``.
+
+    Unknown setting names are returned unchanged. Numeric settings are
+    validated against predefined ranges. Boolean settings normalize any
+    truthy value to ``"True"`` and everything else to ``"False"``.
+    ``None`` is returned when validation fails.
+    """
+
+    if value is None:
+        return None
+
+    key = str(name or "").upper()
+    val = str(value).strip()
+
+    if key in BOOLEAN_SETTINGS:
+        return (
+            "True" if val.lower() in {"true", "1", "t", "y", "yes", "on"} else "False"
+        )
+
+    if key in INTEGER_RANGES:
+        try:
+            ivalue = int(val)
+        except (TypeError, ValueError):
+            return None
+        min_val, max_val = INTEGER_RANGES[key]
+        if min_val is not None and ivalue < min_val:
+            return None
+        if max_val is not None and ivalue > max_val:
+            return None
+        return str(ivalue)
+
+    return val

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -23,3 +23,7 @@ Focusing any input field shows a tooltip on screen with a description pulled fro
 ### Selectable Options
 
 Common settings like `HOST`, `LANG`, `LOG_LEVEL`, and `TZ` now use a single autocomplete field. Typing shows suggestions for common values, but any text can be entered. The `PORT` field enforces non‑privileged ports (1024–65535) to avoid permission errors.
+
+### Validation
+
+Values submitted through the form are validated on the server. Numeric fields like `PORT` or `MAX_WORKERS` must contain valid integers within the accepted range. Boolean options are normalized to `True` or `False` so unexpected text does not pollute the database.

--- a/tests/test_setting_validation.py
+++ b/tests/test_setting_validation.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.validators import validate_setting
+
+
+class TestValidateSetting(unittest.TestCase):
+    def test_valid_port(self):
+        self.assertEqual(validate_setting("PORT", "8080"), "8080")
+
+    def test_invalid_port_range(self):
+        self.assertIsNone(validate_setting("PORT", "80"))
+
+    def test_invalid_port_type(self):
+        self.assertIsNone(validate_setting("PORT", "abc"))
+
+    def test_integer_setting(self):
+        self.assertEqual(validate_setting("MAX_WORKERS", "4"), "4")
+        self.assertIsNone(validate_setting("MAX_WORKERS", "bad"))
+
+    def test_passthrough_unknown(self):
+        self.assertEqual(validate_setting("CUSTOM", " value "), "value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate settings values in the settings page
- mention new validation in the docs
- test setting validation helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684228eb812483339e565f73ca72198d