### PR TITLE
Add unit tests for local OUI loading

### DIFF
--- a/tests/test_camera_discovery_ouis.py
+++ b/tests/test_camera_discovery_ouis.py
@@ -1,0 +1,43 @@
+import unittest
+import tempfile
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import camera_discovery
+
+
+class TestLoadLocalOuis(unittest.TestCase):
+    def test_load_local_ouis_parsing(self):
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write(
+                "# comment\n"
+                "00:11:22 SomeVendor\n"
+                "33-44-55 AnotherVendor\n"
+                "0044 invalid\n"
+                "malformed\n"
+                "aa:bb:cc:dd:ee AnotherOne\n"
+            )
+            path = tmp.name
+        try:
+            with patch.object(camera_discovery, "_OUI_FILES", [path, "/nonexistent"]):
+                vendors = camera_discovery._load_local_ouis()
+            expected = {
+                "001122": "SomeVendor",
+                "334455": "AnotherVendor",
+                "aabbcc": "AnotherOne",
+            }
+            self.assertEqual(vendors, expected)
+        finally:
+            os.unlink(path)
+
+    def test_load_local_ouis_missing_file(self):
+        with patch.object(camera_discovery, "_OUI_FILES", ["/does/not/exist"]):
+            vendors = camera_discovery._load_local_ouis()
+        self.assertEqual(vendors, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests verifying `_load_local_ouis` parses valid OUI entries
- ensure invalid lines and missing files are ignored

## Testing
- `flake8 tests/test_camera_discovery_ouis.py`
- `pytest -q tests/test_camera_discovery_ouis.py`

------
https://chatgpt.com/codex/tasks/task_e_6844f465fab08333a4743161b53f4d57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify correct parsing of OUI entries and handling of missing files in camera discovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->