### PR TITLE
Remove duplicate camera heading

### DIFF
--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -68,7 +68,6 @@
         <details title="Expand to add a new camera">
             <summary>Add Camera</summary>
             <div id="template-form" title="Form to add a new template">
-                <h3>Add Camera</h3>
                 <form id="add-template-form" action="/templates" method="post" onsubmit="return validateForm()" title="Enter details for the new template">
                     <div>
                         <label for="name" title="Name of the template">Template Name:</label>


### PR DESCRIPTION
## Summary
- clean up duplicate "Add Camera" header in discovery tab

## Testing
- `flake8`
- `pytest -q` *(fails: KeyboardInterrupt, but shows 281 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68426fb49d24833394497abf61156f12