### PR TITLE
Improve discovery error messages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2904,10 +2904,15 @@ def init_routes(app: Flask) -> None:
                 )
 
             def run():
-                camera_discovery.discover_cameras(
-                    progress_callback=progress, subnets=nets
-                )
-                q.put({"done": True})
+                try:
+                    camera_discovery.discover_cameras(
+                        progress_callback=progress, subnets=nets
+                    )
+                except Exception as e:  # pragma: no cover - network
+                    logging.exception("discovery scan failed: %s", e)
+                    q.put({"error": str(e)})
+                finally:
+                    q.put({"done": True})
 
             thread = Thread(target=run, daemon=True)
             thread.start()

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -219,6 +219,13 @@ if (button) {
         let plan = [];
         source.onmessage = (event) => {
             const data = JSON.parse(event.data);
+            if (data.error) {
+                console.error('Discovery error', data.error);
+                msg.textContent = `Error discovering cameras: ${data.error}`;
+                progress.style.display = 'none';
+                source.close();
+                return;
+            }
             if (data.total) {
                 progress.max = 100;
                 progress.value = 0;
@@ -250,8 +257,8 @@ if (button) {
             }
         };
         source.onerror = (e) => {
-            console.error('Discovery error', e);
-            msg.textContent = 'Error discovering cameras';
+            console.error('Discovery connection error', e);
+            msg.textContent = `Error discovering cameras: ${e?.message || e}`;
             progress.style.display = 'none';
             source.close();
         };

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -37,6 +37,11 @@ An optional CIDR can be supplied via the new input field to restrict discovery t
 
 During the scan you will see messages like `Scanning onvif (3 found)...`. The stage name shows which discovery method just finished, while the number in parentheses reflects how many cameras have been detected so far.
 
+If a discovery step raises an exception, the stream now includes an `error` field
+containing the message. The Discover page displays this text after the generic
+"Error discovering cameras" notice so you can quickly identify what failed
+without digging through log files.
+
 ## Camera scanning logic
 
 The discovery code combines multiple approaches:


### PR DESCRIPTION
## Summary
- send discovery scan errors to the client
- display detailed errors on the Discover tab
- document error reporting in camera discovery docs

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433f0ba44c8333889431d0e59e0825