### PR TITLE
fix: slim mobile footer

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1310,18 +1310,23 @@ footer.fade-out {
 
 @media (max-width: 600px) {
   footer {
-    padding: 5px 10px 0;
+    padding: 0 10px;
+    height: 20px;
+    line-height: 20px;
   }
   .footer-nav {
     gap: 5px;
-    font-size: 0.85em;
+    font-size: 0.75em;
+  }
+  .footer-nav a {
+    padding: 0 4px;
   }
   .footer-copy,
   .footer-build {
     display: none;
   }
   main {
-    padding-bottom: 45px;
+    padding-bottom: 20px;
   }
 }
 .alert-success {


### PR DESCRIPTION
## Summary
- set mobile footer height to a compact 20px

## Testing
- `flake8`
- `pytest -q`
- `npx prettier --write app/static/css/style.css`

------
https://chatgpt.com/codex/tasks/task_e_6844e82caa24833381ddb75f9377d106