### PR TITLE
Fix stream.png placeholder issue

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1520,6 +1520,8 @@ def init_routes(app: Flask) -> None:
                 except OSError:
                     # File might have been removed between glob and stat
                     continue
+                if not screenshots._is_valid_png(f):
+                    continue
                 files_with_mtime.append((f, mtime))
             if not files_with_mtime:
                 continue
@@ -1537,12 +1539,22 @@ def init_routes(app: Flask) -> None:
         last_time = time.time()
         last_shot = most_recent_file
 
-        if os.path.exists(most_recent_file):
+        if os.path.exists(most_recent_file) and screenshots._is_valid_png(
+            most_recent_file
+        ):
             return send_file(most_recent_file)
-        if last_file and os.path.exists(last_file):
+        if (
+            last_file
+            and os.path.exists(last_file)
+            and screenshots._is_valid_png(last_file)
+        ):
             last_shot = last_file
             return send_file(last_file)  # better than nothing
-        if last_shot and os.path.exists(last_shot):
+        if (
+            last_shot
+            and os.path.exists(last_shot)
+            and screenshots._is_valid_png(last_shot)
+        ):
             return send_file(last_shot)
         abort(404)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,6 +232,18 @@ error* because the response is missing or invalid.
 - When a clip fails to load, the live player now skips to the next camera
   instead of stalling on the error message.
 
+### Problem: "All" PNG stream always shows "No screenshot available"
+
+The live viewer requests `/stream.png` to display the most recent frame from any
+camera. If the newest PNG is corrupt or missing the placeholder image is shown
+instead.
+
+**Solution:**
+- Ensure each camera is capturing screenshots in `data/screenshots`.
+- Remove any zero-byte or invalid PNG files. Glimpser now skips corrupt images
+  when choosing the latest shot.
+- Use `/take_screenshot/<camera>` to capture a fresh frame if needed.
+
 ## 12. Layout Issues
 
 ### Problem: Buttons at the bottom of the Templates page are hidden

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -67,6 +67,18 @@ class TestStreamPngRoute(unittest.TestCase):
             resp = self.client.get("/stream.png")
         self.assertEqual(resp.status_code, 200)
 
+    def test_skips_invalid_png(self):
+        self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
+        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        invalid = os.path.join(img_dir, "cam1_bad.png")
+        with open(invalid, "wb") as fh:
+            fh.write(b"not an image")
+        valid = os.path.join(img_dir, "cam1_good.png")
+        Image.new("RGB", (1, 1)).save(valid)
+        resp = self.client.get("/stream.png")
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(len(resp.data), 0)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary
- skip corrupt PNG files when locating the most recent screenshot
- mention fix in troubleshooting guide
- test invalid PNG case

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433fde09608333a52ab7a55350a7d9