### PR TITLE
Add rotate control for mobile

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -133,3 +133,13 @@
     overflow: auto;
   }
 }
+
+#rotate-video {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  #rotate-video {
+    display: inline-block;
+  }
+}

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -113,6 +113,8 @@ export function setupVideoControls() {
   const seekBar = document.getElementById("seek-bar");
   const volumeBar = document.getElementById("volume-bar");
   const castButton = document.getElementById("cast-button");
+  const rotateButton = document.getElementById("rotate-video");
+  let rotateAngle = 0;
 
   if (playPauseButton) {
     playPauseButton.addEventListener("click", () => {
@@ -134,6 +136,13 @@ export function setupVideoControls() {
       else if (video.mozRequestFullScreen) video.mozRequestFullScreen();
       else if (video.webkitRequestFullscreen) video.webkitRequestFullscreen();
       else if (video.msRequestFullscreen) video.msRequestFullscreen();
+    });
+  }
+  if (rotateButton) {
+    rotateButton.addEventListener("click", () => {
+      rotateAngle = (rotateAngle + 90) % 360;
+      const container = document.querySelector(".video-container");
+      if (container) container.style.transform = `rotate(${rotateAngle}deg)`;
     });
   }
   if (seekBar) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -28,6 +28,7 @@
         <!-- <button id="cast-button">Cast</button> -->
                 <button id="full-screen" title='fullscreen' aria-label="Toggle fullscreen"><i class="fas fa-expand"></i></button>
                 <button id="toggle-details" title="Show details" aria-label="Toggle details"><i class="fas fa-info-circle"></i></button>
+                <button id="rotate-video" title="Rotate 90°" aria-label="Rotate video"><i class="fas fa-sync-alt"></i></button>
 
     <select id="video-source" onchange="changeVideoSource()">
         <option value="png" title="View a series of PNG images">PNG Stream</option>

--- a/docs/rotate_button.md
+++ b/docs/rotate_button.md
@@ -1,0 +1,3 @@
+# Rotate Button
+
+The live player includes a rotate control on mobile. Tapping the button rotates the video container 90° each time. The control only appears on screens below 768&nbsp;px wide so desktop layouts remain uncluttered.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Jog Shuttle: jog_shuttle.md
       - Live All: live_all.md
       - Live Scrub: live_scrub.md
+      - Rotate Button: rotate_button.md
       - MCP Integration: mcp_integration.md
       - Onboarding Guide: onboarding.md
       - Scorecard: scorecard.md


### PR DESCRIPTION
## Summary
- add rotate button to the live video player
- show rotate button on small screens
- rotate the container via JS
- document the new rotate control

## Testing
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844e7b3f85483338ab411c597815edd