### PR TITLE
Remove duplicate set_capture_failed implementation

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -804,23 +804,6 @@ def set_capture_failed(name: str, failed: bool) -> None:
         session.close()
 
 
-def set_capture_failed(name: str, failed: bool) -> None:
-    """Set ``capture_failed`` flag for ``name``."""
-    name = validate_template_name(name)
-    if name is None:
-        return
-
-    manager = TemplateManager()
-    session = manager.get_session()
-    try:
-        template = session.query(Template).filter_by(name=name).first()
-        if template:
-            template.capture_failed = bool(failed)
-            session.commit()
-    finally:
-        session.close()
-
-
 def _update_scheduler_job(name: str, frequency: int) -> None:
     """Reschedule the APScheduler job for ``name`` if it exists.
 


### PR DESCRIPTION
## Summary
- remove the first copy of `set_capture_failed` from `template_manager`

## Testing
- `flake8 app/utils/template_manager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425d643d4883339d0acacfb8c7bf1c