### PR TITLE
Fix logs.js loading

### DIFF
--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -32,4 +32,4 @@
 
     <div id="log-connection-status" class="hidden"></div>
 
-    <script src="{{ url_for('static', filename='js/logs.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/logs.js') }}"></script>


### PR DESCRIPTION
## Summary
- load `logs.js` as a module so browsers correctly parse it

## Testing
- `black .`
- `flake8`
- `pytest`
- `npm test` *(fails: 2 failed, 8 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68422e3802908333946c595c71ceeba3