### PR TITLE
Fix toolbar position and add caption tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bulk tools menu is expanded by default on the captions page
 - Enumerated settings use a single autocomplete field instead of a dropdown and separate text box
 - Live video retries now use exponential backoff to reduce repeated ffmpeg errors
+- Template toolbar now anchors to the lower left of detail pages
+- Image thumbnails show captions in their tooltips
 
 ### Fixed
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1115,6 +1115,7 @@ input:checked + .slider:before {
   position: fixed;
   bottom: 0.5rem;
   left: 0.5rem;
+  right: initial;
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -463,6 +463,7 @@ function updateTemplateDetails() {
   }
 
   video.title = details.last_caption;
+  image.title = details.last_caption;
   templateDetailsContainer.style.display = "block";
   templateDetailsContainer.innerHTML = `
         <div>

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -707,7 +707,7 @@ export async function loadTemplates() {
           const templateDiv = document.createElement("div");
           templateDiv.classList.add("templateDiv");
           templateDiv.innerHTML = `
-            <img src="/last_screenshot/${name}" alt="${name}" style="width:100%">
+            <img src="/last_screenshot/${name}" alt="${name}" style="width:100%" title="${template.last_caption} (${humanizedTimestamp})">
             <div class="camera-name">${name}</div>
             <div class="timestamp" title="${
               lastScreenshotTime === NO_TIMESTAMP_PLACEHOLDER


### PR DESCRIPTION
## Summary
- move template toolbar to lower left
- show caption in tooltip for image views
- note toolbar/tooltip changes in changelog

## Testing
- `npm run format`
- `npm run lint:js`
- `npm run lint:css`
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844c6ec2ee483338f1c5c2a1fb8aee8