### PR TITLE
Enable chyron on nav hover

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -261,6 +261,16 @@ export function initNav() {
       // Keep the caption visible until a new one arrives
     };
 
+    if (captionsIcon && captionChyron) {
+      captionsIcon.addEventListener("mouseenter", () => {
+        const text = captionsIcon.dataset.caption;
+        if (text) showCaption(text);
+      });
+      captionsIcon.addEventListener("mouseleave", () => {
+        captionChyron.classList.remove("show");
+      });
+    }
+
     const checkCaptions = async () => {
       if (!captionsIcon) return;
       try {
@@ -271,7 +281,8 @@ export function initNav() {
             : "/captions_status";
         const data = await fetchJson(url);
         if (!data) return;
-        captionsIcon.title = data.caption || "";
+        captionsIcon.dataset.caption = data.caption || "";
+        captionsIcon.removeAttribute("title");
         if (data.timestamp) {
           const ts = new Date(data.timestamp.replace(" ", "T") + "Z");
           if (!lastCaptionTime || ts > lastCaptionTime) {

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -95,7 +95,6 @@
         href="/captions"
         id="captions"
         class="settings-icon"
-        title="Read and update camera LLMs"
         aria-label="Read and update camera LLMs"
       >
         <svg width="20" height="20">

--- a/tests/js/nav_chyron.test.js
+++ b/tests/js/nav_chyron.test.js
@@ -1,0 +1,53 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <a id="captions"></a>
+  <div id="caption-chyron" data-speed="240"></div>
+  <nav></nav>
+`;
+
+let initNav;
+
+beforeAll(async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () =>
+        Promise.resolve({ caption: "Hello", timestamp: "2024-01-01 00:00:00" }),
+    }),
+  );
+  global.setInterval = jest.fn();
+  const mod = await import("../../app/static/js/nav.js");
+  initNav = mod.initNav;
+});
+
+describe("caption hover", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    initNav();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    await Promise.resolve();
+  });
+
+  test("sets caption dataset", () => {
+    const icon = document.getElementById("captions");
+    expect(icon.dataset.caption).toBe("Hello");
+    expect(icon.title).toBe("");
+  });
+
+  test("mouse enter shows chyron", () => {
+    const icon = document.getElementById("captions");
+    const chyron = document.getElementById("caption-chyron");
+    icon.dispatchEvent(new Event("mouseenter"));
+    expect(chyron.classList.contains("show")).toBe(true);
+  });
+
+  test("mouse leave hides chyron", () => {
+    const icon = document.getElementById("captions");
+    const chyron = document.getElementById("caption-chyron");
+    icon.dispatchEvent(new Event("mouseenter"));
+    icon.dispatchEvent(new Event("mouseleave"));
+    expect(chyron.classList.contains("show")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- show caption in chyron when hovering the nav icon
- drop long tooltip from nav icon
- test chyron hover behavior

## Testing
- `flake8`
- `pytest -q`
- `npm test`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845ca8c32148333a7c0ed8d4d962ea2