### PR TITLE
Optimize SSE log streaming

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2996,10 +2996,12 @@ def init_routes(app: Flask) -> None:
         search = request.args.get("search")
 
         def generate():
-            while True:
-                # Get query parameters for filtering logs
+            last_ts = None
+            last_len = 0
+            heartbeat_interval = 30
+            last_beat = time.time()
 
-                # Read and filter logs from memory
+            while True:
                 logs = read_logs_from_memory(
                     level=level,
                     source=source,
@@ -3008,11 +3010,19 @@ def init_routes(app: Flask) -> None:
                     search=search,
                 )
 
-                # Limit the number of logs sent to improve performance
                 logs = logs[:50]
+                newest = logs[0]["timestamp"] if logs else None
 
-                yield f"data: {json.dumps(logs, default=str)}\n\n"
-                time.sleep(1)  # Send updates every second
+                if newest != last_ts or len(logs) != last_len:
+                    last_ts = newest
+                    last_len = len(logs)
+                    yield f"data: {json.dumps(logs, default=str)}\n\n"
+                    last_beat = time.time()
+                elif time.time() - last_beat >= heartbeat_interval:
+                    yield ": heartbeat\n\n"
+                    last_beat = time.time()
+
+                time.sleep(1)
 
         return Response(generate(), mimetype="text/event-stream")
 

--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -1,3 +1,9 @@
+function escapeHtml(str) {
+  const div = document.createElement("div");
+  div.textContent = String(str);
+  return div.innerHTML;
+}
+
 export function updateTable(logs) {
   const tbody = document.querySelector("#log-table tbody");
   if (!tbody) return;
@@ -5,10 +11,10 @@ export function updateTable(logs) {
   logs.forEach((log) => {
     const row = document.createElement("tr");
     row.innerHTML = `
-            <td data-label="Timestamp">${log.timestamp}</td>
-            <td data-label="Level">${log.level}</td>
-            <td data-label="Source">${log.source}</td>
-            <td data-label="Message">${log.message}</td>
+            <td data-label="Timestamp">${escapeHtml(log.timestamp)}</td>
+            <td data-label="Level">${escapeHtml(log.level)}</td>
+            <td data-label="Source">${escapeHtml(log.source)}</td>
+            <td data-label="Message">${escapeHtml(log.message)}</td>
         `;
     tbody.appendChild(row);
   });

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -159,6 +159,7 @@ Redirects to the *System Status* tab on the Settings page which displays metrics
 **GET /stream_logs**
 
 Streams log records via Server-Sent Events. Optional query parameters `level`, `source`, `start_date`, `end_date`, and `search` allow filtering. The `/logs` page and *System Status* tab use this endpoint for the live log viewer.
+The endpoint only emits new records when they appear and sends a small `heartbeat` comment roughly every 30 seconds so idle connections stay open without unnecessary traffic.
 
 ### 9. List Stored Videos
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -42,6 +42,7 @@ name, last image time, last caption time, any KPI column, or status.
 **GET /stream_logs**
 
 This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the *System Status* tab consume this endpoint to display updates in real time.
+Updates are pushed only when new log lines appear. To keep idle connections alive the server sends a `heartbeat` comment roughly every 30 seconds.
 
 To filter logs by level and message text, you could request:
 


### PR DESCRIPTION
## Summary
- escape log values when populating the log table
- throttle `/stream_logs` to only send updates when new logs arrive and emit a heartbeat comment
- document new streaming behavior

## Testing
- `npm run format:js:write`
- `black app/routes.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684435adc46c83339db09a682c23d144