### PR TITLE
Fix jog shuttle thrash

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -75,6 +75,10 @@ const seekBar = document.getElementById("seek-bar");
 const jogShuttle = document.getElementById("jog-shuttle");
 let jogInterval = null;
 let jogging = false;
+let lastJogEvent = null;
+let jogFrame = null;
+let lastJogSpeed = 0;
+let lastJogDirection = 0;
 let isSeeking = false;
 const groupSelector = document.getElementById("group-selector");
 // Track whether template details are shown. Expose on window so inline
@@ -1053,16 +1057,29 @@ function applyJog(speed, direction) {
   }
 }
 
-function handleJogMove(e) {
-  if (!jogging) return;
+function processJogMove() {
+  if (!lastJogEvent) return;
   const rect = jogShuttle.getBoundingClientRect();
-  const x = e.clientX - rect.left - rect.width / 2;
+  const x = lastJogEvent.clientX - rect.left - rect.width / 2;
   const radius = rect.width / 2;
   const norm = Math.max(-1, Math.min(1, x / radius));
   const level = Math.min(4, Math.floor(Math.abs(norm) * 4));
   const speed = Math.pow(2, level);
   if (speed === 0) return;
-  applyJog(speed, Math.sign(norm));
+  lastJogSpeed = speed;
+  lastJogDirection = Math.sign(norm);
+  applyJog(lastJogSpeed, lastJogDirection);
+}
+
+function handleJogMove(e) {
+  if (!jogging) return;
+  lastJogEvent = e;
+  if (!jogFrame) {
+    jogFrame = requestAnimationFrame(() => {
+      jogFrame = null;
+      processJogMove();
+    });
+  }
 }
 
 function stopJog() {
@@ -1071,17 +1088,19 @@ function stopJog() {
     clearInterval(jogInterval);
     jogInterval = null;
   }
-  video.pause();
+  applyJog(lastJogSpeed, lastJogDirection);
 }
 
 function initJogShuttle() {
   if (!jogShuttle) return;
   jogShuttle.addEventListener("mousedown", (e) => {
     jogging = true;
+    video.pause();
     handleJogMove(e);
   });
   jogShuttle.addEventListener("touchstart", (e) => {
     jogging = true;
+    video.pause();
     handleJogMove(e.touches[0]);
   });
   window.addEventListener("touchmove", (e) => {

--- a/docs/jog_shuttle.md
+++ b/docs/jog_shuttle.md
@@ -3,3 +3,5 @@
 The live viewer offers a jog-shuttle widget for cameras that support video playback. Drag within the circle to scrub forward or backward. The farther you drag from the center the faster playback runs (1x, 2x, 4x and so on). Crossing the center reverses direction. Releasing the control pauses and snaps back to neutral.
 
 The jog-shuttle appears only when an individual camera is selected and the **MP4** or **Loop** source is active. Other sources like MJPG or live streams are not seekable, so the control is hidden.
+
+Input events are throttled per animation frame for smooth scrubbing.


### PR DESCRIPTION
## Summary
- throttle jog-shuttle updates with requestAnimationFrame
- pause while scrubbing and resume at release
- document smoother jog-shuttle behavior

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844388fd880833394bb35bb494f796c