### PR TITLE
Fix log viewer search flood

### DIFF
--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -24,6 +24,7 @@ export function initLogs() {
 
     let eventSource;
     let reconnectTimer;
+    let inputTimer;
 
     function startEventStream() {
       if (eventSource) {
@@ -62,7 +63,9 @@ export function initLogs() {
     });
 
     searchInput.addEventListener("input", () => {
-      startEventStream();
+      clearTimeout(inputTimer);
+      // debounce to avoid excessive stream restarts while typing
+      inputTimer = setTimeout(startEventStream, 300);
     });
 
     levelSelect.addEventListener("change", () => {


### PR DESCRIPTION
## Summary
- debounce log stream restarts when typing in the log search field

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684433bc014483338369bfead589f9aa