### PR TITLE
Improve offline caching

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,6 +1,7 @@
 const CACHE_NAME = 'glimpser-offline-v1';
 const MAX_SHOTS = 20;
 const OFFLINE_URLS = [
+  '/',
   '/status',
   '/discover',
   '/settings',

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,5 +1,5 @@
 # Offline Preview
 
-A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the System Status tab (`/settings?tab=status-tab`), the main Settings page, and the Templates page (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
+A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the dashboard (`/`), the System Status tab (`/settings?tab=status-tab`), the main Settings page, and the Templates page (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
 
 MJPEG endpoints now fall back to the oldest frame stored on disk if no recent frame is available. This means `/stream.mjpg` and related routes always yield at least one image even when the camera is offline.

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- cache the dashboard in the service worker
- document offline dashboard access

## Testing
- `npm run format`
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684271af443083339b815d198d72b289