### PR TITLE
Add dynamic CLI help to help page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1529,6 +1529,14 @@ def init_routes(app: Flask) -> None:
     def help_page():
         return render_template("help.html", page_title="Help")
 
+    @app.route("/cli_help")
+    @login_required
+    def cli_help():
+        """Return CLI help text."""
+        from app.utils.cli import cli_help_text
+
+        return Response(cli_help_text(), mimetype="text/plain")
+
     @app.route("/settings_help")
     @login_required
     def settings_help():

--- a/app/static/js/cli_help.js
+++ b/app/static/js/cli_help.js
@@ -1,0 +1,20 @@
+export function initCliHelp() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const button = document.getElementById("load-cli-help");
+    const output = document.getElementById("cli-help");
+    if (!button || !output) return;
+
+    button.addEventListener("click", async () => {
+      button.disabled = true;
+      try {
+        const res = await fetch("/cli_help");
+        output.textContent = await res.text();
+      } catch (err) {
+        output.textContent = "Failed to load help.";
+        console.error(err);
+      } finally {
+        output.classList.remove("hidden");
+      }
+    });
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -19,6 +19,7 @@ import { initControlsDropdown } from "./controls.js";
 import { initAutocomplete } from "./autocomplete.js";
 import { initCosts } from "./costs.js";
 import { initAdvanced } from "./advanced.js";
+import { initCliHelp } from "./cli_help.js";
 
 initTemplates();
 initVideoControls();
@@ -42,3 +43,4 @@ initControlsDropdown();
 initAutocomplete();
 initCosts();
 initAdvanced();
+initCliHelp();

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -54,6 +54,8 @@ content %}
       Control Glimpser from the command line. Run
       <code>glimpser --help</code> to list all commands.
     </p>
+    <button id="load-cli-help" class="btn">Show CLI Help</button>
+    <pre id="cli-help" class="cli-help hidden" aria-live="polite"></pre>
     {% endcall %}
   </div>
 

--- a/app/utils/cli.py
+++ b/app/utils/cli.py
@@ -1,0 +1,94 @@
+"""CLI helper utilities."""
+
+from __future__ import annotations
+
+import argparse
+
+import app.config as config
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Return the ``argparse`` parser used for the ``glimpser`` CLI."""
+    parser = argparse.ArgumentParser(description=f"Glimpser {config.VERSION}")
+    parser.add_argument(
+        "--db-path",
+        default=config.DATABASE_PATH,
+        help=f"Path to the database file (default: {config.DATABASE_PATH})",
+    )
+    parser.add_argument(
+        "--host",
+        default=config.HOST,
+        help=f"Host for the web server (default: {config.HOST})",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=config.PORT,
+        help=f"Port for the web server (default: {config.PORT})",
+    )
+    parser.add_argument(
+        "--log-path",
+        default=config.LOGGING_PATH,
+        help=f"Path to the log file (default: {config.LOGGING_PATH})",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=config.LOG_LEVEL,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--console-log",
+        action="store_true",
+        help="Enable logging to the console",
+        default=False,
+    )
+    parser.add_argument(
+        "--debug", action="store_true", default=config.DEBUG, help="Enable debug mode"
+    )
+    parser.add_argument(
+        "--no-scheduler",
+        action="store_true",
+        help="Disable the background scheduler",
+        default=False,
+    )
+    parser.add_argument(
+        "--no-watchdog",
+        action="store_true",
+        help="Disable the watchdog thread",
+        default=False,
+    )
+    parser.add_argument(
+        "--no-crawlers",
+        action="store_true",
+        help="Skip scheduling crawler jobs",
+        default=False,
+    )
+    parser.add_argument(
+        "--screenshot-dir",
+        default=config.SCREENSHOT_DIRECTORY,
+        help="Directory for storing screenshots",
+    )
+    parser.add_argument(
+        "--video-dir",
+        default=config.VIDEO_DIRECTORY,
+        help="Directory for storing video files",
+    )
+    parser.add_argument(
+        "--summaries-dir",
+        default=config.SUMMARIES_DIRECTORY,
+        help="Directory for storing summaries",
+    )
+    return parser
+
+
+def parse_arguments(arg_list: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments and return the populated ``Namespace``."""
+    parser = build_argument_parser()
+    return parser.parse_args(arg_list)
+
+
+def cli_help_text() -> str:
+    """Return the formatted ``--help`` text for the CLI."""
+    parser = build_argument_parser()
+    return parser.format_help()

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -19,6 +19,7 @@ Key topics covered include:
 - Offline preview of recent snapshots and locally hosted fonts.
 - Links to the rest of the documentation under `docs/`.
 - Tooltips across the interface for quick explanations.
+- Inline viewing of command-line help via the **Show CLI Help** button.
 - A link to the project on [GitHub](https://github.com/KristopherKubicki/glimpser) where you can report issues or contribute.
 
 ## Viewing Captures

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ import socket
 import app.config as config
 from app import create_app
 from app import scheduler
+from app.utils.cli import build_argument_parser, cli_help_text
 from app.utils.scheduling import get_system_metrics, stop_background_tasks
 
 banner = """
@@ -28,87 +29,14 @@ banner = """
 
 
 def parse_arguments(arg_list=None):
-    """
-    Parse command-line arguments for the Glimpser application.
-
-    This function sets up the argument parser and defines various command-line options
-    for configuring the application, including paths for database, logs, and media files,
-    as well as server and logging settings.
-
-    Returns:
-        argparse.Namespace: An object containing the parsed arguments.
-    """
-    parser = argparse.ArgumentParser(description="Glimpser %s" % config.VERSION)
-    parser.add_argument(
-        "--db-path",
-        default=config.DATABASE_PATH,
-        help="Path to the database file (default: %s)" % config.DATABASE_PATH,
-    )
-    parser.add_argument(
-        "--host",
-        default=config.HOST,
-        help="Host for the web server (default: %s)" % config.HOST,
-    )
-    parser.add_argument(
-        "--port",
-        type=int,
-        default=config.PORT,
-        help="Port for the web server (default: %s)" % config.PORT,
-    )
-    parser.add_argument(
-        "--log-path",
-        default=config.LOGGING_PATH,
-        help="Path to the log file (default: %s)" % config.LOGGING_PATH,
-    )
-    parser.add_argument(
-        "--log-level",
-        default=config.LOG_LEVEL,
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        help="Logging level",
-    )
-    parser.add_argument(
-        "--console-log",
-        action="store_true",
-        help="Enable logging to the console",
-        default=False,
-    )
-    parser.add_argument(
-        "--debug", action="store_true", default=config.DEBUG, help="Enable debug mode"
-    )
-    parser.add_argument(
-        "--no-scheduler",
-        action="store_true",
-        help="Disable the background scheduler",
-        default=False,
-    )
-    parser.add_argument(
-        "--no-watchdog",
-        action="store_true",
-        help="Disable the watchdog thread",
-        default=False,
-    )
-    parser.add_argument(
-        "--no-crawlers",
-        action="store_true",
-        help="Skip scheduling crawler jobs",
-        default=False,
-    )
-    parser.add_argument(
-        "--screenshot-dir",
-        default=config.SCREENSHOT_DIRECTORY,
-        help="Directory for storing screenshots",
-    )
-    parser.add_argument(
-        "--video-dir",
-        default=config.VIDEO_DIRECTORY,
-        help="Directory for storing video files",
-    )
-    parser.add_argument(
-        "--summaries-dir",
-        default=config.SUMMARIES_DIRECTORY,
-        help="Directory for storing summaries",
-    )
+    """Return parsed command-line arguments."""
+    parser = build_argument_parser()
     return parser.parse_args(arg_list)
+
+
+def get_cli_help() -> str:
+    """Return the formatted ``--help`` text."""
+    return cli_help_text()
 
 
 def setup_config(args=None):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,6 +193,10 @@ class TestMain(unittest.TestCase):
             main.setup_config(args)
         config.ENFORCE_DOMAIN_IN_HOST = old_enforce
 
+    def test_cli_help_text(self):
+        text = main.get_cli_help()
+        self.assertIn("--db-path", text)
+
     @patch("main.create_app")
     @patch("main.ensure_directories")
     @patch("main.generate_credentials_if_needed")


### PR DESCRIPTION
## Summary
- expose a `/cli_help` route for command-line help text
- show CLI help from the help page with a new button
- load CLI help via `cli_help.js`
- document the new feature in `help_page.md`
- test `get_cli_help` helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684508a99c1c83339188c1b3563bb4ac