### PR TITLE
Fix service worker startup stall

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -1,23 +1,23 @@
-const CACHE_NAME = 'glimpser-offline-v1';
+const CACHE_NAME = "glimpser-offline-v1";
 const MAX_SHOTS = 20;
 const OFFLINE_URLS = [
-  '/',
-  '/status',
-  '/discover',
-  '/settings',
-  '/templates',
-  '/static/css/style.css',
-  '/static/css/player.css',
-  '/static/js/script.js',
+  "/",
+  "/status",
+  "/discover",
+  "/settings",
+  "/templates",
+  "/static/css/style.css",
+  "/static/css/player.css",
+  "/static/js/script.js",
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS)),
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener("fetch", (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
@@ -26,16 +26,22 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  if (/\.jpe?g$/i.test(url.pathname) || url.pathname.startsWith('/last_screenshot') || url.pathname.endsWith('/stream.png')) {
+  if (
+    /\.jpe?g$/i.test(url.pathname) ||
+    url.pathname.startsWith("/last_screenshot") ||
+    url.pathname.endsWith("/stream.png")
+  ) {
     event.respondWith(cacheLatestShots(request));
     return;
   }
 });
 
 function networkFirst(request) {
-  return fetch(request)
-    .then(response => {
-      caches.open(CACHE_NAME).then(cache => cache.put(request, response.clone()));
+  return promiseTimeout(fetch(request), 5000)
+    .then((response) => {
+      caches
+        .open(CACHE_NAME)
+        .then((cache) => cache.put(request, response.clone()));
       return response;
     })
     .catch(() => caches.match(request));
@@ -43,12 +49,14 @@ function networkFirst(request) {
 
 function cacheLatestShots(request) {
   return promiseTimeout(fetch(request), 3000)
-    .then(response => {
-      if (response.status === 504) throw new Error('Gateway timeout');
+    .then((response) => {
+      if (response.status === 504) throw new Error("Gateway timeout");
       const clone = response.clone();
-      caches.open(CACHE_NAME).then(async cache => {
+      caches.open(CACHE_NAME).then(async (cache) => {
         await cache.put(request, clone);
-        const keys = (await cache.keys()).filter(k => k.url.includes('/last_screenshot') || /\.jpe?g$/i.test(k.url));
+        const keys = (await cache.keys()).filter(
+          (k) => k.url.includes("/last_screenshot") || /\.jpe?g$/i.test(k.url),
+        );
         while (keys.length > MAX_SHOTS) {
           await cache.delete(keys.shift());
         }
@@ -61,7 +69,10 @@ function cacheLatestShots(request) {
 function promiseTimeout(promise, ms) {
   let timeoutId;
   const timeout = new Promise((_, reject) => {
-    timeoutId = setTimeout(() => reject(new Error('timeout')), ms);
+    timeoutId = setTimeout(() => reject(new Error("timeout")), ms);
   });
-  return Promise.race([promise.finally(() => clearTimeout(timeoutId)), timeout]);
+  return Promise.race([
+    promise.finally(() => clearTimeout(timeoutId)),
+    timeout,
+  ]);
 }

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -2,4 +2,6 @@
 
 A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the dashboard (`/`), the System Status tab (`/settings?tab=status-tab`), the main Settings page, and the Templates page (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
 
+Requests now time out after five seconds so the UI quickly falls back to the cached pages when the server is slow or restarting.
+
 MJPEG endpoints now fall back to the oldest frame stored on disk if no recent frame is available. This means `/stream.mjpg` and related routes always yield at least one image even when the camera is offline.


### PR DESCRIPTION
## Summary
- avoid long waits when the backend is unavailable by timing out service worker network requests after 5s
- document fallback timing in offline preview guide

## Testing
- `black .`
- `flake8`
- `pytest -q`
- `npx prettier --check app/static/sw.js`

------
https://chatgpt.com/codex/tasks/task_e_6845862d010c8333819b108d0596b5b4