### PR TITLE
Lock advanced settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -89,6 +89,7 @@ from app.utils.settings_tooltips import (
     SETTINGS_CHOICES,
     NUMERIC_FIELDS,
     EMAIL_FIELDS,
+    LOCKED_SETTINGS,
 )
 
 from app.utils.screenshots import (
@@ -3115,6 +3116,7 @@ def init_routes(app: Flask) -> None:
             danger_enabled=danger_enabled,
             numeric_fields=NUMERIC_FIELDS,
             email_fields=EMAIL_FIELDS,
+            locked_settings=LOCKED_SETTINGS,
             file_info=file_info,
             page_title="Settings",
         )

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1073,6 +1073,22 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
+/* Visually disable locked settings */
+.settings-table input[data-locked] + .slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settings-table input[data-locked]:not([type="checkbox"]) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+body.advanced-enabled .settings-table input[data-locked] {
+  opacity: 1;
+  cursor: auto;
+}
+
 .xpath-input-container input {
   width: 70%;
 }

--- a/app/static/js/advanced.js
+++ b/app/static/js/advanced.js
@@ -1,19 +1,24 @@
 export function initAdvanced() {
   document.addEventListener("DOMContentLoaded", () => {
     const toggle = document.getElementById("advanced-toggle");
-    if (!toggle) return;
-    const enabled = sessionStorage.getItem("advanced-enabled") === "true";
-    if (enabled) {
-      toggle.checked = true;
-      document.body.classList.add("advanced-enabled");
-    }
-
-    const update = () => {
-      const state = toggle.checked;
+    const locked = document.querySelectorAll("[data-locked]");
+    const applyState = (state) => {
       document.body.classList.toggle("advanced-enabled", state);
       sessionStorage.setItem("advanced-enabled", String(state));
+      locked.forEach((el) => {
+        el.disabled = !state;
+      });
     };
 
-    toggle.addEventListener("change", update);
+    if (!toggle) {
+      applyState(false);
+      return;
+    }
+
+    const enabled = sessionStorage.getItem("advanced-enabled") === "true";
+    toggle.checked = enabled;
+    applyState(enabled);
+
+    toggle.addEventListener("change", () => applyState(toggle.checked));
   });
 }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -90,6 +90,7 @@
                     value="True"
                     {% if setting.value == 'True' %}checked{% endif %}
                     data-boolean
+                    {% if setting.name in locked_settings %}disabled data-locked{% endif %}
                   />
                   <span class="slider round"></span>
                 </label>
@@ -99,6 +100,15 @@
                   name="{{ setting.name }}"
                   value="{{ setting.value }}"
                   title="Edit value for {{ setting.name }}"
+                  {%
+                  if
+                  setting.name
+                  in
+                  locked_settings
+                  %}disabled
+                  data-locked{%
+                  endif
+                  %}
                 />
                 {% else %}
                 <input
@@ -106,6 +116,15 @@
                   name="{{ setting.name }}"
                   value="{{ setting.value }}"
                   title="Edit value for {{ setting.name }}"
+                  {%
+                  if
+                  setting.name
+                  in
+                  locked_settings
+                  %}disabled
+                  data-locked{%
+                  endif
+                  %}
                 />
                 {% endif %}
               </td>

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -155,3 +155,7 @@ NUMERIC_FIELDS = {
 
 # Fields that expect email addresses.
 EMAIL_FIELDS = {"EMAIL_SENDER", "EMAIL_RECIPIENTS"}
+
+# Settings that are hidden behind the advanced toggle on the UI. Their
+# corresponding form inputs are disabled unless advanced mode is enabled.
+LOCKED_SETTINGS = {"CLIP_MODEL_NAME"}

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -160,5 +160,6 @@ Additional variables control AI behaviour and external tools:
 - `FFMPEG_THREADS` – number of threads ffmpeg uses when encoding (default `5`)
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
+  This setting is read-only until Advanced Options are enabled.
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/tests/js/advanced.test.js
+++ b/tests/js/advanced.test.js
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
   <input id="advanced-toggle" type="checkbox" />
+  <input id="locked" data-locked />
 `;
 
 let initAdvanced;
@@ -32,4 +33,15 @@ test("initial state reads from sessionStorage", () => {
   document.dispatchEvent(new Event("DOMContentLoaded"));
   expect(document.body.classList.contains("advanced-enabled")).toBe(true);
   expect(document.getElementById("advanced-toggle").checked).toBe(true);
+});
+
+test("locked inputs toggle disabled state", () => {
+  initAdvanced();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const toggle = document.getElementById("advanced-toggle");
+  const locked = document.getElementById("locked");
+  expect(locked.disabled).toBe(true);
+  toggle.checked = true;
+  toggle.dispatchEvent(new Event("change"));
+  expect(locked.disabled).toBe(false);
 });


### PR DESCRIPTION
## Summary
- disable certain values unless advanced mode is active
- expose locked setting names to templates
- toggle disabled state of locked inputs
- document CLIP model edit restrictions
- test advanced toggle behaviour

## Testing
- `pre-commit run --all-files` *(fails: CalledProcessError: pip install build dependencies)*
- `pytest -q`
- `npm test --silent` *(fails: tests/js/url_test.test.js shows status after fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68459183dd90833394651cc52f83a98c