### PR TITLE
Add tests for settings_tooltips coverage

### DIFF
--- a/tests/test_settings_tooltips.py
+++ b/tests/test_settings_tooltips.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.settings_tooltips import SETTINGS_TOOLTIPS, SETTINGS_CHOICES
+import app.config as config
+
+
+class TestSettingsTooltips(unittest.TestCase):
+    def test_required_keys_present(self):
+        self.assertIn("API_KEY", SETTINGS_TOOLTIPS)
+        self.assertIn("CHATGPT_KEY", SETTINGS_TOOLTIPS)
+
+    def test_choices_have_tooltip_or_default(self):
+        for key in SETTINGS_CHOICES:
+            with self.subTest(key=key):
+                self.assertTrue(
+                    key in SETTINGS_TOOLTIPS or hasattr(config, key),
+                    f"Missing tooltip and default for {key}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test that required settings tooltips are present
- ensure every SETTINGS_CHOICES key has a tooltip or a default in `app.config`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bc6214a083339d3cbfa3698236fd