### PR TITLE
Improve watchdog logic

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -29,6 +29,8 @@ from app.config import (
     WATCHDOG_FAILURE_THRESHOLD,
     WATCHDOG_RESTART_COOLDOWN,
     WATCHDOG_MAX_FILE_HANDLES,
+    WATCHDOG_CPU_THRESHOLD,
+    WATCHDOG_MEMORY_THRESHOLD,
 )
 from app.utils.email_alerts import email_alert
 from app.utils.sms_alerts import sms_alert
@@ -172,10 +174,11 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
     def _watchdog_thread():
         """Background health monitor.
 
-        The thread issues requests to ``/health`` and inspects the number of
-        open file handles every 10 seconds.  When either check fails it first
-        restores the backed-up configuration and then exits the process so that
-        an external supervisor can restart it.  A 15 minute cooldown prevents
+        The thread issues requests to ``/health`` and performs additional
+        checks every 30 seconds. When CPU or memory usage exceeds configured
+        thresholds the number of open file handles is inspected. If any check
+        fails the previous configuration is restored and the process exits so
+        an external supervisor can restart it. A 15 minute cooldown prevents
         rapid restart loops.
         """
         last_restart_time = 0
@@ -185,7 +188,7 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         failure_threshold = WATCHDOG_FAILURE_THRESHOLD
 
         while not stop_event.is_set():
-            time.sleep(10)  # Check every 10 seconds
+            time.sleep(30)  # Check every 30 seconds
             if not app.debug:
                 try:
                     # Check app responsiveness
@@ -194,13 +197,20 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
                         if response.status_code != 200:
                             raise Exception("Application is not responding correctly")
 
-                    # Check file handle usage
                     current_process = psutil.Process()
-                    open_files = current_process.open_files()
-                    if len(open_files) > max_file_handles:
-                        raise Exception(
-                            f"Too many open file handles: {len(open_files)}"
-                        )
+                    cpu_usage = psutil.cpu_percent(interval=0.1)
+                    mem_usage = psutil.virtual_memory().percent
+
+                    # Only check open files when system usage is high
+                    if (
+                        cpu_usage > WATCHDOG_CPU_THRESHOLD
+                        or mem_usage > WATCHDOG_MEMORY_THRESHOLD
+                    ):
+                        open_files = current_process.open_files()
+                        if len(open_files) > max_file_handles:
+                            raise Exception(
+                                f"Too many open file handles: {len(open_files)}"
+                            )
 
                 except Exception as e:
                     logging.error("Application error detected: %s", e)

--- a/app/config.py
+++ b/app/config.py
@@ -363,6 +363,8 @@ HEALTH_STATUS_ALWAYS_VISIBLE = (
 WATCHDOG_FAILURE_THRESHOLD = int(get_setting("WATCHDOG_FAILURE_THRESHOLD", 3))
 WATCHDOG_RESTART_COOLDOWN = int(get_setting("WATCHDOG_RESTART_COOLDOWN", 900))
 WATCHDOG_MAX_FILE_HANDLES = int(get_setting("WATCHDOG_MAX_FILE_HANDLES", 1000))
+WATCHDOG_CPU_THRESHOLD = int(get_setting("WATCHDOG_CPU_THRESHOLD", 80))
+WATCHDOG_MEMORY_THRESHOLD = int(get_setting("WATCHDOG_MEMORY_THRESHOLD", 80))
 
 # Background discovery runs on a schedule when enabled.  Set this
 # to ``True`` to run an hourly scan automatically.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -8,12 +8,14 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Loads configuration values and sets up logging.
 - Initializes routes from `app/routes.py`.
 - Starts the background scheduler and optional watchdog thread.
-  The watchdog performs health checks and only triggers a restart after a
-  configurable number of failures. Tune `WATCHDOG_FAILURE_THRESHOLD`,
-  `WATCHDOG_RESTART_COOLDOWN`, and `WATCHDOG_MAX_FILE_HANDLES` to adjust
-  this behaviour. When repeated failures occur the watchdog calls
-  `sys.exit(1)`, so run Glimpser under a supervisor that automatically
-  restarts the process. Requests to `/health` include the configured API
+  The watchdog performs health checks every 30 seconds and only triggers
+  a restart after a configurable number of failures. Tune
+  `WATCHDOG_FAILURE_THRESHOLD`, `WATCHDOG_RESTART_COOLDOWN`,
+  `WATCHDOG_MAX_FILE_HANDLES`, `WATCHDOG_CPU_THRESHOLD` and
+  `WATCHDOG_MEMORY_THRESHOLD` to adjust this behaviour. When repeated
+  failures occur the watchdog calls `sys.exit(1)`, so run Glimpser under a
+  supervisor that automatically restarts the process. Requests to `/health`
+  include the configured API
   key so the check succeeds even when login is required. See the
   `glimpser.service` snippet in `build_packages.sh` or the `restart`
   option in `docker-compose.yaml` for examples of how to enable

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -132,6 +132,8 @@ Settings controlling how frames are captured from video sources:
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
 - `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)
 - `WATCHDOG_MAX_FILE_HANDLES` – open file handle limit before triggering a restart (default `1000`)
+- `WATCHDOG_CPU_THRESHOLD` – CPU usage percentage that triggers open-file checks (default `80`)
+- `WATCHDOG_MEMORY_THRESHOLD` – memory usage percentage that triggers open-file checks (default `80`)
 - `DISCOVERY_AUTOSTART` – run hourly background discovery automatically (default `False`)
 
 ### Stealth Browser Defaults


### PR DESCRIPTION
## Summary
- throttle health checks to every 30s
- skip file-handle check unless CPU or memory usage is high
- document new watchdog thresholds

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684584a7788c8333a0627988050baa1f