### PR TITLE
Improve login page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1431,6 +1431,10 @@ footer.fade-out {
   color: var(--text-color);
 }
 
+.warning {
+  color: #b80000;
+}
+
 input[type="text"],
 input[type="password"] {
   width: 100%;
@@ -1470,6 +1474,17 @@ input[type="submit"]:hover {
 /* Utility classes extracted from inline styles */
 .hidden {
   display: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .advanced-only {

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -1,7 +1,17 @@
 export function initLogin() {
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.getElementById("login-form");
+    const noteEl = document.getElementById("security-note");
     if (!form) return;
+    if (noteEl) {
+      if (location.protocol === "https:") {
+        noteEl.textContent = "Your credentials are encrypted in transit.";
+      } else {
+        noteEl.textContent =
+          "Warning: credentials sent over HTTP are not secure.";
+        noteEl.classList.add("warning");
+      }
+    }
     form.addEventListener("submit", (e) => {
       const user = form.elements["username"].value.trim();
       const pass = form.elements["password"].value.trim();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,29 +7,32 @@ content %}
       <use href="{{ url_for('static', filename='icons/sprite.svg') }}#lock" />
     </svg>
   </div>
-  <p class="security-note">Your credentials are encrypted in transit.</p>
+  <p id="security-note" class="security-note"></p>
   <form
     id="login-form"
     method="post"
     class="login-form"
+    autocomplete="off"
     title="Enter your credentials"
   >
     <div class="form-field">
-      <label for="username">Username</label>
+      <label for="username" class="sr-only">Username</label>
       <input
         id="username"
         type="text"
         name="username"
+        placeholder="Username"
         required
         title="Enter your username"
       />
     </div>
     <div class="form-field">
-      <label for="password">Password</label>
+      <label for="password" class="sr-only">Password</label>
       <input
         id="password"
         type="password"
         name="password"
+        placeholder="Password"
         required
         title="Enter your password"
       />

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -58,6 +58,12 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn("username", inputs)
         self.assertIn("password", inputs)
 
+    def test_login_placeholders(self):
+        parser = parse_template(Path("app/templates/login.html"))
+        placeholders = {i.get("placeholder") for i in parser.forms[0]["inputs"]}
+        self.assertIn("Username", placeholders)
+        self.assertIn("Password", placeholders)
+
     def test_discover_add_camera_form_inputs(self):
         parser = parse_template(Path("app/templates/_discover_tab.html"))
         add_form = None


### PR DESCRIPTION
## Summary
- streamline the login form with placeholder labels
- warn users when credentials aren't encrypted over HTTP
- add sr-only and warning utility classes
- test login placeholders

## Testing
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845cf58a3ec8333b3140875aa94fd35