### PR TITLE
Replace advanced button with toggle

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -106,7 +106,13 @@ content %}
 
           <div id="management-tab" class="tab-content">
               <h3>Configuration Management</h3>
-              <button id="advanced-toggle" class="settings-icon" type="button" title="Toggle advanced options">Advanced</button>
+              <div class="checkbox-row">
+                  <span>Advanced Options</span>
+                  <label class="switch" title="Toggle advanced options">
+                      <input id="advanced-toggle" type="checkbox" />
+                      <span class="slider round"></span>
+                  </label>
+              </div>
               <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
             <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
             <input type="file" name="file" accept=".json" title="Select configuration file to upload">

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -5,7 +5,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 ## Sections
 
 - **Add New Setting** – quickly create additional key/value pairs.
-- **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the button under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
+- **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Danger Mode** – shows the detected browser path, whether shortcuts are patched, and if the debugging port is open. You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -85,6 +85,13 @@ class TestHtmlTemplates(unittest.TestCase):
         else:
             self.fail("sprite.svg preload link missing")
 
+    def test_settings_has_advanced_toggle(self):
+        parser = parse_template(Path("app/templates/settings.html"))
+        inputs = [i for form in parser.forms for i in form["inputs"]]
+        advanced = next((i for i in inputs if i.get("id") == "advanced-toggle"), None)
+        self.assertIsNotNone(advanced, "advanced-toggle missing")
+        self.assertEqual(advanced.get("type"), "checkbox")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- convert advanced options button to a toggle switch
- document the new advanced toggle
- verify presence of advanced toggle in templates

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d47fd0a88333b8d13d8864b6380e