### PR TITLE
Implement hover-only controls button

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -206,6 +206,15 @@ h2 {
 #controls-wrapper summary {
   cursor: pointer;
   font-weight: 600;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s;
+}
+
+#controls-wrapper.show-summary summary,
+#controls-wrapper[open] summary {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 #controls-wrapper {

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -4,6 +4,19 @@ export function initControlsDropdown() {
     if (!details) return;
 
     let hideTimeout;
+    let buttonTimeout;
+
+    const showButton = () => {
+      details.classList.add("show-summary");
+      clearTimeout(buttonTimeout);
+      if (!details.open) {
+        buttonTimeout = setTimeout(
+          () => details.classList.remove("show-summary"),
+          3000,
+        );
+      }
+    };
+
     const scheduleHide = () => {
       clearTimeout(hideTimeout);
       hideTimeout = setTimeout(() => {
@@ -11,6 +24,7 @@ export function initControlsDropdown() {
         setTimeout(() => {
           details.removeAttribute("open");
           details.classList.remove("fade-out");
+          showButton();
         }, 500);
       }, 5000);
     };
@@ -18,15 +32,17 @@ export function initControlsDropdown() {
     const showControls = () => {
       if (!details.open) return;
       details.classList.remove("fade-out");
+      showButton();
       scheduleHide();
     };
 
     details.addEventListener("toggle", showControls);
 
     if (details.open) showControls();
+    else showButton();
 
     ["mousemove", "scroll"].forEach((evt) => {
-      document.addEventListener(evt, showControls);
+      document.addEventListener(evt, showButton);
     });
   });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -39,7 +39,7 @@ block content %}
   </div>
 
   <div id="prompts-tab" class="tab-content active">
-    <details id="controls-wrapper" class="filter-controls" open>
+    <details id="controls-wrapper" class="filter-controls">
       <summary>Search &amp; Filters</summary>
       <div class="controls-inner">
         <label for="search-input" title="Search by name or group"

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
-<details id="controls-wrapper" open>
+<details id="controls-wrapper">
   <summary>Controls</summary>
   <div id="template-controls">
     <div id="search-container">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,7 +3,7 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
 
-<details id="controls-wrapper" open>
+<details id="controls-wrapper">
   <summary>Controls</summary>
   <section id="template-controls">
     <input

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -14,3 +14,5 @@ also appears on the **Captions** and **Group** pages.
 
 Search, width slider and legend controls now start collapsed in a dropdown to keep the dashboard uncluttered.
 The dropdown closes automatically after a few seconds without mouse or scroll activity.
+On desktop screens the **Controls** button itself stays hidden until you move the
+mouse, fading out again when idle just like the toolbar on template pages.

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
-  <details id="controls-wrapper" open>
+  <details id="controls-wrapper">
     <summary>Controls</summary>
   </details>
 `;
@@ -17,6 +17,7 @@ beforeAll(async () => {
 describe("controls dropdown", () => {
   test("auto collapses after inactivity", () => {
     const details = document.getElementById("controls-wrapper");
+    details.setAttribute("open", "");
     initControlsDropdown();
     document.dispatchEvent(new Event("DOMContentLoaded"));
     jest.advanceTimersByTime(5000);
@@ -24,5 +25,14 @@ describe("controls dropdown", () => {
     jest.advanceTimersByTime(500);
     expect(details.hasAttribute("open")).toBe(false);
     expect(details.classList.contains("fade-out")).toBe(false);
+  });
+
+  test("button shows and hides on activity", () => {
+    const details = document.getElementById("controls-wrapper");
+    initControlsDropdown();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    expect(details.classList.contains("show-summary")).toBe(true);
+    jest.advanceTimersByTime(3000);
+    expect(details.classList.contains("show-summary")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- hide Controls button until hovered
- show/hide button with JS
- collapse controls by default in index, group and captions pages
- note new behaviour in docs
- update JS tests for fading controls

## Testing
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d5309e0083338a9dac404ae61a7e