### PR TITLE
Fix nav group dropdown visibility

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -8,11 +8,13 @@
 <div id="caption-chyron" class="caption-chyron" aria-live="polite" data-speed="{{ CHYRON_SPEED }}"></div>
 <nav>
   <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+  {% if session.get('user_id') %}
   <div class="nav-left">
     <select id="nav-group-dropdown" title="Jump to group"></select>
     <select id="nav-camera-dropdown" title="Jump to camera" style="display:none"></select>
     <!-- Discover icon moved to nav-right for consistency -->
   </div>
+  {% endif %}
 
   <div class="nav-center">
     {% if template_name %}

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -6,9 +6,9 @@ The main template view scales thumbnails with the width slider and the page now 
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 
-Group links in the header are now available through a dropdown menu. The list
-populates asynchronously from the `/groups` endpoint and fits neatly inside the
-hamburger layout on small screens.
+Group links in the header are now available through a dropdown menu when logged
+in. The list populates asynchronously from the `/groups` endpoint and fits
+neatly inside the hamburger layout on small screens.
 
 Selecting a group from that dropdown while on the **Live** page now updates the
 camera selector immediately without reloading the page, keeping navigation


### PR DESCRIPTION
## Summary
- hide the group dropdown when not logged in
- note group dropdown visibility in responsive design docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425edac27c833382f3fd1434396538