### PR TITLE
Move advanced toggle to settings

### DIFF
--- a/app/static/js/advanced.js
+++ b/app/static/js/advanced.js
@@ -2,8 +2,12 @@ export function initAdvanced() {
   document.addEventListener("DOMContentLoaded", () => {
     const btn = document.getElementById("advanced-toggle");
     if (!btn) return;
+    if (sessionStorage.getItem("advanced-enabled") === "true") {
+      document.body.classList.add("advanced-enabled");
+    }
     btn.addEventListener("click", () => {
-      document.body.classList.toggle("advanced-enabled");
+      const enabled = document.body.classList.toggle("advanced-enabled");
+      sessionStorage.setItem("advanced-enabled", String(enabled));
     });
   });
 }

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -138,15 +138,6 @@
         <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
       </svg>
     </a>
-    <button
-      id="advanced-toggle"
-      class="settings-icon"
-      title="Toggle advanced options"
-      aria-label="Advanced"
-      type="button"
-    >
-      Advanced
-    </button>
     {% else %}
     <a
       href="{{ url_for('login') }}"

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -122,18 +122,17 @@ content %}
                 />
                 {% endif %}
             </td>
-            <td>
-              <button
-                type="submit"
-                name="action"
-                value="delete"
-                title="Delete {{ setting.name }}"
-                onclick="return confirmDeleteSetting('{{ setting.name }}')"
-                class="advanced-only"
-              >
-                Delete
-              </button>
-            </td>
+              <td class="advanced-only">
+                <button
+                  type="submit"
+                  name="action"
+                  value="delete"
+                  title="Delete {{ setting.name }}"
+                  onclick="return confirmDeleteSetting('{{ setting.name }}')"
+                  >
+                  Delete
+                </button>
+              </td>
           </tr>
           {% endfor %}
         </tbody>
@@ -160,7 +159,7 @@ content %}
                         <th class="searchable">Setting</th>
                         <th class="searchable">Value</th>
                         <th class="searchable">Explanation</th>
-                        <th>Action</th>
+                        <th class="advanced-only">Action</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -180,7 +179,7 @@ content %}
                               {% endif %}
                         </td>
                         <td class="setting-explanation">{{ tooltips.get(setting.name, '') }}</td>
-                        <td>
+                        <td class="advanced-only">
                             <button type="submit" name="action" value="delete" title="Delete {{ setting.name }}" onclick="return confirmDeleteSetting('{{ setting.name }}')" class="advanced-only">Delete</button>
                         </td>
                     </tr>
@@ -201,9 +200,10 @@ content %}
         {% endif %}
         {% endfor %}
 
-        <div id="management-tab" class="tab-content">
-            <h3>Configuration Management</h3>
-            <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
+          <div id="management-tab" class="tab-content">
+              <h3>Configuration Management</h3>
+              <button id="advanced-toggle" class="settings-icon" type="button" title="Toggle advanced options">Advanced</button>
+              <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
             <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
             <input type="file" name="file" accept=".json" title="Select configuration file to upload">
             <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
@@ -225,9 +225,10 @@ content %}
          </div>
     </div>
 
-    <div id="management-tab" class="tab-content">
-      <h3>Configuration Management</h3>
-      <button
+      <div id="management-tab" class="tab-content">
+        <h3>Configuration Management</h3>
+        <button id="advanced-toggle" class="settings-icon" type="button" title="Toggle advanced options">Advanced</button>
+        <button
         type="submit"
         name="action"
         value="backup"

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -5,7 +5,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 ## Sections
 
 - **Add New Setting** – quickly create additional key/value pairs.
-- **Current Settings** – edit existing values. Delete actions appear when the **Advanced** tab is enabled. Tabs switch between setting groups and the **Management** tab holds backup and offline options.
+- **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the button under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Danger Mode** – shows the detected browser path, whether shortcuts are patched, and if the debugging port is open. You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.

--- a/tests/js/advanced.test.js
+++ b/tests/js/advanced.test.js
@@ -1,0 +1,32 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <button id="advanced-toggle"></button>
+`;
+
+let initAdvanced;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/advanced.js");
+  initAdvanced = mod.initAdvanced;
+});
+
+afterEach(() => {
+  document.body.classList.remove("advanced-enabled");
+  sessionStorage.clear();
+});
+
+test("click toggles advanced state and stores it", () => {
+  initAdvanced();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  document.getElementById("advanced-toggle").click();
+  expect(document.body.classList.contains("advanced-enabled")).toBe(true);
+  expect(sessionStorage.getItem("advanced-enabled")).toBe("true");
+});
+
+test("initial state reads from sessionStorage", () => {
+  sessionStorage.setItem("advanced-enabled", "true");
+  initAdvanced();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  expect(document.body.classList.contains("advanced-enabled")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- move Advanced button from nav to settings Management tab
- persist advanced mode in sessionStorage
- hide action column until advanced mode enabled
- document updated toggle location
- test advanced JS behavior

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`
- `npx prettier -w app/templates/settings.html` *(fails: Unexpected closing tag)*

------
https://chatgpt.com/codex/tasks/task_e_6844c259d7dc833391bb0645ffba3dd7