### PR TITLE
Fix yt_dlp import error

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -939,9 +939,14 @@ def download_pdf(
 
 
 def is_enhanced(url):
-    extractors = youtube_dl.extractor.gen_extractors()
-    for e in extractors:
-        if e.suitable(url) and e.IE_NAME != "generic":
+    """Return True if ``yt_dlp`` has a specialized extractor for the URL."""
+    try:
+        extractors = youtube_dl.extractor.list_extractors()
+    except Exception as e:  # pragma: no cover - defensive
+        logging.warning("yt_dlp extractor check failed: %s", e)
+        return False
+    for extractor in extractors:
+        if extractor.suitable(url) and extractor.IE_NAME != "generic":
             return True
     return False
 


### PR DESCRIPTION
## Summary
- avoid ImportError in `is_enhanced`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684456c5d88883338118b7a600669227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when checking if a URL has enhanced extraction support, reducing potential errors and ensuring more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->