### PR TITLE
Clarify watchdog exit and restart guidance

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -3,6 +3,7 @@
 This guide provides a high-level look at Glimpser's core components and how they interact.
 
 ## Flask Application Initialization (`app/__init__.py`)
+
 - Creates the Flask application instance.
 - Loads configuration values and sets up logging.
 - Initializes routes from `app/routes.py`.
@@ -10,15 +11,22 @@ This guide provides a high-level look at Glimpser's core components and how they
   The watchdog performs health checks and only triggers a restart after a
   configurable number of failures. Tune `WATCHDOG_FAILURE_THRESHOLD`,
   `WATCHDOG_RESTART_COOLDOWN`, and `WATCHDOG_MAX_FILE_HANDLES` to adjust
-  this behaviour. Requests to `/health` include the configured API key so
-  the check succeeds even when login is required.
+  this behaviour. When repeated failures occur the watchdog calls
+  `sys.exit(1)`, so run Glimpser under a supervisor that automatically
+  restarts the process. Requests to `/health` include the configured API
+  key so the check succeeds even when login is required. See the
+  `glimpser.service` snippet in `build_packages.sh` or the `restart`
+  option in `docker-compose.yaml` for examples of how to enable
+  automatic restarts.
 
 ## Configuration Handling (`app/config.py`)
+
 - Loads environment variables and values stored in the database.
 - Exposes settings such as `SECRET_KEY`, database location and retention policy limits.
 - Includes helper functions to back up and restore configuration state.
 
 ## Utility Modules (`app/utils/`)
+
 - Collection of helpers for image processing, database access, notifications and more.
 - Key modules include:
   - `db.py` – SQLAlchemy setup and database initialization.
@@ -28,6 +36,7 @@ This guide provides a high-level look at Glimpser's core components and how they
   - `email_alerts.py`, `sms_alerts.py` and `cap_alerts.py` – sending notifications.
 
 ## Scheduler Jobs (`app/utils/scheduling.py`)
+
 - Uses APScheduler to run periodic tasks.
 - Jobs include crawler scheduling, video archiving, discovery and summarization.
 - Tasks run asynchronously so functions like `schedule_discovery` and `schedule_summarization` never block the caller.
@@ -35,19 +44,21 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Stale crawler jobs are removed when templates are updated.
 
 ## How Components Fit Together
+
 ```
  Client Request ---> Routes (app/routes.py) ----> Models (app/models/) ----> Database
                            |                           |
                            v                           v
                      Utility Functions ----> Scheduler Jobs / Background Tasks
 ```
+
 - Routes handle incoming API or web requests.
 - Models define the database schema.
 - Utility functions perform processing and are called by both routes and scheduled jobs.
 - Background tasks run outside request/response cycles to capture data and generate summaries.
 
-
 ## Data Flow from Camera to UI
+
 1. **Camera Source** – Each camera is defined in the database as a template specifying the capture URL and parameters.
 2. **Capture Job** – The scheduler runs `capture_template` jobs that use `screenshots.py` to grab frames or video from the source.
 3. **Database Update** – Captured metadata and any motion events are stored via `db.py` while images are written to `data/screenshots/`.


### PR DESCRIPTION
## Summary
- document watchdog `sys.exit(1)` behaviour
- recommend running under systemd or Docker for automatic restart

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844320cd7048333977ba0b363166ac9