### PR TITLE
Fix timezone handling for human readable times

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -16,7 +16,7 @@ import shutil
 import textwrap
 
 from apscheduler.triggers.cron import CronTrigger
-from dateutil import parser
+from dateutil import parser, tz
 from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw, ImageFont
 from transformers import CLIPProcessor, CLIPModel
@@ -30,6 +30,7 @@ from app.config import (
     LOGGING_PATH,
     FFMPEG_PATH,
     FFMPEG_HWACCEL,
+    TZ,
 )
 from app.utils.db import SessionLocal
 from app.models import Summary
@@ -1117,7 +1118,8 @@ def get_feed_status():
     """Return a list of status dictionaries for each configured feed."""
 
     templates = get_templates()
-    now = datetime.datetime.utcnow()
+    zone = tz.gettz(TZ) or tz.UTC
+    now = datetime.datetime.now(zone)
     feeds = []
 
     def _humanize(ts: str | None) -> str | None:
@@ -1126,6 +1128,7 @@ def get_feed_status():
             return None
         try:
             dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+            dt = dt.replace(tzinfo=datetime.timezone.utc).astimezone(zone)
         except Exception:
             return ts
 
@@ -1151,7 +1154,8 @@ def get_feed_status():
             return None
         try:
             dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
-            return dt.isoformat() + "Z"
+            dt = dt.replace(tzinfo=datetime.timezone.utc).astimezone(zone)
+            return dt.isoformat()
         except Exception:
             return ts
 

--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -65,7 +65,6 @@ def get_latest_date(directory, ext="png"):
         logging.warning("file error %s", e)
         return None
 
-    # Convert the timestamp to UTC datetime string
-    # return datetime.utcfromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")
-    #  I think there is a risk of double timestamping here, so I removed the UTC conversion
-    return datetime.fromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")
+    # Convert to a consistent UTC timestamp string so downstream code can
+    # safely interpret the value regardless of the host timezone.
+    return datetime.utcfromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,3 +58,5 @@ The Live View page displays the time of the latest frame in the
 lower-right corner using the same format. Timestamp parsing was improved so
 times display correctly across time zones instead of always showing
 "just now".
+Human readable timestamps now use the configured timezone instead of UTC for
+consistent display across the interface.


### PR DESCRIPTION
## Summary
- convert latest file dates to UTC consistently
- honor configured timezone when formatting feed status timestamps
- document that human readable timestamps use the configured timezone

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d373e98c83339c5fd928630cadd2