### PR TITLE
Fix formatting for tests

### DIFF
--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- fix black formatting in `tests/test_clock_route.py`

## Testing
- `black . --check`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684237f0b6308333965eedcbf565cdd9