### PR TITLE
Improve template controls UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -206,27 +206,9 @@ h2 {
 #template-controls {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 5px;
   margin-bottom: 10px;
-}
-
-#controls-wrapper.closed #template-controls {
-  display: none;
-}
-
-#controls-toggle {
-  cursor: pointer;
-  font-weight: 600;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.5s;
-}
-
-#controls-wrapper.show-toggle #controls-toggle,
-#controls-wrapper:not(.closed) #controls-toggle {
-  opacity: 1;
-  pointer-events: auto;
 }
 
 #controls-wrapper {

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -1,53 +1,25 @@
 export function initControlsDropdown() {
   document.addEventListener("DOMContentLoaded", () => {
     const wrapper = document.getElementById("controls-wrapper");
-    const toggle = document.getElementById("controls-toggle");
-    if (!wrapper || !toggle) return;
+    if (!wrapper) return;
 
-    let hideTimeout;
-    let buttonTimeout;
+    const isMobile = window.matchMedia("(max-width: 767px)").matches;
+    if (isMobile) {
+      return;
+    }
 
-    const showButton = () => {
-      wrapper.classList.add("show-toggle");
-      clearTimeout(buttonTimeout);
-      if (wrapper.classList.contains("closed")) {
-        buttonTimeout = setTimeout(
-          () => wrapper.classList.remove("show-toggle"),
-          3000,
-        );
-      }
-    };
-
-    const scheduleHide = () => {
-      clearTimeout(hideTimeout);
-      hideTimeout = setTimeout(() => {
-        wrapper.classList.add("fade-out");
-        setTimeout(() => {
-          wrapper.classList.add("closed");
-          wrapper.classList.remove("fade-out");
-          showButton();
-        }, 500);
-      }, 5000);
-    };
-
+    let fadeTimeout;
     const showControls = () => {
-      if (wrapper.classList.contains("closed")) return;
       wrapper.classList.remove("fade-out");
-      showButton();
-      scheduleHide();
+      clearTimeout(fadeTimeout);
+      fadeTimeout = setTimeout(() => wrapper.classList.add("fade-out"), 3000);
     };
-
-    toggle.addEventListener("click", () => {
-      wrapper.classList.toggle("closed");
-      if (!wrapper.classList.contains("closed")) showControls();
-      else showButton();
-    });
-
-    if (!wrapper.classList.contains("closed")) showControls();
-    else showButton();
 
     ["mousemove", "scroll"].forEach((evt) => {
-      document.addEventListener(evt, showButton);
+      document.addEventListener(evt, showControls);
     });
+    wrapper.addEventListener("mouseover", showControls);
+
+    showControls();
   });
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,8 +3,7 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
 
-<div id="controls-wrapper" class="closed">
-  <button id="controls-toggle" type="button">Controls</button>
+<div id="controls-wrapper">
   <section id="template-controls">
     <input
       type="text"

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -1,10 +1,7 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `
-  <div id="controls-wrapper" class="closed">
-    <button id="controls-toggle" type="button">Controls</button>
-  </div>
-`;
+const html = `<div id="controls-wrapper"></div>`;
+document.body.innerHTML = html;
 
 jest.useFakeTimers();
 
@@ -15,24 +12,33 @@ beforeAll(async () => {
 });
 
 describe("controls dropdown", () => {
-  test("auto collapses after inactivity", () => {
+  beforeEach(() => {
+    document.body.innerHTML = html;
+    jest.clearAllMocks();
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+  });
+  test("fades out after inactivity on desktop", () => {
     const wrapper = document.getElementById("controls-wrapper");
-    wrapper.classList.remove("closed");
+    initControlsDropdown();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.advanceTimersByTime(3000);
+    expect(wrapper.classList.contains("fade-out")).toBe(true);
+  });
+
+  test("remains visible on mobile", () => {
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: true,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    }));
+    const wrapper = document.getElementById("controls-wrapper");
     initControlsDropdown();
     document.dispatchEvent(new Event("DOMContentLoaded"));
     jest.advanceTimersByTime(5000);
-    expect(wrapper.classList.contains("fade-out")).toBe(true);
-    jest.advanceTimersByTime(500);
-    expect(wrapper.classList.contains("closed")).toBe(true);
     expect(wrapper.classList.contains("fade-out")).toBe(false);
-  });
-
-  test("button shows and hides on activity", () => {
-    const wrapper = document.getElementById("controls-wrapper");
-    initControlsDropdown();
-    document.dispatchEvent(new Event("DOMContentLoaded"));
-    expect(wrapper.classList.contains("show-toggle")).toBe(true);
-    jest.advanceTimersByTime(3000);
-    expect(wrapper.classList.contains("show-toggle")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- make the template controls show on hover instead of using a button
- keep controls visible on mobile
- ensure template controls stay on one line
- update tests for new behaviour

## Testing
- `npm test --silent`
- `pytest -q` *(fails: KeyboardInterrupt)*
- `pre-commit run --all-files` *(fails: could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684596c514788333a1eb35d2fc10f6c6