### PR TITLE
Add input validation for settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Footer warns when a newer release is available
 - Stream error overlay distinguishes network and unsupported format errors
 - Sortable KPI table on captions page with filtering
+- Input validation for numeric settings on the configuration page
 
 ### Changed
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -109,7 +109,11 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
-from app.utils.validators import validate_template_name, validate_update_data
+from app.utils.validators import (
+    validate_template_name,
+    validate_update_data,
+    SETTING_VALIDATORS,
+)
 from app.utils.profiling import profile_route, get_latency_stats
 from scripts.update_chrome_shortcut import (
     update_chrome_shortcuts,
@@ -2708,6 +2712,14 @@ def init_routes(app: Flask) -> None:
                     if name in SETTINGS_CHOICES:
                         update_setting(name, value)
                         continue
+
+                    validator = SETTING_VALIDATORS.get(name)
+                    if validator:
+                        checked = validator(value)
+                        if checked is None:
+                            flash(f"Invalid value for {name}", "error")
+                            return redirect(url_for("settings")), 400
+                        value = checked
 
                     update_setting(name, value)
             return redirect(url_for("settings"))

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -3,6 +3,7 @@
 from werkzeug.utils import secure_filename
 import re
 from urllib.parse import urlparse
+from typing import Callable
 
 
 def validate_proxy(proxy: str | None) -> str | None:
@@ -199,3 +200,38 @@ def validate_update_data(data: dict) -> dict:
         sanitized[key] = _to_bool(data.get(key, False))
 
     return sanitized
+
+
+# Validators for individual settings used on the Settings page.
+# Each function returns a sanitized string or ``None`` when the
+# provided value is invalid.
+
+
+def _validate_int_range(value: str | None, minimum: int, maximum: int) -> str | None:
+    try:
+        ivalue = int(value)
+    except (TypeError, ValueError):
+        return None
+    if ivalue < minimum or ivalue > maximum:
+        return None
+    return str(ivalue)
+
+
+def _validate_choice(value: str | None, choices: list[str]) -> str | None:
+    if value in choices:
+        return value
+    return None
+
+
+ALLOWED_LOG_LEVELS = ["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"]
+
+SETTING_VALIDATORS: dict[str, Callable[[str], str | None]] = {
+    "PORT": lambda v: _validate_int_range(v, 1024, 65535),
+    "EMAIL_SMTP_PORT": lambda v: _validate_int_range(v, 1, 65535),
+    "MAX_WORKERS": lambda v: _validate_int_range(v, 1, 128),
+    "LIVE_FALLBACK_FPS": lambda v: _validate_int_range(v, 1, 60),
+    "LIVE_MAX_FAILURES": lambda v: _validate_int_range(v, 1, 100),
+    "SESSION_TIMEOUT_MINUTES": lambda v: _validate_int_range(v, 1, 1440),
+    "LOG_LEVEL": lambda v: _validate_choice(v, ALLOWED_LOG_LEVELS),
+    "FLASK_LOG_LEVEL": lambda v: _validate_choice(v, ALLOWED_LOG_LEVELS),
+}

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -23,3 +23,5 @@ Focusing any input field shows a tooltip on screen with a description pulled fro
 ### Selectable Options
 
 Common settings like `HOST`, `LANG`, `LOG_LEVEL`, and `TZ` now use a single autocomplete field. Typing shows suggestions for common values, but any text can be entered. The `PORT` field enforces non‑privileged ports (1024–65535) to avoid permission errors.
+Worker counts, SMTP ports, and other numeric values also reject out of range
+entries so mistakes surface immediately.

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -167,6 +167,14 @@ class TestSettingsRoute(unittest.TestCase):
             response = self.client.post("/settings", data={"action": "download"})
         self.assertEqual(response.status_code, 302)
 
+    def test_invalid_port_rejected(self):
+        with patch("app.routes.session", {"user_id": 1}), patch(
+            "app.routes.login_required", lambda x: x
+        ):
+            response = self.client.post("/settings", data={"PORT": "80"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIsNone(self._get_value("PORT"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add numeric validators in `validators.py`
- validate form values on `/settings`
- reject invalid ports in tests
- document validation
- note validation in changelog

## Testing
- `black app/utils/validators.py app/routes.py tests/test_settings_route.py`
- `flake8 app/utils/validators.py app/routes.py tests/test_settings_route.py`
- `pytest -q tests/test_settings_route.py`

------
https://chatgpt.com/codex/tasks/task_e_684361b7b984833382e936bf2060a603