### PR TITLE
Add danger mode indicators

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1768,6 +1768,21 @@ details > summary {
   background-color: red;
 }
 
+.danger-icon {
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}
+.danger-icon.disabled {
+  color: red;
+}
+.danger-icon.user {
+  color: orange;
+}
+
+.feed-status tr.danger-disabled {
+  opacity: 0.5;
+}
+
 .metrics-list li {
   margin-bottom: 0.25rem;
 }

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -65,7 +65,9 @@
   </thead>
   <tbody>
     {% for feed in feeds %}
-    <tr class="{{ feed.status }}">
+    <tr
+      class="{{ feed.status }}{% if feed.danger_reason %} danger-{{ feed.danger_reason }}{% endif %}"
+    >
       <td data-label="Feed" data-value="{{ feed.name }}">
         <a href="{{ url_for('template_details', template_name=feed.name) }}"
           >{{ feed.name }}</a
@@ -115,6 +117,19 @@
         {{ feed.llm_cost_estimate }}
       </td>
       <td data-label="Status" data-value="{{ feed.status }}">
+        {% if feed.danger_reason %}
+        <svg
+          width="12"
+          height="12"
+          class="danger-icon {{ feed.danger_reason }}"
+          aria-label="Danger mode required"
+          title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'User active' }}"
+        >
+          <use
+            href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+          />
+        </svg>
+        {% endif %}
         <span
           class="status-dot {{ feed.status }}"
           title="{{ feed.tooltip }}"

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,4 +1,3 @@
-
 {% extends 'base.html' %} {% from 'components.html' import card %} {% block
 content %} {% include '_status_tab.html' %} {% endblock %} {% extends
 'base.html' %} {% from 'components.html' import card %} {% block content %}
@@ -94,7 +93,9 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
   </thead>
   <tbody>
     {% for feed in feeds %}
-    <tr class="{{ feed.status }}">
+    <tr
+      class="{{ feed.status }}{% if feed.danger_reason %} danger-{{ feed.danger_reason }}{% endif %}"
+    >
       <td data-label="Feed" data-value="{{ feed.name }}">
         <a href="{{ url_for('template_details', template_name=feed.name) }}"
           >{{ feed.name }}</a
@@ -144,6 +145,19 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
         {{ feed.llm_cost_estimate }}
       </td>
       <td data-label="Status" data-value="{{ feed.status }}">
+        {% if feed.danger_reason %}
+        <svg
+          width="12"
+          height="12"
+          class="danger-icon {{ feed.danger_reason }}"
+          aria-label="Danger mode required"
+          title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'User active' }}"
+        >
+          <use
+            href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+          />
+        </svg>
+        {% endif %}
         <span
           class="status-dot {{ feed.status }}"
           title="{{ feed.tooltip }}"
@@ -156,4 +170,3 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
 {% endcall %} {% include 'logs.html' %} {% endblock %}
-

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -47,6 +47,8 @@ from .screenshots import (
     throttle_cache,
     load_font,
     cas_error,
+    check_user_activity,
+    is_chrome_debug_port_open,
 )
 from .template_manager import (
     get_template,
@@ -1141,6 +1143,10 @@ def get_feed_status():
     now = datetime.datetime.utcnow()
     feeds = []
 
+    danger_enabled = get_setting("DANGER_MODE", "True") == "True"
+    port_open = is_chrome_debug_port_open("127.0.0.1", 9222)
+    user_idle = not check_user_activity(timeout=1)
+
     def _humanize(ts: str | None) -> str | None:
         """Return a simple "time ago" string for the given timestamp."""
         if not ts:
@@ -1230,6 +1236,14 @@ def get_feed_status():
 
         tooltip = " | ".join(tooltip_parts) if tooltip_parts else "OK"
 
+        danger = bool(template.get("danger", False))
+        danger_reason = None
+        if danger:
+            if not (danger_enabled and port_open):
+                danger_reason = "disabled"
+            elif not user_idle:
+                danger_reason = "user"
+
         feeds.append(
             {
                 "name": name,
@@ -1245,6 +1259,8 @@ def get_feed_status():
                 "storage_usage_bytes": storage_bytes,
                 "llm_response_count": llm_responses,
                 "llm_cost_estimate": llm_cost,
+                "danger": danger,
+                "danger_reason": danger_reason,
             }
         )
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -15,6 +15,10 @@ Below the system metrics the page lists each configured feed with a color-coded 
 - **Green** – the feed is updating on schedule.
 - **Yellow** – the last capture is behind its configured frequency.
 - **Red** – capturing failed or the feed is offline.
+- Cameras marked as **Danger** show a hazard icon when the feature is required.
+  The icon is orange if Danger mode is available but suppressed due to recent
+  user activity and red when Danger mode is disabled or Chrome's debugging port
+  is closed. Rows for disabled feeds are slightly greyed out.
 
 The dashboard also shows when the most recent system summary was generated. The
 same table appears on the _System Status_ tab under Settings so you can review

--- a/tests/test_feed_status_tooltip.py
+++ b/tests/test_feed_status_tooltip.py
@@ -50,6 +50,18 @@ class TestFeedStatusTooltip(unittest.TestCase):
         self.assertIn("Offline since", tooltip)
         self.assertIn("Last log:", tooltip)
 
+    def test_danger_reason_set(self):
+        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        templates = {"cam1": {"danger": True, "last_screenshot_time": now}}
+        with (
+            patch("app.utils.scheduling.get_templates", return_value=templates),
+            patch("app.utils.scheduling.check_user_activity", return_value=True),
+            patch("app.utils.scheduling.is_chrome_debug_port_open", return_value=True),
+            patch("app.utils.scheduling.get_setting", return_value="True"),
+        ):
+            feeds = scheduling.get_feed_status()
+        self.assertEqual(feeds[0]["danger_reason"], "user")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show hazard icon for danger-mode templates when unavailable or user active
- gray out rows when danger mode is disabled
- expose danger reason from `get_feed_status`
- document the new dashboard indicators
- test danger reason logic

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844c775424c83338cb897bd5772b90e