### PR TITLE
Remove redundant FFmpeg codec options

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -275,8 +275,6 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
                     "+igndts+ignidx+genpts+fastseek+discardcorrupt",
                     "-an",
                     "-dn",
-                    "-c:v",
-                    "h264",
                     "-i",
                     os.path.abspath(in_process_video),
                     "-i",
@@ -485,8 +483,6 @@ def compile_to_video(camera_path, video_path) -> bool:
                 "concat",
                 "-r",
                 "25",  # for some reason the standard for png?
-                "-c:v",
-                "png",
                 "-use_wallclock_as_timestamps",
                 "1",
                 "-err_detect",

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -23,3 +23,7 @@ and the operation is aborted so corrupted videos do not linger.
 Videos automatically rotate into a `final_*.mp4` once roughly 600 frames
 (about 24 seconds) accumulate. A small tolerance in the duration check prevents
 rounding errors from delaying rotation.
+
+The FFmpeg commands have been simplified so that each output is encoded only
+once. Redundant `-c:v` parameters were removed to prevent unnecessary
+transcoding, which keeps processing time minimal.


### PR DESCRIPTION
## Summary
- prune unnecessary `-c:v` flags in `video_archiver`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684345f53e80833385139e9f3ef7893f