### PR TITLE
Remove redundant metadata from template view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -390,8 +390,6 @@ function updateTemplateDetails() {
   templateDetailsContainer.style.display = "block";
   templateDetailsContainer.innerHTML = `
         <div>
-            <strong>Last Screenshot:</strong> ${details.last_screenshot_time || "N/A"}<br/>
-            <strong>Last Video:</strong> ${details.last_video_time || "N/A"}<br/>
             <strong>Last Caption:</strong> ${details.last_caption || "N/A"}<br/>
             ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ""}
             ${details.capture_failed ? "<strong>Capture Failed</strong><br/>" : ""}

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -432,8 +432,6 @@ function changeCamera() {
             templateDetailsContainer.style.display = 'block';
             templateDetailsContainer.innerHTML = `
                 <div>
-                    <strong>Last Screenshot:</strong> ${details.last_screenshot_time || 'N/A'}<br/>
-                    <strong>Last Video:</strong> ${details.last_video_time || 'N/A'}<br/>
                     <strong>Last Caption:</strong> ${details.last_caption || 'N/A'}<br/>
                     ${details.offline_since ? `<strong>Offline Since:</strong> ${details.offline_since}<br/>` : ''}
                     ${details.capture_failed ? '<strong>Capture Failed</strong><br/>' : ''}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -119,8 +119,6 @@ function updateVideo(templateName) {
 
     <div id="camera-metadata">
         <ul>
-            <li><strong>Last Screenshot:</strong> {{ template_details.last_screenshot_time }}</li>
-            <li><strong>Last Video:</strong> {{ template_details.last_video_time }}</li>
             <li><strong>Last Caption:</strong> {{ template_details.last_caption }}</li>
             <li><strong>Caption Time:</strong> {{ template_details.last_caption_time }}</li>
             {% if template_details.offline_since %}


### PR DESCRIPTION
## Summary
- clean up the bottom metadata in template details
- remove `Last Screenshot`/`Last Video` lines from the live view overlay

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684333cdae74833385bab17c6155c52e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the display of "Last Screenshot" and "Last Video" timestamps from the template details sections in the live view and camera metadata panels. Only relevant details such as "Last Caption," "Offline Since," and "Capture Failed" are now shown. No other visible changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->