### PR TITLE
Fix mobile layout of templates grid

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -237,6 +237,13 @@ h2 {
     grid-template-columns: 1fr; /* Single column layout on mobile */
     padding: 10px; /* Reduce padding on mobile */
   }
+  #grid-width-slider {
+    display: none;
+  }
+  .templateDiv {
+    width: 100%;
+    flex: 0 0 100%;
+  }
 
   /* Improve form layout on mobile */
   #template-form,
@@ -442,7 +449,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +832,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -23,6 +23,7 @@ export function initTemplates() {
       .getElementById("template-form")
       ?.closest("details");
     const slider = document.getElementById("grid-width-slider");
+    const isMobile = window.matchMedia("(max-width: 767px)").matches;
     const templateList = document.getElementById("template-list");
     const captionToggle = document.getElementById("toggle-captions");
     const MAX_THUMBNAIL_HEIGHT = 1080;
@@ -135,7 +136,17 @@ export function initTemplates() {
 
       slider.addEventListener("input", handleSlider);
       slider.addEventListener("change", handleSlider);
-      handleSlider();
+      if (isMobile) {
+        slider.style.display = "none";
+        slider.value = Math.min(window.innerWidth, slider.max);
+        handleSlider();
+        window.addEventListener("resize", () => {
+          slider.value = Math.min(window.innerWidth, slider.max);
+          handleSlider();
+        });
+      } else {
+        handleSlider();
+      }
     }
 
     if (form) {

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- hide grid width slider on mobile
- force templates to full width when screen is small
- apply minor formatting fixes

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684249538334833391924d29de6d6cd2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mobile responsiveness by updating the layout and hiding the grid width slider on smaller screens.
- **Style**
  - Enhanced mobile styles to ensure elements occupy full width and provide a better user experience on mobile devices.
- **Tests**
  - Minor formatting update in test setup without affecting test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->