### PR TITLE
Silence EventSource errors in logs test

### DIFF
--- a/tests/js/logs.test.js
+++ b/tests/js/logs.test.js
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 // tests/js/logs.test.js
 // Mock DOM elements for logs.js
 
@@ -11,51 +11,62 @@ document.body.innerHTML = `
 `;
 
 let updateTable;
+let consoleErrorMock;
 
 beforeAll(async () => {
-  const mod = await import('../../app/static/js/logs.js');
+  const mod = await import("../../app/static/js/logs.js");
   updateTable = mod.updateTable;
+  consoleErrorMock = jest.spyOn(console, "error").mockImplementation(() => {});
 });
 
-describe('logs.js', () => {
+afterAll(() => {
+  consoleErrorMock.mockRestore();
+});
+
+describe("logs.js", () => {
   beforeEach(() => {
-    document.querySelector('#log-table tbody').innerHTML = '';
+    document.querySelector("#log-table tbody").innerHTML = "";
   });
 
-  test('updateTable populates rows based on log data', () => {
+  test("updateTable populates rows based on log data", () => {
     const logs = [
-      { timestamp: 'now', level: 'INFO', source: 'system', message: 'a' },
-      { timestamp: 'later', level: 'WARN', source: 'system', message: 'b' },
+      { timestamp: "now", level: "INFO", source: "system", message: "a" },
+      { timestamp: "later", level: "WARN", source: "system", message: "b" },
     ];
 
     updateTable(logs);
 
-    const rows = document.querySelectorAll('#log-table tbody tr');
+    const rows = document.querySelectorAll("#log-table tbody tr");
     expect(rows).toHaveLength(2);
-    expect(rows[0].textContent).toContain('INFO');
-    expect(rows[1].textContent).toContain('WARN');
+    expect(rows[0].textContent).toContain("INFO");
+    expect(rows[1].textContent).toContain("WARN");
   });
 
-  test('reconnects when the event stream errors', () => {
+  test("reconnects when the event stream errors", () => {
     jest.useFakeTimers();
     const esInstances = [];
     global.EventSource = jest.fn(() => {
-      const es = { onmessage: null, onerror: null, onopen: null, close: jest.fn() };
+      const es = {
+        onmessage: null,
+        onerror: null,
+        onopen: null,
+        close: jest.fn(),
+      };
       esInstances.push(es);
       return es;
     });
 
-    document.dispatchEvent(new Event('DOMContentLoaded'));
+    document.dispatchEvent(new Event("DOMContentLoaded"));
     expect(EventSource).toHaveBeenCalledTimes(1);
 
-    esInstances[0].onerror(new Event('error'));
-    const status = document.getElementById('log-connection-status');
-    expect(status.classList.contains('hidden')).toBe(false);
+    esInstances[0].onerror(new Event("error"));
+    const status = document.getElementById("log-connection-status");
+    expect(status.classList.contains("hidden")).toBe(false);
 
     jest.advanceTimersByTime(3000);
     expect(EventSource).toHaveBeenCalledTimes(2);
 
     esInstances[1].onopen();
-    expect(status.classList.contains('hidden')).toBe(true);
+    expect(status.classList.contains("hidden")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- suppress `console.error` in `logs.test.js` to avoid noisy output

## Testing
- `flake8`
- `pytest -q`
- `npm t`


------
https://chatgpt.com/codex/tasks/task_e_6844c31710c88333bdd1c52087347ead