### PR TITLE
Handle job timeouts by marking device offline

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -46,6 +46,7 @@ from .screenshots import (
     is_mostly_blank,
     throttle_cache,
     load_font,
+    cas_error,
 )
 from .template_manager import (
     get_template,
@@ -146,6 +147,18 @@ def run_with_timeout(func, args=(), timeout=300):
         process.terminate()
         process.join()
         logging.warning("Process terminated due to timeout")
+        if args and isinstance(args[0], str):
+            try:
+                mark_offline(args[0])
+            except Exception:
+                pass
+            try:
+                if len(args) > 1 and isinstance(args[1], dict):
+                    url = args[1].get("url")
+                    if url:
+                        cas_error(url)
+            except Exception:
+                pass
 
 
 MAX_IMAGE_TIME_DIFF = datetime.timedelta(minutes=5)

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -42,6 +42,21 @@ class TestRunWithTimeout(unittest.TestCase):
         run_with_timeout(slow, args=(d,), timeout=0.2)
         self.assertIsNone(d.get("done"))
 
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    @patch("app.utils.scheduling.cas_error")
+    @patch("app.utils.scheduling.mark_offline")
+    def test_timeout_marks_offline(self, mock_offline, mock_cas_error, _online):
+        def slow(name, template):
+            time.sleep(1)
+
+        run_with_timeout(
+            slow,
+            args=("cam1", {"url": "http://ex"}),
+            timeout=0.2,
+        )
+        mock_offline.assert_called_once_with("cam1")
+        mock_cas_error.assert_called_once_with("http://ex")
+
 
 class TestAddMotionAndCaption(unittest.TestCase):
     def test_image_updated_with_caption_and_motion(self):


### PR DESCRIPTION
## Summary
- mark devices offline and escalate backoff if a scheduled job times out
- test that timeouts trigger mark_offline

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c2e237248333abfac91f891761b5