### PR TITLE
feat(live): separate group and camera selectors

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -65,6 +65,7 @@ const jogShuttle = document.getElementById("jog-shuttle");
 let jogInterval = null;
 let jogging = false;
 let isSeeking = false;
+const groupSelector = document.getElementById("group-selector");
 // Track whether template details are shown. Expose on window so inline
 // scripts and other modules can share this state.
 window.detailsVisible = false;
@@ -72,6 +73,52 @@ window.detailsVisible = false;
 // a camera repeatedly fails. Track the last message and time displayed.
 let lastErrorMessage = "";
 let lastErrorTime = 0;
+
+function updateCameraOptions(group) {
+  const camSelect = document.getElementById("camera-selector");
+  if (!camSelect) return;
+  camSelect.innerHTML = "";
+  if (!group || group === "all") {
+    camSelect.style.display = "none";
+    const opt = document.createElement("option");
+    opt.value = "All";
+    opt.textContent = "All";
+    camSelect.appendChild(opt);
+    camSelect.value = "All";
+    return;
+  }
+  camSelect.style.display = "";
+  const groupOpt = document.createElement("option");
+  groupOpt.value = `group-${group}`;
+  groupOpt.textContent = `Group: ${group}`;
+  camSelect.appendChild(groupOpt);
+  Object.entries(templateDetails)
+    .filter(
+      ([cam, det]) =>
+        det.groups &&
+        det.groups
+          .split(",")
+          .map((s) => s.trim())
+          .includes(group),
+    )
+    .map(([cam]) => cam)
+    .sort()
+    .forEach((cam) => {
+      const opt = document.createElement("option");
+      opt.value = cam;
+      opt.textContent = cam;
+      camSelect.appendChild(opt);
+    });
+  camSelect.value = `group-${group}`;
+}
+
+function changeGroup() {
+  const group = groupSelector ? groupSelector.value : "all";
+  const navGroup = document.getElementById("nav-group-dropdown");
+  if (navGroup) navGroup.value = group;
+  updateCameraOptions(group);
+  changeCamera();
+}
 
 // Restore previously selected camera, source and speed from localStorage so
 // reloading the page keeps user preferences. If the user specified a camera in
@@ -88,6 +135,13 @@ function loadSavedPreferences() {
     ) {
       currentCamera = savedCam;
       camSelect.value = savedCam;
+      if (groupSelector) {
+        if (savedCam === "All") {
+          groupSelector.value = "all";
+        } else if (savedCam.startsWith("group-")) {
+          groupSelector.value = savedCam.split("group-")[1];
+        }
+      }
     }
     if (navGroup) {
       if (currentCamera === "All") {
@@ -96,6 +150,7 @@ function loadSavedPreferences() {
         navGroup.value = currentCamera.split("group-")[1];
       }
     }
+    if (groupSelector) updateCameraOptions(groupSelector.value);
   }
 
   const sourceSelect = document.getElementById("video-source");
@@ -350,6 +405,13 @@ function changeCamera() {
       navGroup.value = selectedValue.split("group-")[1];
     } else {
       navGroup.value = "";
+    }
+  }
+  if (groupSelector) {
+    if (selectedValue === "All") {
+      groupSelector.value = "all";
+    } else if (selectedValue.startsWith("group-")) {
+      groupSelector.value = selectedValue.split("group-")[1];
     }
   }
 

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -57,6 +57,13 @@ export function initNav() {
           if (cameraDropdown && currentCamera) {
             cameraDropdown.value = currentCamera;
           }
+          const grpSelector = document.getElementById("group-selector");
+          if (grpSelector) {
+            grpSelector.value = currentGroup;
+            if (typeof window.updateCameraOptions === "function") {
+              window.updateCameraOptions(currentGroup);
+            }
+          }
         }
       } catch (error) {
         console.error("Error loading groups:", error);
@@ -100,15 +107,12 @@ export function initNav() {
         if (!groupDropdown.value) return;
         if (
           window.location.pathname.startsWith("/live") &&
-          typeof window.changeCamera === "function"
+          typeof window.changeGroup === "function"
         ) {
-          const camSelector = document.getElementById("camera-selector");
-          if (camSelector) {
-            camSelector.value =
-              groupDropdown.value === "all"
-                ? "All"
-                : `group-${groupDropdown.value}`;
-            window.changeCamera();
+          const grpSelector = document.getElementById("group-selector");
+          if (grpSelector) {
+            grpSelector.value = groupDropdown.value || "all";
+            window.changeGroup();
             loadNavCameras(groupDropdown.value);
             return;
           }

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -39,9 +39,8 @@
         <option value="mjpg" selected title="View an MJPEG (Motion JPEG) stream">MJPG</option>
     </select>
 
-
-    <select id="camera-selector" onchange="changeCamera()">
-        <option value="All" title="View all cameras">All</option>
+    <select id="group-selector" onchange="changeGroup()">
+        <option value="all" title="View all groups">All</option>
         {% set all_groups = [] %}
         {% for camera, details in template_details.items() %}
             {% if details.groups %}
@@ -53,8 +52,11 @@
             {% endif %}
         {% endfor %}
         {% for group in all_groups|unique|sort %}
-            <option value="group-{{ group }}" title="View cameras in group {{ group }}">Group: {{ group }}</option>
+            <option value="{{ group }}" title="View group {{ group }}">{{ group }}</option>
         {% endfor %}
+    </select>
+
+    <select id="camera-selector" onchange="changeCamera()" style="display:none">
         {% for camera in template_details.keys()|sort %}
             <option value="{{ camera }}" title="View camera {{ camera }}">Camera: {{ camera }}</option>
         {% endfor %}

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -10,7 +10,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **System Performance icon** – shows CPU, memory and other metrics. It hides
   when the system is healthy unless `HEALTH_STATUS_ALWAYS_VISIBLE` is set.
 - **Danger Mode icon** – appears only when Danger mode is available. Hovering over it explains why the feature may be disabled.
- - **Discover Cameras icon** – opens the Settings page to the Discover tab.
+- **Discover Cameras icon** – opens the Settings page to the Discover tab.
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of
   inactivity the newest global summary slowly scrolls across the top in gray text.
@@ -41,6 +41,7 @@ Interactive forms now include additional tooltips:
 - **Captions** – upload and filter controls have descriptive titles.
 - **Danger Mode** – the checkbox, save button and modal controls all include tooltips.
 - **Live video player** – tooltip now refreshes with the full caption as it updates.
+- **Group selector** – choose a group on the live page. Selecting one reveals a second dropdown for cameras and syncs with the navigation bar.
 - **Info icon** – toggles camera metadata on the live page.
 - **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
 


### PR DESCRIPTION
## Summary
- split group selection from camera selection on the live page
- keep dropdowns synced with the navigation bar
- document new group selector

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842fa7e81d0833383eb5b9e6d9f0e15