### PR TITLE
Fix offline banner login check

### DIFF
--- a/app/static/js/network_banner.js
+++ b/app/static/js/network_banner.js
@@ -1,0 +1,30 @@
+export function initNetworkBanner() {
+  document.addEventListener("DOMContentLoaded", () => {
+    if (typeof window.IS_LOGGED_IN !== "undefined" && !window.IS_LOGGED_IN) {
+      return;
+    }
+
+    const banner = document.getElementById("network-banner");
+    if (!banner) return;
+
+    const checkStatus = async () => {
+      try {
+        const res = await fetch("/network_status");
+        const data = await res.json();
+        if (data.online) {
+          banner.classList.remove("show");
+          banner.textContent = "";
+        } else {
+          banner.textContent = "Offline mode";
+          banner.classList.add("show");
+        }
+      } catch {
+        banner.textContent = "Offline mode";
+        banner.classList.add("show");
+      }
+    };
+
+    checkStatus();
+    setInterval(checkStatus, 10000);
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -20,33 +20,7 @@ import { initAutocomplete } from "./autocomplete.js";
 import { initCosts } from "./costs.js";
 import { initAdvanced } from "./advanced.js";
 import { initCliHelp } from "./cli_help.js";
-
-function initNetworkBanner() {
-  document.addEventListener("DOMContentLoaded", () => {
-    const banner = document.getElementById("network-banner");
-    if (!banner) return;
-
-    const checkStatus = async () => {
-      try {
-        const res = await fetch("/network_status");
-        const data = await res.json();
-        if (data.online) {
-          banner.classList.remove("show");
-          banner.textContent = "";
-        } else {
-          banner.textContent = "Offline mode";
-          banner.classList.add("show");
-        }
-      } catch {
-        banner.textContent = "Offline mode";
-        banner.classList.add("show");
-      }
-    };
-
-    checkStatus();
-    setInterval(checkStatus, 10000);
-  });
-}
+import { initNetworkBanner } from "./network_banner.js";
 
 initTemplates();
 initVideoControls();

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -1,17 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif %}</title>
-    <meta name="description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
-    <meta property="og:title" content="{% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif %}">
-    <meta property="og:description" content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/player.css') }}">
-    <link rel="preload" href="{{ url_for('static', filename='icons/sprite.svg') }}" as="image" type="image/svg+xml" crossorigin>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-    <script type="module" src="{{ url_for('static', filename='js/script.js') }}"></script>
-</head>
-
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      {% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif
+      %}
+    </title>
+    <meta
+      name="description"
+      content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}"
+    />
+    <meta
+      property="og:title"
+      content="{% if page_title %}Glimpser – {{ page_title }}{% else %}Glimpser{% endif %}"
+    />
+    <meta
+      property="og:description"
+      content="{{ meta_description or 'Real-time monitoring and summarization for camera streams.' }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/style.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/player.css') }}"
+    />
+    <link
+      rel="preload"
+      href="{{ url_for('static', filename='icons/sprite.svg') }}"
+      as="image"
+      type="image/svg+xml"
+      crossorigin
+    />
+    <link
+      rel="icon"
+      type="image/x-icon"
+      href="{{ url_for('static', filename='favicon.ico') }}"
+    />
+    <script>
+      window.IS_LOGGED_IN = {{ 'true' if session.get('user_id') else 'false' }};
+    </script>
+    <script
+      type="module"
+      src="{{ url_for('static', filename='js/script.js') }}"
+    ></script>
+  </head>
+</html>

--- a/tests/js/network_banner.test.js
+++ b/tests/js/network_banner.test.js
@@ -1,0 +1,38 @@
+import { jest } from "@jest/globals";
+
+let initNetworkBanner;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/network_banner.js");
+  initNetworkBanner = mod.initNetworkBanner;
+});
+
+beforeEach(() => {
+  document.body.innerHTML =
+    '<div id="network-banner" class="network-banner"></div>';
+  global.fetch = jest.fn();
+  window.IS_LOGGED_IN = true;
+  jest.clearAllMocks();
+});
+
+test("does nothing when not logged in", () => {
+  window.IS_LOGGED_IN = false;
+  initNetworkBanner();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  expect(fetch).not.toHaveBeenCalled();
+  const banner = document.getElementById("network-banner");
+  expect(banner.classList.contains("show")).toBe(false);
+});
+
+test("shows banner when offline", async () => {
+  global.fetch.mockResolvedValueOnce({
+    json: () => Promise.resolve({ online: false }),
+  });
+  initNetworkBanner();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  const banner = document.getElementById("network-banner");
+  expect(fetch).toHaveBeenCalledWith("/network_status");
+  expect(banner.classList.contains("show")).toBe(true);
+  expect(banner.textContent).toBe("Offline mode");
+});


### PR DESCRIPTION
## Summary
- add global login flag
- hide offline banner when not logged in
- extract network banner to its own module
- test banner logic

## Testing
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `flake8`
- `pytest -q` *(fails: AttributeError in scheduling tests)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845bd3ced5c8333aa3f0c12baaa7171