### PR TITLE
Add offline job queue

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ from app.utils.scheduling import (
     schedule_crawlers,
     schedule_summarization,
     schedule_discovery,
+    schedule_offline_job_processor,
     scheduler,
     start_log_caching,
     start_metrics_collection,
@@ -160,6 +161,7 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
                 id="retention_cleanup", func=retention_cleanup, trigger="cron", day="*"
             )
             schedule_summarization()
+            schedule_offline_job_processor()
             if DISCOVERY_AUTOSTART:
                 schedule_discovery()
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,4 +1,5 @@
 from .user import User
 from .summary import Summary
+from .offline_job import OfflineJob
 
-__all__ = ["User", "Summary"]
+__all__ = ["User", "Summary", "OfflineJob"]

--- a/app/models/offline_job.py
+++ b/app/models/offline_job.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Text
+
+from app.utils.db import Base
+
+
+class OfflineJob(Base):
+    """Queued job that could not run due to offline mode."""
+
+    __tablename__ = "offline_jobs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    function = Column(String, nullable=False)
+    args = Column(Text, nullable=False)
+    timeout = Column(Integer, nullable=False)
+    timestamp = Column(Integer, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<OfflineJob id={self.id} function={self.function}>"

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -32,8 +32,9 @@ from app.config import (
     FFMPEG_HWACCEL,
 )
 from app.utils.db import SessionLocal
-from app.models import Summary
+from app.models import Summary, OfflineJob
 from .network import is_system_online
+import importlib
 
 from .detect import calculate_difference_fast
 from .image_processing import chatgpt_compare
@@ -122,6 +123,22 @@ def run_with_timeout(func, args=(), timeout=300):
                 mark_offline(args[0])
             except Exception:
                 pass
+        session = SessionLocal()
+        try:
+            session.add(
+                OfflineJob(
+                    function=f"{func.__module__}.{func.__name__}",
+                    args=json.dumps(list(args)),
+                    timeout=timeout,
+                    timestamp=int(time.time()),
+                )
+            )
+            session.commit()
+        except Exception as exc:
+            session.rollback()
+            logging.error("Failed to queue offline job: %s", exc)
+        finally:
+            session.close()
         return
 
     try:
@@ -1338,3 +1355,44 @@ def stop_discovery() -> None:
         scheduler.remove_job("background_discovery")
     except Exception:
         pass
+
+
+def process_offline_jobs() -> None:
+    """Run any jobs queued while the system was offline."""
+
+    if not is_system_online():
+        return
+
+    session = SessionLocal()
+    try:
+        jobs = session.query(OfflineJob).order_by(OfflineJob.id).all()
+        for job in jobs:
+            try:
+                module_name, func_name = job.function.rsplit(".", 1)
+                mod = importlib.import_module(module_name)
+                func = getattr(mod, func_name)
+                run_with_timeout(
+                    func, args=tuple(json.loads(job.args)), timeout=job.timeout
+                )
+                session.delete(job)
+                session.commit()
+            except Exception as exc:
+                session.rollback()
+                logging.error("Failed to run offline job %s: %s", job.id, exc)
+    finally:
+        session.close()
+
+
+def schedule_offline_job_processor() -> None:
+    """Schedule periodic processing of queued offline jobs."""
+
+    try:
+        scheduler.add_job(
+            func=process_offline_jobs,
+            trigger="interval",
+            seconds=30,
+            id="process_offline_jobs",
+            replace_existing=True,
+        )
+    except Exception as e:
+        logging.error("job schedule error: %s", e)

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -7,3 +7,5 @@ The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.requ
 This approach keeps the application responsive even when external services are slow or offline.
 
 The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond.
+
+Skipped jobs are stored in the `offline_jobs` table. A background task checks connectivity every 30 seconds and re-runs any queued tasks once the system comes back online.

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -5,6 +5,7 @@ import tempfile
 from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
+import json
 from PIL import Image
 import sys
 
@@ -15,7 +16,16 @@ from app.utils.scheduling import (
     run_with_timeout,
     add_motion_and_caption,
     get_system_metrics,
+    process_offline_jobs,
 )
+
+
+dummy_log = []
+
+
+def dummy_job(arg):
+    """Helper function for offline job tests."""
+    dummy_log.append(arg)
 
 
 class TestRunWithTimeout(unittest.TestCase):
@@ -90,6 +100,89 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertTrue(metrics["machine_hwaccel"])
         self.assertTrue(metrics["ffmpeg_hwaccel"])
         self.assertTrue(metrics["hwaccel_enabled"])
+
+
+class TestOfflineJobQueue(unittest.TestCase):
+    @patch("app.utils.scheduling.multiprocessing.Process")
+    @patch("app.utils.scheduling.SessionLocal")
+    @patch("app.utils.scheduling.is_system_online", return_value=False)
+    def test_queue_created_when_offline(
+        self, _online, mock_session_local, mock_process
+    ):
+        class DummySession:
+            def __init__(self):
+                self.added = []
+                self.committed = False
+
+            def add(self, obj):
+                self.added.append(obj)
+
+            def commit(self):
+                self.committed = True
+
+            def rollback(self):
+                pass
+
+            def close(self):
+                pass
+
+        session = DummySession()
+        mock_session_local.return_value = session
+
+        run_with_timeout(lambda: None, timeout=1)
+
+        self.assertEqual(len(session.added), 1)
+        self.assertTrue(session.committed)
+        mock_process.assert_not_called()
+
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    @patch("app.utils.scheduling.SessionLocal")
+    def test_process_runs_and_clears_jobs(self, mock_session_local, _online):
+        class DummyQuery:
+            def __init__(self, session):
+                self.session = session
+
+            def order_by(self, *args, **kwargs):
+                return self
+
+            def all(self):
+                return list(self.session.jobs)
+
+        class DummySession:
+            def __init__(self, jobs):
+                self.jobs = jobs
+                self.deleted = []
+
+            def query(self, model):
+                return DummyQuery(self)
+
+            def delete(self, obj):
+                self.deleted.append(obj)
+                self.jobs.remove(obj)
+
+            def commit(self):
+                pass
+
+            def rollback(self):
+                pass
+
+            def close(self):
+                pass
+
+        job = scheduling.OfflineJob(
+            function="tests.test_scheduling_more.dummy_job",
+            args=json.dumps(["ok"]),
+            timeout=1,
+            timestamp=0,
+        )
+        session = DummySession([job])
+        mock_session_local.return_value = session
+
+        with patch("app.utils.scheduling.run_with_timeout") as mock_run:
+            process_offline_jobs()
+
+        mock_run.assert_called_once()
+        self.assertIn(job, session.deleted)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- track offline jobs in new model
- queue skipped jobs when offline
- process queued jobs once connectivity returns
- document offline job queue
- add regression tests for queuing and processing offline jobs

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68457e93ed44833396c200548afaaac0