### PR TITLE
Fix chrome version check and scheduler reuse

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -98,8 +98,10 @@ class GracefulAPScheduler(APScheduler):
                 # Shutdown the scheduler
                 super().shutdown(wait)
 
-                # Additional cleanup if needed
-                self._scheduler = None
+                # Reinitialize scheduler for future use without requiring a
+                # full application restart. This allows tests or other
+                # components to continue scheduling jobs after shutdown.
+                self.set_scheduler(BackgroundScheduler())
             else:
                 logging.info("Scheduler is not running.")
         except Exception as e:

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1919,7 +1919,7 @@ def get_chrome_version(chrome_path):
         chrome_version[chrome_path] = (version, time.time())
     except Exception as e:
         logging.error(f"Chrome version exception error: {e}")
-        return chrome_version.get(chrome_path, extract_version())
+        return chrome_version.get(chrome_path, extract_version(chrome_path))
 
     return int(version)
 


### PR DESCRIPTION
## Summary
- fix fallback path for chrome version extraction
- reinitialize scheduler after shutdown

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c29a062c8333b4cdd92df314a9c7