### PR TITLE
feat: extend system metrics

### DIFF
--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -1,71 +1,124 @@
 <div class="scheduler-controls">
-    <button id="toggle-scheduler" class="btn btn-primary" title="Start or stop the scheduler">
-        Loading...
-    </button>
-    <span id="scheduler-status" title="Current scheduler status">Checking status...</span>
+  <button
+    id="toggle-scheduler"
+    class="btn btn-primary"
+    title="Start or stop the scheduler"
+  >
+    Loading...
+  </button>
+  <span id="scheduler-status" title="Current scheduler status"
+    >Checking status...</span
+  >
 </div>
 
 <h1>System Status</h1>
 
 {% call card('System Metrics') %}
 <ul class="metrics-list">
-    <li title="Current CPU utilization">CPU Usage:
-        <progress class="metric-bar" value="{{ metrics.cpu_usage }}" max="100"></progress>
-        {{ metrics.cpu_usage }}%
-    </li>
-    <li title="Current memory utilization">Memory Usage:
-        <progress class="metric-bar" value="{{ metrics.memory_usage }}" max="100"></progress>
-        {{ metrics.memory_usage }}%
-    </li>
-    <li title="Disk space used">Disk Usage:
-        <progress class="metric-bar" value="{{ metrics.disk_usage }}" max="100"></progress>
-        {{ metrics.disk_usage }}%
-    </li>
-    <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
-    <li title="Number of active threads">Thread Count: {{ metrics.thread_count }}</li>
-    <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+  <li title="Current CPU utilization">
+    CPU Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.cpu_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.cpu_usage }}%
+  </li>
+  <li title="Current memory utilization">
+    Memory Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.memory_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.memory_usage }}%
+  </li>
+  <li title="Disk space used">
+    Disk Usage:
+    <progress
+      class="metric-bar"
+      value="{{ metrics.disk_usage }}"
+      max="100"
+    ></progress>
+    {{ metrics.disk_usage }}%
+  </li>
+  <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
+  <li title="Number of active threads">
+    Thread Count: {{ metrics.thread_count }}
+  </li>
+  <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+  <li title="Installed ffmpeg version">
+    FFmpeg Version: {{ metrics.ffmpeg_version }}
+  </li>
+  <li title="Hardware acceleration devices present">
+    Machine HW Accel: {{ metrics.machine_hwaccel }}
+  </li>
+  <li title="ffmpeg has hardware acceleration support">
+    FFmpeg HW Accel: {{ metrics.ffmpeg_hwaccel }}
+  </li>
+  <li title="Hardware acceleration enabled via config">
+    HW Accel Enabled: {{ metrics.hwaccel_enabled }}
+  </li>
+  <li title="Danger mode enabled setting">
+    Danger Mode: {{ metrics.danger_mode }}
+  </li>
 </ul>
-{% endcall %}
-
-{% call card('Feed Status') %}
+{% endcall %} {% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">
-    <thead>
-        <tr>
-            <th class="sortable" data-type="string">Feed</th>
-            <th class="sortable" data-type="date">Last Image</th>
-            <th class="sortable" data-type="date">Last Caption</th>
-            <th class="sortable" data-type="string">Status</th>
-        </tr>
-    </thead>
-    <tbody>
+  <thead>
+    <tr>
+      <th class="sortable" data-type="string">Feed</th>
+      <th class="sortable" data-type="date">Last Image</th>
+      <th class="sortable" data-type="date">Last Caption</th>
+      <th class="sortable" data-type="string">Status</th>
+    </tr>
+  </thead>
+  <tbody>
     {% for feed in feeds %}
-        <tr class="{{ feed.status }}">
-            <td data-label="Feed" data-value="{{ feed.name }}"><a href="{{ url_for('template_details', template_name=feed.name) }}">{{ feed.name }}</a></td>
-            <td data-label="Last Image" data-value="{{ feed.last_screenshot_time or '' }}">
-                {% if feed.last_screenshot_display %}
-                <span class="humanized-time" data-time="{{ feed.last_screenshot_time }}" title="{{ feed.last_screenshot_time }}">
-                    {{ feed.last_screenshot_display }}
-                </span>
-                {% else %}
-                N/A
-                {% endif %}
-            </td>
-            <td data-label="Last Caption" data-value="{{ feed.last_caption_time or '' }}">
-                {% if feed.last_caption_display %}
-                <span class="humanized-time" data-time="{{ feed.last_caption_time }}" title="{{ feed.last_caption_time }}">
-                    {{ feed.last_caption_display }}
-                </span>
-                {% else %}
-                N/A
-                {% endif %}
-            </td>
-            <td data-label="Status" data-value="{{ feed.status }}"><span class="status-dot {{ feed.status }}" title="{{ feed.tooltip }}"></span></td>
-        </tr>
+    <tr class="{{ feed.status }}">
+      <td data-label="Feed" data-value="{{ feed.name }}">
+        <a href="{{ url_for('template_details', template_name=feed.name) }}"
+          >{{ feed.name }}</a
+        >
+      </td>
+      <td
+        data-label="Last Image"
+        data-value="{{ feed.last_screenshot_time or '' }}"
+      >
+        {% if feed.last_screenshot_display %}
+        <span
+          class="humanized-time"
+          data-time="{{ feed.last_screenshot_time }}"
+          title="{{ feed.last_screenshot_time }}"
+        >
+          {{ feed.last_screenshot_display }}
+        </span>
+        {% else %} N/A {% endif %}
+      </td>
+      <td
+        data-label="Last Caption"
+        data-value="{{ feed.last_caption_time or '' }}"
+      >
+        {% if feed.last_caption_display %}
+        <span
+          class="humanized-time"
+          data-time="{{ feed.last_caption_time }}"
+          title="{{ feed.last_caption_time }}"
+        >
+          {{ feed.last_caption_display }}
+        </span>
+        {% else %} N/A {% endif %}
+      </td>
+      <td data-label="Status" data-value="{{ feed.status }}">
+        <span
+          class="status-dot {{ feed.status }}"
+          title="{{ feed.tooltip }}"
+        ></span>
+      </td>
+    </tr>
     {% endfor %}
-    </tbody>
+  </tbody>
 </table>
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
-{% endcall %}
-
-{% include 'logs.html' %}
+{% endcall %} {% include 'logs.html' %}

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,14 +1,6 @@
-
-
-{% extends 'base.html' %}
-{% from 'components.html' import card %}
-{% block content %}
-{% include '_status_tab.html' %}
-{% endblock %}
-
-                                             
 {% extends 'base.html' %} {% from 'components.html' import card %} {% block
-content %}
+content %} {% include '_status_tab.html' %} {% endblock %} {% extends
+'base.html' %} {% from 'components.html' import card %} {% block content %}
 
 <div class="scheduler-controls">
   <button
@@ -70,6 +62,9 @@ content %}
   </li>
   <li title="Hardware acceleration enabled via config">
     HW Accel Enabled: {{ metrics.hwaccel_enabled }}
+  </li>
+  <li title="Danger mode enabled setting">
+    Danger Mode: {{ metrics.danger_mode }}
   </li>
 </ul>
 {% endcall %} {% call card('Feed Status') %}
@@ -151,4 +146,3 @@ content %}
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
 {% endcall %} {% include 'logs.html' %} {% endblock %}
-

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -30,6 +30,7 @@ from app.config import (
     LOGGING_PATH,
     FFMPEG_PATH,
     FFMPEG_HWACCEL,
+    get_setting,
 )
 from app.utils.db import SessionLocal
 from app.models import Summary
@@ -1048,6 +1049,11 @@ def get_system_metrics():
         "machine_hwaccel": machine_supports_hwaccel(),
         "ffmpeg_hwaccel": ffmpeg_supports_hwaccel(),
         "hwaccel_enabled": bool(FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false"),
+        "gpu_support": machine_supports_hwaccel(),
+        "ffmpeg_gpu_enabled": bool(
+            FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false"
+        ),
+        "danger_mode": get_setting("DANGER_MODE", "True") == "True",
     }
 
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-This endpoint now redirects to the *System Status* tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator.
+This endpoint now redirects to the _System Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator.
 
 ### Feed Dashboard
 
@@ -33,15 +33,17 @@ name, last image time, last caption time, any KPI column, or status.
 - **Thread Count** – active thread count for the application
 - **Uptime** – elapsed time since the app started
 - **FFmpeg Version** – version string reported by the ffmpeg binary
-- **Machine HW Accel** – whether GPU devices are detected
+- **Machine HW Accel** – whether GPU devices are detected (GPU support)
 - **FFmpeg HW Accel** – whether ffmpeg supports hardware acceleration
 - **HW Accel Enabled** – if hardware acceleration is configured
+- **FFmpeg GPU Enabled** – whether ffmpeg is currently using GPU acceleration
+- **Danger Mode Enabled** – whether the DANGER_MODE setting is on
 
 ## Streaming Logs
 
 **GET /stream_logs**
 
-This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the *System Status* tab consume this endpoint to display updates in real time.
+This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the _System Status_ tab consume this endpoint to display updates in real time.
 
 To filter logs by level and message text, you could request:
 
@@ -51,7 +53,7 @@ To filter logs by level and message text, you could request:
 
 ## Using the Live Log Viewer
 
-1. Open the *System Status* tab under Settings or navigate to `/logs` after logging in.
+1. Open the _System Status_ tab under Settings or navigate to `/logs` after logging in.
 2. Use the search box and dropdowns to filter log output.
 3. Hover over each field for a tooltip explaining the filter.
 4. Results update automatically via `/stream_logs`.
@@ -59,7 +61,7 @@ To filter logs by level and message text, you could request:
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 
-The *System Status* tab also appears as a **System Status** camera under Discover.
+The _System Status_ tab also appears as a **System Status** camera under Discover.
 Adding it lets Glimpser capture periodic screenshots of its own health metrics.
 An accompanying **Internal Caption** camera shows `/internal_caption.mjpg` so you
 can monitor recent caption text without leaving the dashboard.
@@ -82,7 +84,7 @@ History tab.
 ## System Performance Icon
 
 The System Performance icon in the navigation bar provides quick access to the
-*System Status* tab. When all metrics look healthy the icon now hides to reduce
+_System Status_ tab. When all metrics look healthy the icon now hides to reduce
 clutter. Set the `HEALTH_STATUS_ALWAYS_VISIBLE` option to `True` if you prefer
 to keep it shown at all times.
 

--- a/main.py
+++ b/main.py
@@ -237,6 +237,9 @@ def output_shutdown_stats():
     logging.info("Machine HW Accel: %s", metrics["machine_hwaccel"])
     logging.info("FFmpeg HW Accel: %s", metrics["ffmpeg_hwaccel"])
     logging.info("HW Accel Enabled: %s", metrics["hwaccel_enabled"])
+    logging.info("GPU Support: %s", metrics["gpu_support"])
+    logging.info("FFmpeg GPU Enabled: %s", metrics["ffmpeg_gpu_enabled"])
+    logging.info("Danger Mode: %s", metrics["danger_mode"])
     logging.info("Thank you for running Glimpser. Goodbye!")
 
 

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -24,6 +24,9 @@ class TestMainUtilities(unittest.TestCase):
             "machine_hwaccel": True,
             "ffmpeg_hwaccel": True,
             "hwaccel_enabled": True,
+            "gpu_support": True,
+            "ffmpeg_gpu_enabled": True,
+            "danger_mode": True,
         }
         mock_metrics.return_value = metrics
 
@@ -41,6 +44,9 @@ class TestMainUtilities(unittest.TestCase):
             ("Machine HW Accel: %s", metrics["machine_hwaccel"]),
             ("FFmpeg HW Accel: %s", metrics["ffmpeg_hwaccel"]),
             ("HW Accel Enabled: %s", metrics["hwaccel_enabled"]),
+            ("GPU Support: %s", metrics["gpu_support"]),
+            ("FFmpeg GPU Enabled: %s", metrics["ffmpeg_gpu_enabled"]),
+            ("Danger Mode: %s", metrics["danger_mode"]),
             ("Thank you for running Glimpser. Goodbye!",),
         ]
         self.assertEqual([c.args for c in mock_log.call_args_list], expected)

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -61,10 +61,12 @@ class TestGetSystemMetrics(unittest.TestCase):
     @patch("app.utils.scheduling.ffmpeg_version", return_value="6.0")
     @patch("app.utils.scheduling.machine_supports_hwaccel", return_value=True)
     @patch("app.utils.scheduling.ffmpeg_supports_hwaccel", return_value=True)
+    @patch("app.utils.scheduling.get_setting", return_value="True")
     @patch.object(scheduling, "FFMPEG_HWACCEL", "cuda")
     def test_metrics_fields(
         self,
         mock_ffmpeg_hwaccel,
+        mock_get_setting,
         mock_machine,
         mock_version,
         mock_psutil,
@@ -90,6 +92,9 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertTrue(metrics["machine_hwaccel"])
         self.assertTrue(metrics["ffmpeg_hwaccel"])
         self.assertTrue(metrics["hwaccel_enabled"])
+        self.assertTrue(metrics["gpu_support"])
+        self.assertTrue(metrics["ffmpeg_gpu_enabled"])
+        self.assertTrue(metrics["danger_mode"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add more system metrics including GPU state and Danger mode
- show the additional metrics in status templates
- log the new metrics on shutdown
- document new metric fields
- update tests for new metrics

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68422e933a7c8333aa3242c96c87cadf