### PR TITLE
Streamline template tools UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1101,6 +1101,26 @@ input:checked + .slider:before {
   margin-top: 20px;
 }
 
+.template-actions {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  transition: opacity 0.5s;
+  z-index: 1000;
+}
+
+.template-actions.fade-out {
+  opacity: 0;
+}
+
+.template-actions button {
+  padding: 6px 12px;
+  font-size: 0.9rem;
+}
+
 @media (max-width: 600px) {
   .form-row {
     grid-template-columns: 1fr;

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -441,11 +441,32 @@ function closePromptModal() {
 
 
 
-    <button id="instant-screenshot-btn" onclick="takeInstantScreenshot('{{ template_name }}')" title="Take a screenshot of the template immediately">Take Instant Screenshot</button>
-    <button id="update-video-btn" onclick="updateVideo('{{ template_name }}')" title="Update the video for this template">Update Video</button>
-    <button id="show-camera-details-btn" onclick="showCameraDetails('{{ template_name }}')" title="Show camera details and endpoints">Show Camera Details</button>
-    <button id="open-url-btn" onclick="window.open('{{ template_details.url }}', '_blank')" title="Open the monitored page">Open Page</button>
-    <br/>
+    <div class="template-actions">
+        <button id="instant-screenshot-btn" onclick="takeInstantScreenshot('{{ template_name }}')" title="Take instant screenshot">Snapshot</button>
+        <button id="update-video-btn" onclick="updateVideo('{{ template_name }}')" title="Update video">Update Video</button>
+        <button id="show-camera-details-btn" onclick="showCameraDetails('{{ template_name }}')" title="Show camera details">Details</button>
+        <button id="open-url-btn" onclick="window.open('{{ template_details.url }}', '_blank')" title="Open page">Open</button>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const actions = document.querySelector('.template-actions');
+            if (!actions) return;
+            let fadeTimeout;
+            const show = () => {
+                actions.classList.remove('fade-out');
+                clearTimeout(fadeTimeout);
+                fadeTimeout = setTimeout(() => actions.classList.add('fade-out'), 3000);
+            };
+            ['mouseenter', 'mousemove'].forEach((evt) => {
+                actions.addEventListener(evt, show);
+            });
+            actions.addEventListener('mouseleave', () => {
+                fadeTimeout = setTimeout(() => actions.classList.add('fade-out'), 3000);
+            });
+            show();
+        });
+    </script>
 
 
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -38,6 +38,7 @@ Interactive forms now include additional tooltips:
 
 - **Add Camera** – explains each field on the Discover tab and the "Structured" XPath buttons.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
+- **Template toolbar** – quick actions fade in when hovering over the top-right corner of the details page.
 - **Captions** – upload and filter controls have descriptive titles. The metric dropdown filters feeds by count or storage and updates the list immediately.
 - **Danger Mode** – the checkbox, save button and modal controls all include tooltips.
 - **Live video player** – tooltip now refreshes with the full caption as it updates.


### PR DESCRIPTION
## Summary
- refine the template actions layout for compact display
- add CSS for `.template-actions` container
- fade the template actions toolbar when idle
- document new fade behavior in the tooltips docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844b75ec9c08333a9056da58249c9da