### PR TITLE
Add caption playback feature

### DIFF
--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -53,12 +53,25 @@ export function initCaptions() {
       if (table && data.answer) {
         const now = new Date().toISOString().replace("T", " ").slice(0, 19);
         const rowQ = document.createElement("tr");
-        rowQ.innerHTML = `<td>${now}</td><td>Q: ${chatQuestion.value}</td>`;
+        rowQ.innerHTML = `<td>${now}</td><td>Q: ${chatQuestion.value}</td><td><button class="play-caption" title="Play caption">&#9658;</button></td>`;
+        rowQ.querySelector("button").dataset.caption =
+          `Q: ${chatQuestion.value}`;
         const rowA = document.createElement("tr");
-        rowA.innerHTML = `<td>${now}</td><td>A: ${data.answer}</td>`;
+        rowA.innerHTML = `<td>${now}</td><td>A: ${data.answer}</td><td><button class="play-caption" title="Play caption">&#9658;</button></td>`;
+        rowA.querySelector("button").dataset.caption = `A: ${data.answer}`;
         table.prepend(rowA);
         table.prepend(rowQ);
       }
+    });
+
+    const captionsTable = document.getElementById("captions-table");
+    captionsTable?.addEventListener("click", (e) => {
+      const btn = e.target.closest(".play-caption");
+      if (!btn || !window.speechSynthesis) return;
+      const text = btn.dataset.caption;
+      if (!text) return;
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(new SpeechSynthesisUtterance(text));
     });
 
     document.getElementById("camera-table")?.addEventListener("click", (e) => {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -204,12 +204,13 @@
         <tr>
           <th class="sortable" data-type="date">Timestamp</th>
           <th class="sortable" data-type="string">Caption</th>
+          <th>Play</th>
         </tr>
       </thead>
       <tbody>
         {% if not lcaptions %}
         <tr class="no-data">
-          <td colspan="2">No captions available</td>
+          <td colspan="3">No captions available</td>
         </tr>
         {% else %} {% for caption in lcaptions %} {% for lc in caption %} {% if
         caption[lc] != "" %}
@@ -218,6 +219,16 @@
             <span class="humanized-time" data-time="{{ lc }}">{{ lc }}</span>
           </td>
           <td>{{ caption[lc] }}</td>
+          <td>
+            <button
+              class="play-caption"
+              data-caption="{{ caption[lc]|e }}"
+              title="Play caption"
+              type="button"
+            >
+              &#9658;
+            </button>
+          </td>
         </tr>
         {% endif %} {% endfor %} {% endfor %} {% endif %}
       </tbody>

--- a/docs/caption_audio_playback.md
+++ b/docs/caption_audio_playback.md
@@ -1,0 +1,5 @@
+# Caption Audio Playback
+
+The Captions history tab now includes a **Play** button next to each entry.
+Clicking the button uses your browser's Text‑to‑Speech engine to read the
+caption aloud. If speech synthesis is unavailable the button does nothing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Dashboard Border Legend](border_legend.md)
 - [LLM Cost Tracking](cost_tracking.md)
 - [Captions Chatbot](chatbot.md)
+- [Caption Audio Playback](caption_audio_playback.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)
 - [Configuration Management](config_management.md)


### PR DESCRIPTION
## Summary
- add Play column with button on captions history
- use Web Speech API to read caption text
- document caption audio playback

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d3e0c1188333873045f93cd9f59f