### PR TITLE
Auto collapse controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -208,6 +208,14 @@ h2 {
   font-weight: 600;
 }
 
+#controls-wrapper {
+  transition: opacity 0.5s;
+}
+
+#controls-wrapper.fade-out {
+  opacity: 0;
+}
+
 #template-controls input[type="text"],
 #template-controls select {
   padding: 5px;

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -6,17 +6,27 @@ export function initControlsDropdown() {
     let hideTimeout;
     const scheduleHide = () => {
       clearTimeout(hideTimeout);
-      hideTimeout = setTimeout(() => details.removeAttribute("open"), 5000);
+      hideTimeout = setTimeout(() => {
+        details.classList.add("fade-out");
+        setTimeout(() => {
+          details.removeAttribute("open");
+          details.classList.remove("fade-out");
+        }, 500);
+      }, 5000);
     };
 
-    details.addEventListener("toggle", () => {
-      if (details.open) scheduleHide();
-    });
+    const showControls = () => {
+      if (!details.open) return;
+      details.classList.remove("fade-out");
+      scheduleHide();
+    };
+
+    details.addEventListener("toggle", showControls);
+
+    if (details.open) showControls();
 
     ["mousemove", "scroll"].forEach((evt) => {
-      document.addEventListener(evt, () => {
-        if (details.open) scheduleHide();
-      });
+      document.addEventListener(evt, showControls);
     });
   });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -1,4 +1,5 @@
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {% block content %}
+{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
+block content %}
 <div class="captions-page" data-latest-caption="{{ latest_caption }}">
   <script>
     function updateTemplate(templateName) {
@@ -38,7 +39,7 @@
   </div>
 
   <div id="prompts-tab" class="tab-content active">
-    <details class="filter-controls" open>
+    <details id="controls-wrapper" class="filter-controls" open>
       <summary>Search &amp; Filters</summary>
       <div class="controls-inner">
         <label for="search-input" title="Search by name or group"

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,38 +1,42 @@
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {% block content %}
-<div>
-  <div id="search-container">
+{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
+block content %}
+<details id="controls-wrapper" open>
+  <summary>Controls</summary>
+  <div id="template-controls">
+    <div id="search-container">
+      <input
+        type="text"
+        id="search-input"
+        placeholder="Search cameras"
+        title="Enter search terms"
+      />
+    </div>
     <input
-      type="text"
-      id="search-input"
-      placeholder="Search cameras"
-      title="Enter search terms"
+      type="range"
+      id="grid-width-slider"
+      min="50"
+      max="3840"
+      value="360"
+      title="Adjust the width of the template grid"
     />
+    {{ status_legend() }}
+    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+    <button
+      id="live-all-button"
+      style="display: none"
+      title="Return to latest screenshot"
+    >
+      Live
+    </button>
+    <button
+      id="toggle-captions"
+      title="Toggle caption overlays"
+      aria-label="Toggle caption overlays"
+    >
+      Hide Captions
+    </button>
   </div>
-  <input
-    type="range"
-    id="grid-width-slider"
-    min="50"
-    max="3840"
-    value="360"
-    title="Adjust the width of the template grid"
-  />
-  {{ status_legend() }}
-  <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-  <button
-    id="live-all-button"
-    style="display: none"
-    title="Return to latest screenshot"
-  >
-    Live
-  </button>
-  <button
-    id="toggle-captions"
-    title="Toggle caption overlays"
-    aria-label="Toggle caption overlays"
-  >
-    Hide Captions
-  </button>
-</div>
+</details>
 <div
   id="template-list"
   title="List of all templates"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,40 +1,41 @@
 <!-- app/templates/index.html -->
 
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {% block content %}
+{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
+block content %}
 
-<details id="controls-wrapper">
+<details id="controls-wrapper" open>
   <summary>Controls</summary>
   <section id="template-controls">
-  <input
-    type="text"
-    id="search-input"
-    placeholder="Search cameras"
-    title="Enter search terms"
-  />
-  <input
-    type="range"
-    id="grid-width-slider"
-    min="50"
-    max="3840"
-    value="360"
-    title="Adjust the width of the template grid"
-  />
-  {{ status_legend() }}
-  <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-  <button
-    id="live-all-button"
-    style="display: none"
-    title="Return to latest screenshot"
-  >
-    Live
-  </button>
-  <button
-    id="toggle-captions"
-    title="Toggle caption overlays"
-    aria-label="Toggle caption overlays"
-  >
-    Hide Captions
-  </button>
+    <input
+      type="text"
+      id="search-input"
+      placeholder="Search cameras"
+      title="Enter search terms"
+    />
+    <input
+      type="range"
+      id="grid-width-slider"
+      min="50"
+      max="3840"
+      value="360"
+      title="Adjust the width of the template grid"
+    />
+    {{ status_legend() }}
+    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+    <button
+      id="live-all-button"
+      style="display: none"
+      title="Return to latest screenshot"
+    >
+      Live
+    </button>
+    <button
+      id="toggle-captions"
+      title="Toggle caption overlays"
+      aria-label="Toggle caption overlays"
+    >
+      Hide Captions
+    </button>
   </section>
 </details>
 

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -1,0 +1,28 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <details id="controls-wrapper" open>
+    <summary>Controls</summary>
+  </details>
+`;
+
+jest.useFakeTimers();
+
+let initControlsDropdown;
+
+beforeAll(async () => {
+  ({ initControlsDropdown } = await import("../../app/static/js/controls.js"));
+});
+
+describe("controls dropdown", () => {
+  test("auto collapses after inactivity", () => {
+    const details = document.getElementById("controls-wrapper");
+    initControlsDropdown();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.advanceTimersByTime(5000);
+    expect(details.classList.contains("fade-out")).toBe(true);
+    jest.advanceTimersByTime(500);
+    expect(details.hasAttribute("open")).toBe(false);
+    expect(details.classList.contains("fade-out")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add open attribute so index controls auto-hide
- wrap group controls in a collapsible details element
- apply controls wrapper to captions filters
- fade controls via CSS and JS
- test auto-collapsing behaviour in Jest

## Testing
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c1b5a9988333a47f9ba075679a2d