### PR TITLE
Expand internal help docs

### DIFF
--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -104,6 +104,51 @@ content %}
         >GitHub</a
       >. Contributions are welcome!
     </p>
+    {% endcall %} {% call card('GitHub Resources') %}
+    <p>
+      Check the
+      <a
+        href="https://github.com/KristopherKubicki/glimpser/issues"
+        target="_blank"
+        >issue tracker</a
+      >
+      for known bugs and feature requests.
+    </p>
+    <ul>
+      <li>
+        <a
+          href="https://github.com/KristopherKubicki/glimpser/issues/new"
+          target="_blank"
+          >Open a new issue</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://github.com/KristopherKubicki/glimpser/pulls"
+          target="_blank"
+          >Active pull requests</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://github.com/KristopherKubicki/glimpser/wiki"
+          target="_blank"
+          >Project wiki</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://github.com/KristopherKubicki/glimpser/releases"
+          target="_blank"
+          >Release notes</a
+        >
+      </li>
+    </ul>
+    <p>
+      See the
+      <a href="../docs/developer_guide.md" target="_blank">developer guide</a>
+      for contribution steps.
+    </p>
     {% endcall %} {% call card('Need More Help?') %}
     <p>
       Visit <a href="https://glimpser.net" target="_blank">glimpser.net</a> for

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -30,3 +30,22 @@ Click **Live All** to switch every tile to a real-time feed and **Play All** to 
 Keyboard shortcuts help you navigate quickly: `Space` or `k` toggles play or pause, `m` mutes audio, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the bottom of the help page.
+
+## GitHub Resources
+
+If you run into a bug or have an idea for improvement, head over to the
+[issue tracker](https://github.com/KristopherKubicki/glimpser/issues). You can
+review open bug reports, ask for features, or create a new ticket.
+
+The project changelog and
+[release notes](https://github.com/KristopherKubicki/glimpser/releases) live on
+GitHub so you can see what's new in each version.
+
+Follow development by checking the list of
+[open pull requests](https://github.com/KristopherKubicki/glimpser/pulls) and
+additional tutorials in the
+[project wiki](https://github.com/KristopherKubicki/glimpser/wiki).
+
+We welcome pull requests! Review the
+[CONTRIBUTING](../CONTRIBUTING.md) guide and search existing issues before
+starting work on a patch.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -92,6 +92,12 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIsNotNone(advanced, "advanced-toggle missing")
         self.assertEqual(advanced.get("type"), "checkbox")
 
+    def test_help_links_to_github(self):
+        path = Path("app/templates/help.html")
+        with open(path, encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("github.com/KristopherKubicki/glimpser", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add GitHub resources card to the help page
- document GitHub links in the help page docs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ed8856b48333b27ff0f25e0af781