### PR TITLE
Remove redundant settings headers

### DIFF
--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -11,8 +11,6 @@
   >
 </div>
 
-<h1>System Status</h1>
-
 {% call card('System Metrics') %}
 <ul class="metrics-list">
   <li title="Current CPU utilization">
@@ -52,7 +50,9 @@
   <li title="Number of active threads">
     Thread Count: <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
-  <li title="System uptime">Uptime: <span id="uptime-value">{{ metrics.uptime }}</span></li>
+  <li title="System uptime">
+    Uptime: <span id="uptime-value">{{ metrics.uptime }}</span>
+  </li>
 </ul>
 {% endcall %} {% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -53,7 +53,6 @@
       class="tab-content{% if loop.first %} active{% endif %}"
     >
       <section class="setting-section">
-        <h2>{{ group }} Settings</h2>
         <table class="settings-table">
           <thead>
             <tr>

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -11,6 +11,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.
+- **Tab headers removed** – the active tab is highlighted, freeing space.
 - **System Status** – view CPU, memory, disk usage, and live logs.
 - **Certain tabs start collapsed** – Capture, Credentials & Management, and
   Integrations & Other appear collapsed until expanded.


### PR DESCRIPTION
## Summary
- drop per-tab heading in Settings view
- remove extra System Status heading
- document the change in the settings docs

## Testing
- `pre-commit run --all-files` *(failed: could not install dependencies)*
- `pytest -q` *(failed: AttributeError in scheduler tests)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459745d44c8333932524072879b483