### PR TITLE
Fix slider min width logic

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -35,10 +35,11 @@ export function initTemplates() {
         const templateCount =
           templateList?.querySelectorAll(".templateDiv").length || 1;
 
-        // Minimum width needed to fit all tiles across the page
-        const widthForColumns = Math.ceil(window.innerWidth / templateCount);
+        // Estimate square layout so four cameras become a 2x2 grid
+        const columns = Math.ceil(Math.sqrt(templateCount));
+        const widthForColumns = Math.ceil(window.innerWidth / columns);
 
-        // Minimum width needed so combined rows fill the screen vertically
+        // Minimum width so rows also fit vertically within the viewport
         const aspectRatio = 9 / 16;
         const widthForHeight = Math.sqrt(
           (window.innerHeight * window.innerWidth) /
@@ -47,11 +48,15 @@ export function initTemplates() {
         const widthForMaxHeight = MAX_THUMBNAIL_HEIGHT / aspectRatio;
         slider.max = Math.min(slider.max, widthForMaxHeight);
 
+        // Never shrink thumbnails below 5% of the viewport or ~200px
+        const sizeFloor = Math.max(200, window.innerWidth * 0.05);
+        // Choose the larger of our safety floor or the size needed to keep
+        // all rows and columns visible without scrolling
         const computedMin = Math.max(
-          50,
+          sizeFloor,
           Math.min(
             slider.max,
-            Math.ceil(Math.max(widthForColumns, widthForHeight)),
+            Math.ceil(Math.min(widthForColumns, widthForHeight)),
           ),
         );
 

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -3,6 +3,7 @@
 Glimpser now adapts to phones and tablets. The navigation menu collapses into a hamburger button on narrow screens and tables reflow vertically to avoid horizontal scrolling. Video grids automatically switch to a single column when viewed on devices without hover capability or small viewports.
 
 The main template view scales thumbnails with the width slider and the page now uses smooth scrolling for longer lists. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping. When a group is opened, the slider defaults to the smallest width that keeps all cameras visible without scrolling.
+The width calculation assumes a roughly square layout so four cameras appear in a 2×2 grid at minimum slider width. Thumbnails never shrink below 5% of the viewport or about 200 px to prevent unusably small previews.
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 


### PR DESCRIPTION
## Summary
- enforce minimum tile width in `updateSliderLimits`
- document minimum tile size in responsive design guide

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845043db03c8333bb015a3fffa0f2f0