### PR TITLE
Fix grid sizing on group page

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -35,10 +35,14 @@ export function initTemplates() {
         const templateCount =
           templateList?.querySelectorAll(".templateDiv").length || 1;
 
-        // Minimum width needed to fit all tiles across the page
-        const widthForColumns = Math.ceil(window.innerWidth / templateCount);
+        const gap = parseFloat(getComputedStyle(templateList).gap || "0") || 0;
 
-        // Minimum width needed so combined rows fill the screen vertically
+        // Maximum width to fit all tiles across the page
+        const widthForColumns = Math.floor(
+          (window.innerWidth - gap * (templateCount - 1)) / templateCount,
+        );
+
+        // Maximum width so combined rows fill the screen vertically
         const aspectRatio = 9 / 16;
         const widthForHeight = Math.sqrt(
           (window.innerHeight * window.innerWidth) /
@@ -51,7 +55,7 @@ export function initTemplates() {
           50,
           Math.min(
             slider.max,
-            Math.ceil(Math.max(widthForColumns, widthForHeight)),
+            Math.floor(Math.min(widthForColumns, widthForHeight)),
           ),
         );
 


### PR DESCRIPTION
## Summary
- update template slider limit calculations so all tiles fit at minimum size

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6843459bd9f48333835d725ea86756c0