### PR TITLE
Fix duplicate discovery script variables

### DIFF
--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -150,13 +150,15 @@
     {% endcall %}
 </div>
 <script>
-const button = document.getElementById('discover-btn');
-const msg = document.getElementById('discover-message');
-const progress = document.getElementById('discover-progress');
-const body = document.getElementById('discover-body');
-const exportJson = document.getElementById('export-json');
-const exportCsv = document.getElementById('export-csv');
-const renderInfo = (info) => {
+document.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('discover-btn');
+  const msg = document.getElementById('discover-message');
+  const progress = document.getElementById('discover-progress');
+  const body = document.getElementById('discover-body');
+  const exportJson = document.getElementById('export-json');
+  const exportCsv = document.getElementById('export-csv');
+
+  const renderInfo = (info) => {
     if (!info) return '';
     const pieces = [];
     if (info.name) pieces.push(info.name);
@@ -164,14 +166,16 @@ const renderInfo = (info) => {
     if (info.path) pieces.push(info.path);
     if (info.sdp) pieces.push('SDP available');
     Object.entries(info).forEach(([k, v]) => {
-        if (!['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'].includes(k)) {
-            pieces.push(`${k}: ${v}`);
-        }
+      if (!['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'].includes(k)) {
+        pieces.push(`${k}: ${v}`);
+      }
     });
     return pieces.join(' ');
-};
-let results = [];
-if (button) {
+  };
+
+  let results = [];
+
+  if (button) {
     button.addEventListener('click', async () => {
         msg.textContent = 'Searching...';
         try {
@@ -274,6 +278,7 @@ const exportData = (fmt) => {
         URL.revokeObjectURL(url);
     });
 };
-if (exportJson) exportJson.addEventListener('click', () => exportData('json'));
-if (exportCsv) exportCsv.addEventListener('click', () => exportData('csv'));
+  if (exportJson) exportJson.addEventListener('click', () => exportData('json'));
+  if (exportCsv) exportCsv.addEventListener('click', () => exportData('csv'));
+});
 </script>


### PR DESCRIPTION
## Summary
- ensure discovery tab JS runs inside DOMContentLoaded handler to avoid global variable redeclarations

## Testing
- `npm run format:js:write`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6842d9606ed8833389a93218d5d630be