### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,13 +16,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.11
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: ${{ matrix.python-version }}
     - name: Cache pip
       uses: actions/cache@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live video streaming endpoint `/live_video`
 - Python 3.11 compatibility
 - Python 3.12 compatibility
+- Python 3.13 compatibility
 - mDNS/Zeroconf camera discovery
 - MAC vendor lookup now consults local databases and an online API
 - Footer warns when a newer release is available

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Glimpser
 
 [![Python application](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml)
-[![Pylint 3.8 - 3.12](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.8)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)
+[![Pylint 3.8 - 3.13](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.8)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)
 [![CodeQL](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml)
 [![Docs Build](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/glimpser)](https://github.com/KristopherKubicki/glimpser/releases/latest)
@@ -59,7 +59,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 
 ### Prerequisites
 
-- Python 3.8 to 3.12
+- Python 3.8 to 3.13
 
 ### Steps
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 ## Prerequisites
 
-- Python 3.8 to 3.12
+- Python 3.8 to 3.13
 - Git (for cloning the repository)
 
 ## Installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This guide provides detailed instructions for installing and setting up Glimpser
 - **Architecture**: Glimpser is primarily designed for x86 architecture.
   - ARM support may require additional work and is not guaranteed.
 - **Operating System**: Linux (Ubuntu 20.04 LTS or later recommended)
-- **Python**: Version 3.8 to 3.12
+- **Python**: Version 3.8 to 3.13
 
 ## Installation Steps
 

--- a/docs/pylint_checks.md
+++ b/docs/pylint_checks.md
@@ -1,6 +1,6 @@
 # Pylint Checks
 
-The workflow `.github/workflows/pylint.yml` runs Pylint on each push. It sets up a matrix of Python versions `3.8` through `3.12`. For every version it:
+The workflow `.github/workflows/pylint.yml` runs Pylint on each push. It sets up a matrix of Python versions `3.8` through `3.13`. For every version it:
 
 1. Checks out the repository.
 2. Installs Pylint using `pip`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,8 +6,8 @@ This guide addresses common issues that users might encounter while using Glimps
 
 ### Problem: Dependencies fail to install
 
-**Solution:**
-- Ensure you're using Python 3.8 or newer (tested up to 3.12): `python --version`
+-**Solution:**
+- Ensure you're using Python 3.8 or newer (tested up to 3.13): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
 - Double-check that you're working in the correct virtual environment.

--- a/scripts/generate_release_badges.py
+++ b/scripts/generate_release_badges.py
@@ -9,6 +9,7 @@ BADGES = [
     "[![Pylint 3.10](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.10)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)",
     "[![Pylint 3.11](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.11)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)",
     "[![Pylint 3.12](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.12)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)",
+    "[![Pylint 3.13](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.13)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)",
     "[![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/glimpser)](https://github.com/KristopherKubicki/glimpser/releases/latest)",
     "[![PyPI version](https://img.shields.io/pypi/v/glimpser)](https://pypi.org/project/glimpser/)",
     "[![Coverage](https://codecov.io/gh/KristopherKubicki/glimpser/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/glimpser)",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     python_requires=">=3.8",
     entry_points={


### PR DESCRIPTION
## Summary
- extend CI test matrix to run on Python 3.13
- list Python 3.13 classifier and docs

## Testing
- `flake8 . --exclude node_modules`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684587158fb88333b8698f430d17ca3a