### PR TITLE
Remove captions icon on mobile

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -766,7 +766,8 @@ nav a.active {
   /* Hide elements that waste space on mobile */
   #nav-clock,
   #caption-chyron,
-  .flash-messages {
+  .flash-messages,
+  #captions {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- hide captions icon on mobile view

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844cee2ac0c833382384cd2b0ba8089