### PR TITLE
Add TWILIO_FROM_NUMBER setting

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -378,6 +378,7 @@ EMAIL_PASSWORD = get_setting("EMAIL_PASSWORD", "")
 TWILIO_SID = get_setting("TWILIO_SID", "")
 TWILIO_TOKEN = get_setting("TWILIO_TOKEN", "")
 TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")
+TWILIO_FROM_NUMBER = get_setting("TWILIO_FROM_NUMBER", "")
 
 # Common Alerting Protocol settings
 CAP_ENDPOINT = get_setting("CAP_ENDPOINT", "")

--- a/app/utils/sms_alerts.py
+++ b/app/utils/sms_alerts.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from app.config import TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER
+from app.config import (
+    TWILIO_SID,
+    TWILIO_TOKEN,
+    TWILIO_NUMBER,
+    TWILIO_FROM_NUMBER,
+)
 
 
 def send_sms_alert(message):
@@ -14,7 +19,8 @@ def send_sms_alert(message):
         Body text for the SMS message.
 
     The alert is only attempted if ``TWILIO_SID``, ``TWILIO_TOKEN`` and
-    ``TWILIO_NUMBER`` are all configured. Any failure is logged.
+    ``TWILIO_NUMBER`` are all configured. Any failure is logged. The SMS is
+    sent from ``TWILIO_FROM_NUMBER`` to ``TWILIO_NUMBER``.
     """
     if not all([TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER]):
         logging.info("SMS alerts are disabled.")
@@ -28,7 +34,7 @@ def send_sms_alert(message):
 
     try:
         client = Client(TWILIO_SID, TWILIO_TOKEN)
-        client.messages.create(body=message, from_=TWILIO_NUMBER, to=TWILIO_NUMBER)
+        client.messages.create(body=message, from_=TWILIO_FROM_NUMBER, to=TWILIO_NUMBER)
         logging.info("SMS alert sent successfully")
     except Exception as exc:
         logging.error("Error sending SMS alert: %s", exc)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -95,6 +95,7 @@ Configure these values to enable Twilio SMS alerts:
 
 - `TWILIO_SID` – your Twilio account SID
 - `TWILIO_TOKEN` – your Twilio auth token
+- `TWILIO_FROM_NUMBER` – number that sends the messages
 - `TWILIO_NUMBER` – phone number that receives alerts
 
 ## CAP Settings

--- a/tests/test_sms_alerts.py
+++ b/tests/test_sms_alerts.py
@@ -33,11 +33,13 @@ class TestSMSAlerts(unittest.TestCase):
         ):
             with patch("app.utils.sms_alerts.TWILIO_SID", "sid"), patch(
                 "app.utils.sms_alerts.TWILIO_TOKEN", "token"
-            ), patch("app.utils.sms_alerts.TWILIO_NUMBER", "+123"):
+            ), patch("app.utils.sms_alerts.TWILIO_NUMBER", "+123"), patch(
+                "app.utils.sms_alerts.TWILIO_FROM_NUMBER", "+999"
+            ):
                 send_sms_alert("Body")
                 mock_client_class.assert_called_once_with("sid", "token")
                 client_instance.messages.create.assert_called_once_with(
-                    body="Body", from_="+123", to="+123"
+                    body="Body", from_="+999", to="+123"
                 )
 
     def test_sms_alert_wrapper(self):


### PR DESCRIPTION
## Summary
- add TWILIO_FROM_NUMBER setting
- use new setting when sending SMS alerts
- update tests for SMS alert helper
- document Twilio sender configuration

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425d6d64c483338116f637e06c6ea0