### PR TITLE
Enable dark mode by default

### DIFF
--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -14,11 +14,11 @@ export function initThemeToggle() {
       }
     };
 
-    let current =
-      localStorage.getItem("theme") ||
-      (window.matchMedia("(prefers-color-scheme: light)").matches
-        ? "light"
-        : "dark");
+    let current = localStorage.getItem("theme");
+    if (!current) {
+      current = "dark";
+      localStorage.setItem("theme", current);
+    }
     applyTheme(current);
 
     if (toggle) {

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -1,9 +1,9 @@
 # Dark Mode Support
 
-Glimpser's interface now adapts to your system's preferred color scheme.
-The CSS defines variables for background and text colors with light and dark
-variants. Forms and tables use these variables so elements remain readable in
-both themes.
+Glimpser starts in dark mode for new users, storing the preference in
+`localStorage`. You can switch to light mode at any time with the theme
+toggle. The CSS defines variables for background and text colors with light and
+dark variants, so forms and tables remain readable in both themes.
 
 You can force the interface into light or dark mode using the toggle on the
 settings page. The switch stores your choice in `localStorage` so your
@@ -20,4 +20,3 @@ the dark background.
 The captions page uses the same theme variables. Prompt and response fields now
 inherit `--form-bg-color` and `--form-text-color` so text remains legible when
 switching themes.
-

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,15 +1,15 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 
 document.body.innerHTML = `<input id="url"><span id="url-status"></span>`;
 
 let initUrlTester;
 
 beforeAll(async () => {
-  ({ initUrlTester } = await import('../../app/static/js/url_test.js'));
+  ({ initUrlTester } = await import("../../app/static/js/url_test.js"));
 });
 
-describe('url_test', () => {
-  test('shows status after fetch', async () => {
+describe("url_test", () => {
+  test("shows status after fetch", async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
@@ -17,14 +17,14 @@ describe('url_test', () => {
       }),
     );
     initUrlTester();
-    document.dispatchEvent(new Event('DOMContentLoaded'));
-    const input = document.getElementById('url');
-    input.value = 'http://example.com';
-    input.dispatchEvent(new Event('change'));
-    await Promise.resolve();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    const input = document.getElementById("url");
+    input.value = "http://example.com";
+    input.dispatchEvent(new Event("change"));
+    await new Promise(process.nextTick);
     expect(fetch).toHaveBeenCalled();
-    const status = document.getElementById('url-status');
-    expect(status.textContent).toBe('✓');
-    expect(status.classList.contains('ok')).toBe(true);
+    const status = document.getElementById("url-status");
+    expect(status.textContent).toBe("✓");
+    expect(status.classList.contains("ok")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- default new users to dark mode in theme toggle
- document the default in dark mode docs
- fix url test timing for JS suite

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458fced4fc83338eff4c267012a1e9