### PR TITLE
Fix stylelint errors in nav and CSS

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -208,6 +208,7 @@ h2 {
     auto-fit,
     minmax(50px, var(--tile-size))
   ); /* Use CSS variable */
+
   gap: 5px;
   padding: 10px;
   justify-content: center;
@@ -317,6 +318,7 @@ select:hover {
     255,
     0.7
   ); /* Semi-transparent white background */
+
   border-radius: 50%;
   padding: calc(5px * var(--tile-scale, 1));
   display: none; /* Hide by default */
@@ -442,7 +444,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +827,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -45,7 +45,7 @@
       </a>
     </div>
     <a href="/live" id="live" aria-label="Open Live page">
-      <div id="navClock" class="cool-clock" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}" style="{% if not CLOCK_NAVBAR %}display:none;{% endif %}" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
+      <div id="nav-clock" class="cool-clock" data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}" style="{% if not CLOCK_NAVBAR %}display:none;{% endif %}" title="Open the Live page. Select a camera and choose 'Live Video' for realtime streaming." aria-label="Open Live page for realtime streaming">
         <div class="clock-face">
           <div class="clock-hands">
             <div class="hand hour-hand"></div>


### PR DESCRIPTION
## Summary
- fix `declaration-empty-line-before` warnings in `style.css`
- rename `#navClock` to `#nav-clock` for lint compliance

## Testing
- `flake8`
- `pytest -q`
- `npm run lint:css`

------
https://chatgpt.com/codex/tasks/task_e_68422d54647483339fb2a90fc2e8866d