### PR TITLE
Fix scheduler test cleanup

### DIFF
--- a/tests/test_scheduler_start_once.py
+++ b/tests/test_scheduler_start_once.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from app import create_app
 from app.utils.scheduling import scheduler
+from apscheduler.schedulers.background import BackgroundScheduler
 
 
 def test_scheduler_starts_once():
@@ -20,14 +21,14 @@ def test_scheduler_starts_once():
 
     with (
         patch.object(scheduler, "start", side_effect=start_wrapper),
-        patch("app.__init__.schedule_crawlers"),
-        patch("app.__init__.schedule_summarization"),
-        patch("app.__init__.schedule_offline_job_processor"),
-        patch("app.__init__.schedule_discovery"),
-        patch("app.__init__.start_metrics_collection"),
-        patch("app.__init__.start_log_caching"),
-        patch("app.__init__.email_alert"),
-        patch("app.__init__.sms_alert"),
+        patch("app.schedule_crawlers"),
+        patch("app.schedule_summarization"),
+        patch("app.schedule_offline_job_processor"),
+        patch("app.schedule_discovery"),
+        patch("app.start_metrics_collection"),
+        patch("app.start_log_caching"),
+        patch("app.email_alert"),
+        patch("app.sms_alert"),
     ):
         create_app(enable_watchdog=False, schedule=True)
         # allow background thread to run
@@ -35,3 +36,4 @@ def test_scheduler_starts_once():
         assert len(calls) == 1
 
     scheduler.shutdown(wait=False)
+    scheduler.set_scheduler(BackgroundScheduler())


### PR DESCRIPTION
## Summary
- ensure scheduler is reset after shutdown
- patch scheduler functions using package root

## Testing
- `flake8 tests/test_scheduler_start_once.py`
- `black --check tests/test_scheduler_start_once.py`
- `pytest -q`
- `pre-commit run --all-files` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6845c03ecb70833399c1d548d95dee7e