### PR TITLE
Adjust toolbar position and modal handling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1137,6 +1137,7 @@ body.advanced-enabled .settings-table input[data-locked] {
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
+  max-width: 80vw;
   background-color: rgba(0, 0, 0, 0.7);
   color: #fff;
   padding: 0.25rem 0.5rem;

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -736,20 +736,27 @@ block content %}
   }
 
   function openModal(id) {
+    const target = document.getElementById(id);
+    if (!target) return;
+    const currentlyVisible = target.style.display === "block";
     document.querySelectorAll(".modal").forEach((m) => {
       m.style.display = "none";
     });
-    document.getElementById(id).style.display = "block";
+    if (!currentlyVisible) {
+      target.style.display = "block";
+      document.querySelector(".template-actions")?.classList.remove("fade-out");
+    } else {
+      document.querySelector(".template-actions")?.classList.remove("fade-out");
+    }
   }
 
   function closeGenericModal(id) {
     document.getElementById(id).style.display = "none";
+    document.querySelector(".template-actions")?.classList.remove("fade-out");
   }
 </script>
 
 <div class="template-actions fade-out">
-  <p><strong>Last Caption:</strong> {{ template_details.last_caption }}</p>
-  <p><strong>Caption Time:</strong> {{ template_details.last_caption_time }}</p>
   <button onclick="openModal('videos-modal')" title="Show recent videos">
     Recent Videos
   </button>
@@ -759,6 +766,8 @@ block content %}
   <button onclick="openModal('edit-template-modal')" title="Edit this template">
     Edit Template
   </button>
+  <p><strong>Last Caption:</strong> {{ template_details.last_caption }}</p>
+  <p><strong>Caption Time:</strong> {{ template_details.last_caption_time }}</p>
 </div>
 
 <script>
@@ -766,16 +775,24 @@ block content %}
     const actions = document.querySelector(".template-actions");
     if (!actions) return;
     let fadeTimeout;
+    const modalVisible = () =>
+      Array.from(document.querySelectorAll(".modal")).some(
+        (m) => m.style.display === "block",
+      );
     const show = () => {
       actions.classList.remove("fade-out");
       clearTimeout(fadeTimeout);
-      fadeTimeout = setTimeout(() => actions.classList.add("fade-out"), 3000);
+      if (!modalVisible()) {
+        fadeTimeout = setTimeout(() => actions.classList.add("fade-out"), 3000);
+      }
     };
     ["mouseenter", "mousemove"].forEach((evt) => {
       actions.addEventListener(evt, show);
     });
     actions.addEventListener("mouseleave", () => {
-      fadeTimeout = setTimeout(() => actions.classList.add("fade-out"), 3000);
+      if (!modalVisible()) {
+        fadeTimeout = setTimeout(() => actions.classList.add("fade-out"), 3000);
+      }
     });
     show();
   });


### PR DESCRIPTION
## Summary
- update player toolbar order and toggle logic
- keep toolbar visible while modals show
- limit toolbar width to avoid overlap with timestamp

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: could not install dependencies)*
- `pytest` *(fails: 5 failed tests)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459657b424833395086635793531e9