### PR TITLE
Remove exclude_docs usage

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,2 @@
+- Avoid custom mkdocs options like `exclude_docs`.
+- Keep navigation entries updated directly in `mkdocs.yml`.


### PR DESCRIPTION
## Summary
- document not to use `exclude_docs` in mkdocs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843a0cd800c833386a20e8466c1565b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidelines advising against using custom MkDocs options like `exclude_docs`.
  - Provided instructions to maintain navigation entries by updating the `mkdocs.yml` configuration file directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->