### PR TITLE
Add Live button toggle on dashboard

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -17,8 +17,9 @@ export function initVideoControls() {
     const playAllButton = document.getElementById("play-all-button");
     const liveAllButton = document.getElementById("live-all-button");
     let playAllActive = false;
-    let liveAllActive = false;
     let playAllObserver;
+
+    if (liveAllButton) liveAllButton.style.display = "none";
 
     function handlePlayAll(entries) {
       entries.forEach((entry) => {
@@ -44,6 +45,7 @@ export function initVideoControls() {
             video.load();
           });
           playAllButton.textContent = "Play All";
+          if (liveAllButton) liveAllButton.style.display = "none";
         } else {
           playAllObserver = new IntersectionObserver(handlePlayAll, {
             threshold: 0.25,
@@ -57,6 +59,7 @@ export function initVideoControls() {
             safePlay(video);
           });
           playAllButton.textContent = "Pause All";
+          if (liveAllButton) liveAllButton.style.display = "inline-block";
         }
         playAllActive = !playAllActive;
       });
@@ -65,24 +68,17 @@ export function initVideoControls() {
     if (liveAllButton) {
       liveAllButton.addEventListener("click", () => {
         const videos = document.querySelectorAll(".templateDiv video");
+        if (playAllObserver) playAllObserver.disconnect();
         videos.forEach((video) => {
           const name = video.getAttribute("data-name");
-          const source = video.querySelector("source");
-          if (liveAllActive) {
-            source.src = `/last_video/${name}`;
-            video.poster = `/last_screenshot/${name}`;
-            video.load();
-            video.pause();
-            video.currentTime = 0;
-          } else {
-            source.src = `/live_video?camera=${encodeURIComponent(name)}`;
-            video.poster = "";
-            video.load();
-            safePlay(video);
-          }
+          video.pause();
+          video.src = "";
+          video.poster = `/last_screenshot/${name}?t=${Date.now()}`;
+          video.load();
         });
-        liveAllButton.textContent = liveAllActive ? "Live All" : "Stop Live";
-        liveAllActive = !liveAllActive;
+        playAllActive = false;
+        playAllButton.textContent = "Play All";
+        liveAllButton.style.display = "none";
       });
     }
 

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,5 +1,4 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <div>
   <label for="search-input" title="Search for cameras or groups">Search:</label>
   <input
@@ -17,7 +16,13 @@
     title="Adjust the width of the template grid"
   />
   <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-  <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <button
+    id="live-all-button"
+    style="display: none"
+    title="Return to latest screenshot"
+  >
+    Live
+  </button>
   <button
     id="toggle-captions"
     title="Toggle caption overlays"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,7 +26,13 @@
     >
   </span>
   <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-  <button id="live-all-button" title="Live stream all cameras">Live All</button>
+  <button
+    id="live-all-button"
+    style="display: none"
+    title="Return to latest screenshot"
+  >
+    Live
+  </button>
   <button
     id="toggle-captions"
     title="Toggle caption overlays"

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Configuration Guide](configuration_guide.md)
 - [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)
-- [Live All Playback](live_all.md)
+- [Dashboard Live Button](live_all.md)
 - [Live View Scrubbing](live_scrub.md)
 - [Jog-Shuttle Control](jog_shuttle.md)
 - [Developer Guide](developer_guide.md)

--- a/docs/live_all.md
+++ b/docs/live_all.md
@@ -1,5 +1,7 @@
-# Live All Playback
+# Dashboard Live Button
 
-The dashboard offers a **Live All** button next to **Play All**. **Live All** switches every tile to a real-time stream and clicking it again restores the latest screenshot.
+When **Play All** is active the button label toggles between _Play All_ and _Pause All_. Each tile plays its latest archived clip while visible.
 
-The **Play All** button now toggles between *Play All* and *Pause All*. Clicking *Play All* starts playback of each camera's most recent archived video while the tiles are onscreen. Choosing *Pause All* stops playback and shows the newest screenshot without contacting the live stream.
+A **Live** button appears whenever playback is running or paused. Selecting **Live** stops all players and restores the most recent screenshot for every tile, returning the dashboard to the default view.
+
+


### PR DESCRIPTION
## Summary
- toggle the Live button based on Play All state
- show Live button only when playback active
- document the updated dashboard controls

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68422c965f9883338bf9c6128fd11cab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the dashboard controls: the "Live" button now appears only during playback and allows users to stop all videos and return to the latest screenshots with a single action.
- **Style**
  - The "Live" button is now initially hidden and has updated text and tooltip for clarity.
- **Documentation**
  - Documentation updated to reflect the new behavior and naming of the dashboard's "Live" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->