### PR TITLE
feat(ui): responsive controls panel

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -211,11 +211,11 @@ h2 {
   margin-bottom: 10px;
 }
 
-#controls-wrapper:not([open]) #template-controls {
+#controls-wrapper.closed #template-controls {
   display: none;
 }
 
-#controls-wrapper summary {
+#controls-toggle {
   cursor: pointer;
   font-weight: 600;
   opacity: 0;
@@ -223,8 +223,8 @@ h2 {
   transition: opacity 0.5s;
 }
 
-#controls-wrapper.show-summary summary,
-#controls-wrapper[open] summary {
+#controls-wrapper.show-toggle #controls-toggle,
+#controls-wrapper:not(.closed) #controls-toggle {
   opacity: 1;
   pointer-events: auto;
 }

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -1,17 +1,18 @@
 export function initControlsDropdown() {
   document.addEventListener("DOMContentLoaded", () => {
-    const details = document.getElementById("controls-wrapper");
-    if (!details) return;
+    const wrapper = document.getElementById("controls-wrapper");
+    const toggle = document.getElementById("controls-toggle");
+    if (!wrapper || !toggle) return;
 
     let hideTimeout;
     let buttonTimeout;
 
     const showButton = () => {
-      details.classList.add("show-summary");
+      wrapper.classList.add("show-toggle");
       clearTimeout(buttonTimeout);
-      if (!details.open) {
+      if (wrapper.classList.contains("closed")) {
         buttonTimeout = setTimeout(
-          () => details.classList.remove("show-summary"),
+          () => wrapper.classList.remove("show-toggle"),
           3000,
         );
       }
@@ -20,25 +21,29 @@ export function initControlsDropdown() {
     const scheduleHide = () => {
       clearTimeout(hideTimeout);
       hideTimeout = setTimeout(() => {
-        details.classList.add("fade-out");
+        wrapper.classList.add("fade-out");
         setTimeout(() => {
-          details.removeAttribute("open");
-          details.classList.remove("fade-out");
+          wrapper.classList.add("closed");
+          wrapper.classList.remove("fade-out");
           showButton();
         }, 500);
       }, 5000);
     };
 
     const showControls = () => {
-      if (!details.open) return;
-      details.classList.remove("fade-out");
+      if (wrapper.classList.contains("closed")) return;
+      wrapper.classList.remove("fade-out");
       showButton();
       scheduleHide();
     };
 
-    details.addEventListener("toggle", showControls);
+    toggle.addEventListener("click", () => {
+      wrapper.classList.toggle("closed");
+      if (!wrapper.classList.contains("closed")) showControls();
+      else showButton();
+    });
 
-    if (details.open) showControls();
+    if (!wrapper.classList.contains("closed")) showControls();
     else showButton();
 
     ["mousemove", "scroll"].forEach((evt) => {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -39,8 +39,8 @@ block content %}
   </div>
 
   <div id="prompts-tab" class="tab-content active">
-    <details id="controls-wrapper" class="filter-controls">
-      <summary>Search &amp; Filters</summary>
+    <div id="controls-wrapper" class="filter-controls closed">
+      <button id="controls-toggle" type="button">Search &amp; Filters</button>
       <div class="controls-inner">
         <label for="search-input" title="Search by name or group"
           >Search:</label
@@ -102,7 +102,7 @@ block content %}
           <option value="next_desc">Next &darr;</option>
         </select>
       </div>
-    </details>
+    </div>
 
     <h2>Camera Notes</h2>
     <div id="template-list">

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
-<details id="controls-wrapper">
-  <summary>Controls</summary>
+<div id="controls-wrapper" class="closed">
+  <button id="controls-toggle" type="button">Controls</button>
   <div id="template-controls">
     <div id="search-container">
       <input
@@ -41,7 +41,7 @@ block content %}
       </label>
     </div>
   </div>
-</details>
+</div>
 <div
   id="template-list"
   title="List of all templates"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,8 +3,8 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
 
-<details id="controls-wrapper">
-  <summary>Controls</summary>
+<div id="controls-wrapper" class="closed">
+  <button id="controls-toggle" type="button">Controls</button>
   <section id="template-controls">
     <input
       type="text"
@@ -42,7 +42,7 @@ block content %}
       </label>
     </div>
   </section>
-</details>
+</div>
 
 <section id="template-list-section">
   <div

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -1,9 +1,9 @@
 import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
-  <details id="controls-wrapper">
-    <summary>Controls</summary>
-  </details>
+  <div id="controls-wrapper" class="closed">
+    <button id="controls-toggle" type="button">Controls</button>
+  </div>
 `;
 
 jest.useFakeTimers();
@@ -16,23 +16,23 @@ beforeAll(async () => {
 
 describe("controls dropdown", () => {
   test("auto collapses after inactivity", () => {
-    const details = document.getElementById("controls-wrapper");
-    details.setAttribute("open", "");
+    const wrapper = document.getElementById("controls-wrapper");
+    wrapper.classList.remove("closed");
     initControlsDropdown();
     document.dispatchEvent(new Event("DOMContentLoaded"));
     jest.advanceTimersByTime(5000);
-    expect(details.classList.contains("fade-out")).toBe(true);
+    expect(wrapper.classList.contains("fade-out")).toBe(true);
     jest.advanceTimersByTime(500);
-    expect(details.hasAttribute("open")).toBe(false);
-    expect(details.classList.contains("fade-out")).toBe(false);
+    expect(wrapper.classList.contains("closed")).toBe(true);
+    expect(wrapper.classList.contains("fade-out")).toBe(false);
   });
 
   test("button shows and hides on activity", () => {
-    const details = document.getElementById("controls-wrapper");
+    const wrapper = document.getElementById("controls-wrapper");
     initControlsDropdown();
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    expect(details.classList.contains("show-summary")).toBe(true);
+    expect(wrapper.classList.contains("show-toggle")).toBe(true);
     jest.advanceTimersByTime(3000);
-    expect(details.classList.contains("show-summary")).toBe(false);
+    expect(wrapper.classList.contains("show-toggle")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- replace `<details>` wrappers with a responsive controls panel
- update toggle logic and tests

## Testing
- `flake8`
- `pre-commit run --all-files` *(failed: could not install dependencies)*
- `pytest` *(1 failing test)*
- `npm test` *(1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_68458fbef8c88333b56217bad26b8cba