### PR TITLE
Enable live system metrics

### DIFF
--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -1,19 +1,36 @@
 let cpuData = [];
 const maxDataPoints = 60;
 
+function setProgress(el, value) {
+  if (!el) return;
+  if (el.tagName === "PROGRESS") {
+    el.value = value;
+  } else {
+    el.style.width = `${value}%`;
+  }
+}
+
 export function updatePerformanceMetrics() {
   return fetch("/health")
     .then((response) => response.json())
     .then((data) => {
       const cpuVal = document.getElementById("cpu-value");
       if (cpuVal) cpuVal.textContent = `${data.cpu_usage}%`;
-      const cpuBar = document.getElementById("cpu-bar");
-      if (cpuBar) cpuBar.style.width = `${data.cpu_usage}%`;
+      setProgress(document.getElementById("cpu-bar"), data.cpu_usage);
 
       const memoryVal = document.getElementById("memory-value");
       if (memoryVal) memoryVal.textContent = `${data.memory_usage}%`;
-      const memoryBar = document.getElementById("memory-bar");
-      if (memoryBar) memoryBar.style.width = `${data.memory_usage}%`;
+      setProgress(document.getElementById("memory-bar"), data.memory_usage);
+
+      const diskVal = document.getElementById("disk-value");
+      if (diskVal) diskVal.textContent = `${data.disk_usage}%`;
+      setProgress(document.getElementById("disk-bar"), data.disk_usage);
+
+      const openFiles = document.getElementById("open-files");
+      if (openFiles) openFiles.textContent = data.open_files;
+
+      const threadCount = document.getElementById("thread-count");
+      if (threadCount) threadCount.textContent = data.thread_count;
 
       const uptimeVal = document.getElementById("uptime-value");
       if (uptimeVal) uptimeVal.textContent = data.uptime;

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -18,35 +18,41 @@
   <li title="Current CPU utilization">
     CPU Usage:
     <progress
+      id="cpu-bar"
       class="metric-bar"
       value="{{ metrics.cpu_usage }}"
       max="100"
     ></progress>
-    {{ metrics.cpu_usage }}%
+    <span id="cpu-value">{{ metrics.cpu_usage }}%</span>
+    <canvas id="cpu-sparkline" width="100" height="20"></canvas>
   </li>
   <li title="Current memory utilization">
     Memory Usage:
     <progress
+      id="memory-bar"
       class="metric-bar"
       value="{{ metrics.memory_usage }}"
       max="100"
     ></progress>
-    {{ metrics.memory_usage }}%
+    <span id="memory-value">{{ metrics.memory_usage }}%</span>
   </li>
   <li title="Disk space used">
     Disk Usage:
     <progress
+      id="disk-bar"
       class="metric-bar"
       value="{{ metrics.disk_usage }}"
       max="100"
     ></progress>
-    {{ metrics.disk_usage }}%
+    <span id="disk-value">{{ metrics.disk_usage }}%</span>
   </li>
-  <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
+  <li title="Open file handles">
+    Open Files: <span id="open-files">{{ metrics.open_files }}</span>
+  </li>
   <li title="Number of active threads">
-    Thread Count: {{ metrics.thread_count }}
+    Thread Count: <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
-  <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+  <li title="System uptime">Uptime: <span id="uptime-value">{{ metrics.uptime }}</span></li>
 </ul>
 {% endcall %} {% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -22,35 +22,41 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
   <li title="Current CPU utilization">
     CPU Usage:
     <progress
+      id="cpu-bar"
       class="metric-bar"
       value="{{ metrics.cpu_usage }}"
       max="100"
     ></progress>
-    {{ metrics.cpu_usage }}%
+    <span id="cpu-value">{{ metrics.cpu_usage }}%</span>
+    <canvas id="cpu-sparkline" width="100" height="20"></canvas>
   </li>
   <li title="Current memory utilization">
     Memory Usage:
     <progress
+      id="memory-bar"
       class="metric-bar"
       value="{{ metrics.memory_usage }}"
       max="100"
     ></progress>
-    {{ metrics.memory_usage }}%
+    <span id="memory-value">{{ metrics.memory_usage }}%</span>
   </li>
   <li title="Disk space used">
     Disk Usage:
     <progress
+      id="disk-bar"
       class="metric-bar"
       value="{{ metrics.disk_usage }}"
       max="100"
     ></progress>
-    {{ metrics.disk_usage }}%
+    <span id="disk-value">{{ metrics.disk_usage }}%</span>
   </li>
-  <li title="Open file handles">Open Files: {{ metrics.open_files }}</li>
+  <li title="Open file handles">
+    Open Files: <span id="open-files">{{ metrics.open_files }}</span>
+  </li>
   <li title="Number of active threads">
-    Thread Count: {{ metrics.thread_count }}
+    Thread Count: <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
-  <li title="System uptime">Uptime: {{ metrics.uptime }}</li>
+  <li title="System uptime">Uptime: <span id="uptime-value">{{ metrics.uptime }}</span></li>
   <li title="Installed ffmpeg version">
     FFmpeg: {{ metrics.ffmpeg_version }} ({{ metrics.ffmpeg_path }})
   </li>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-This endpoint now redirects to the _System Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator.
+This endpoint now redirects to the _System Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator. Metrics refresh automatically every few seconds.
 
 ### Feed Dashboard
 

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -7,6 +7,10 @@ document.body.innerHTML = `
   <div id="cpu-bar"></div>
   <div id="memory-value"></div>
   <div id="memory-bar"></div>
+  <div id="disk-value"></div>
+  <div id="disk-bar"></div>
+  <div id="open-files"></div>
+  <div id="thread-count"></div>
   <div id="uptime-value"></div>
   <canvas id="cpu-sparkline" width="100" height="20"></canvas>
 `;
@@ -40,7 +44,14 @@ describe('performance.js', () => {
   });
 
   test('updatePerformanceMetrics fetches metrics and updates DOM', async () => {
-    const mockData = { cpu_usage: 50, memory_usage: 40, uptime: '1h' };
+    const mockData = {
+      cpu_usage: 50,
+      memory_usage: 40,
+      disk_usage: 70,
+      open_files: 5,
+      thread_count: 8,
+      uptime: '1h',
+    };
     global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve(mockData) }));
 
     await updatePerformanceMetrics();
@@ -48,6 +59,9 @@ describe('performance.js', () => {
     expect(fetch).toHaveBeenCalledWith('/health');
     expect(document.getElementById('cpu-value').textContent).toBe('50%');
     expect(document.getElementById('memory-value').textContent).toBe('40%');
+    expect(document.getElementById('disk-value').textContent).toBe('70%');
+    expect(document.getElementById('open-files').textContent).toBe('5');
+    expect(document.getElementById('thread-count').textContent).toBe('8');
     expect(document.getElementById('uptime-value').textContent).toBe('1h');
 
     const ctxCalled = canvas.getContext();


### PR DESCRIPTION
## Summary
- add IDs to metrics for dynamic update
- refresh metrics via JavaScript
- document auto-refreshing metrics
- extend tests for new metrics

## Testing
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q` *(fails: TestSettingsRoute::test_download_without_backup)*
- `npm test` *(fails: url_test shows status after fetch)*

------
https://chatgpt.com/codex/tasks/task_e_684591aec1688333a4d8a4c9a112d386