### PR TITLE
Fix settings layout and toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1934,3 +1934,10 @@ details > summary {
 .danger-mode-box.on {
   border-color: var(--danger-on-color);
 }
+
+/* Spacing for management actions */
+#management-tab button,
+#management-tab input[type="file"] {
+  margin: 0.5rem 0;
+  display: block;
+}

--- a/app/static/js/advanced.js
+++ b/app/static/js/advanced.js
@@ -1,13 +1,19 @@
 export function initAdvanced() {
   document.addEventListener("DOMContentLoaded", () => {
-    const btn = document.getElementById("advanced-toggle");
-    if (!btn) return;
-    if (sessionStorage.getItem("advanced-enabled") === "true") {
+    const toggle = document.getElementById("advanced-toggle");
+    if (!toggle) return;
+    const enabled = sessionStorage.getItem("advanced-enabled") === "true";
+    if (enabled) {
+      toggle.checked = true;
       document.body.classList.add("advanced-enabled");
     }
-    btn.addEventListener("click", () => {
-      const enabled = document.body.classList.toggle("advanced-enabled");
-      sessionStorage.setItem("advanced-enabled", String(enabled));
-    });
+
+    const update = () => {
+      const state = toggle.checked;
+      document.body.classList.toggle("advanced-enabled", state);
+      sessionStorage.setItem("advanced-enabled", String(state));
+    };
+
+    toggle.addEventListener("change", update);
   });
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -51,104 +51,6 @@ content %}
     </a>
   </div>
 
-  <form method="POST" action="{{ url_for('settings') }}" id="settings-form">
-    {% for group, items in grouped_settings.items() %}
-    <div
-      id="{{ group|replace(' ', '-') }}-tab"
-      class="tab-content{% if loop.first %} active{% endif %}"
-    >
-      <h3>{{ group }} Settings</h3>
-      <table class="settings-table">
-        <thead>
-          <tr>
-            <th class="searchable">Setting</th>
-            <th class="searchable">Value</th>
-            <th>Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for setting in items %}
-          <tr>
-            <td title="{{ tooltips.get(setting.name, '') }}">
-              {{ setting.name }}
-            </td>
-            <td>
-              {% if setting.value|lower in ['true', 'false'] %}
-              <label class="switch">
-                <input
-                  type="checkbox"
-                  name="{{ setting.name }}"
-                  value="True"
-                  {% if setting.value|lower == 'true' %}checked{% endif %}
-                  data-boolean
-                />
-                <span class="slider round"></span>
-              </label>
-                {% elif setting.name in choices %}
-                <input
-                  type="text"
-                  name="{{ setting.name }}"
-                  list="{{ setting.name }}-options"
-                  value="{{ setting.value }}"
-                  title="Select or enter value for {{ setting.name }}"
-                />
-                <datalist id="{{ setting.name }}-options">
-                  {% for option in choices[setting.name] %}
-                  <option value="{{ option }}"></option>
-                  {% endfor %}
-                </datalist>
-                {% elif setting.name == 'PORT' %}
-              <input
-                type="number"
-                name="PORT"
-                min="1024"
-                max="65535"
-                value="{{ setting.value }}"
-                title="Edit port"
-              />
-              {% elif 'KEY' in setting.name %}
-                <input
-                  type="password"
-                  name="{{ setting.name }}"
-                  value="{{ setting.value }}"
-                  title="Edit value for {{ setting.name }}"
-                />
-                {% else %}
-                <input
-                  type="text"
-                  name="{{ setting.name }}"
-                  value="{{ setting.value }}"
-                  title="Edit value for {{ setting.name }}"
-                />
-                {% endif %}
-            </td>
-              <td class="advanced-only">
-                <button
-                  type="submit"
-                  name="action"
-                  value="delete"
-                  title="Delete {{ setting.name }}"
-                  onclick="return confirmDeleteSetting('{{ setting.name }}')"
-                  >
-                  Delete
-                </button>
-              </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% if loop.first %}
-    <div id="discover-tab" class="tab-content">
-      {% include '_discover_tab.html' %}
-    </div>
-    <div id="status-tab" class="tab-content">
-      {% include '_status_tab.html' %}
-    </div>
-    {% endif %} {% endfor %}
-
-
-
     <form method="POST" action="{{ url_for('settings') }}" id="settings-form">
         {% for group, items in grouped_settings.items() %}
         <div id="{{ group|replace(' ', '-') }}-tab" class="tab-content{% if loop.first %} active{% endif %}">
@@ -200,34 +102,12 @@ content %}
         {% endif %}
         {% endfor %}
 
-          <div id="management-tab" class="tab-content">
-              <h3>Configuration Management</h3>
-              <button id="advanced-toggle" class="settings-icon" type="button" title="Toggle advanced options">Advanced</button>
-              <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
-            <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
-            <input type="file" name="file" accept=".json" title="Select configuration file to upload">
-            <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
-
-            <h3>Danger Mode</h3>
-            <ul class="danger-info">
-                <li>Browser: {{ danger_info.browser }}</li>
-                <li>Path: {{ danger_info.path }}</li>
-                <li>
-                    Shortcut Patched:
-                    <span class="status-dot {{ 'ok' if danger_info.patched else 'error' }}" title="{{ 'patched' if danger_info.patched else 'needs patch' }}"></span>
-                </li>
-                <li>
-                    Running:
-                    <span class="status-dot {{ 'ok' if danger_info.running else 'error' }}" title="{{ 'running' if danger_info.running else 'not running' }}"></span>
-                </li>
-            </ul>
-            <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
-         </div>
-    </div>
-
       <div id="management-tab" class="tab-content">
         <h3>Configuration Management</h3>
-        <button id="advanced-toggle" class="settings-icon" type="button" title="Toggle advanced options">Advanced</button>
+        <label class="switch" title="Toggle advanced options">
+          <input id="advanced-toggle" type="checkbox" />
+          <span class="slider round"></span>
+        </label>
         <button
         type="submit"
         name="action"

--- a/tests/js/advanced.test.js
+++ b/tests/js/advanced.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
-  <button id="advanced-toggle"></button>
+  <input id="advanced-toggle" type="checkbox" />
 `;
 
 let initAdvanced;
@@ -16,10 +16,12 @@ afterEach(() => {
   sessionStorage.clear();
 });
 
-test("click toggles advanced state and stores it", () => {
+test("change toggles advanced state and stores it", () => {
   initAdvanced();
   document.dispatchEvent(new Event("DOMContentLoaded"));
-  document.getElementById("advanced-toggle").click();
+  const el = document.getElementById("advanced-toggle");
+  el.checked = true;
+  el.dispatchEvent(new Event("change"));
   expect(document.body.classList.contains("advanced-enabled")).toBe(true);
   expect(sessionStorage.getItem("advanced-enabled")).toBe("true");
 });
@@ -29,4 +31,5 @@ test("initial state reads from sessionStorage", () => {
   initAdvanced();
   document.dispatchEvent(new Event("DOMContentLoaded"));
   expect(document.body.classList.contains("advanced-enabled")).toBe(true);
+  expect(document.getElementById("advanced-toggle").checked).toBe(true);
 });


### PR DESCRIPTION
## Summary
- de-duplicate settings template
- show advanced column only in advanced mode
- convert advanced toggle to a switch
- tweak management button spacing
- update advanced toggle logic and tests

## Testing
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844c65586bc83338ea03093ff2e91a1