### PR TITLE
Use thread-local webdriver

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -47,6 +47,7 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from webdriver_manager.chrome import ChromeDriverManager
+import threading
 
 try:
     from pynput import mouse, keyboard
@@ -182,15 +183,16 @@ def load_font(size):
 # Global flag to track user activity
 user_active = False
 
-_DRIVER = None
+_driver_local = threading.local()
 
 
 def get_driver(opts):
-    global _DRIVER
-    if _DRIVER is None:
+    driver = getattr(_driver_local, "driver", None)
+    if driver is None:
         service = Service(ChromeDriverManager().install())
-        _DRIVER = webdriver.Chrome(service=service, options=opts)
-    return _DRIVER
+        driver = webdriver.Chrome(service=service, options=opts)
+        _driver_local.driver = driver
+    return driver
 
 
 _session = None
@@ -1984,8 +1986,8 @@ def kill_driver_process(driver):
         logging.error(f"Error killing Chrome process: {e}")
     finally:
         # Ensure future calls create a new driver
-        global _DRIVER
-        _DRIVER = None
+        if hasattr(_driver_local, "driver"):
+            _driver_local.driver = None
 
 
 def launch_headless_chrome(driver_options, version=None):

--- a/docs/driver_pool.md
+++ b/docs/driver_pool.md
@@ -1,0 +1,3 @@
+# Browser Driver Management
+
+Concurrent screenshot jobs previously reused a single global Selenium driver which led to `invalid session id` errors when threads collided. The driver is now stored in `threading.local()` so each thread gets its own browser instance. Every capture function calls `quit()` in a `finally` block and clears the thread-local slot so stale sessions are never reused.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - Camera Discovery: camera_discovery.md
       - Camera Fix: camera_fix.md
       - Capture Process: capture_process.md
+      - Browser Driver Management: driver_pool.md
       - Captions Live Update: captions_live_update.md
       - Floating Navigation Bar: floating_nav.md
       - Command Line Reference: command_line.md
@@ -74,5 +75,3 @@ nav:
       - Scorecard: scorecard.md
       - Startup Tips: startup_tips.md
       - Style Guide: style_guide.md
-
-

--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -30,10 +30,12 @@ class TestHttpSession(unittest.TestCase):
 
 class TestGetDriver(unittest.TestCase):
     def setUp(self):
-        ss._DRIVER = None
+        if hasattr(ss._driver_local, "driver"):
+            ss._driver_local.driver = None
 
     def tearDown(self):
-        ss._DRIVER = None
+        if hasattr(ss._driver_local, "driver"):
+            ss._driver_local.driver = None
 
     def test_driver_cached(self):
         with (


### PR DESCRIPTION
## Summary
- store Chrome driver in `threading.local()`
- reset the thread driver when killing processes
- update tests for the new driver strategy
- describe driver management in docs and add to navigation

## Testing
- `flake8 app/utils/screenshots.py tests/test_screenshots_misc.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443637b2f48333948b13f9e7bb3e90