### PR TITLE
Fix scheduler double start

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -251,8 +251,10 @@ def create_app(enable_watchdog=True, schedule=True, crawlers=True):
         """Initialize scheduler and monitoring in a low priority thread."""
         backup_config()
 
-        if schedule and (
-            os.environ.get("WERKZEUG_RUN_MAIN") == "true" or not app.debug
+        if (
+            schedule
+            and (os.environ.get("WERKZEUG_RUN_MAIN") == "true" or not app.debug)
+            and not scheduler.running
         ):
             scheduler.start()
             logging.info("Initializing scheduler...")

--- a/tests/test_scheduler_start_once.py
+++ b/tests/test_scheduler_start_once.py
@@ -1,0 +1,37 @@
+import time
+from unittest.mock import patch
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+from app.utils.scheduling import scheduler
+
+
+def test_scheduler_starts_once():
+    calls = []
+
+    original_start = scheduler.start
+
+    def start_wrapper(*args, **kwargs):
+        calls.append(1)
+        return original_start(*args, **kwargs)
+
+    with (
+        patch.object(scheduler, "start", side_effect=start_wrapper),
+        patch("app.__init__.schedule_crawlers"),
+        patch("app.__init__.schedule_summarization"),
+        patch("app.__init__.schedule_offline_job_processor"),
+        patch("app.__init__.schedule_discovery"),
+        patch("app.__init__.start_metrics_collection"),
+        patch("app.__init__.start_log_caching"),
+        patch("app.__init__.email_alert"),
+        patch("app.__init__.sms_alert"),
+    ):
+        create_app(enable_watchdog=False, schedule=True)
+        # allow background thread to run
+        time.sleep(0.1)
+        assert len(calls) == 1
+
+    scheduler.shutdown(wait=False)


### PR DESCRIPTION
## Summary
- avoid starting the scheduler twice in background thread
- add regression test for single scheduler start

## Testing
- `flake8`
- `pytest tests/test_scheduler_start_once.py`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68458f8c48a48333920091b0b6e0e1eb