### PR TITLE
Fix dark mode toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -444,6 +444,18 @@ body.light-mode {
   --table-border-color: #ddd;
 }
 
+body.dark-mode {
+  --bg-color: rgb(16, 16, 16);
+  --secondary-bg-color: #222;
+  --text-color: rgb(191, 191, 191);
+  --form-bg-color: var(--secondary-bg-color);
+  --form-text-color: var(--text-color);
+  --table-header-bg-color: #2a2a2a;
+  --table-row-alt-bg-color: #1a1a1a;
+  --table-hover-bg-color: #333;
+  --table-border-color: #444;
+}
+
 .camera-name,
 .timestamp {
   position: absolute;

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -6,6 +6,7 @@ export function initThemeToggle() {
 
     const applyTheme = (theme) => {
       document.body.classList.toggle("light-mode", theme === "light");
+      document.body.classList.toggle("dark-mode", theme === "dark");
       if (useEl) {
         useEl.setAttribute(
           "href",

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,15 +1,15 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 
 document.body.innerHTML = `<input id="url"><span id="url-status"></span>`;
 
 let initUrlTester;
 
 beforeAll(async () => {
-  ({ initUrlTester } = await import('../../app/static/js/url_test.js'));
+  ({ initUrlTester } = await import("../../app/static/js/url_test.js"));
 });
 
-describe('url_test', () => {
-  test('shows status after fetch', async () => {
+describe("url_test", () => {
+  test("shows status after fetch", async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
@@ -17,14 +17,14 @@ describe('url_test', () => {
       }),
     );
     initUrlTester();
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    const input = document.getElementById('url');
-    input.value = 'http://example.com';
-    input.dispatchEvent(new Event('change'));
-    await Promise.resolve();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    const input = document.getElementById("url");
+    input.value = "http://example.com";
+    input.dispatchEvent(new Event("change"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetch).toHaveBeenCalled();
-    const status = document.getElementById('url-status');
-    expect(status.textContent).toBe('✓');
-    expect(status.classList.contains('ok')).toBe(true);
+    const status = document.getElementById("url-status");
+    expect(status.textContent).toBe("✓");
+    expect(status.classList.contains("ok")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- ensure the UI can force dark mode by adding `dark-mode` styles
- update the theme toggle logic to toggle `dark-mode`
- stabilize async URL test

## Testing
- `npm test`
- `pytest -q`
- `flake8`
- `pre-commit run --all-files` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68458de13440833391d82224b2b20b25