### PR TITLE
Fix alerts configuration tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -378,6 +378,9 @@ EMAIL_PASSWORD = get_setting("EMAIL_PASSWORD", "")
 TWILIO_SID = get_setting("TWILIO_SID", "")
 TWILIO_TOKEN = get_setting("TWILIO_TOKEN", "")
 TWILIO_NUMBER = get_setting("TWILIO_NUMBER", "")
+# Allows specifying a different sending number; defaults to TWILIO_NUMBER for
+# backward compatibility.
+TWILIO_FROM_NUMBER = get_setting("TWILIO_FROM_NUMBER", TWILIO_NUMBER)
 
 # Common Alerting Protocol settings
 CAP_ENDPOINT = get_setting("CAP_ENDPOINT", "")

--- a/app/utils/email_alerts.py
+++ b/app/utils/email_alerts.py
@@ -44,7 +44,12 @@ def send_email_alert(subject, body):
     message.attach(MIMEText(body, "plain"))
 
     try:
-        with smtplib.SMTP(EMAIL_SMTP_SERVER, int(EMAIL_SMTP_PORT)) as server:
+        # Use a short timeout so network issues fail fast during alerting
+        with smtplib.SMTP(
+            EMAIL_SMTP_SERVER,
+            int(EMAIL_SMTP_PORT),
+            timeout=5,
+        ) as server:
             if EMAIL_USE_TLS.lower() == "true":
                 server.starttls()
             server.login(EMAIL_USERNAME, EMAIL_PASSWORD)

--- a/app/utils/sms_alerts.py
+++ b/app/utils/sms_alerts.py
@@ -2,7 +2,12 @@
 
 import logging
 
-from app.config import TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER
+from app.config import (
+    TWILIO_SID,
+    TWILIO_TOKEN,
+    TWILIO_NUMBER,
+    TWILIO_FROM_NUMBER,
+)
 
 
 def send_sms_alert(message):
@@ -28,7 +33,8 @@ def send_sms_alert(message):
 
     try:
         client = Client(TWILIO_SID, TWILIO_TOKEN)
-        client.messages.create(body=message, from_=TWILIO_NUMBER, to=TWILIO_NUMBER)
+        from_number = TWILIO_FROM_NUMBER or TWILIO_NUMBER
+        client.messages.create(body=message, from_=from_number, to=TWILIO_NUMBER)
         logging.info("SMS alert sent successfully")
     except Exception as exc:
         logging.error("Error sending SMS alert: %s", exc)

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -96,6 +96,7 @@ Configure these values to enable Twilio SMS alerts:
 - `TWILIO_SID` – your Twilio account SID
 - `TWILIO_TOKEN` – your Twilio auth token
 - `TWILIO_NUMBER` – phone number that receives alerts
+- `TWILIO_FROM_NUMBER` – optional number used to send messages
 
 ## CAP Settings
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,10 @@ Set the `GLIMPSER_DATABASE_PATH` environment variable before starting the app. T
 Ensure the `EMAIL_ENABLED` setting is set to `True` and configure the remaining email settings (SMTP server, username, password). These options can be adjusted from the web interface or the configuration file.
 
 ### How do I enable SMS alerts?
-Set `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` in the configuration. When these values are present, Glimpser will send important alerts via text message as well as email.
+Configure `TWILIO_SID`, `TWILIO_TOKEN`, and `TWILIO_NUMBER` for the destination phone.
+If your Twilio account uses a different sending number, set `TWILIO_FROM_NUMBER`
+as well. When these values are present, Glimpser will send important alerts via
+text message as well as email.
 ### Why is the thumbnail size slider so narrow?
 The slider automatically adjusts to the current browser width and scales thumbnails vertically as well as horizontally. Thumbnails now resize by changing their width and height directly, so the entire frame stays visible. Sizes are capped around 1080&nbsp;px high to keep previews from slowing the page. If the control still feels cramped, widen the window or tweak the CSS in `style.css` for your layout.
 

--- a/tests/test_email_alerts.py
+++ b/tests/test_email_alerts.py
@@ -48,7 +48,7 @@ class TestEmailAlerts(unittest.TestCase):
             "app.utils.email_alerts.EMAIL_PASSWORD", "pass"
         ):
             send_email_alert("Subject", "Body")
-            mock_smtp.assert_called_once_with("smtp.example.com", 587)
+            mock_smtp.assert_called_once_with("smtp.example.com", 587, timeout=5)
             smtp_mock.starttls.assert_called_once()
             smtp_mock.login.assert_called_once_with("user", "pass")
             smtp_mock.sendmail.assert_called_once()

--- a/tests/test_sms_alerts.py
+++ b/tests/test_sms_alerts.py
@@ -33,11 +33,14 @@ class TestSMSAlerts(unittest.TestCase):
         ):
             with patch("app.utils.sms_alerts.TWILIO_SID", "sid"), patch(
                 "app.utils.sms_alerts.TWILIO_TOKEN", "token"
-            ), patch("app.utils.sms_alerts.TWILIO_NUMBER", "+123"):
+            ), patch("app.utils.sms_alerts.TWILIO_NUMBER", "+123"), patch(
+                "app.utils.sms_alerts.TWILIO_FROM_NUMBER",
+                "+999",
+            ):
                 send_sms_alert("Body")
                 mock_client_class.assert_called_once_with("sid", "token")
                 client_instance.messages.create.assert_called_once_with(
-                    body="Body", from_="+123", to="+123"
+                    body="Body", from_="+999", to="+123"
                 )
 
     def test_sms_alert_wrapper(self):


### PR DESCRIPTION
## Summary
- add SMTP timeout when sending email alerts
- support `TWILIO_FROM_NUMBER` for SMS alerts
- document new SMS option
- update alert tests

## Testing
- `flake8 app/utils/email_alerts.py app/utils/sms_alerts.py app/config.py tests/test_email_alerts.py tests/test_sms_alerts.py`
- `pytest -q`
- `mkdocs build --strict --site-dir site`


------
https://chatgpt.com/codex/tasks/task_e_6843627d33b083339553f289d5735f74