### PR TITLE
Add docs build workflow page

### DIFF
--- a/docs/docs_build.md
+++ b/docs/docs_build.md
@@ -1,0 +1,9 @@
+# Docs Build Workflow
+
+The `.github/workflows/docs-build.yml` workflow ensures documentation builds successfully on every push and pull request. It performs the following steps:
+
+- Checks out the repository and sets up Python 3.x.
+- Installs MkDocs using `pip`.
+- Runs `mkdocs build --strict` to verify the documentation compiles without errors.
+
+If the build step fails, the workflow prevents the PR from being merged.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Docker Build Verification](docker_build.md)
 - [CodeQL Security Scanning](codeql.md)
 - [Continuous Integration Checks](ci_checks.md)
+- [Docs Build Workflow](docs_build.md)
 - [System Monitoring and Logs](system_monitoring.md)
 - [Danger Mode](danger_mode.md)
 - [FAQ](faq.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - UI Design Guidelines: design_guidelines.md
       - Developer Guide: developer_guide.md
       - Docker Build Verification: docker_build.md
+      - Docs Build Workflow: docs_build.md
       - CodeQL Security Scanning: codeql.md
       - FAQ: faq.md
       - Getting Started: getting_started.md


### PR DESCRIPTION
## Summary
- document the docs build workflow
- link the new docs build page in index and mkdocs config

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457f48fc1483339417b7cff3e2b88c