### PR TITLE
Fix nav icon alignment

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -506,6 +506,7 @@ header h1 img {
 nav {
   display: flex; /* Flexbox for layout */
   gap: 10px; /* Tighter spacing */
+  margin-left: auto; /* Keep navigation on the right */
 }
 
 .menu-toggle {
@@ -521,6 +522,10 @@ nav {
   display: flex;
   align-items: center;
   gap: 5px; /* Reduce spacing */
+}
+
+.nav-right {
+  margin-left: auto; /* Keep icons aligned to the right */
 }
 
 .nav-center {


### PR DESCRIPTION
## Summary
- ensure nav takes up remaining header space so icons stay right
- keep nav-right icons aligned to the right edge

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425d49ae108333a6217472711d0e51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved alignment of navigation elements in the header, ensuring navigation items and icons are right-aligned for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->