### PR TITLE
Refine flake8 settings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,10 @@
 [flake8]
 max-line-length = 88
-ignore = E,W,F
+ignore = E203,E265,E402,E501,E721,E722,E741,F401,F402,F811,F841,W503
 exclude =
     .git,
     __pycache__,
     build,
-    dist
+    dist,
+    node_modules
 

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -346,7 +346,9 @@ def idle_seconds_x11() -> int:
 def idle_seconds_loginctl() -> int:
     """Return seconds of user idleness according to systemd-logind.
     0  → actively using keyboard/mouse right now."""
-    import os, subprocess, time
+    import os
+    import subprocess
+    import time
 
     uid = os.getuid()
     try:
@@ -1468,10 +1470,9 @@ def should_use_phantom_browser(
     """Determine if a lightweight browser should be used for capture."""
     return (
         re.findall(r"^https?://", url, flags=re.I)
-        and
         # dedicated_selector in [None, ""] and
         # popup_xpath in [None, ""] and
-        not stealth
+        and not stealth
         and not browser
         and not is_enhanced(url)
         and not danger
@@ -2413,7 +2414,7 @@ def capture_screenshot_and_har(
         # let's confirm it's actually open.
         if not is_chrome_debug_port_open("127.0.0.1", 9222):
             logging.warning(
-                f"[capture_screenshot_and_har] Danger mode requested, but no Chrome on port 9222."
+                "[capture_screenshot_and_har] Danger mode requested, but no Chrome on port 9222."
             )
             return False
 

--- a/main.py
+++ b/main.py
@@ -7,7 +7,10 @@ import subprocess
 import argparse
 import random
 import time
-import signal, sys, threading, atexit
+import signal
+import sys
+import threading
+import atexit
 import socket
 
 import app.config as config

--- a/tests/test_db_ensure_column.py
+++ b/tests/test_db_ensure_column.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest


### PR DESCRIPTION
## Summary
- remove blanket ignore rules in `.flake8`
- exclude `node_modules` from linting
- fix a few style violations uncovered by stricter linting

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f9b102a883339b9f200aa01cde35