### PR TITLE
Improve SSE error logging

### DIFF
--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -36,6 +36,12 @@ function debounce(fn, delay) {
   };
 }
 
+function logEventSourceError(src, err) {
+  const states = ["CONNECTING", "OPEN", "CLOSED"];
+  const state = states[src.readyState] || `unknown (${src.readyState})`;
+  console.error(`EventSource failed (state: ${state}):`, err);
+}
+
 export function initLogs() {
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.getElementById("log-filter-form");
@@ -67,7 +73,7 @@ export function initLogs() {
       };
 
       eventSource.onerror = (error) => {
-        console.error("EventSource failed:", error);
+        logEventSourceError(eventSource, error);
         if (status) {
           status.textContent = "Connection lost. Reconnecting...";
           status.classList.remove("hidden");

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -67,6 +67,7 @@ To filter logs by level and message text, you could request:
 3. Hover over each field for a tooltip explaining the filter.
 4. Results update automatically via `/stream_logs`.
 5. If the connection drops, the viewer automatically reconnects after a few seconds and shows a short notice while retrying. Duplicate requests with the same level and search text are ignored server-side to avoid unnecessary generators.
+6. When the connection cannot be established, the browser console now logs the EventSource state to aid troubleshooting.
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 


### PR DESCRIPTION
## Summary
- improve error reporting in `logs.js`
- document new console logging for failed log viewer connections

## Testing
- `flake8`
- `pytest -q`
- `npm test` *(fails: command not found)*
- `npm run lint:js` *(fails: command not found)*
- `npm run format` *(fails: command not found)*
- `npm run size-audit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cebe4118833395061201a338ba34