### PR TITLE
Remove redundant navigation links

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1644,13 +1644,6 @@ details > summary {
   z-index: 10;
 }
 
-.group-links {
-  margin-top: 0.5em;
-}
-
-.group-links a {
-  margin-right: 0.5em;
-}
 
 @media screen and (max-width: 600px) {
   .feed-status,

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -110,7 +110,6 @@
             <h3 class="section-title">Need More Help?</h3>
             <p>If you need further assistance, please visit <a href="https://glimpser.net" target="_blank">glimpser.net</a> or the <a href="https://github.com/KristopherKubicki/glimpser" target="_blank">GitHub repository</a> for updates and to report issues.</p>
         </section>
-        <p><a href="{{ url_for('index') }}">Back to Glimpser</a></p>
     </main>
 
 {% endblock %}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -236,13 +236,6 @@ function updateVideo(templateName) {
             <div class="form-row">
                 <label for="groups" title="Groups for the template">Groups:</label>
                 <input type="text" id="groups" name="groups" value="{{ template_details.groups }}" title="Enter comma-separated group names">
-                {% if template_details.groups %}
-                <div class="group-links">
-                    {% for g in template_details.groups.split(',') %}
-                    <a href="/group/{{ g.strip() }}" class="group-link" title="View group {{ g.strip() }}">{{ g.strip() }}</a>
-                    {% endfor %}
-                </div>
-                {% endif %}
             </div>
 
             <div class="form-row">

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -28,5 +28,4 @@ available media types, and `[`/`]` adjust playback speed. On phones and tablets,
 swipe left or right on the video to switch cameras or swipe up or down to change
 the media type quickly.
 
-Navigate back to the main interface using the **Back to Glimpser** link at the
-bottom of the help page.
+Click the Glimpser logo in the navigation bar to return to the main interface.


### PR DESCRIPTION
## Summary
- clean up extra group links on template details
- drop footer link from the help page
- update help doc for new navigation
- remove obsolete CSS rules

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422dd594ac8333b1452bc627b03829