### PR TITLE
Improve theme toggle

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -257,7 +257,7 @@ def create_app(
                     # Reset failure count on successful check
                     failure_count = 0
 
-    # Send alerts when the application starts  
+    # Send alerts when the application starts
     def _start_background_components() -> None:
         """Initialize scheduler and monitoring in a low priority thread."""
         backup_config()

--- a/app/static/js/tabs.js
+++ b/app/static/js/tabs.js
@@ -8,6 +8,7 @@ export function initTabs() {
     tabs.forEach((tab) => {
       tab.addEventListener("click", () => {
         const target = tab.dataset.tab;
+        if (!target) return;
         tabs.forEach((t) => t.classList.remove("active"));
         contents.forEach((c) => c.classList.remove("active"));
         tab.classList.add("active");

--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -25,9 +25,11 @@ export function initThemeToggle() {
     if (toggle) {
       toggle.addEventListener("click", (e) => {
         e.preventDefault();
+        e.stopPropagation();
         current = current === "light" ? "dark" : "light";
         localStorage.setItem("theme", current);
         applyTheme(current);
+        document.querySelector('.tab-link[data-tab="General-tab"]')?.click();
       });
     }
   });

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ banner = """\033[96m
                               |_|
 \033[0m"""
 
+
 def parse_arguments(arg_list=None):
     """Return parsed command-line arguments."""
     parser = build_argument_parser()

--- a/tests/js/theme.test.js
+++ b/tests/js/theme.test.js
@@ -1,0 +1,33 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <a id="theme-toggle"><svg><use href="#sun"></use></svg></a>
+  <button id="gen-tab" class="tab-link" data-tab="General-tab"></button>
+`;
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: () => ({ matches: false }),
+});
+
+let initThemeToggle;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/theme.js");
+  initThemeToggle = mod.initThemeToggle;
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+test("clicking toggle switches theme and activates General tab", () => {
+  const btn = document.getElementById("gen-tab");
+  btn.click = jest.fn();
+  initThemeToggle();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  document.getElementById("theme-toggle").click();
+  expect(localStorage.getItem("theme")).toBe("light");
+  expect(btn.click).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- prevent tabs script from hiding content when clicking a link without a `data-tab`
- ensure switching themes activates the General tab
- format stray whitespace
- test theme toggle behavior

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: could not install build dependencies)*
- `pytest -q` *(1 failed: tests/test_settings_route.py::TestSettingsRoute::test_download_without_backup)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684593747ec483339f01245065e2d9fe