### PR TITLE
Improve chat UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1646,11 +1646,20 @@ details > summary {
 }
 
 .modal-content {
-  background-color: #fefefe;
+  background-color: #222;
+  color: #eee;
   margin: 15% auto;
   padding: 20px;
   border: 1px solid #888;
   width: 80%;
+  border-radius: 8px;
+}
+#chat-modal .modal-content {
+  width: 90%;
+  max-width: 600px;
+}
+#chat-submit {
+  margin-top: 0.5rem;
 }
 
 .close-icon {

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -32,12 +32,15 @@ export function initCaptions() {
 
     chatOpen?.addEventListener("click", () => {
       if (chatModal) chatModal.style.display = "block";
+      if (chatAnswer) chatAnswer.textContent = "";
+      chatQuestion?.focus();
     });
     chatClose?.addEventListener("click", () => {
       if (chatModal) chatModal.style.display = "none";
     });
     chatSubmit?.addEventListener("click", async () => {
-      if (!chatQuestion || !chatQuestion.value) return;
+      if (!chatQuestion || !chatQuestion.value.trim()) return;
+      if (chatAnswer) chatAnswer.textContent = "Thinking...";
       const start = document.getElementById("caption-start")?.value;
       const end = document.getElementById("caption-end")?.value;
       const resp = await fetch("/captions_chat", {

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1311,6 +1311,7 @@ document.addEventListener("keydown", (event) => {
   if (
     event.target.tagName === "INPUT" ||
     event.target.tagName === "SELECT" ||
+    event.target.tagName === "TEXTAREA" ||
     event.target.isContentEditable
   ) {
     return;

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -363,6 +363,7 @@ export function initNav() {
         if (
           e.target.tagName === "INPUT" ||
           e.target.tagName === "SELECT" ||
+          e.target.tagName === "TEXTAREA" ||
           e.target.isContentEditable
         )
           return;


### PR DESCRIPTION
## Summary
- refine chat modal style
- show progress text while waiting for answer
- focus textarea on chat open
- ignore global shortcuts in textareas

## Testing
- `black app`
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844cb4f47c883338f09e5548375b14c