### PR TITLE
Require authentication for mjpg streams

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1558,6 +1558,7 @@ def init_routes(app: Flask) -> None:
             "TEARDOWN",
         ],
     )
+    @login_required
     def handle_rtsp():
 
         session_id = request.headers.get("Session", str(uuid.uuid4()))
@@ -1658,6 +1659,7 @@ def init_routes(app: Flask) -> None:
         return "Method Not Allowed", 405
 
     @app.route("/stream.mjpg", methods=["GET"])
+    @login_required
     def stream_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
@@ -1671,6 +1673,7 @@ def init_routes(app: Flask) -> None:
         )
 
     @app.route("/motion.mjpg", methods=["GET"])
+    @login_required
     def motion_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
@@ -1684,6 +1687,7 @@ def init_routes(app: Flask) -> None:
         )
 
     @app.route("/caption.mjpg", methods=["GET"])
+    @login_required
     def caption_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")
@@ -1698,6 +1702,7 @@ def init_routes(app: Flask) -> None:
         )
 
     @app.route("/internal_caption.mjpg", methods=["GET"])
+    @login_required
     def internal_caption_mjpg():
         return Response(
             generate_caption_loop(),
@@ -1705,6 +1710,7 @@ def init_routes(app: Flask) -> None:
         )
 
     @app.route("/motion_caption.mjpg", methods=["GET"])
+    @login_required
     def motion_caption_mjpg():
         group = request.args.get("group")
         camera = request.args.get("camera")

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -10,12 +10,15 @@ from app import create_app
 
 class TestMotionMjpg(unittest.TestCase):
     def setUp(self):
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
         self.app = create_app(enable_watchdog=False, schedule=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()
 
     def tearDown(self):
+        self.login_patch.stop()
         self.app_context.pop()
 
     def _check_call(self, url, expected_camera, expected_group):

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -10,6 +10,8 @@ import app.routes as routes
 
 class TestRTSP(unittest.TestCase):
     def setUp(self):
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
         self.app = create_app(enable_watchdog=False, schedule=False)
         self.app.testing = True
         self.client = self.app.test_client()
@@ -17,6 +19,7 @@ class TestRTSP(unittest.TestCase):
         self.app_context.push()
 
     def tearDown(self):
+        self.login_patch.stop()
         self.app_context.pop()
         routes.rtsp_sessions.clear()
 


### PR DESCRIPTION
## Summary
- protect mjpg and RTSP test routes with `@login_required`
- update tests to patch authentication

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845810c251c8333add531f25e90c807