### PR TITLE
Improve captions prompt UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -442,7 +442,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +825,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {
@@ -1088,17 +1088,28 @@ video.hover-video[data-timestamp]::after {
   pointer-events: none;
 }
 
+.notes-form {
+  position: relative;
+}
+
 .notes-textarea {
   width: 100%;
   height: 60px;
   margin-top: 5px;
   resize: vertical;
+  background-color: var(--form-bg-color);
+  color: var(--form-text-color);
+  border: 1px solid var(--table-border-color);
+  padding-right: 2rem;
 }
 
 .update-button {
-  width: 100%;
-  padding: 5px;
-  margin-top: 5px;
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  width: auto;
+  padding: 4px;
+  margin-top: 0;
 }
 
 /* Footer Styles */

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -142,13 +142,11 @@
               <form id="form-{{ camera }}" class="notes-form caption-box">
                 <div class="chat-box">
                   <div class="chat-prompt">
-                    <label for="notes-{{ camera }}">Prompt:</label>
                     <textarea id="notes-{{ camera }}" class="notes-textarea">
 {{ template_details[camera]['notes'] }}</textarea
                     >
                   </div>
                   <div class="chat-response">
-                    <label>Response:</label>
                     <div class="last-caption">
                       {{ template_details[camera]['last_caption'] }}
                     </div>
@@ -158,8 +156,13 @@
                   class="update-button"
                   data-template="{{ camera }}"
                   title="Send updated prompt"
+                  aria-label="Send updated prompt"
                 >
-                  Send
+                  <svg width="16" height="16" aria-hidden="true">
+                    <use
+                      href="{{ url_for('static', filename='icons/sprite.svg') }}#login"
+                    />
+                  </svg>
                 </button>
               </form>
             </td>


### PR DESCRIPTION
## Summary
- streamline Captions prompt layout
- dim textarea in dark mode
- shrink send button and use icon

## Testing
- `flake8`
- `pytest`
- `npx prettier -w app/templates/captions.html app/static/css/style.css`


------
https://chatgpt.com/codex/tasks/task_e_68426c7b10388333a4489b23a7af82d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the appearance of the notes form and textarea, including repositioning the update button to the bottom-right corner for better usability.
- **New Features**
  - Updated the send button in the notes form to use an icon instead of text, with improved accessibility via an aria-label.
- **Refactor**
  - Removed visible text labels from the camera notes form for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->