### PR TITLE
Add Danger Mode details

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -136,11 +136,13 @@ from app.utils.profiling import profile_route, get_latency_stats
 from scripts.update_chrome_shortcut import (
     update_chrome_shortcuts_info,
     shortcuts_need_patch,
+    first_shortcut_path,
 )
 from app.utils.screenshots import (
     is_chrome_debug_port_open,
     check_user_activity,
     get_chrome_path,
+    get_chrome_version,
     load_font,
 )
 from app.utils.email_alerts import send_email_alert
@@ -1246,6 +1248,8 @@ def init_routes(app: Flask) -> None:
                 "ready": port_open and idle and enabled,
                 "browser": os.path.basename(browser_path) if browser_path else None,
                 "path": browser_path,
+                "version": get_chrome_version(browser_path) if browser_path else None,
+                "shortcut": str(first_shortcut_path() or ""),
                 "patched": patched,
             }
         )
@@ -3095,6 +3099,8 @@ def init_routes(app: Flask) -> None:
         danger_info = {
             "browser": os.path.basename(chrome_path) if chrome_path else "N/A",
             "path": chrome_path or "N/A",
+            "version": get_chrome_version(chrome_path) if chrome_path else "N/A",
+            "shortcut": str(first_shortcut_path() or "N/A"),
             "patched": not shortcuts_need_patch(),
             "running": is_chrome_debug_port_open("127.0.0.1", 9222),
         }

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -170,10 +170,20 @@
         Upload Configuration
       </button>
 
-      <h3>Danger Mode</h3>
+      <h3>
+        Danger Mode
+        <a
+          href="../docs/danger_mode.md"
+          target="_blank"
+          title="Open Danger Mode documentation"
+          >docs</a
+        >
+      </h3>
       <ul class="danger-info">
         <li>Browser: {{ danger_info.browser }}</li>
         <li>Path: {{ danger_info.path }}</li>
+        <li>Version: {{ danger_info.version }}</li>
+        <li>Shortcut: {{ danger_info.shortcut }}</li>
         <li>
           Shortcut Patched:
           <span

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -19,6 +19,7 @@ After Chrome updates, shortcuts may revert to their original command line. Two a
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
 - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the _Update Chrome Shortcut_ button on the Settings page or the _Patch Chrome Shortcuts_ button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
 - **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
+- **Default shortcut locations**: `%USERPROFILE%\Desktop`, `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs`. The Settings page shows the first shortcut found.
 
 After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -7,7 +7,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Add New Setting** – quickly create additional key/value pairs.
 - **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
-- **Danger Mode** – shows the detected browser path, whether shortcuts are patched, and if the debugging port is open. You can also update Chrome shortcuts from here.
+- **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -97,5 +97,35 @@ def shortcuts_need_patch() -> bool:
     return False
 
 
+def first_shortcut_path() -> Path | None:
+    """Return the first Chrome shortcut found in standard locations."""
+    if os.name != "nt" or win32com is None:
+        return None
+
+    shell = win32com.client.Dispatch("WScript.Shell")
+    locations = [
+        Path(os.environ.get("USERPROFILE", "")) / "Desktop",
+        Path(os.environ.get("APPDATA", ""))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs",
+        Path(os.environ.get("ProgramData", ""))
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs",
+    ]
+
+    for loc in locations:
+        if loc.exists():
+            for shortcut in loc.rglob("*.lnk"):
+                if "chrome" in shortcut.name.lower():
+                    # Touching the shortcut ensures it resolves correctly
+                    shell.CreateShortcut(str(shortcut))
+                    return shortcut
+    return None
+
+
 if __name__ == "__main__":  # pragma: no cover - manual usage
     sys.exit(0 if update_chrome_shortcuts() else 1)

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -20,11 +20,15 @@ class TestDangerStatusEndpoint(unittest.TestCase):
     def tearDown(self):
         self.login_patch.stop()
 
+    @patch("app.routes.get_chrome_version", return_value=120)
+    @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=True)
     @patch("app.routes.check_user_activity", return_value=False)
-    def test_danger_ready(self, mock_idle, mock_port, mock_patch, mock_path):
+    def test_danger_ready(
+        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+    ):
         resp = self.client.get("/danger_status")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
@@ -36,15 +40,21 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "ready": True,
                 "browser": "chrome",
                 "path": "/usr/bin/chrome",
+                "version": 120,
+                "shortcut": "/tmp/Chrome.lnk",
                 "patched": True,
             },
         )
 
+    @patch("app.routes.get_chrome_version", return_value=120)
+    @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=False)
     @patch("app.routes.check_user_activity", return_value=False)
-    def test_danger_port_closed(self, mock_idle, mock_port, mock_patch, mock_path):
+    def test_danger_port_closed(
+        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+    ):
         """Should report not ready when the debug port is closed."""
         resp = self.client.get("/danger_status")
         self.assertEqual(resp.status_code, 200)
@@ -57,15 +67,21 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "ready": False,
                 "browser": "chrome",
                 "path": "/usr/bin/chrome",
+                "version": 120,
+                "shortcut": "/tmp/Chrome.lnk",
                 "patched": True,
             },
         )
 
+    @patch("app.routes.get_chrome_version", return_value=120)
+    @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=True)
     @patch("app.routes.check_user_activity", return_value=True)
-    def test_danger_user_active(self, mock_idle, mock_port, mock_patch, mock_path):
+    def test_danger_user_active(
+        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+    ):
         """Should report not ready when user activity is detected."""
         resp = self.client.get("/danger_status")
         self.assertEqual(resp.status_code, 200)
@@ -78,6 +94,8 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "ready": False,
                 "browser": "chrome",
                 "path": "/usr/bin/chrome",
+                "version": 120,
+                "shortcut": "/tmp/Chrome.lnk",
                 "patched": True,
             },
         )

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -53,11 +53,17 @@ class TestSettingsRoute(unittest.TestCase):
         # Avoid restarting the interpreter during tests
         self.restart_patch = patch("app.routes.restart_server")
         self.restart_patch.start()
+        self.chrome_patch = patch("app.routes.get_chrome_version", return_value=120)
+        self.shortcut_patch = patch("app.routes.first_shortcut_path", return_value=None)
+        self.chrome_patch.start()
+        self.shortcut_patch.start()
 
     def tearDown(self):
         self.restart_patch.stop()
         self.app_context.pop()
         self.env_patch.stop()
+        self.chrome_patch.stop()
+        self.shortcut_patch.stop()
 
         # Reload modules back to default environment
         import app


### PR DESCRIPTION
## Summary
- clarify Danger Mode details on the Settings page
- note default shortcut locations in the Danger Mode doc
- expose Chrome version and shortcut path in the backend
- show the extra fields on the Settings page
- update related tests

## Testing
- `pytest tests/test_danger_status_endpoint.py tests/test_shortcuts_need_patch.py -q`
- `pytest tests/test_settings_route.py::TestSettingsRoute::test_download_without_backup -vv` *(passes individually)*
- `pre-commit run --all-files` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845914682f88333bb0e414741a91e71