### PR TITLE
Fix timestamp formatting

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -228,18 +228,17 @@ export function getSelectedGroup() {
   return "all";
 }
 
-export function timeAgo(utcDateString) {
-  if (!utcDateString) return "just now";
+export function timeAgo(dateString) {
+  if (!dateString) return "just now";
   const now = new Date();
-  const iso =
-    utcDateString instanceof Date
-      ? utcDateString.toISOString()
-      : utcDateString.includes("T")
-        ? utcDateString
-        : `${utcDateString.replace(" ", "T")}Z`;
-  const utcDate = new Date(iso);
-  if (Number.isNaN(utcDate.getTime())) return "just now";
-  const diffInSeconds = Math.floor((now - utcDate) / 1000);
+  const date =
+    dateString instanceof Date
+      ? dateString
+      : new Date(
+          dateString.includes("T") ? dateString : dateString.replace(" ", "T"),
+        );
+  if (Number.isNaN(date.getTime())) return "just now";
+  const diffInSeconds = Math.floor((now - date) / 1000);
   if (diffInSeconds < 0) return "in the future";
 
   const intervals = [
@@ -258,9 +257,14 @@ export function timeAgo(utcDateString) {
   return "just now";
 }
 
-export function formatExactTime(utcDateString) {
-  const date = new Date(utcDateString);
-  return `UTC: ${date.toUTCString()}\nLocal: ${date.toString()}`;
+export function formatExactTime(dateString) {
+  const date =
+    dateString instanceof Date
+      ? dateString
+      : new Date(
+          dateString.includes("T") ? dateString : dateString.replace(" ", "T"),
+        );
+  return date.toString();
 }
 
 export function isMobile() {

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1151,7 +1151,7 @@ def get_feed_status():
             return None
         try:
             dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
-            return dt.isoformat() + "Z"
+            return dt.isoformat()
         except Exception:
             return ts
 


### PR DESCRIPTION
## Summary
- display ISO timestamps without trailing Z
- parse timestamp strings as local time on the frontend
- show local time only in tooltip details

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df08fa488333ab60b3fb245d4ae6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date parsing for time display functions to handle various input formats more reliably.
  - Updated time formatting to show a simpler local time string.
  - Adjusted internal logic to avoid appending unnecessary timezone indicators to date strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->