### PR TITLE
Update AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@ Keep commits small and focused.
 Use conventional commit messages.
 Format code with `black` and/or `prettier`
 Run `flake8` for lint checks.
+Run `pre-commit run --all-files`.
 Run tests with `pytest`.
+Use `npm test` for JavaScript changes.
 Document major changes in `docs/`.
 Summaries must cite changed files.
 PR description must mention test results.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,2 +1,2 @@
-- Avoid custom mkdocs options like `exclude_docs`.
+- The project uses `exclude_docs`; keep it in sync with `mkdocs.yml`.
 - Keep navigation entries updated directly in `mkdocs.yml`.


### PR DESCRIPTION
## Summary
- mention running pre-commit and npm tests in the main `AGENTS.md`
- clarify docs guidance about `exclude_docs`

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --files AGENTS.md docs/AGENTS.md` *(fails: Could not find setuptools due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684586a6d4308333ba8e57ea71f33e35