### PR TITLE
Add URL tester to camera form

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import time
 import uuid
+import requests
 from datetime import datetime, timedelta
 from dateutil import tz
 
@@ -3244,6 +3245,25 @@ def init_routes(app: Flask) -> None:
         }
         template_manager.save_template(name, template)
         return jsonify({"status": "success"})
+
+    @app.route("/templates/test_url")
+    @login_required
+    def test_template_url() -> Response:
+        """Return JSON indicating whether the given URL is reachable."""
+
+        url = request.args.get("url") or ""
+        url = validators.validate_url(url)
+        if not url:
+            return jsonify({"ok": False, "error": "invalid"}), 400
+
+        try:
+            resp = requests.head(url, timeout=5)
+            ok = resp.status_code < 400
+        except Exception as exc:  # pragma: no cover - network
+            logging.warning("url check failed: %s", exc)
+            return jsonify({"ok": False, "error": "unreachable"}), 400
+
+        return jsonify({"ok": ok, "status": resp.status_code})
 
     @app.route("/discover/export", methods=["POST"])
     @login_required

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -169,6 +169,18 @@ main {
 .dynamic-tooltip.hidden {
   opacity: 0;
 }
+.url-status {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  margin-left: 4px;
+}
+.url-status.ok {
+  color: #5cb85c;
+}
+.url-status.bad {
+  color: #d9534f;
+}
 .link {
   color: rgb(192, 192, 192);
 }

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -1,0 +1,38 @@
+export function initUrlTester() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const input = document.getElementById("url");
+    const status = document.getElementById("url-status");
+    if (!input || !status) return;
+
+    let controller;
+    const check = async () => {
+      const url = input.value.trim();
+      status.textContent = "";
+      status.className = "url-status";
+      if (!url) return;
+      controller?.abort();
+      controller = new AbortController();
+      status.textContent = "…";
+      try {
+        const res = await fetch(`/templates/test_url?url=${encodeURIComponent(url)}`, {
+          signal: controller.signal,
+        });
+        const data = await res.json();
+        if (res.ok && data.ok) {
+          status.textContent = "✓";
+          status.classList.add("ok");
+        } else {
+          status.textContent = "✗";
+          status.classList.add("bad");
+        }
+      } catch {
+        if (controller.signal.aborted) return;
+        status.textContent = "✗";
+        status.classList.add("bad");
+      }
+    };
+
+    input.addEventListener("blur", check);
+    input.addEventListener("change", check);
+  });
+}

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -75,6 +75,7 @@
 
                         <label for="url" title="URL to monitor">URL:</label>
                         <input type="url" id="url" name="url" required title="Enter the URL to monitor">
+                        <span id="url-status" class="url-status" title="URL test result"></span>
 
                         <label for="frequency" title="How often to check the URL">Frequency (minutes):</label>
                         <input type="number" id="frequency" name="frequency" value="30" min="1" required title="Enter how often to check the URL (in minutes)">
@@ -292,3 +293,4 @@ const exportData = (fmt) => {
   if (exportCsv) exportCsv.addEventListener('click', () => exportData('csv'));
 });
 </script>
+<script type="module" src="{{ url_for('static', filename='js/url_test.js') }}"></script>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,9 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 3. Choose a data source type (e.g., camera, dashboard, or video stream).
 
-4. Configure the source settings (URL, refresh rate, etc.).
+4. Configure the source settings (URL, refresh rate, etc.). A small status icon
+   next to the URL turns green once the address is reachable, helping catch typos
+   before saving.
 
 5. Save the source configuration.
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -37,6 +37,7 @@ These tooltips aim to make the interface self‑explanatory and easier to naviga
 Interactive forms now include additional tooltips:
 
 - **Add Camera** – explains each field on the Discover tab and the "Structured" XPath buttons.
+- **URL tester** – a tooltip shows "checking" then "valid" or "invalid" next to the URL field.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
 - **Template toolbar** – quick actions appear at the bottom-left of the details page and fade out when idle.
 - **Captions** – upload and filter controls have descriptive titles. The metric dropdown filters feeds by count or storage and updates the list immediately.

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+document.body.innerHTML = `<input id="url"><span id="url-status"></span>`;
+
+let initUrlTester;
+
+beforeAll(async () => {
+  ({ initUrlTester } = await import('../../app/static/js/url_test.js'));
+});
+
+describe('url_test', () => {
+  test('shows status after fetch', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      }),
+    );
+    initUrlTester();
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const input = document.getElementById('url');
+    input.value = 'http://example.com';
+    input.dispatchEvent(new Event('change'));
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalled();
+    const status = document.getElementById('url-status');
+    expect(status.textContent).toBe('✓');
+    expect(status.classList.contains('ok')).toBe(true);
+  });
+});

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import threading
+from unittest.mock import patch
+import http.server
+from werkzeug.serving import make_server
+import requests
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app import create_app
+
+
+class ServerThread(threading.Thread):
+    def __init__(self, app):
+        super().__init__(daemon=True)
+        self.server = make_server("127.0.0.1", 0, app)
+        self.port = self.server.server_port
+
+    def run(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.shutdown()
+
+
+@pytest.fixture()
+def tmp_http_server(tmp_path):
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    yield server
+    server.shutdown()
+    thread.join()
+
+
+def test_url_test_endpoint(tmp_http_server):
+    with patch("app.routes.login_required", lambda x: x):
+        app = create_app(enable_watchdog=False, schedule=False)
+        server = ServerThread(app)
+        server.start()
+        try:
+            url = f"http://127.0.0.1:{tmp_http_server.server_port}"
+            resp = requests.get(
+                f"http://127.0.0.1:{server.port}/templates/test_url",
+                params={"url": url},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["ok"]
+        finally:
+            server.shutdown()


### PR DESCRIPTION
## Summary
- add `/templates/test_url` endpoint
- integrate URL tester into Add Camera form
- show status icon next to URL input
- style URL tester indicator
- document new URL tester feature
- add unit tests for endpoint and JS

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845097e835883339c97bc4875c548f8