### PR TITLE
Improve scrub bar smoothness

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -35,11 +35,17 @@
   flex-direction: column;
   align-items: center;
   opacity: 0;
-  transition: opacity 0.3s;
+  transform: translateY(20px);
+  pointer-events: none;
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
   max-width: 100vw;
 }
 .video-container:hover .video-controls {
   opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
 }
 .video-controls button {
   background-color: transparent;

--- a/docs/live_scrub.md
+++ b/docs/live_scrub.md
@@ -2,4 +2,6 @@
 
 The live viewer shows a time slider whenever **MP4** or **Loop** playback is selected. Drag the slider to seek within the current clip. The video pauses while scrubbing and resumes once released. You can also click the video to toggle play or pause.
 
+The controls fade into view when you hover over the video for a cleaner look. They are inactive when hidden so you won't accidentally scrub.
+
 Scrubbing works only for individual cameras. When other sources such as MJPG or Live video are selected, the slider is hidden because those streams aren't seekable. If you don't see the scrub bar, switch the media source to **MP4** or **Loop** for that camera.


### PR DESCRIPTION
## Summary
- smooth appearance of video controls with pointer events and slide animation
- document new hover behavior for scrubbing

## Testing
- `npx prettier -w app/static/css/player.css docs/live_scrub.md`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bdc537448333b5a2dc1ea296e09d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved video controls with a smooth slide-in and fade-in effect on hover, and disabled interaction when hidden for a cleaner interface.

- **Documentation**
  - Updated documentation to reflect the enhanced appearance and behavior of playback controls, including their fade-in effect and inactive state when hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->