### PR TITLE
Add FFmpeg timeout handling

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -48,13 +48,22 @@ def trim_group_name(group_name):
     return group_name.replace(" ", "_").lower()
 
 
-def run_ffmpeg(command):
-    """Execute an FFmpeg command and log output."""
+def run_ffmpeg(command, timeout: int = 30):
+    """Execute an FFmpeg command and log output.
+
+    Parameters
+    ----------
+    command: list[str]
+        Full ffmpeg command to execute.
+    timeout: int, optional
+        Number of seconds before the process is terminated. Defaults to 30.
+    """
     result = subprocess.run(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        timeout=timeout,
     )
     if result.stdout:
         logging.debug("ffmpeg stdout: %s", result.stdout.strip())
@@ -205,7 +214,7 @@ def compile_videos(input_file, output_file):
     )
 
     try:
-        run_ffmpeg(create_command)
+        run_ffmpeg(create_command, timeout=30)
         if os.path.exists(output_file) and os.path.getsize(output_file) > 300:
             if is_video_expired(output_file, MAX_COMPRESSED_VIDEO_AGE):
                 logging.info("Rotating expired output %s", output_file)
@@ -296,7 +305,7 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
                 ]
             )
             try:
-                run_ffmpeg(concat_command)
+                run_ffmpeg(concat_command, timeout=30)
                 os.rename(concat_video, in_process_video)
                 file_updated = True
                 output_video = os.path.join(VIDEO_DIRECTORY, "latest_camera.mp4")
@@ -520,7 +529,7 @@ def compile_to_video(camera_path, video_path) -> bool:
 
         lout, lerr = None, None
         try:
-            run_ffmpeg(create_command)
+            run_ffmpeg(create_command, timeout=30)
             if is_video_expired(temp_video, MAX_COMPRESSED_VIDEO_AGE):
                 logging.warning("creation time mismatch for %s", temp_video)
         except Exception as e:

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 import tempfile
+import subprocess
 from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -18,6 +19,7 @@ from app.utils.video_archiver import (
     ConcatStatus,
     compile_to_video,
     archive_screenshots,
+    run_ffmpeg,
 )
 from app.config import VIDEO_DIRECTORY
 
@@ -252,7 +254,7 @@ class TestVideoArchiver(unittest.TestCase):
 
         captured_lines = []
 
-        def fake_run(cmd):
+        def fake_run(cmd, timeout=30):
             if isinstance(cmd, list) and "-i" in cmd:
                 idx = cmd.index("-i") + 1
                 with open(cmd[idx]) as f:
@@ -305,6 +307,12 @@ class TestVideoArchiver(unittest.TestCase):
         ):
             archive_screenshots()
         mock_log.assert_called_once()
+
+    @patch("subprocess.run")
+    def test_run_ffmpeg_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=1)
+        with self.assertRaises(subprocess.TimeoutExpired):
+            run_ffmpeg(["ffmpeg"], timeout=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying a timeout when running ffmpeg commands
- propagate the timeout through video archiver helpers
- ensure test coverage for ffmpeg timeouts

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424faf7efc83338ea84940340f68e5