### PR TITLE
Improve captions chat modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stream error overlay distinguishes network and unsupported format errors
 - Sortable KPI table on captions page with filtering
 - Captions chat modal adds keyboard shortcuts, server error feedback and a
-  conversation history panel
+  conversation history panel with auto-scroll and accessibility tweaks
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Footer warns when a newer release is available
 - Stream error overlay distinguishes network and unsupported format errors
 - Sortable KPI table on captions page with filtering
+- Captions chat modal adds keyboard shortcuts, server error feedback and a
+  conversation history panel
 
 ### Changed
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1499,6 +1499,12 @@ details > summary {
   overflow-y: auto;
   white-space: pre-wrap;
 }
+.chat-history {
+  margin-bottom: 1rem;
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
 
 .form-error {
   color: red;

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -27,37 +27,80 @@ export function initCaptions() {
     const chatSubmit = document.getElementById("chat-submit");
     const chatQuestion = document.getElementById("chat-question");
     const chatAnswer = document.getElementById("chat-answer");
+    const chatHistory = document.getElementById("chat-history");
+
+    const closeChat = () => {
+      if (chatModal) chatModal.style.display = "none";
+    };
 
     chatOpen?.addEventListener("click", () => {
-      if (chatModal) chatModal.style.display = "block";
+      if (chatModal) {
+        chatModal.style.display = "block";
+        if (chatQuestion) {
+          chatQuestion.value = "";
+          chatQuestion.focus();
+        }
+      }
     });
-    chatClose?.addEventListener("click", () => {
-      if (chatModal) chatModal.style.display = "none";
+    chatClose?.addEventListener("click", closeChat);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && chatModal?.style.display === "block") {
+        closeChat();
+      }
     });
-    chatSubmit?.addEventListener("click", async () => {
-      if (!chatQuestion || !chatQuestion.value) return;
+
+    const sendQuestion = async () => {
+      if (!chatQuestion || !chatQuestion.value.trim()) return;
       const start = document.getElementById("caption-start")?.value;
       const end = document.getElementById("caption-end")?.value;
-      const resp = await fetch("/captions_chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ question: chatQuestion.value, start, end }),
-      });
-      const data = await resp.json();
-      if (chatAnswer) {
-        chatAnswer.textContent = data.truncated
-          ? `${data.answer}\n(Input truncated)`
-          : data.answer;
+      if (chatAnswer) chatAnswer.textContent = "Thinking...";
+      try {
+        const resp = await fetch("/captions_chat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ question: chatQuestion.value, start, end }),
+        });
+        const data = await resp.json();
+        if (chatAnswer) {
+          chatAnswer.textContent = data.truncated
+            ? `${data.answer}\n(Input truncated)`
+            : data.answer;
+        }
+        if (chatHistory) {
+          const q = document.createElement("div");
+          q.textContent = `Q: ${chatQuestion.value}`;
+          const a = document.createElement("div");
+          a.textContent = `A: ${data.answer}`;
+          chatHistory.append(q, a);
+        }
+        const table = document.querySelector("#captions-table tbody");
+        if (table && data.answer) {
+          const now = new Date().toISOString().replace("T", " ").slice(0, 19);
+          const rowQ = document.createElement("tr");
+          const qTime = document.createElement("td");
+          qTime.textContent = now;
+          const qText = document.createElement("td");
+          qText.textContent = `Q: ${chatQuestion.value}`;
+          rowQ.append(qTime, qText);
+          const rowA = document.createElement("tr");
+          const aTime = document.createElement("td");
+          aTime.textContent = now;
+          const aText = document.createElement("td");
+          aText.textContent = `A: ${data.answer}`;
+          rowA.append(aTime, aText);
+          table.prepend(rowA);
+          table.prepend(rowQ);
+        }
+      } catch (err) {
+        if (chatAnswer) chatAnswer.textContent = "Unable to reach server";
       }
-      const table = document.querySelector("#captions-table tbody");
-      if (table && data.answer) {
-        const now = new Date().toISOString().replace("T", " ").slice(0, 19);
-        const rowQ = document.createElement("tr");
-        rowQ.innerHTML = `<td>${now}</td><td>Q: ${chatQuestion.value}</td>`;
-        const rowA = document.createElement("tr");
-        rowA.innerHTML = `<td>${now}</td><td>A: ${data.answer}</td>`;
-        table.prepend(rowA);
-        table.prepend(rowQ);
+    };
+
+    chatSubmit?.addEventListener("click", sendQuestion);
+    chatQuestion?.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        sendQuestion();
       }
     });
 

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -91,6 +91,13 @@ export function initCaptions() {
           table.prepend(rowA);
           table.prepend(rowQ);
         }
+        if (chatHistory) {
+          chatHistory.scrollTop = chatHistory.scrollHeight;
+        }
+        if (chatQuestion) {
+          chatQuestion.value = "";
+          chatQuestion.focus();
+        }
       } catch (err) {
         if (chatAnswer) chatAnswer.textContent = "Unable to reach server";
       }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -222,7 +222,7 @@
         {% endif %} {% endfor %} {% endfor %} {% endif %}
       </tbody>
     </table>
-    <div id="chat-modal" class="modal" role="dialog" aria-modal="true">
+    <div id="chat-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="chat-title">
       <div class="modal-content">
         <span id="chat-close" class="close-icon" title="Close dialog">&times;</span>
         <h3 id="chat-title">Captions Chat</h3>
@@ -233,7 +233,7 @@
           placeholder="Ask a question..."
         ></textarea>
         <button id="chat-submit" type="button">Ask</button>
-        <div id="chat-answer" class="chat-answer"></div>
+        <div id="chat-answer" class="chat-answer" aria-live="polite"></div>
       </div>
     </div>
   </div>

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -222,9 +222,11 @@
         {% endif %} {% endfor %} {% endfor %} {% endif %}
       </tbody>
     </table>
-    <div id="chat-modal" class="modal">
+    <div id="chat-modal" class="modal" role="dialog" aria-modal="true">
       <div class="modal-content">
-        <span id="chat-close" class="close-icon">&times;</span>
+        <span id="chat-close" class="close-icon" title="Close dialog">&times;</span>
+        <h3 id="chat-title">Captions Chat</h3>
+        <div id="chat-history" class="chat-history"></div>
         <textarea
           id="chat-question"
           class="prompt-textarea"

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -7,3 +7,14 @@ date range) to the language model configured by `CHATGPT_KEY`.
 If more than 100 entries match your filters, the request is truncated and the
 response notes the limitation. Both your question and the answer are appended to
 the captions stream for reference.
+
+### UI details
+
+* The chat input is focused and cleared each time the modal opens for quicker
+  follow‑up questions.
+* Press **Enter** to submit and **Shift+Enter** for a new line.
+* A "Thinking…" placeholder appears while the backend processes the request
+  and a friendly error message is shown on network failure.
+* The conversation history is displayed inside the modal and also added to the
+  captions table.
+* The dialog is accessible via the Escape key and uses `role="dialog"`.

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -16,5 +16,10 @@ the captions stream for reference.
 * A "Thinking…" placeholder appears while the backend processes the request
   and a friendly error message is shown on network failure.
 * The conversation history is displayed inside the modal and also added to the
-  captions table.
-* The dialog is accessible via the Escape key and uses `role="dialog"`.
+  captions table. The list automatically scrolls to the newest entry.
+* The input clears and regains focus after each submission for faster
+  follow‑ups.
+* The answer container uses `aria-live="polite"` so screen readers announce
+  responses.
+* The dialog is accessible via the Escape key and uses `role="dialog"` with
+  `aria-labelledby` pointing to the modal title.

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- enhance captions chatbot UX with focus handling, keyboard shortcuts and error feedback
- display conversation history within the modal
- add `chat-history` styles
- document the improved chat interface

## Testing
- `npx prettier --write 'app/static/js/**/*.js'`
- `black app tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457fc0c6f08333944e6ddafe8bd0f4