### PR TITLE
Update danger mode section in settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2728,6 +2728,7 @@ def init_routes(app: Flask) -> None:
         metrics = scheduling.get_system_metrics()
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
+        danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
@@ -2737,6 +2738,7 @@ def init_routes(app: Flask) -> None:
             last_summary=last_summary,
             choices=SETTINGS_CHOICES,
             page_title="Settings",
+            danger_enabled=danger_enabled,
         )
 
     # Retained for backwards compatibility; redirect to the health endpoint.

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -364,6 +364,8 @@ video:hover + .play-icon {
   --table-row-alt-bg-color: #1a1a1a;
   --table-hover-bg-color: #333;
   --table-border-color: #444;
+  --danger-border-off: #b94a48;
+  --danger-border-on: #ff2d2d;
   /* Duration for the chyron scroll animation */
   --chyron-speed: 240s;
   /* Typography */
@@ -442,7 +444,7 @@ body.light-mode {
 }
 
 .hide-captions .caption-overlay {
-    display: none;
+  display: none;
 }
 
 #status-legend {
@@ -825,17 +827,17 @@ a {
 }
 
 .clock-overlay {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-    z-index: 10;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
 }
 
 .digital-clock {
-    font-size: 14px;
-    line-height: 25px;
-    text-align: center;
-    color: var(--text-color);
+  font-size: 14px;
+  line-height: 25px;
+  text-align: center;
+  color: var(--text-color);
 }
 
 .clock-face {
@@ -1721,6 +1723,21 @@ details > summary {
 
 .tab-content.active {
   display: block;
+}
+
+/* Danger Mode highlight on settings page */
+.danger-section {
+  border: 2px solid var(--danger-border-off);
+  padding: 10px;
+  margin-top: 10px;
+}
+
+.danger-section.on {
+  border-color: var(--danger-border-on);
+}
+
+.danger-section.off {
+  border-color: var(--danger-border-off);
 }
 
 #log-connection-status {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -193,19 +193,17 @@ content %}
             <input type="file" name="file" accept=".json" title="Select configuration file to upload">
             <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
 
-            <h3>Danger Mode</h3>
-            <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
-
-
-      <h3>Danger Mode</h3>
-      <button
-        type="submit"
-        name="action"
-        value="update_shortcut"
-        title="Update Chrome shortcuts for Danger mode"
-      >
-        Update Chrome Shortcut
-      </button>
+            <div class="danger-section {{ 'on' if danger_enabled else 'off' }}">
+                <h3>Danger Mode</h3>
+                <p>
+                    Shortcuts are typically located in
+                    <code>%USERPROFILE%\Desktop</code> and
+                    <code>%APPDATA%\Microsoft\Windows\Start Menu\Programs</code>.
+                    You can also run
+                    <code>python scripts/update_chrome_shortcut.py</code> manually.
+                </p>
+                <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
+            </div>
     </div>
 
     <input

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -7,7 +7,10 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Add New Setting** – quickly create additional key/value pairs.
 - **Current Settings** – edit existing values or delete them. Tabs switch between setting groups and the **Management** tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
-- **Danger Mode** – update Chrome shortcuts with the required flags.
+- **Danger Mode** – update Chrome shortcuts with the required flags. The page
+  lists typical paths such as `%USERPROFILE%\Desktop` and
+  `%APPDATA%\Microsoft\Windows\Start Menu\Programs` so you know which
+  shortcuts are patched.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.


### PR DESCRIPTION
## Summary
- highlight Danger Mode on the management tab with red border
- show typical shortcut paths and script reference
- expose danger state to template
- document updated Danger Mode section

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844160c334483339b795b2e5a32b845