### PR TITLE
Add caption to MJPG tooltip in live view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -700,7 +700,9 @@ function updateFrameTimestamp() {
   );
   container.setAttribute(
     "title",
-    formatExactTime(details.last_screenshot_time),
+    details.last_caption
+      ? `${formatExactTime(details.last_screenshot_time)} - ${details.last_caption}`
+      : formatExactTime(details.last_screenshot_time),
   );
 }
 
@@ -1402,3 +1404,5 @@ function handleTouchEnd(event) {
 
 document.addEventListener("touchstart", handleTouchStart, { passive: true });
 document.addEventListener("touchend", handleTouchEnd, { passive: true });
+
+export { updateFrameTimestamp };

--- a/tests/js/live_tooltip.test.js
+++ b/tests/js/live_tooltip.test.js
@@ -1,0 +1,56 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container"></div>
+  <video id="live-video"></video>
+  <img id="live-image">
+  <div id="template-details"></div>
+  <div id="speed-container"></div>
+  <input id="speed-slider" value="0">
+  <span id="speed-value"></span>
+  <div id="video-overlay"></div>
+  <div id="loading-indicator"></div>
+  <div id="play-pause-indicator"></div>
+  <div id="offline-indicator"></div>
+  <div id="offline-message"></div>
+  <div id="capture-error-indicator"></div>
+  <div id="capture-error-message"></div>
+  <div id="stream-error-indicator"></div>
+  <div id="stream-error-message"></div>
+  <div id="error-message"></div>
+  <button id="play-pause"></button>
+  <div id="toggle-details"></div>
+  <input id="seek-bar">
+  <div id="jog-shuttle"></div>
+  <select id="group-selector"></select>
+  <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
+`;
+Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: jest.fn(),
+});
+
+window.templateDetails = {
+  All: { last_screenshot_time: "2023-01-01 00:00:00", last_caption: "Hello" },
+};
+
+// stub fetch and timers used during module initialization
+global.fetch = jest.fn(() =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+);
+
+jest.useFakeTimers();
+
+describe("updateFrameTimestamp", () => {
+  let updateFrameTimestamp;
+  beforeAll(async () => {
+    const mod = await import("../../app/static/js/live.js");
+    updateFrameTimestamp = mod.updateFrameTimestamp;
+  });
+
+  test("adds caption to tooltip", () => {
+    const container = document.querySelector(".video-container");
+    updateFrameTimestamp();
+    expect(container.title).toContain("Hello");
+  });
+});


### PR DESCRIPTION
## Summary
- show last caption in MJPG tooltip on live view
- export `updateFrameTimestamp` for testing
- cover caption tooltip logic in new Jest test

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d0c507d08333954b7d2f2f4c0a58