### PR TITLE
Fix ffmpeg process cleanup in live stream

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -558,27 +558,39 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
     failures = 0
     last_log = 0.0
     while True:
-        process = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        chunk_yielded = False
-
+        process: subprocess.Popen | None = None
         try:
-            while True:
-                chunk = process.stdout.read(1024 * 1024)
-                if not chunk:
-                    break
-                yield chunk
-                chunk_yielded = True
-                if process.poll() is not None:
-                    break
+            process = subprocess.Popen(
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            chunk_yielded = False
+
+            try:
+                while True:
+                    try:
+                        chunk = process.stdout.read(1024 * 1024)
+                    except BrokenPipeError:
+                        raise GeneratorExit
+                    if not chunk:
+                        break
+                    yield chunk
+                    chunk_yielded = True
+                    if process.poll() is not None:
+                        break
+            except GeneratorExit:
+                if process:
+                    process.kill()
+                    process.wait(timeout=1)
+                return
+            finally:
+                if process:
+                    process.kill()
+                    process.wait(timeout=1)
         except GeneratorExit:
-            process.kill()
-            process.wait(timeout=1)
+            if process:
+                process.kill()
+                process.wait(timeout=1)
             return
-        finally:
-            process.kill()
-            process.wait(timeout=1)
 
         if process.returncode == 0:
             return
@@ -2953,7 +2965,7 @@ def init_routes(app: Flask) -> None:
         last_summary = scheduling.get_last_summary_time()
         danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
         cost_summary, total_tokens, total_cost = template_manager.get_llm_cost_summary()
-        
+
         chrome_path = get_chrome_path()
         danger_info = {
             "browser": os.path.basename(chrome_path) if chrome_path else "N/A",
@@ -2962,7 +2974,6 @@ def init_routes(app: Flask) -> None:
             "running": is_chrome_debug_port_open("127.0.0.1", 9222),
         }
 
-    
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,


### PR DESCRIPTION
## Summary
- close ffmpeg subprocess when client disconnects
- handle BrokenPipeError to stop spawning new processes

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684436242d88833390fa52580f066c75