### PR TITLE
Consolidate settings tabs

### DIFF
--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -60,6 +60,9 @@ SETTINGS_GROUPS = {
         "MAX_WORKERS",
         "LOG_LEVEL",
         "FLASK_LOG_LEVEL",
+        "CLOCK_OVERLAY",
+        "CLOCK_DIGITAL",
+        "CLOCK_NAVBAR",
     ],
     "Credentials": [
         "USER_NAME",
@@ -103,7 +106,7 @@ SETTINGS_GROUPS = {
         "FFMPEG_HWACCEL",
         "FFMPEG_THREADS",
     ],
-    "Email": [
+    "Notifications": [
         "EMAIL_ENABLED",
         "EMAIL_SENDER",
         "EMAIL_RECIPIENTS",
@@ -112,9 +115,11 @@ SETTINGS_GROUPS = {
         "EMAIL_USE_TLS",
         "EMAIL_USERNAME",
         "EMAIL_PASSWORD",
+        "TWILIO_SID",
+        "TWILIO_TOKEN",
+        "TWILIO_NUMBER",
+        "CAP_ENDPOINT",
+        "CAP_SENDER",
     ],
-    "SMS": ["TWILIO_SID", "TWILIO_TOKEN", "TWILIO_NUMBER"],
-    "CAP": ["CAP_ENDPOINT", "CAP_SENDER"],
-    "MCP": ["MCP_SERVER_COMMAND", "MCP_SERVER_URL"],
-    "Clock": ["CLOCK_OVERLAY", "CLOCK_DIGITAL", "CLOCK_NAVBAR"],
+    "Integrations": ["MCP_SERVER_COMMAND", "MCP_SERVER_URL"],
 }

--- a/docs/clock_settings.md
+++ b/docs/clock_settings.md
@@ -1,9 +1,9 @@
 # Clock Settings
 
-The application includes a configurable clock that can appear in multiple places. Open the **Settings** page and switch to the **Clock** tab to adjust its behaviour.
+The application includes a configurable clock that can appear in multiple places. Open the **Settings** page and use the **General** tab to adjust its behaviour.
 
-* **CLOCK_OVERLAY** – display the clock on video overlays.
-* **CLOCK_DIGITAL** – show the clock as digital text rather than an analogue face.
-* **CLOCK_NAVBAR** – show or hide the navigation bar clock.
+- **CLOCK_OVERLAY** – display the clock on video overlays.
+- **CLOCK_DIGITAL** – show the clock as digital text rather than an analogue face.
+- **CLOCK_NAVBAR** – show or hide the navigation bar clock.
 
 The standalone `/clock` page presents a large clock which reflects these settings.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -77,7 +77,11 @@ user table in sync.
 
 You can change these paths via the settings table or by editing `app/config.py` if you maintain a custom build.
 
-## Email Settings
+## Notification Settings
+
+Email, SMS, and CAP alerts now appear under the **Notifications** tab.
+
+### Email
 
 To enable email notifications, configure the following:
 
@@ -89,7 +93,7 @@ To enable email notifications, configure the following:
 - `EMAIL_USE_TLS` – whether to use TLS (default `True`)
 - `EMAIL_USERNAME` and `EMAIL_PASSWORD` – authentication credentials (default user name `your-username`)
 
-## SMS Settings
+### SMS
 
 Configure these values to enable Twilio SMS alerts:
 
@@ -97,7 +101,7 @@ Configure these values to enable Twilio SMS alerts:
 - `TWILIO_TOKEN` – your Twilio auth token
 - `TWILIO_NUMBER` – phone number that receives alerts
 
-## CAP Settings
+### CAP
 
 Set these variables to enable Common Alerting Protocol alerts:
 


### PR DESCRIPTION
## Summary
- group clock settings with general settings
- combine email, SMS and CAP under a new Notifications tab
- update configuration guide and clock docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422bae62408333b04bfd39e7b8032e