### PR TITLE
Fix player group filter

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -37,6 +37,12 @@ if (!templateDetails["All"]) {
   };
 }
 
+function getCameraNames() {
+  return Object.keys(templateDetails).filter(
+    (key) => key !== "All" && !key.startsWith("group-"),
+  );
+}
+
 // Allow embedding the live view for a specific camera by reading the
 // ``camera`` query parameter. When provided and valid, restrict the camera
 // selector to that camera and start playback for it immediately.
@@ -379,7 +385,7 @@ function changeCamera() {
     currentCamera = "All";
     templateDetails["All"] = {
       url: "/stream.mp4", // Set the URL for the MP4 stream without a group
-      groupCameras: Object.keys(templateDetails).filter((key) => key !== "All"), // Add all cameras
+      groupCameras: getCameraNames(), // Add all cameras but skip groups
       // Add other necessary properties for the "All" group, if needed
     };
     isConnected = true;
@@ -630,9 +636,7 @@ function playLoop() {
     let groupCameras;
     if (currentCamera === "All") {
       // If the "All" group is selected, get all camera names
-      groupCameras = Object.keys(templateDetails).filter(
-        (key) => key !== "All",
-      );
+      groupCameras = getCameraNames();
     } else {
       // If a specific group is selected, get the cameras in that group
       const groupName = currentCamera.split("group-")[1];
@@ -801,9 +805,7 @@ function playLive() {
   if (currentCamera.startsWith("group-") || currentCamera === "All") {
     let groupCameras;
     if (currentCamera === "All") {
-      groupCameras = Object.keys(templateDetails).filter(
-        (key) => key !== "All",
-      );
+      groupCameras = getCameraNames();
     } else {
       const groupName = currentCamera.split("group-")[1];
       const groupDetails = templateDetails["group-" + groupName];
@@ -900,9 +902,7 @@ function playPNG() {
   } else if (currentCamera === "All") {
     // Special handling for the "All" option
     let cameraIndex = 0;
-    const allCameras = Object.keys(templateDetails).filter(
-      (key) => key !== "All",
-    );
+    const allCameras = getCameraNames();
     const refreshAllPNG = () => {
       if (cameraIndex >= allCameras.length) {
         cameraIndex = 0;
@@ -1108,9 +1108,7 @@ function updateSpeedContainer() {
   let cameraCount = 0;
   if (isGroupView) {
     if (currentCamera === "All") {
-      cameraCount = Object.keys(templateDetails).filter(
-        (k) => k !== "All",
-      ).length;
+      cameraCount = getCameraNames().length;
     } else {
       const details = templateDetails[currentCamera];
       cameraCount =
@@ -1401,4 +1399,4 @@ function handleTouchEnd(event) {
 document.addEventListener("touchstart", handleTouchStart, { passive: true });
 document.addEventListener("touchend", handleTouchEnd, { passive: true });
 
-export { updateFrameTimestamp };
+export { updateFrameTimestamp, getCameraNames };

--- a/tests/js/get_camera_names.test.js
+++ b/tests/js/get_camera_names.test.js
@@ -1,0 +1,63 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="video-overlay"></div>
+  <img id="live-image" />
+  <video id="live-video"></video>
+  <div id="template-details"></div>
+  <div id="speed-container"></div>
+  <input id="speed-slider" />
+  <span id="speed-value"></span>
+  <div id="loading-indicator"></div>
+  <div id="play-pause-indicator"></div>
+  <div id="offline-indicator"></div>
+  <div id="offline-message"></div>
+  <div id="capture-error-indicator"></div>
+  <div id="capture-error-message"></div>
+  <div id="stream-error-indicator"></div>
+  <div id="stream-error-message"></div>
+  <div id="error-message"></div>
+  <button id="play-pause"></button>
+  <div id="toggle-details"></div>
+  <input id="seek-bar" />
+  <div id="jog-shuttle"></div>
+  <select id="video-source"><option value="mjpg">MJPG</option></select>
+  <select id="camera-selector"></select>
+  <select id="group-selector"></select>
+`;
+
+window.templateDetails = {
+  cam1: { last_screenshot_time: "2023-01-01 00:00:00" },
+  cam2: { last_screenshot_time: "2023-01-01 00:00:00" },
+};
+
+describe("getCameraNames", () => {
+  let getCameraNames;
+  let changeCamera;
+  beforeAll(async () => {
+    const mod = await import("../../app/static/js/live.js");
+    getCameraNames = mod.getCameraNames;
+    changeCamera = window.changeCamera;
+  });
+
+  test("filters out group entries", () => {
+    const selector = document.getElementById("camera-selector");
+    selector.innerHTML = `
+      <option value="All">All</option>
+      <option value="group-test">group-test</option>
+      <option value="cam1">cam1</option>
+      <option value="cam2">cam2</option>
+    `;
+    selector.value = "group-test";
+    changeCamera();
+
+    selector.value = "All";
+    changeCamera();
+
+    expect(getCameraNames()).toEqual(["cam1", "cam2"]);
+    expect(window.templateDetails["All"].groupCameras).toEqual([
+      "cam1",
+      "cam2",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore group keys when building camera lists
- export helper to list camera names
- test group filter logic for "All" view

## Testing
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest` *(fails: AttributeError in scheduling tests)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459a018ea88333ad67860926be6dbf