### PR TITLE
feat: highlight danger mode section

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2728,6 +2728,7 @@ def init_routes(app: Flask) -> None:
         metrics = scheduling.get_system_metrics()
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
+        danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
@@ -2737,6 +2738,7 @@ def init_routes(app: Flask) -> None:
             last_summary=last_summary,
             choices=SETTINGS_CHOICES,
             page_title="Settings",
+            danger_enabled=danger_enabled,
         )
 
     # Retained for backwards compatibility; redirect to the health endpoint.

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -364,6 +364,8 @@ video:hover + .play-icon {
   --table-row-alt-bg-color: #1a1a1a;
   --table-hover-bg-color: #333;
   --table-border-color: #444;
+  --danger-on-border: #ff4c4c;
+  --danger-off-border: #b84c4c;
   /* Duration for the chyron scroll animation */
   --chyron-speed: 240s;
   /* Typography */
@@ -382,6 +384,8 @@ video:hover + .play-icon {
     --table-row-alt-bg-color: #fafafa;
     --table-hover-bg-color: #e0e0e0;
     --table-border-color: #ddd;
+    --danger-on-border: #ff4c4c;
+    --danger-off-border: #cc6666;
   }
 }
 
@@ -426,6 +430,17 @@ body.light-mode {
   border: 2px solid red;
 }
 
+.danger-section {
+  border: 2px solid var(--danger-off-border);
+  padding: 10px;
+  margin-top: 10px;
+  border-radius: 5px;
+}
+
+.danger-section.active {
+  border-color: var(--danger-on-border);
+}
+
 .caption-overlay {
   position: absolute;
   left: 0;
@@ -442,7 +457,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +840,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -193,20 +193,11 @@ content %}
             <input type="file" name="file" accept=".json" title="Select configuration file to upload">
             <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
 
-            <h3>Danger Mode</h3>
-            <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
-
-
-      <h3>Danger Mode</h3>
-      <button
-        type="submit"
-        name="action"
-        value="update_shortcut"
-        title="Update Chrome shortcuts for Danger mode"
-      >
-        Update Chrome Shortcut
-      </button>
-    </div>
+            <div id="danger-section" class="danger-section{% if danger_enabled %} active{% endif %}">
+                <h3>Danger Mode</h3>
+                <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
+            </div>
+        </div>
 
     <input
       type="hidden"

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -7,7 +7,7 @@ Danger mode allows Glimpser to leverage your existing Chrome session for capturi
 1. **Launch Chrome with the debugging port open.** The exact command varies by platform:
    - **Linux**: `google-chrome --remote-debugging-port=9222`
    - **macOS**: `open /Applications/Google\ Chrome.app --args --remote-debugging-port=9222`
-   - **Windows**: modify your Chrome shortcut to append `--remote-debugging-port=9222` to the *Target* field.
+   - **Windows**: modify your Chrome shortcut to append `--remote-debugging-port=9222` to the _Target_ field.
 2. Leave this Chrome window running. Glimpser will connect to the existing instance when the port is detected.
 
 If Chrome is not started with this flag, Danger mode will be unavailable.
@@ -17,8 +17,15 @@ If Chrome is not started with this flag, Danger mode will be unavailable.
 After Chrome updates, shortcuts may revert to their original command line. Two approaches can help keep the debug port enabled:
 
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
-- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the *Update Chrome Shortcut* button on the Settings page or the *Patch Chrome Shortcuts* button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
+- **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the _Update Chrome Shortcut_ button on the Settings page or the _Patch Chrome Shortcuts_ button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
 - **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
+
+Windows stores Start Menu shortcuts in two locations:
+
+- `%APPDATA%\Microsoft\Windows\Start Menu\Programs`
+- `%ProgramData%\Microsoft\Windows\Start Menu\Programs`
+
+The helper script scans these folders (and your Desktop) for `*.lnk` files named `chrome` and adds the flag if missing.
 
 After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 


### PR DESCRIPTION
## Summary
- mark Danger Mode block on Settings page with a colored border
- expose Danger Mode state to the template
- add CSS for the border colors
- document default Windows shortcut locations

## Testing
- `npm run format:js:write`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843900b39908333a8140b0fb96612fe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visual highlighting for the "Danger Mode" section in settings, with dynamic border colors indicating its status.

- **Style**
  - Introduced new CSS variables and classes to support "danger" state styling.

- **Documentation**
  - Updated instructions for managing Chrome shortcuts and clarified where Windows Start Menu shortcuts are stored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->