### PR TITLE
Improve live view backoff

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -338,6 +338,11 @@ LIVE_FALLBACK_FPS = int(get_setting("LIVE_FALLBACK_FPS", 1))
 # not wasted.
 LIVE_MAX_FAILURES = int(get_setting("LIVE_MAX_FAILURES", 10))
 
+# Maximum seconds to wait between live stream restarts when ffmpeg exits
+# without producing any output. The delay increases exponentially on each
+# consecutive failure up to this limit.
+LIVE_MAX_RETRY_DELAY = int(get_setting("LIVE_MAX_RETRY_DELAY", 30))
+
 # Duration of the caption chyron scroll in seconds. Set to 0 to disable
 # the chyron entirely. When enabled, the same value controls how long
 # the banner remains visible after a caption arrives.

--- a/app/routes.py
+++ b/app/routes.py
@@ -546,7 +546,11 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
                 logging.warning("ffmpeg exited with %s, retrying", process.returncode)
                 last_log = now
 
-        time.sleep(2)
+        # Slow down retries when ffmpeg repeatedly fails to avoid excessive
+        # process churn. The delay doubles after each failure up to the
+        # configured maximum but resets to two seconds once a chunk is sent.
+        delay = 2 if failures == 0 else min(2**failures, config.LIVE_MAX_RETRY_DELAY)
+        time.sleep(delay)
 
 
 login_attempts = {}

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -118,6 +118,7 @@ Settings controlling how frames are captured from video sources:
 - `ANALYZE_DURATION_OTHER` – analyzeduration for other protocols (default `20M`)
 - `LIVE_FALLBACK_FPS` – still-frame refresh rate when live video fails (default `1`)
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
+- `LIVE_MAX_RETRY_DELAY` – maximum seconds between live stream retries (default `30`)
 - `CHYRON_SPEED` – seconds the caption chyron scrolls; set to `0` to disable (default `0`)
 - `HEALTH_STATUS_ALWAYS_VISIBLE` – keep the System Performance icon visible even when the system is healthy (default `False`)
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -207,6 +207,8 @@ snapshot image rather than a true video stream.
 - HTTP errors like `403 Forbidden` or repeated ffmpeg timeouts typically mean
   the stream is blocked. Verify the URL is accessible from the host running
   Glimpser and check for required credentials or firewall rules.
+- When ffmpeg repeatedly fails, retries now back off exponentially up to
+  `LIVE_MAX_RETRY_DELAY` seconds so the server isn't hammered.
 - Some cameras reject ffmpeg if it does not send browser-style headers. The
   live stream now includes the configured `UA`, `referer` and `origin` headers.
   Adjust these settings if your camera expects a specific user agent.


### PR DESCRIPTION
## Summary
- add `LIVE_MAX_RETRY_DELAY` config option
- slow down `ffmpeg` retries with exponential backoff
- document new setting and behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433459bea0833386486cc14da607ca