### PR TITLE
Add captions page overview docs

### DIFF
--- a/docs/captions_page.md
+++ b/docs/captions_page.md
@@ -1,0 +1,15 @@
+# Captions Page Overview
+
+The **Captions** interface centralizes prompt management, caption history, and bulk tools.
+It is organized into three tabs:
+
+- **Prompts** – shows a grid of cameras with filters for name, group, and metrics.
+  Use the width slider to resize thumbnails and the caption overlay toggle to hide text.
+- **History** – lists the latest captions with search and date range controls.
+  When sorted by Timestamp in descending order, new entries appear automatically.
+  A Chat button opens a modal where you can ask questions about recent captions.
+- **Bulk Tools** – download or upload a TSV file to update prompts in bulk.
+
+You can also toggle the scrolling chyron banner from the history tab.
+The page displays token usage and estimated LLM costs when available.
+See [Captions Live Update](captions_live_update.md) and [Captions Chatbot](chatbot.md) for details on those features.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Dashboard Time Display](#dashboard-time)
 - [Dashboard Border Legend](border_legend.md)
 - [LLM Cost Tracking](cost_tracking.md)
+- [Captions Page Overview](captions_page.md)
 - [Captions Chatbot](chatbot.md)
 - [UI and Navigation Tooltips](tooltips.md)
 - [Settings Page Overview](settings_page.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Video Archiver: video_archiver.md
       - Dashboard Border Legend: border_legend.md
       - Caption Overlay Toggle: caption_overlay_toggle.md
+      - Captions Page Overview: captions_page.md
       - Captions Chatbot: chatbot.md
       - Continuous Integration Checks: ci_checks.md
       - Jog-Shuttle Control: jog_shuttle.md


### PR DESCRIPTION
## Summary
- document the captions interface in a new `captions_page.md`
- add the page to the documentation index
- include the new page in `mkdocs.yml`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d0dd5dac8333a96723f8c3a6659d