### PR TITLE
Add --no-log-cache flag

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -59,7 +59,12 @@ class SQLAlchemyHandler(logging.Handler):
 """
 
 
-def create_app(enable_watchdog=True, schedule=True, crawlers=True):
+def create_app(
+    enable_watchdog: bool = True,
+    schedule: bool = True,
+    crawlers: bool = True,
+    log_cache: bool = True,
+):
     """Create and configure the Flask application.
 
     This function sets up the entire Flask application, including:
@@ -84,6 +89,11 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         When ``True`` (the default) crawler jobs are scheduled.  Pass
         ``False`` to skip scheduling crawlers, which is useful during
         testing or when using the application purely for playback.
+
+    log_cache : bool, optional
+        When ``True`` (the default) a background thread tails the log file
+        so recent entries can be served via the web UI.  Pass ``False`` to
+        disable this thread during debugging or unit tests.
 
     Returns
     -------
@@ -258,7 +268,8 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
     if schedule:
         start_metrics_collection()
 
-    start_log_caching()
+    if log_cache:
+        start_log_caching()
 
     # Send alerts when the application starts
     email_alert(

--- a/app/utils/cli.py
+++ b/app/utils/cli.py
@@ -65,6 +65,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
         default=False,
     )
     parser.add_argument(
+        "--no-log-cache",
+        action="store_true",
+        help="Disable the log caching thread",
+        default=False,
+    )
+    parser.add_argument(
         "--screenshot-dir",
         default=config.SCREENSHOT_DIRECTORY,
         help="Directory for storing screenshots",

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -18,6 +18,7 @@ The primary application script accepts the following options:
 | `--no-scheduler` | Disable the background scheduler. |
 | `--no-watchdog` | Disable the watchdog thread. |
 | `--no-crawlers` | Skip scheduling crawler jobs. |
+| `--no-log-cache` | Disable the log caching thread. |
 | `--screenshot-dir` | Directory for storing screenshots. |
 | `--video-dir` | Directory for storing video files. |
 | `--summaries-dir` | **Deprecated:** summaries are now stored in the database. |

--- a/main.py
+++ b/main.py
@@ -156,9 +156,13 @@ def create_application(args=None):
     schedule = not getattr(args, "no_scheduler", False)
     enable_watchdog = not getattr(args, "no_watchdog", False)
     crawlers = not getattr(args, "no_crawlers", False)
+    log_cache = not getattr(args, "no_log_cache", False)
 
     return create_app(
-        enable_watchdog=enable_watchdog, schedule=schedule, crawlers=crawlers
+        enable_watchdog=enable_watchdog,
+        schedule=schedule,
+        crawlers=crawlers,
+        log_cache=log_cache,
     )
 
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -19,7 +19,7 @@ from app import create_app
 
 class TestAuthentication(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(enable_watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -39,7 +39,7 @@ class TestClockRoute(unittest.TestCase):
         )
         conn.commit()
         conn.close()
-        self.app = app.create_app(enable_watchdog=False, schedule=False)
+        self.app = app.create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -17,7 +17,7 @@ class TestStatusDashboard(unittest.TestCase):
         self.session_patch = patch("app.routes.session", {"user_id": 1})
         self.login_patch.start()
         self.session_patch.start()
-        self.app = app.create_app(enable_watchdog=False, schedule=False)
+        self.app = app.create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
 
     def tearDown(self):

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -81,7 +81,7 @@ def screenshot_server(tmp_path):
     for p in patches:
         p.start()
 
-    app = create_app(enable_watchdog=False, schedule=False)
+    app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
     server = ServerThread(app)
     server.start()
     url = f"http://127.0.0.1:{server.port}"

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -45,7 +45,7 @@ class ServerThread(Thread):
 
 @pytest.fixture(scope="module")
 def live_server(tmp_path_factory):
-    application = app.create_app(enable_watchdog=False, schedule=False)
+    application = app.create_app(enable_watchdog=False, schedule=False, log_cache=False)
     data_dir = tmp_path_factory.mktemp("data")
     prev_cwd = os.getcwd()
     os.chdir(data_dir)
@@ -134,7 +134,7 @@ def live_server_with_user(tmp_path_factory):
     )
     generate_credentials.generate_credentials(args)
 
-    application = app.create_app(enable_watchdog=False, schedule=False)
+    application = app.create_app(enable_watchdog=False, schedule=False, log_cache=False)
     prev_cwd = os.getcwd()
     os.chdir(data_dir)
     server = ServerThread(application)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,7 +12,7 @@ from app import create_app
 
 class TestCreateApp(unittest.TestCase):
     def setUp(self):
-        self.app = create_app(enable_watchdog=False, schedule=False)  # maybe?
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)  # maybe?
         self.client = self.app.test_client()
 
     def test_app_creation(self):

--- a/tests/test_installation_and_first_use.py
+++ b/tests/test_installation_and_first_use.py
@@ -32,7 +32,7 @@ class TestInstallationAndFirstUse(unittest.TestCase):
         config.SUMMARIES_DIRECTORY = os.path.join(self.temp_dir, "summaries")
 
         # Create the Flask test client
-        self.app = create_app(enable_watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
 
     def tearDown(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -144,9 +144,39 @@ class TestMain(unittest.TestCase):
 
         args.no_crawlers = True
 
+        args.no_log_cache = False
         main.create_application(args)
         mock_create_app.assert_called_with(
-            enable_watchdog=False, schedule=False, crawlers=False
+            enable_watchdog=False,
+            schedule=False,
+            crawlers=False,
+            log_cache=True,
+        )
+
+    @patch("main.create_app")
+    def test_create_application_no_log_cache_flag(self, mock_create_app):
+        args = MagicMock()
+        args.db_path = config.DATABASE_PATH
+        args.host = config.HOST
+        args.port = config.PORT
+        args.log_path = config.LOGGING_PATH
+        args.log_level = config.LOG_LEVEL
+        args.console_log = False
+        args.debug = False
+        args.screenshot_dir = config.SCREENSHOT_DIRECTORY
+        args.video_dir = config.VIDEO_DIRECTORY
+        args.summaries_dir = config.SUMMARIES_DIRECTORY
+        args.no_scheduler = False
+        args.no_watchdog = False
+        args.no_crawlers = False
+        args.no_log_cache = True
+
+        main.create_application(args)
+        mock_create_app.assert_called_with(
+            enable_watchdog=True,
+            schedule=True,
+            crawlers=True,
+            log_cache=False,
         )
 
     @patch("logging.info")

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -12,7 +12,7 @@ class TestMotionMjpg(unittest.TestCase):
     def setUp(self):
         self.login_patch = patch("app.routes.login_required", lambda x: x)
         self.login_patch.start()
-        self.app = create_app(enable_watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -13,7 +13,7 @@ class TestRTSP(unittest.TestCase):
     def setUp(self):
         self.login_patch = patch("app.routes.login_required", lambda x: x)
         self.login_patch.start()
-        self.app = create_app(enable_watchdog=False, schedule=False)
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.app.testing = True
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -45,7 +45,7 @@ class TestSettingsRoute(unittest.TestCase):
         conn.commit()
         conn.close()
 
-        self.app = app.create_app(enable_watchdog=False, schedule=False)
+        self.app = app.create_app(enable_watchdog=False, schedule=False, log_cache=False)
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -41,7 +41,7 @@ def tmp_http_server(tmp_path):
 
 def test_url_test_endpoint(tmp_http_server):
     with patch("app.routes.login_required", lambda x: x):
-        app = create_app(enable_watchdog=False, schedule=False)
+        app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         server = ServerThread(app)
         server.start()
         try:


### PR DESCRIPTION
## Summary
- make log caching optional via `--no-log-cache`
- document the new flag
- test flag handling and disable log caching in tests

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68458b9cd47c833389560eda21430d35