### PR TITLE
Fix footer link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped scikit-image to 0.25.0
 - Bumped numpy to 1.26.0
 - Updated default VERSION to 0.2.7 for footer display
+- The footer name now links to https://glimpser.net
 - Bulk tools menu is expanded by default on the captions page
 - Enumerated settings use a single autocomplete field instead of a dropdown and separate text box
 

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -9,7 +9,7 @@
             -->
         </div>
         <nav class="footer-nav">
-            <span class="footer-copy">&copy; <span id="current-year"></span> Glimpser. All rights reserved.</span>
+            <span class="footer-copy">&copy; <span id="current-year"></span> <a href="https://glimpser.net" target="_blank" title="Glimpser website">Glimpser</a>. All rights reserved.</span>
             <a href='https://github.com/KristopherKubicki/glimpser/releases'>v{{VERSION}}{% if VERSION_OUTDATED %}<span title="Update available">&#9888;</span>{% endif %}</a>
             <a href="/help" title="View help documentation">Help</a>
             <a href="https://glimpser.net" target="_blank" title="Project website">About</a>


### PR DESCRIPTION
## Summary
- update footer to link Glimpser name to glimpser.net
- note change in changelog

## Testing
- `black .`
- `flake8`
- `npm run format`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438e1168f4833398edb76e3bc37775