### PR TITLE
Add captions button to controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -240,6 +240,39 @@ h2 {
   min-width: 80px;
 }
 
+#caption-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  padding: 0;
+}
+
+#caption-toggle svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentcolor;
+  stroke-width: 2;
+}
+
+#caption-toggle.active {
+  color: var(--accent-color);
+}
+
+#caption-toggle.off {
+  opacity: 0.7;
+}
+
+#caption-toggle.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 #template-list {
   display: grid;
   grid-template-columns: repeat(

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -16,13 +16,18 @@ let captionsVisible = localStorage.getItem("showCaptions") !== "false";
 
 export function applyCaptionVisibility(width) {
   const templateList = document.getElementById("template-list");
-  const captionToggle = document.getElementById("toggle-captions");
-  const show = captionsVisible && (!width || width >= 150);
+  const captionToggle = document.getElementById("caption-toggle");
+  const enabled = !width || width >= 150;
+  const show = captionsVisible && enabled;
   document.documentElement.classList.toggle("hide-captions", !show);
   templateList
     ?.querySelectorAll(".caption-overlay")
     .forEach((o) => (o.style.display = show ? "block" : "none"));
-  if (captionToggle) captionToggle.checked = captionsVisible;
+  if (captionToggle) {
+    captionToggle.classList.toggle("disabled", !enabled);
+    captionToggle.classList.toggle("active", captionsVisible && enabled);
+    captionToggle.classList.toggle("off", !captionsVisible && enabled);
+  }
 }
 
 export function initTemplates() {
@@ -38,7 +43,7 @@ export function initTemplates() {
       "(hover: none) and (max-width: 767px)",
     ).matches;
     const templateList = document.getElementById("template-list");
-    const captionToggle = document.getElementById("toggle-captions");
+    const captionToggle = document.getElementById("caption-toggle");
     const MAX_THUMBNAIL_HEIGHT = 1080;
     const ASPECT_RATIO = 9 / 16;
     const MAX_THUMBNAIL_WIDTH = Math.round(MAX_THUMBNAIL_HEIGHT / ASPECT_RATIO);
@@ -113,8 +118,9 @@ export function initTemplates() {
     }
 
     if (captionToggle) {
-      captionToggle.addEventListener("change", () => {
-        captionsVisible = captionToggle.checked;
+      captionToggle.addEventListener("click", () => {
+        if (captionToggle.classList.contains("disabled")) return;
+        captionsVisible = !captionsVisible;
         localStorage.setItem("showCaptions", captionsVisible.toString());
         applyCaptionVisibility(parseFloat(slider?.value || "0"));
       });

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -20,6 +20,18 @@ block content %}
       title="Adjust the width of the template grid"
     />
     {{ status_legend() }}
+    <button
+      id="caption-toggle"
+      class="settings-icon"
+      aria-label="Toggle caption overlays"
+      title="Toggle caption overlays"
+    >
+      <svg width="20" height="20">
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#closed-caption"
+        />
+      </svg>
+    </button>
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
     <button
       id="live-all-button"
@@ -28,18 +40,6 @@ block content %}
     >
       Live
     </button>
-    <div class="checkbox-row">
-      <span>Captions</span>
-      <label class="switch" title="Toggle caption overlays">
-        <input
-          id="toggle-captions"
-          type="checkbox"
-          checked
-          aria-label="Toggle caption overlays"
-        />
-        <span class="slider round"></span>
-      </label>
-    </div>
   </div>
 </div>
 <div

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,6 +20,18 @@ block content %}
       title="Adjust the width of the template grid"
     />
     {{ status_legend() }}
+    <button
+      id="caption-toggle"
+      class="settings-icon"
+      aria-label="Toggle caption overlays"
+      title="Toggle caption overlays"
+    >
+      <svg width="20" height="20">
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#closed-caption"
+        />
+      </svg>
+    </button>
     <button id="play-all-button" title="Play/Stop all videos">Play All</button>
     <button
       id="live-all-button"
@@ -28,18 +40,6 @@ block content %}
     >
       Live
     </button>
-    <div class="checkbox-row">
-      <span>Captions</span>
-      <label class="switch" title="Toggle caption overlays">
-        <input
-          id="toggle-captions"
-          type="checkbox"
-          checked
-          aria-label="Toggle caption overlays"
-        />
-        <span class="slider round"></span>
-      </label>
-    </div>
   </section>
 </div>
 

--- a/docs/caption_overlay_toggle.md
+++ b/docs/caption_overlay_toggle.md
@@ -1,4 +1,4 @@
 # Caption Overlay Toggle
 
-Each thumbnail shows the latest caption text at the bottom. A **Captions** switch next to the width slider toggles these overlays. Your preference is stored in `localStorage` so it persists between visits. Captions automatically hide when thumbnails are under 150&nbsp;px wide.
-The width slider is hidden on mobile layouts, but caption overlays can still be toggled with the same switch.
+Each thumbnail shows the latest caption text at the bottom. A **CC** button to the left of **Play All** toggles these overlays. Your preference is stored in `localStorage` so it persists between visits. Captions automatically hide when thumbnails are under 150&nbsp;px wide and the button becomes disabled.
+The width slider is hidden on mobile layouts, but caption overlays can still be toggled with the same button.

--- a/tests/js/caption_toggle.test.js
+++ b/tests/js/caption_toggle.test.js
@@ -1,0 +1,49 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="template-list">
+    <div class="caption-overlay"></div>
+  </div>
+  <input id="grid-width-slider" type="range" value="160">
+  <button id="caption-toggle"></button>
+`;
+
+let initTemplates;
+let applyCaptionVisibility;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/templates.js");
+  initTemplates = mod.initTemplates;
+  applyCaptionVisibility = mod.applyCaptionVisibility;
+});
+
+describe("caption toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.getElementById("caption-toggle").className = "";
+    document.documentElement.classList.remove("hide-captions");
+  });
+
+  test("button disabled when tiles small", () => {
+    applyCaptionVisibility(100);
+    const btn = document.getElementById("caption-toggle");
+    expect(btn.classList.contains("disabled")).toBe(true);
+  });
+
+  test("click toggles visibility", () => {
+    initTemplates();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    const btn = document.getElementById("caption-toggle");
+    applyCaptionVisibility(200);
+    btn.click();
+    expect(document.documentElement.classList.contains("hide-captions")).toBe(
+      true,
+    );
+    expect(btn.classList.contains("active")).toBe(false);
+    btn.click();
+    expect(document.documentElement.classList.contains("hide-captions")).toBe(
+      false,
+    );
+    expect(btn.classList.contains("active")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace captions switch with CC icon button
- update caption toggle behavior and styling
- document updated captions control
- test caption toggle states

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845cfeca81c833385470d032d07377e