### PR TITLE
Fix status icon visibility on mobile

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -776,7 +776,8 @@ nav a.active {
   #nav-clock,
   #caption-chyron,
   .flash-messages,
-  #captions {
+  #captions,
+  #health-status {
     display: none;
   }
 


### PR DESCRIPTION
## Summary
- hide health status icon in the mobile nav bar

## Testing
- `flake8`
- `pytest -q`
- `npx prettier -w app/static/css/style.css`

------
https://chatgpt.com/codex/tasks/task_e_6844e771fff483338bd9859356498086