### PR TITLE
Refine tile layout spacing

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -208,8 +208,9 @@ h2 {
     auto-fit,
     minmax(50px, var(--tile-size))
   ); /* Use CSS variable */
-  gap: 5px;
-  padding: 10px;
+
+  gap: var(--tile-gap);
+  padding: var(--tile-gap);
   justify-content: center;
   max-width: 100%;
 }
@@ -234,8 +235,10 @@ h2 {
     width: 100%;
   }
   #template-list {
+    --tile-gap: 1px;
+
     grid-template-columns: 1fr; /* Single column layout on mobile */
-    padding: 10px; /* Reduce padding on mobile */
+    padding: var(--tile-gap);
   }
 
   /* Improve form layout on mobile */
@@ -270,11 +273,18 @@ select:hover {
   background-color: var(--table-hover-bg-color);
 }
 
+.tile,
+.tile a,
+.templateDiv {
+  margin: 0;
+  padding: 0;
+}
+
 .templateDiv {
   background-color: black;
   overflow: hidden;
   position: relative;
-  border-radius: 5px;
+  border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   flex: 0 0 var(--tile-size);
   width: var(--tile-size);
@@ -317,6 +327,7 @@ select:hover {
     255,
     0.7
   ); /* Semi-transparent white background */
+
   border-radius: 50%;
   padding: calc(5px * var(--tile-scale, 1));
   display: none; /* Hide by default */
@@ -346,6 +357,8 @@ video:hover + .play-icon {
 }
 
 :root {
+  /* easy to tweak later – clamp() keeps it small on phones, readable on 4-K */
+  --tile-gap: clamp(2px, 0.35vw, 6px);
   --tile-size: 360px;
   --grid-item-width: var(--tile-size);
   --grid-item-height: calc(var(--tile-size) * 0.5625);
@@ -419,11 +432,15 @@ body.light-mode {
 }
 
 .recent-screenshot {
-  border: 2px solid var(--accent-color);
+  box-shadow: inset 0 0 0 2px #0c84ff;
 }
 
 .template-error {
-  border: 2px solid red;
+  box-shadow: inset 0 0 0 2px #b00020;
+}
+
+.video-container:hover {
+  border-color: #58a6ff;
 }
 
 .caption-overlay {
@@ -749,7 +766,7 @@ nav a.active {
 
   /* Improve spacing for mobile */
   .video-container {
-    padding: 5px; /* Slightly reduce padding for smaller screens */
+    padding: 0;
   }
 
   /* Adjust slider for mobile */
@@ -795,9 +812,12 @@ a {
 
 /* Adjust padding and margin for better spacing */
 .video-container {
-  padding: 5px; /* Space around the preview */
+  padding: 0;
   height: 100%;
   box-sizing: border-box;
+  border: 1px solid #353535;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 #speed-control-container {

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -1,10 +1,10 @@
 # Dashboard Border Legend
 
-The index page shows each camera tile with a colored border.
-Border thickness is now slimmer (2&nbsp;px) so the legend key no longer
-dominates the layout. The legend now sits next to the **Play All** button on the
-dashboard rather than occupying its own row. A single legend element is rendered
-to avoid duplication when the page loads.
+The index page shows each camera tile with a subtle 1&nbsp;px border. Recent and
+failed captures display an inset 2&nbsp;px glow instead of a thick outline. This
+keeps the layout crisp while still conveying state. The legend now sits next to
+the **Play All** button on the dashboard rather than occupying its own row. A
+single legend element is rendered to avoid duplication when the page loads.
 
 - **Accent border** – blue for recent captures. The color intensity fades by half after one minute,
   again after ten minutes, and so on.

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -2,6 +2,9 @@
 
 Glimpser now adapts to phones and tablets. The navigation menu collapses into a hamburger button on narrow screens and tables reflow vertically to avoid horizontal scrolling. Video grids automatically switch to a single column when viewed on devices without hover capability or small viewports.
 
+A single `--tile-gap` CSS variable controls spacing around each tile. On
+phones the gap shrinks to one pixel so the layout stays dense.
+
 The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping. When a group is opened, the slider defaults to the smallest width that keeps all cameras visible without scrolling.
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.


### PR DESCRIPTION
## Summary
- standardize tile spacing with `--tile-gap`
- remove extra margins
- use a single border plus inset glow for status
- document the new layout tweaks

## Testing
- `npx stylelint 'app/static/css/**/*.css'`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449a4de03c833398df95ce01857660