### PR TITLE
Fix build env

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.11"
     - name: Cache pip
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
## Summary
- use Python 3.11 in CI to avoid failures

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430a21faf483339049e53e34154a6a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow to use Python 3.11 instead of 3.12 for automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->