### PR TITLE
Move settings explanation to tooltips

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -70,7 +70,6 @@
             <tr>
               <th class="searchable">Setting</th>
               <th class="searchable">Value</th>
-              <th class="searchable">Explanation</th>
               <th class="advanced-only">Action</th>
             </tr>
           </thead>
@@ -108,9 +107,6 @@
                   title="Edit value for {{ setting.name }}"
                 />
                 {% endif %}
-              </td>
-              <td class="setting-explanation">
-                {{ tooltips.get(setting.name, '') }}
               </td>
               <td class="advanced-only">
                 <button


### PR DESCRIPTION
## Summary
- drop the Explanation column from the settings table

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: could not install pre-commit environment)*
- `pytest -q` *(fails: 1 failed, 437 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68459393e13c8333a8f7dc9c5dc03ba3