### PR TITLE
Fix slider declaration collision

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -602,22 +602,22 @@ export async function loadTemplates() {
     if (isIndexPage) {
       window.addEventListener("resize", updateGridLayout);
     }
+
+    const sliderEl = document.getElementById("grid-width-slider");
     if (window.updateSliderLimits) {
       window.updateSliderLimits();
-      const slider = document.getElementById("grid-width-slider");
-      if (slider) {
-        slider.value = slider.min;
-        slider.dispatchEvent(new Event("input"));
+      if (sliderEl) {
+        sliderEl.value = sliderEl.min;
+        sliderEl.dispatchEvent(new Event("input"));
       }
-    } else {
-      const slider = document.getElementById("grid-width-slider");
-      if (slider) slider.dispatchEvent(new Event("input"));
+    } else if (sliderEl) {
+      sliderEl.dispatchEvent(new Event("input"));
     }
     updateHumanizedTimes();
     window.dispatchEvent(
       new CustomEvent("templatesLoaded", { detail: { count: templateCount } }),
     );
-    applyCaptionVisibility(parseFloat(slider?.value || "0"));
+    applyCaptionVisibility(parseFloat(sliderEl?.value || "0"));
   } catch (error) {
     console.error("Error loading templates:", error);
     const errorMsg =


### PR DESCRIPTION
## Summary
- avoid redeclaring the `slider` constant in `templates.js`

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684329b23278833395552122509ab5ca