### PR TITLE
Fix slider redeclaration in templates.js

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -602,16 +602,15 @@ export async function loadTemplates() {
     if (isIndexPage) {
       window.addEventListener("resize", updateGridLayout);
     }
+    const slider = document.getElementById("grid-width-slider");
     if (window.updateSliderLimits) {
       window.updateSliderLimits();
-      const slider = document.getElementById("grid-width-slider");
       if (slider) {
         slider.value = slider.min;
         slider.dispatchEvent(new Event("input"));
       }
-    } else {
-      const slider = document.getElementById("grid-width-slider");
-      if (slider) slider.dispatchEvent(new Event("input"));
+    } else if (slider) {
+      slider.dispatchEvent(new Event("input"));
     }
     updateHumanizedTimes();
     window.dispatchEvent(


### PR DESCRIPTION
## Summary
- avoid redeclaring `slider` in `loadTemplates` which caused a syntax error

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432a97dcbc8333bb8df3f7fb4a84bb