### PR TITLE
Fix All nav redirect

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -114,7 +114,7 @@ export function initNav() {
           }
         }
         if (groupDropdown.value === "all") {
-          window.location.href = "/";
+          window.location.href = "/live";
         } else {
           window.location.href = `/group/${encodeURIComponent(
             groupDropdown.value,


### PR DESCRIPTION
## Summary
- clicking **All** in the navigation dropdown should go to `/live`

## Testing
- `flake8`
- `pytest -q`
- `prettier` *(failed: `/usr/bin/env: ‘node’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6842d5bca3ec8333b9f8bc9f79fc5448