### PR TITLE
Fix discovery toggle restart

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -257,7 +257,7 @@ def create_app(
                     # Reset failure count on successful check
                     failure_count = 0
 
-    # Send alerts when the application starts  
+    # Send alerts when the application starts
     def _start_background_components() -> None:
         """Initialize scheduler and monitoring in a low priority thread."""
         backup_config()
@@ -322,8 +322,9 @@ def create_app(
 
         app.scheduler = scheduler
 
-    threading.Thread(
-        target=_start_background_components, name="init-bg", daemon=True
-    ).start()
+    if schedule or enable_watchdog or log_cache:
+        threading.Thread(
+            target=_start_background_components, name="init-bg", daemon=True
+        ).start()
 
     return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -429,8 +429,18 @@ def file_location_metrics(
     return metrics
 
 
-def update_setting(name: str, value: str) -> bool:
-    """Persist a configuration ``name`` and ``value`` to the database."""
+def update_setting(name: str, value: str, restart: bool = True) -> bool:
+    """Persist a configuration ``name`` and ``value`` to the database.
+
+    Parameters
+    ----------
+    name : str
+        Setting name.
+    value : str
+        New setting value.
+    restart : bool, optional
+        Restart the server after updating the setting. Defaults to ``True``.
+    """
 
     name = name.replace("'", "")[:32]
     value = value.replace("'", "")[:1024]
@@ -472,7 +482,7 @@ def update_setting(name: str, value: str) -> bool:
     finally:
         session.close()
 
-    if delta is True:
+    if delta is True and restart:
         # Trigger server restart
         # is there a way to do this on a delay?
         restart_server()
@@ -1332,10 +1342,10 @@ def init_routes(app: Flask) -> None:
             job = scheduling.scheduler.get_job("background_discovery")
             if job:
                 scheduling.stop_discovery()
-                update_setting("DISCOVERY_AUTOSTART", "False")
+                update_setting("DISCOVERY_AUTOSTART", "False", restart=False)
                 return jsonify({"status": "stopped"})
             scheduling.schedule_discovery()
-            update_setting("DISCOVERY_AUTOSTART", "True")
+            update_setting("DISCOVERY_AUTOSTART", "True", restart=False)
             return jsonify({"status": "running"})
         except Exception as e:
             return jsonify({"status": "error", "message": str(e)}), 500

--- a/tests/test_toggle_discovery_endpoint.py
+++ b/tests/test_toggle_discovery_endpoint.py
@@ -28,7 +28,9 @@ class TestToggleDiscoveryEndpoint(unittest.TestCase):
         resp = self.client.post("/toggle_discovery")
         self.assertEqual(resp.status_code, 200)
         mock_schedule.assert_called_once()
-        mock_update.assert_called_once_with("DISCOVERY_AUTOSTART", "True")
+        mock_update.assert_called_once_with(
+            "DISCOVERY_AUTOSTART", "True", restart=False
+        )
         self.assertEqual(resp.get_json(), {"status": "running"})
 
     @patch("app.routes.scheduling.scheduler")
@@ -39,7 +41,9 @@ class TestToggleDiscoveryEndpoint(unittest.TestCase):
         resp = self.client.post("/toggle_discovery")
         self.assertEqual(resp.status_code, 200)
         mock_stop.assert_called_once()
-        mock_update.assert_called_once_with("DISCOVERY_AUTOSTART", "False")
+        mock_update.assert_called_once_with(
+            "DISCOVERY_AUTOSTART", "False", restart=False
+        )
         self.assertEqual(resp.get_json(), {"status": "stopped"})
 
 


### PR DESCRIPTION
## Summary
- avoid restarting server when toggling camera discovery
- skip starting background tasks when disabled
- update tests for new optional restart arg

## Testing
- `flake8 app/routes.py tests/test_toggle_discovery_endpoint.py app/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459425740c833389a8404a047a4e8d