### PR TITLE
Fix mkdocs build config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,3 +44,16 @@ nav:
       - Log Cleaner: log_cleaner.md
       - Video Archiver: video_archiver.md
       - Governance: governance.md
+exclude_docs: |
+  border_legend.md
+  caption_overlay_toggle.md
+  chatbot.md
+  ci_checks.md
+  jog_shuttle.md
+  live_all.md
+  live_scrub.md
+  mcp_integration.md
+  onboarding.md
+  scorecard.md
+  startup_tips.md
+  style_guide.md

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- fix `exclude_docs` syntax so MkDocs stops complaining
- run black on `tests/test_clock_route.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684390569d3c83339649bf50386cee5c