### PR TITLE
Consolidate settings categories

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2714,7 +2714,8 @@ def init_routes(app: Flask) -> None:
 
         settings = get_all_settings()
         grouped_settings = {group: [] for group in SETTINGS_GROUPS}
-        grouped_settings["Other"] = []
+        default_group = "Integrations"
+        grouped_settings.setdefault(default_group, [])
         for setting in settings:
             placed = False
             for group, names in SETTINGS_GROUPS.items():
@@ -2723,7 +2724,7 @@ def init_routes(app: Flask) -> None:
                     placed = True
                     break
             if not placed:
-                grouped_settings["Other"].append(setting)
+                grouped_settings[default_group].append(setting)
 
         metrics = scheduling.get_system_metrics()
         feeds = scheduling.get_feed_status()

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -26,9 +26,6 @@ content %}
       System Status
     </button>
     {% endif %} {% endfor %}
-    <button type="button" class="tab-link" data-tab="management-tab">
-      Management
-    </button>
     <a
       href="{{ url_for('logout') }}"
       class="tab-link logout-link"
@@ -132,6 +129,16 @@ content %}
           {% endfor %}
         </tbody>
       </table>
+      {% if group == 'Credentials & Management' %}
+      <h3>Configuration Management</h3>
+      <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
+      <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
+      <input type="file" name="file" accept=".json" title="Select configuration file to upload">
+      <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
+
+      <h3>Danger Mode</h3>
+      <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
+      {% endif %}
     </div>
     {% if loop.first %}
     <div id="discover-tab" class="tab-content">
@@ -175,6 +182,16 @@ content %}
                     {% endfor %}
                 </tbody>
             </table>
+            {% if group == 'Credentials & Management' %}
+            <h3>Configuration Management</h3>
+            <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
+            <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
+            <input type="file" name="file" accept=".json" title="Select configuration file to upload">
+            <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
+
+            <h3>Danger Mode</h3>
+            <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
+            {% endif %}
         </div>
         {% if loop.first %}
         <div id="discover-tab" class="tab-content">
@@ -186,27 +203,6 @@ content %}
         {% endif %}
         {% endfor %}
 
-        <div id="management-tab" class="tab-content">
-            <h3>Configuration Management</h3>
-            <button type="submit" name="action" value="backup" title="Create a JSON backup of all settings">Backup Configuration</button>
-            <button type="submit" name="action" value="download" title="Download the latest configuration backup">Download Configuration</button>
-            <input type="file" name="file" accept=".json" title="Select configuration file to upload">
-            <button type="submit" name="action" value="upload" title="Restore configuration from uploaded file" onclick="return confirmRestore()">Upload Configuration</button>
-
-            <h3>Danger Mode</h3>
-            <button type="submit" name="action" value="update_shortcut" title="Update Chrome shortcuts for Danger mode">Update Chrome Shortcut</button>
-
-
-      <h3>Danger Mode</h3>
-      <button
-        type="submit"
-        name="action"
-        value="update_shortcut"
-        title="Update Chrome shortcuts for Danger mode"
-      >
-        Update Chrome Shortcut
-      </button>
-    </div>
 
     <input
       type="hidden"

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -46,7 +46,7 @@ SETTINGS_CHOICES = {
 
 # Settings categories used to group configuration values on the settings page.
 # Keys are tab labels while the lists contain setting names assigned to each
-# category. Any values not present here fall under the "Other" tab.
+# category. Any values not present here fall under the "Integrations" tab.
 SETTINGS_GROUPS = {
     "General": [
         "NAME",

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -61,7 +61,7 @@ SETTINGS_GROUPS = {
         "LOG_LEVEL",
         "FLASK_LOG_LEVEL",
     ],
-    "Credentials": [
+    "Credentials & Management": [
         "USER_NAME",
         "USER_PASSWORD_HASH",
         "SECRET_KEY",
@@ -73,15 +73,13 @@ SETTINGS_GROUPS = {
         "SESSION_COOKIE_HTTPONLY",
         "SESSION_TIMEOUT_MINUTES",
     ],
-    "File Locations": [
+    "Capture": [
         "DATABASE_PATH",
         "LOGGING_PATH",
         "BACKUP_PATH",
         "SCREENSHOT_DIRECTORY",
         "VIDEO_DIRECTORY",
         "SUMMARIES_DIRECTORY",
-    ],
-    "Capture": [
         "NUM_FRAMES",
         "CAPTURE_TIMEOUT",
         "PROBE_SIZE_DEFAULT",
@@ -103,7 +101,7 @@ SETTINGS_GROUPS = {
         "FFMPEG_HWACCEL",
         "FFMPEG_THREADS",
     ],
-    "Email": [
+    "Integrations": [
         "EMAIL_ENABLED",
         "EMAIL_SENDER",
         "EMAIL_RECIPIENTS",
@@ -112,9 +110,13 @@ SETTINGS_GROUPS = {
         "EMAIL_USE_TLS",
         "EMAIL_USERNAME",
         "EMAIL_PASSWORD",
+        "TWILIO_SID",
+        "TWILIO_TOKEN",
+        "TWILIO_NUMBER",
+        "CAP_ENDPOINT",
+        "CAP_SENDER",
+        "MCP_SERVER_COMMAND",
+        "MCP_SERVER_URL",
     ],
-    "SMS": ["TWILIO_SID", "TWILIO_TOKEN", "TWILIO_NUMBER"],
-    "CAP": ["CAP_ENDPOINT", "CAP_SENDER"],
-    "MCP": ["MCP_SERVER_COMMAND", "MCP_SERVER_URL"],
     "Clock": ["CLOCK_OVERLAY", "CLOCK_DIGITAL", "CLOCK_NAVBAR"],
 }

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -5,9 +5,9 @@ The **Settings** interface lets you manage configuration values stored in the da
 ## Sections
 
 - **Add New Setting** – quickly create additional key/value pairs.
-- **Current Settings** – edit existing values or delete them. Tabs switch between setting groups and the **Management** tab holds backup and offline options.
-- **Configuration Management** – backup, download, and upload the JSON configuration file.
-- **Danger Mode** – update Chrome shortcuts with the required flags.
+- **Current Settings** – edit existing values or delete them. Tabs include **General**, **Capture**, **Credentials & Management**, **Integrations**, and **Clock**.
+- **Configuration Management** – backup, download, and upload the JSON configuration file. These tools now live under the **Credentials & Management** tab.
+- **Danger Mode** – update Chrome shortcuts with the required flags. Also part of **Credentials & Management**.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.


### PR DESCRIPTION
## Summary
- group all storage options with capture settings
- merge credentials with management tools
- collapse all integration tabs into a single group
- document the new layout on the settings page

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fad25d808333b3674fe28d3fd85e