### PR TITLE
Add rotating logs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -252,6 +252,8 @@ MAX_IN_PROCESS_VIDEO_SIZE = int(
 
 LOG_LEVEL = get_setting("LOG_LEVEL", "WARN")
 FLASK_LOG_LEVEL = get_setting("FLASK_LOG_LEVEL", LOG_LEVEL)
+LOG_MAX_BYTES = int(get_setting("LOG_MAX_BYTES", 10 * 1024 * 1024))
+LOG_BACKUP_COUNT = int(get_setting("LOG_BACKUP_COUNT", 5))
 
 # Session security settings
 SESSION_COOKIE_SECURE = get_setting("SESSION_COOKIE_SECURE", "True") == "True"

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -13,6 +13,8 @@ The primary application script accepts the following options:
 | `--port` | Port for the web server. |
 | `--log-path` | Path to the log file. |
 | `--log-level` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
+| `--log-max-bytes` | Rotate the log after it grows past this size in bytes. |
+| `--log-backup-count` | Number of rotated log files to keep. |
 | `--console-log` | Enable logging to the console. |
 | `--debug` | Enable debug mode. |
 | `--no-scheduler` | Disable the background scheduler. |

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -15,6 +15,8 @@ are used.
 | `GLIMPSER_DATABASE_PATH` | `data/glimpser.db`        | Location of the SQLite database file    |
 | `GLIMPSER_LOGGING_PATH`  | `logs/glimpser.log`       | Path to the main log file               |
 | `GLIMPSER_BACKUP_PATH`   | `data/config_backup.json` | File used when backing up configuration |
+| `GLIMPSER_LOG_MAX_BYTES` | `10485760`                | Rotate the log file after it reaches this size |
+| `GLIMPSER_LOG_BACKUP_COUNT` | `5` | Number of rotated log files to keep |
 
 Relative paths are resolved from the application's root directory. Use an
 absolute path if the backup file should reside elsewhere.
@@ -40,6 +42,8 @@ can modify them in the application interface or directly in the database.
 - `MAX_WORKERS` – number of worker threads (default `8`)
 - `LOG_LEVEL` – logging level (`INFO`, `WARN`, `DEBUG`, etc.)
 - `FLASK_LOG_LEVEL` – logging level used by the Flask app logger (defaults to `LOG_LEVEL`)
+- `LOG_MAX_BYTES` – rotate the main log when it reaches this size in bytes
+- `LOG_BACKUP_COUNT` – number of rotated log files kept
 
 ## User Credentials
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 #  main.py
 
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import subprocess
 import argparse
@@ -63,6 +64,18 @@ def parse_arguments(arg_list=None):
         default=config.LOG_LEVEL,
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Logging level",
+    )
+    parser.add_argument(
+        "--log-max-bytes",
+        type=int,
+        default=config.LOG_MAX_BYTES,
+        help="Rotate log file after it reaches this size in bytes",
+    )
+    parser.add_argument(
+        "--log-backup-count",
+        type=int,
+        default=config.LOG_BACKUP_COUNT,
+        help="Number of rotated log files to keep",
     )
     parser.add_argument(
         "--console-log",
@@ -127,6 +140,10 @@ def setup_config(args=None):
     config.HOST = args.host
     config.PORT = args.port
     config.LOGGING_PATH = args.log_path
+    if "log_max_bytes" in getattr(args, "__dict__", {}):
+        config.LOG_MAX_BYTES = args.log_max_bytes
+    if "log_backup_count" in getattr(args, "__dict__", {}):
+        config.LOG_BACKUP_COUNT = args.log_backup_count
     config.DEBUG_MODE = args.debug
     config.SCREENSHOT_DIRECTORY = args.screenshot_dir
     config.VIDEO_DIRECTORY = args.video_dir
@@ -149,8 +166,12 @@ def setup_logging(args=None):
     # Ensure log directory exists
     os.makedirs(os.path.dirname(config.LOGGING_PATH), exist_ok=True)
 
-    # Set up file logging
-    file_handler = logging.FileHandler(config.LOGGING_PATH)
+    # Set up file logging with rotation
+    file_handler = RotatingFileHandler(
+        config.LOGGING_PATH,
+        maxBytes=config.LOG_MAX_BYTES,
+        backupCount=config.LOG_BACKUP_COUNT,
+    )
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
 


### PR DESCRIPTION
## Summary
- use `RotatingFileHandler` for log files
- allow configuring log rotation via command-line and settings
- document new configuration options

## Testing
- `black main.py app/config.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f9ba78748333b94bcba481ac3b1d