### PR TITLE
Add bundle size audit

### DIFF
--- a/docs/size_audit.md
+++ b/docs/size_audit.md
@@ -1,0 +1,4 @@
+# Bundle Size Audit
+
+`npm run size-audit` checks the gzipped size of every JavaScript file under `app/static/js`.
+If any file exceeds **140&nbsp;KiB**, the command fails so pages stay lightweight on mobile.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Caption Overlay Toggle: caption_overlay_toggle.md
       - Chatbot: chatbot.md
       - CI Checks: ci_checks.md
+      - Bundle Size Audit: size_audit.md
       - Jog Shuttle: jog_shuttle.md
       - Live All: live_all.md
       - Live Scrub: live_scrub.md

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format:js:write": "prettier --write 'app/static/js/**/*.js'",
     "format": "npm run format:js:write",
     "test:js": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=jsdom",
-    "test": "npm run test:js"
+    "test": "npm run test:js",
+    "size-audit": "node scripts/size-audit.js"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/scripts/size-audit.js
+++ b/scripts/size-audit.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { gzip } from "node:zlib";
+import { promisify } from "node:util";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const MAX_SIZE = 140 * 1024; // 140 KiB
+const gzipAsync = promisify(gzip);
+
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(path);
+    } else if (entry.isFile() && path.endsWith(".js")) {
+      yield path;
+    }
+  }
+}
+
+async function check() {
+  let failed = false;
+  for await (const file of walk("app/static/js")) {
+    const content = await readFile(file);
+    const gzipped = await gzipAsync(content);
+    const size = gzipped.length;
+    console.log(`${file}: ${size} bytes`);
+    if (size > MAX_SIZE) {
+      console.error(`ERROR: ${file} exceeds ${MAX_SIZE} bytes`);
+      failed = true;
+    }
+  }
+  if (failed) process.exitCode = 1;
+}
+
+check();


### PR DESCRIPTION
## Summary
- add `size-audit` npm script to ensure gzipped JS files stay below 140 KiB
- document bundle size audit procedure
- include the new doc in navigation

## Testing
- `flake8`
- `pytest -q`
- `npm run size-audit --silent`

------
https://chatgpt.com/codex/tasks/task_e_68457d8407c08333a60e9b84ebdb55e5