### PR TITLE
Add tests for image comparison caching and retention cleanup

### DIFF
--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -18,7 +18,7 @@ from app.utils.screenshots import (
     adjust_bbox_to_aspect_ratio,
     is_mostly_blank,
 )
-from app.utils.image_processing import ChatGPTImageComparison
+from app.utils.image_processing import ChatGPTImageComparison, chatgpt_compare
 
 
 class TestImageProcessing(unittest.TestCase):
@@ -182,6 +182,40 @@ class TestChatGPTImageComparison(unittest.TestCase):
             # Clean up temporary files
             os.remove(image1_path)
             os.remove(image2_path)
+
+
+class TestChatGPTCompareIntegration(unittest.TestCase):
+    @patch("app.utils.image_processing.os.path.exists", return_value=True)
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
+    @patch("app.utils.template_manager.record_llm_usage")
+    @patch("app.utils.llm_cache.store")
+    @patch("app.utils.llm_cache.get")
+    @patch.object(ChatGPTImageComparison, "compare_images")
+    def test_chatgpt_compare_uses_cache(
+        self, mock_compare, mock_get, mock_store, mock_record, mock_exists
+    ):
+        mock_get.return_value = {"response": "cached", "tokens": 3}
+        result = chatgpt_compare("Prompt", ["img.png"], template_name="cam1")
+        self.assertEqual(result, "cached")
+        mock_compare.assert_not_called()
+        mock_store.assert_not_called()
+        mock_record.assert_called_once_with("cam1", 3)
+
+    @patch("app.utils.image_processing.os.path.exists", return_value=True)
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
+    @patch("app.utils.template_manager.record_llm_usage")
+    @patch("app.utils.llm_cache.store")
+    @patch("app.utils.llm_cache.get", return_value=None)
+    @patch.object(ChatGPTImageComparison, "compare_images")
+    def test_chatgpt_compare_calls_api(
+        self, mock_compare, mock_get, mock_store, mock_record, mock_exists
+    ):
+        mock_compare.return_value = ("result", 5)
+        result = chatgpt_compare("Prompt", ["img.png"], template_name="cam1")
+        self.assertEqual(result, "result")
+        mock_compare.assert_called_once()
+        mock_store.assert_called_once_with("Prompt", "result", 5, ["img.png"])
+        mock_record.assert_called_once_with("cam1", 5)
 
 
 if __name__ == "__main__":

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,4 +1,4 @@
-# tests/test_image_processing.py
+# Integration tests for image processing utilities and ChatGPT comparison
 
 import unittest
 import os

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -74,6 +74,37 @@ class TestRetentionPolicy(unittest.TestCase):
         )
         self.assertEqual(mock_delete.call_count, 2)
 
+    def test_retention_cleanup_temp_dirs(self):
+        with tempfile.TemporaryDirectory() as video_dir, tempfile.TemporaryDirectory() as shot_dir:
+            os.makedirs(os.path.join(video_dir, "cam1"))
+            os.makedirs(os.path.join(shot_dir, "cam1"))
+            for root in (video_dir, shot_dir):
+                cam = os.path.join(root, "cam1")
+                for i in range(12):
+                    with open(os.path.join(cam, f"file{i}.txt"), "w") as f:
+                        f.write("data")
+                    time.sleep(0.01)
+
+            with patch.object(
+                retention_policy, "VIDEO_DIRECTORY", video_dir
+            ), patch.object(
+                retention_policy, "SCREENSHOT_DIRECTORY", shot_dir
+            ), patch.object(
+                retention_policy, "MAX_COMPRESSED_VIDEO_AGE", 0
+            ), patch.object(
+                retention_policy, "MAX_RAW_DATA_SIZE", 0
+            ):
+                retention_cleanup()
+
+            self.assertEqual(
+                len(os.listdir(os.path.join(video_dir, "cam1"))),
+                10,
+            )
+            self.assertEqual(
+                len(os.listdir(os.path.join(shot_dir, "cam1"))),
+                10,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -1,4 +1,4 @@
-# tests/retention_policy.py
+# Integration tests for retention_policy cleanup logic
 
 import unittest
 import tempfile


### PR DESCRIPTION
## Summary
- extend `test_image_processing.py` to verify `chatgpt_compare` behaviour
- expand `test_retention_policy.py` to exercise cleanup on temp directories

## Testing
- `pytest tests/test_image_processing.py tests/test_retention_policy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f9c31b908333a3a4b5f215070afa