### PR TITLE
Expand help page

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -217,6 +217,7 @@ SCHEDULER_API_ENABLED = True
 SCREENSHOT_DIRECTORY = "data/screenshots/"
 VIDEO_DIRECTORY = "data/video/"
 SUMMARIES_DIRECTORY = "data/summaries/"
+DOCS_DIRECTORY = "docs"
 
 # Load settings from the database
 UA = get_setting(

--- a/app/routes.py
+++ b/app/routes.py
@@ -57,6 +57,7 @@ from app.config import (
     API_KEY,
     SCREENSHOT_DIRECTORY,
     VIDEO_DIRECTORY,
+    DOCS_DIRECTORY,
     VERSION,
     BACKUP_PATH,
     backup_config,
@@ -1532,6 +1533,24 @@ def init_routes(app: Flask) -> None:
     @login_required
     def help_page():
         return render_template("help.html", page_title="Help")
+
+    @app.route("/docs/<string:filename>")
+    @login_required
+    def docs_file(filename: str):
+        """Serve Markdown documentation files from the repository."""
+        if not allowed_filename(filename):
+            abort(404)
+
+        docs_path = os.path.join(
+            os.path.dirname(os.path.join(__file__)),
+            "..",
+            DOCS_DIRECTORY,
+        )
+        full_path = os.path.join(docs_path, filename)
+        if not os.path.exists(full_path):
+            abort(404)
+
+        return send_from_directory(docs_path, filename)
 
     @app.route("/settings_help")
     @login_required

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -97,6 +97,21 @@ content %}
       >
       and <a href="../docs/faq.md" target="_blank">FAQ</a>.
     </p>
+    {% endcall %} {% call card('Quick Docs') %}
+    <ul class="quick-docs">
+      <li>
+        <a href="../docs/getting_started.md" target="_blank">Getting Started</a>
+      </li>
+      <li>
+        <a href="../docs/configuration_guide.md" target="_blank"
+          >Configuration Guide</a
+        >
+      </li>
+      <li>
+        <a href="../docs/troubleshooting.md" target="_blank">Troubleshooting</a>
+      </li>
+      <li><a href="../docs/faq.md" target="_blank">FAQ</a></li>
+    </ul>
     {% endcall %} {% call card('Contributing & Feedback') %}
     <p>
       Glimpser is open source on

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -42,3 +42,4 @@ The help page is only a starting point. For more details, explore these key docu
 - [Offline Preview](offline_preview.md) for tips on viewing captures without an internet connection
 
 All documentation lives under the `docs/` directory so you can read it offline after cloning the repository.
+You can open any of these Markdown files locally by visiting `/docs/<filename>` in your browser.

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -30,3 +30,15 @@ Click **Live All** to switch every tile to a real-time feed and **Play All** to 
 Keyboard shortcuts help you navigate quickly: `Space` or `k` toggles play or pause, `m` mutes audio, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the bottom of the help page.
+
+## Additional Resources
+
+The help page is only a starting point. For more details, explore these key documentation sections:
+
+- [Getting Started](getting_started.md) for installation and initial setup
+- [Configuration Guide](configuration_guide.md) to tailor Glimpser to your environment
+- [Troubleshooting](troubleshooting.md) if something goes wrong
+- [FAQ](faq.md) for quick answers to common questions
+- [Offline Preview](offline_preview.md) for tips on viewing captures without an internet connection
+
+All documentation lives under the `docs/` directory so you can read it offline after cloning the repository.

--- a/tests/test_docs_endpoint.py
+++ b/tests/test_docs_endpoint.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import unittest
+import tempfile
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestDocsEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        with open(
+            os.path.join(self.temp_dir.name, "test.md"), "w", encoding="utf-8"
+        ) as fh:
+            fh.write("content")
+        self.docs_patch = patch("app.routes.DOCS_DIRECTORY", self.temp_dir.name)
+        self.docs_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.docs_patch.stop()
+        self.temp_dir.cleanup()
+
+    def test_serves_doc_file(self):
+        resp = self.client.get("/docs/test.md")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, b"content")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand the help page documentation
- link docs directly on the HTML help page

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684506ae148083339ef242e6d2008eac