### PR TITLE
Collapse less used settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2996,6 +2996,15 @@ def init_routes(app: Flask) -> None:
 
         # Remove empty groups to avoid blank headings in the UI
         grouped_settings = {g: items for g, items in grouped_settings.items() if items}
+
+        collapsed_groups = {
+            "File Locations",
+            "Capture",
+            "Credentials",
+            "Integrations",
+            "Other",
+            "Management",
+        }
         file_location_items = [
             s
             for s in settings
@@ -3020,6 +3029,7 @@ def init_routes(app: Flask) -> None:
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
+            collapsed_groups=collapsed_groups,
             tooltips=SETTINGS_TOOLTIPS,
             metrics=metrics,
             feeds=feeds,

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -54,7 +54,8 @@ content %}
     <form method="POST" action="{{ url_for('settings') }}" id="settings-form">
         {% for group, items in grouped_settings.items() %}
         <div id="{{ group|replace(' ', '-') }}-tab" class="tab-content{% if loop.first %} active{% endif %}">
-            <h3>{{ group }} Settings</h3>
+            <details class="setting-section" {% if group not in collapsed_groups %}open{% endif %}>
+                <summary>{{ group }} Settings</summary>
             <table class="settings-table">
                 <thead>
                     <tr>
@@ -88,6 +89,7 @@ content %}
                     {% endfor %}
                 </tbody>
             </table>
+            </details>
         </div>
         {% if loop.first %}
         <div id="discover-tab" class="tab-content">
@@ -103,7 +105,8 @@ content %}
         {% endfor %}
 
       <div id="management-tab" class="tab-content">
-        <h3>Configuration Management</h3>
+        <details class="setting-section" {% if 'Management' not in collapsed_groups %}open{% endif %}>
+        <summary>Configuration Management</summary>
         <label class="switch" title="Toggle advanced options">
           <input id="advanced-toggle" type="checkbox" />
           <span class="slider round"></span>
@@ -142,6 +145,8 @@ content %}
 
       <input type="hidden" id="name_to_delete" name="name_to_delete" value="" title="Name of setting to delete" />
       <button type="submit" title="Save all changes">Save Changes</button>
+        </details>
+      </div>
     </form>
   {{ confirm_modal('delete-setting', 'Delete this setting?', 'Delete', 'Cancel') }}
 </main>

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -12,6 +12,8 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.
 - **System Status** – view CPU, memory, disk usage, and live logs.
+- **Certain tabs start collapsed** – File Locations, Capture, Credentials,
+  Integrations, Management, and Other appear collapsed until expanded.
 
 All form elements now use unique IDs across tabs to avoid browser warnings.
 


### PR DESCRIPTION
## Summary
- collapse rarely used settings tabs by default
- document collapsed settings groups in settings page docs

## Testing
- `flake8`
- `pytest -q`
- `npx prettier -w app/templates/settings.html` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6844d030fb4c8333adbfa28d5133ae9e