### PR TITLE
Add slider initialization tests

### DIFF
--- a/tests/js/slider_init.test.js
+++ b/tests/js/slider_init.test.js
@@ -1,0 +1,62 @@
+import { jest } from "@jest/globals";
+
+// tests/js/slider_init.test.js
+
+document.body.innerHTML = `
+  <div id="template-list" style="gap:0"></div>
+  <div id="camera-table"></div>
+  <input id="grid-width-slider" type="range" value="360">
+`;
+
+let initTemplates;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/templates.js");
+  initTemplates = mod.initTemplates;
+});
+
+describe("slider initialization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const list = document.getElementById("template-list");
+    list.innerHTML = "";
+    list.style.gap = "0px";
+  });
+
+  test.each([
+    [1920, 1080, 4, 480],
+    [1920, 1080, 2, 960],
+    [1280, 720, 4, 320],
+  ])(
+    "computes min width %ipx x %ipx with %i cameras",
+    (width, height, count, expected) => {
+      Object.defineProperty(window, "innerWidth", {
+        writable: true,
+        configurable: true,
+        value: width,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        writable: true,
+        configurable: true,
+        value: height,
+      });
+
+      global.fetch = jest.fn(() => new Promise(() => {}));
+
+      const list = document.getElementById("template-list");
+      list.innerHTML = new Array(count)
+        .fill('<div class="templateDiv"></div>')
+        .join("");
+
+      initTemplates();
+      document.dispatchEvent(new Event("DOMContentLoaded"));
+
+      if (window.updateSliderLimits) {
+        window.updateSliderLimits();
+      }
+
+      const slider = document.getElementById("grid-width-slider");
+      expect(slider.min).toBe(expected.toString());
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add tests verifying grid width slider initialization against viewport size and camera count

## Testing
- `npm run test:js`
- `pytest tests/test_noop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68447bae441c8333a8d6f27b51e490fd