### PR TITLE
Fix mobile overflow issue

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -442,7 +442,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -628,6 +628,7 @@ nav a.active {
   margin-left: 10px;
   flex-grow: 1;
   cursor: pointer;
+  max-width: 100%;
 }
 
 .caption-chyron.show {
@@ -637,6 +638,7 @@ nav a.active {
 .caption-chyron.show span {
   display: inline-block;
   padding-left: 100%;
+  min-width: 100%;
   /* Duration comes from the CSS variable; 0 disables animation */
   animation: chyron-scroll var(--chyron-speed) linear infinite;
 }
@@ -825,17 +827,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- format test file with black
- prevent caption chyron from exceeding screen width on mobile

## Testing
- `flake8`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434ddf15b483338cd36f1a09376d87