### PR TITLE
Add subnet dropdown for discovery

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1337,6 +1337,13 @@ def init_routes(app: Flask) -> None:
         """Return current network connectivity status."""
         return jsonify({"online": is_system_online()})
 
+    @app.route("/discover/subnets")
+    @login_required
+    def discover_subnets():
+        """Return local IPv4 subnets as strings."""
+        nets = camera_discovery._local_subnets()
+        return jsonify([str(n) for n in nets])
+
     @app.route("/toggle_discovery", methods=["POST"])
     @login_required
     @profile_route("/toggle_discovery")

--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -55,3 +55,47 @@ export function initDiscoveryToggle() {
     setInterval(refreshStatus, 30000);
   });
 }
+
+export function initSubnetInput() {
+  document.addEventListener("DOMContentLoaded", async () => {
+    const input = document.getElementById("cidr-input");
+    if (!input) return;
+
+    let datalist = document.getElementById("cidr-options");
+    if (!datalist) {
+      datalist = document.createElement("datalist");
+      datalist.id = "cidr-options";
+      if (input.parentNode) {
+        input.parentNode.insertBefore(datalist, input.nextSibling);
+      }
+    }
+    input.setAttribute("list", "cidr-options");
+
+    try {
+      const res = await fetch("/discover/subnets");
+      const nets = await res.json();
+      datalist.innerHTML = nets
+        .map((n) => `<option value="${n}"></option>`)
+        .join("");
+    } catch (err) {
+      console.warn("subnet fetch failed", err);
+    }
+
+    const isValidCidr = (value) => {
+      if (!/^\d{1,3}(?:\.\d{1,3}){3}\/\d{1,2}$/.test(value)) return false;
+      const [ip, prefix] = value.split("/");
+      if (ip.split(".").some((o) => +o > 255)) return false;
+      const p = parseInt(prefix, 10);
+      return p >= 0 && p <= 32;
+    };
+
+    input.addEventListener("input", () => {
+      const val = input.value.trim();
+      if (val && !isValidCidr(val)) {
+        input.setCustomValidity("Invalid CIDR");
+      } else {
+        input.setCustomValidity("");
+      }
+    });
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,7 +1,7 @@
 import { initTemplates } from "./templates.js";
 import { initVideoControls } from "./video.js";
 import { initSchedulerToggle } from "./scheduler.js";
-import { initDiscoveryToggle } from "./discovery.js";
+import { initDiscoveryToggle, initSubnetInput } from "./discovery.js";
 import { initNav } from "./nav.js";
 import { initFormValidation, initAddSettingValidation } from "./form.js";
 import { initFooterFade } from "./footer.js";
@@ -26,6 +26,7 @@ initTemplates();
 initVideoControls();
 initSchedulerToggle();
 initDiscoveryToggle();
+initSubnetInput();
 initNav();
 initFormValidation();
 initAddSettingValidation();

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -1,296 +1,494 @@
 <div class="discovery-page">
-    {% call card('Background Discovery') %}
-    <div class="discovery-controls" title="Manage background discovery">
-        <button id="stop-discovery" class="btn btn-primary" title="Stop background discovery" style="display: none;">Stop Discovery</button>
-        <span id="discovery-bg-status" title="Current background discovery status">Checking...</span>
+  {% call card('Background Discovery') %}
+  <div class="discovery-controls" title="Manage background discovery">
+    <button
+      id="stop-discovery"
+      class="btn btn-primary"
+      title="Stop background discovery"
+      style="display: none"
+    >
+      Stop Discovery
+    </button>
+    <span id="discovery-bg-status" title="Current background discovery status"
+      >Checking...</span
+    >
+  </div>
+  <div class="wizard-step" title="Enter an optional network range">
+    <input
+      id="cidr-input"
+      type="text"
+      placeholder="192.168.1.0/24"
+      title="Optional CIDR to scan"
+      list="cidr-options"
+    />
+    <datalist id="cidr-options"></datalist>
+    <button
+      id="discover-btn"
+      class="btn btn-primary"
+      title="Scan the network for cameras"
+    >
+      Discover
+    </button>
+  </div>
+  {% endcall %} {% call card('Scan Progress') %}
+  <div class="wizard-step" title="Progress of the discovery scan">
+    <progress
+      id="discover-progress"
+      class="discovery-progress hidden"
+      max="100"
+      title="Discovery progress"
+    ></progress>
+    <span id="discover-message" title="Status messages"></span>
+  </div>
+  {% endcall %} {% call card('Results') %}
+  <div class="wizard-step" title="Review results and export if desired">
+    <div class="export-buttons">
+      <button
+        id="export-json"
+        class="btn btn-primary"
+        title="Download results as JSON"
+      >
+        Export JSON
+      </button>
+      <button
+        id="export-csv"
+        class="btn btn-primary"
+        title="Download results as CSV"
+      >
+        Export CSV
+      </button>
     </div>
-    <div class="wizard-step" title="Enter an optional network range">
-        <input id="cidr-input" type="text" placeholder="192.168.1.0/24" title="Optional CIDR to scan">
-        <button id="discover-btn" class="btn btn-primary" title="Scan the network for cameras">Discover</button>
-    </div>
-    {% endcall %}
+    <table class="camera-table">
+      <thead>
+        <tr>
+          <th title="Camera IP address">IP</th>
+          <th title="Protocol type">Protocol</th>
+          <th title="Port number">Port</th>
+          <th title="MAC address">MAC</th>
+          <th title="Device manufacturer">Manufacturer</th>
+          <th title="Additional information">Info</th>
+          <th title="Add camera"></th>
+        </tr>
+      </thead>
+      <tbody id="discover-body">
+        {% for cam in cameras %}
+        <tr>
+          <td>{{ cam.ip }}</td>
+          <td>{{ cam.protocol }}</td>
+          <td>{{ cam.port }}</td>
+          <td>{{ cam.info.mac }}</td>
+          <td>{{ cam.info.manufacturer }}</td>
+          <td>{{ show_info(cam.info) }}</td>
+          <td>
+            <form action="/discover/add" method="post">
+              <input type="hidden" name="ip" value="{{ cam.ip }}" />
+              <input type="hidden" name="protocol" value="{{ cam.protocol }}" />
+              <input type="hidden" name="port" value="{{ cam.port }}" />
+              {% if cam.url %}
+              <input type="hidden" name="url" value="{{ cam.url }}" />
+              {% endif %}
+              <input type="hidden" name="name" value="{{ cam.ip }}" />
+              <button type="submit" title="Add this camera">Add</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endcall %} {% call card('Add Camera') %}
+  <div class="wizard-step" title="Form to add a new camera">
+    <details title="Expand to add a new camera">
+      <summary>Add Camera</summary>
+      <div id="template-form" title="Form to add a new template">
+        <form
+          id="add-template-form"
+          action="/templates"
+          method="post"
+          onsubmit="return validateForm()"
+          title="Enter details for the new template"
+        >
+          <div>
+            <label for="name" title="Name of the template"
+              >Template Name:</label
+            >
+            <input
+              type="text"
+              id="name"
+              name="name"
+              required
+              title="Enter a unique name for this template"
+            />
 
-    {% call card('Scan Progress') %}
-    <div class="wizard-step" title="Progress of the discovery scan">
-        <progress id="discover-progress" class="discovery-progress hidden" max="100" title="Discovery progress"></progress>
-        <span id="discover-message" title="Status messages"></span>
-    </div>
-    {% endcall %}
+            <label for="url" title="URL to monitor">URL:</label>
+            <input
+              type="url"
+              id="url"
+              name="url"
+              required
+              title="Enter the URL to monitor"
+            />
+            <span
+              id="url-status"
+              class="url-status"
+              title="URL test result"
+            ></span>
 
-    {% call card('Results') %}
-    <div class="wizard-step" title="Review results and export if desired">
-        <div class="export-buttons">
-            <button id="export-json" class="btn btn-primary" title="Download results as JSON">Export JSON</button>
-            <button id="export-csv" class="btn btn-primary" title="Download results as CSV">Export CSV</button>
-        </div>
-        <table class="camera-table">
-            <thead>
-                <tr>
-                    <th title="Camera IP address">IP</th>
-                    <th title="Protocol type">Protocol</th>
-                    <th title="Port number">Port</th>
-                    <th title="MAC address">MAC</th>
-                    <th title="Device manufacturer">Manufacturer</th>
-                    <th title="Additional information">Info</th>
-                    <th title="Add camera"></th>
-                </tr>
-            </thead>
-            <tbody id="discover-body">
-            {% for cam in cameras %}
-            <tr>
-                <td>{{ cam.ip }}</td>
-                <td>{{ cam.protocol }}</td>
-                <td>{{ cam.port }}</td>
-                <td>{{ cam.info.mac }}</td>
-                <td>{{ cam.info.manufacturer }}</td>
-                <td>{{ show_info(cam.info) }}</td>
-                <td>
-                    <form action="/discover/add" method="post">
-                        <input type="hidden" name="ip" value="{{ cam.ip }}">
-                        <input type="hidden" name="protocol" value="{{ cam.protocol }}">
-                        <input type="hidden" name="port" value="{{ cam.port }}">
-                        {% if cam.url %}
-                        <input type="hidden" name="url" value="{{ cam.url }}">
-                        {% endif %}
-                        <input type="hidden" name="name" value="{{ cam.ip }}">
-                        <button type="submit" title="Add this camera">Add</button>
-                    </form>
-                </td>
-            </tr>
-            {% endfor %}
-            </tbody>
-</table>
-    </div>
-    {% endcall %}
+            <label for="frequency" title="How often to check the URL"
+              >Frequency (minutes):</label
+            >
+            <input
+              type="number"
+              id="frequency"
+              name="frequency"
+              value="30"
+              min="1"
+              required
+              title="Enter how often to check the URL (in minutes)"
+            />
 
-    {% call card('Add Camera') %}
-    <div class="wizard-step" title="Form to add a new camera">
-        <details title="Expand to add a new camera">
-            <summary>Add Camera</summary>
-            <div id="template-form" title="Form to add a new template">
-                <form id="add-template-form" action="/templates" method="post" onsubmit="return validateForm()" title="Enter details for the new template">
-                    <div>
-                        <label for="name" title="Name of the template">Template Name:</label>
-                        <input type="text" id="name" name="name" required title="Enter a unique name for this template">
+            <label for="timeout" title="Maximum time to wait for a response"
+              >Timeout (seconds):</label
+            >
+            <input
+              type="number"
+              id="timeout"
+              name="timeout"
+              value="10"
+              min="1"
+              required
+              title="Enter the maximum time to wait for a response (in seconds)"
+            />
 
-                        <label for="url" title="URL to monitor">URL:</label>
-                        <input type="url" id="url" name="url" required title="Enter the URL to monitor">
-                        <span id="url-status" class="url-status" title="URL test result"></span>
+            <label for="notes" title="Additional notes">Notes:</label>
+            <textarea
+              id="notes"
+              name="notes"
+              title="Enter any additional notes or comments"
+            ></textarea>
 
-                        <label for="frequency" title="How often to check the URL">Frequency (minutes):</label>
-                        <input type="number" id="frequency" name="frequency" value="30" min="1" required title="Enter how often to check the URL (in minutes)">
+            <label for="object_filter" title="Filter for specific objects"
+              >Object Filter:</label
+            >
+            <input
+              type="text"
+              id="object_filter"
+              name="object_filter"
+              title="Enter object types to filter (e.g., 'person,car')"
+            />
 
-                        <label for="timeout" title="Maximum time to wait for a response">Timeout (seconds):</label>
-                        <input type="number" id="timeout" name="timeout" value="10" min="1" required title="Enter the maximum time to wait for a response (in seconds)">
+            <label
+              for="object_confidence"
+              title="Minimum confidence for object detection"
+              >Object Confidence:</label
+            >
+            <input
+              type="number"
+              id="object_confidence"
+              name="object_confidence"
+              min="0"
+              max="1"
+              step="0.01"
+              title="Enter the minimum confidence level for object detection (0-1)"
+            />
 
-                        <label for="notes" title="Additional notes">Notes:</label>
-                        <textarea id="notes" name="notes" title="Enter any additional notes or comments"></textarea>
-
-                        <label for="object_filter" title="Filter for specific objects">Object Filter:</label>
-                        <input type="text" id="object_filter" name="object_filter" title="Enter object types to filter (e.g., 'person,car')">
-
-                        <label for="object_confidence" title="Minimum confidence for object detection">Object Confidence:</label>
-                        <input type="number" id="object_confidence" name="object_confidence" min="0" max="1" step="0.01" title="Enter the minimum confidence level for object detection (0-1)">
-
-                        <label for="popup_xpath">Popup XPath:</label>
-                        <div class="xpath-input-container">
-                            <input type="text" id="popup_xpath" name="popup_xpath">
-                            <button type="button" onclick="showStructuredInput('popup_xpath')" title="Open structured XPath editor">Structured</button>
-                        </div>
-
-                        <label for="dedicated_xpath">Dedicated XPath:</label>
-                        <div class="xpath-input-container">
-                            <input type="text" id="dedicated_xpath" name="dedicated_xpath">
-                            <button type="button" onclick="showStructuredInput('dedicated_xpath')" title="Open structured XPath editor">Structured</button>
-                        </div>
-
-                        <label for="callback_url" title="URL for notifications">Callback URL:</label>
-                        <input type="url" id="callback_url" name="callback_url" title="Enter URL to receive notifications">
-
-                        <label for="proxy" title="Proxy server address">Proxy:</label>
-                        <input type="text" id="proxy" name="proxy" title="Enter proxy server address (optional)">
-
-                        <label for="auth_username" title="Username for camera authentication">Username:</label>
-                        <input type="text" id="auth_username" name="auth_username" title="Camera username">
-
-                        <label for="auth_password" title="Password for camera authentication">Password:</label>
-                        <input type="password" id="auth_password" name="auth_password" title="Camera password">
-
-                        <label for="groups" title="Groups for the template, comma separated ">Groups:</label>
-                        <input type="text" id="groups" name="groups" title="Enter comma-separated group names">
-
-                        <label for="rollback_frames" title="Number of frames to rollback">Rollback Frames:</label>
-                        <input type="number" id="rollback_frames" name="rollback_frames" value="0" min="0" title="Enter number of frames to rollback">
-                    </div>
-                    <br/>
-
-                    <div class="checkbox-row">
-                        <label for="invert" title="Invert image colors">
-                            <input type="checkbox" id="invert" name="invert" title="Invert colors of the captured image"> Invert
-                        </label>
-                        <label for="dark" title="Use dark mode">
-                            <input type="checkbox" id="dark" name="dark" checked title="Enable dark mode for the captured page"> Dark Mode
-                        </label>
-                        <label for="headless" title="Run in headless mode">
-                            <input type="checkbox" id="headless" name="headless" checked title="Run browser in headless mode"> Headless
-                        </label>
-                        <label for="stealth" title="Use stealth mode">
-                            <input type="checkbox" id="stealth" name="stealth" title="Use stealth mode to avoid detection"> Stealth
-                        </label>
-                    </div>
-                    <br/>
-
-                    <div class="form-actions">
-                        <input type="submit" value="Submit" title="Submit the template">
-                    </div>
-                </form>
+            <label for="popup_xpath">Popup XPath:</label>
+            <div class="xpath-input-container">
+              <input type="text" id="popup_xpath" name="popup_xpath" />
+              <button
+                type="button"
+                onclick="showStructuredInput('popup_xpath')"
+                title="Open structured XPath editor"
+              >
+                Structured
+              </button>
             </div>
-        </details>
-    </div>
-    {% endcall %}
+
+            <label for="dedicated_xpath">Dedicated XPath:</label>
+            <div class="xpath-input-container">
+              <input type="text" id="dedicated_xpath" name="dedicated_xpath" />
+              <button
+                type="button"
+                onclick="showStructuredInput('dedicated_xpath')"
+                title="Open structured XPath editor"
+              >
+                Structured
+              </button>
+            </div>
+
+            <label for="callback_url" title="URL for notifications"
+              >Callback URL:</label
+            >
+            <input
+              type="url"
+              id="callback_url"
+              name="callback_url"
+              title="Enter URL to receive notifications"
+            />
+
+            <label for="proxy" title="Proxy server address">Proxy:</label>
+            <input
+              type="text"
+              id="proxy"
+              name="proxy"
+              title="Enter proxy server address (optional)"
+            />
+
+            <label
+              for="auth_username"
+              title="Username for camera authentication"
+              >Username:</label
+            >
+            <input
+              type="text"
+              id="auth_username"
+              name="auth_username"
+              title="Camera username"
+            />
+
+            <label
+              for="auth_password"
+              title="Password for camera authentication"
+              >Password:</label
+            >
+            <input
+              type="password"
+              id="auth_password"
+              name="auth_password"
+              title="Camera password"
+            />
+
+            <label
+              for="groups"
+              title="Groups for the template, comma separated "
+              >Groups:</label
+            >
+            <input
+              type="text"
+              id="groups"
+              name="groups"
+              title="Enter comma-separated group names"
+            />
+
+            <label for="rollback_frames" title="Number of frames to rollback"
+              >Rollback Frames:</label
+            >
+            <input
+              type="number"
+              id="rollback_frames"
+              name="rollback_frames"
+              value="0"
+              min="0"
+              title="Enter number of frames to rollback"
+            />
+          </div>
+          <br />
+
+          <div class="checkbox-row">
+            <label for="invert" title="Invert image colors">
+              <input
+                type="checkbox"
+                id="invert"
+                name="invert"
+                title="Invert colors of the captured image"
+              />
+              Invert
+            </label>
+            <label for="dark" title="Use dark mode">
+              <input
+                type="checkbox"
+                id="dark"
+                name="dark"
+                checked
+                title="Enable dark mode for the captured page"
+              />
+              Dark Mode
+            </label>
+            <label for="headless" title="Run in headless mode">
+              <input
+                type="checkbox"
+                id="headless"
+                name="headless"
+                checked
+                title="Run browser in headless mode"
+              />
+              Headless
+            </label>
+            <label for="stealth" title="Use stealth mode">
+              <input
+                type="checkbox"
+                id="stealth"
+                name="stealth"
+                title="Use stealth mode to avoid detection"
+              />
+              Stealth
+            </label>
+          </div>
+          <br />
+
+          <div class="form-actions">
+            <input type="submit" value="Submit" title="Submit the template" />
+          </div>
+        </form>
+      </div>
+    </details>
+  </div>
+  {% endcall %}
 </div>
 <script>
-document.addEventListener('DOMContentLoaded', () => {
-  const button = document.getElementById('discover-btn');
-  const msg = document.getElementById('discover-message');
-  const progress = document.getElementById('discover-progress');
-  const body = document.getElementById('discover-body');
-  const exportJson = document.getElementById('export-json');
-  const exportCsv = document.getElementById('export-csv');
+  document.addEventListener("DOMContentLoaded", () => {
+    const button = document.getElementById("discover-btn");
+    const msg = document.getElementById("discover-message");
+    const progress = document.getElementById("discover-progress");
+    const body = document.getElementById("discover-body");
+    const exportJson = document.getElementById("export-json");
+    const exportCsv = document.getElementById("export-csv");
 
-  const renderInfo = (info) => {
-    if (!info) return '';
-    const pieces = [];
-    if (info.name) pieces.push(info.name);
-    if (info.xaddr) pieces.push(info.xaddr);
-    if (info.path) pieces.push(info.path);
-    if (info.sdp) pieces.push('SDP available');
-    Object.entries(info).forEach(([k, v]) => {
-      if (!['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'].includes(k)) {
-        pieces.push(`${k}: ${v}`);
-      }
-    });
-    return pieces.join(' ');
-  };
-
-  let results = [];
-
-  if (button) {
-    button.addEventListener('click', async () => {
-        msg.textContent = 'Searching...';
-        try {
-            const res = await fetch('/discovery_status');
-            const data = await res.json();
-            if (data.status !== 'running') {
-                await fetch('/toggle_discovery', { method: 'POST' });
-            }
-        } catch (e) {
-            console.warn('Unable to start background discovery', e);
+    const renderInfo = (info) => {
+      if (!info) return "";
+      const pieces = [];
+      if (info.name) pieces.push(info.name);
+      if (info.xaddr) pieces.push(info.xaddr);
+      if (info.path) pieces.push(info.path);
+      if (info.sdp) pieces.push("SDP available");
+      Object.entries(info).forEach(([k, v]) => {
+        if (
+          !["name", "xaddr", "path", "sdp", "mac", "manufacturer"].includes(k)
+        ) {
+          pieces.push(`${k}: ${v}`);
         }
-        progress.style.display = 'inline';
+      });
+      return pieces.join(" ");
+    };
+
+    let results = [];
+
+    if (button) {
+      button.addEventListener("click", async () => {
+        msg.textContent = "Searching...";
+        try {
+          const res = await fetch("/discovery_status");
+          const data = await res.json();
+          if (data.status !== "running") {
+            await fetch("/toggle_discovery", { method: "POST" });
+          }
+        } catch (e) {
+          console.warn("Unable to start background discovery", e);
+        }
+        progress.style.display = "inline";
         progress.value = 0;
-        body.innerHTML = '';
+        body.innerHTML = "";
         results = [];
-        const cidr = document.getElementById('cidr-input').value.trim();
-        const url = cidr ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}` : '/discover/scan_stream';
+        const cidr = document.getElementById("cidr-input").value.trim();
+        const url = cidr
+          ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}`
+          : "/discover/scan_stream";
         const source = new EventSource(url);
         const known = new Set();
         const addRow = (cam) => {
-            const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
-            if (known.has(key)) return;
-            known.add(key);
-            results.push(cam);
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
+          const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
+          if (known.has(key)) return;
+          known.add(key);
+          results.push(cam);
+          const tr = document.createElement("tr");
+          tr.innerHTML = `
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
                     <td>${cam.port}</td>
-                    <td>${cam.info.mac || ''}</td>
-                    <td>${cam.info.manufacturer || ''}</td>
+                    <td>${cam.info.mac || ""}</td>
+                    <td>${cam.info.manufacturer || ""}</td>
                     <td>${renderInfo(cam.info)}</td>
                     <td>
                         <form action="/discover/add" method="post">
                             <input type="hidden" name="ip" value="${cam.ip}">
                             <input type="hidden" name="protocol" value="${cam.protocol}">
                             <input type="hidden" name="port" value="${cam.port}">
-                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ''}
+                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ""}
                             <input type="hidden" name="name" value="${cam.ip}">
                             <button type="submit" title="Add this camera">Add</button>
                         </form>
                     </td>`;
-            body.appendChild(tr);
+          body.appendChild(tr);
         };
         let plan = [];
         source.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.error) {
-                console.error('Discovery error', data.error);
-                msg.textContent = `Error discovering cameras: ${data.error}`;
-                progress.style.display = 'none';
-                source.close();
-                return;
+          const data = JSON.parse(event.data);
+          if (data.error) {
+            console.error("Discovery error", data.error);
+            msg.textContent = `Error discovering cameras: ${data.error}`;
+            progress.style.display = "none";
+            source.close();
+            return;
+          }
+          if (data.total) {
+            progress.max = 100;
+            progress.value = 0;
+            plan = data.stages || [];
+            if (data.subnets) {
+              msg.textContent = `Scanning networks: ${data.subnets.join(", ")}. Plan: ${plan.join(", ")}`;
             }
-            if (data.total) {
-                progress.max = 100;
-                progress.value = 0;
-                plan = data.stages || [];
-                if (data.subnets) {
-                    msg.textContent = `Scanning networks: ${data.subnets.join(', ')}. Plan: ${plan.join(', ')}`;
-                }
-                return;
-            }
-            if (data.done) {
-                msg.textContent = `Found ${known.size} cameras.`;
-                progress.style.display = 'none';
-                source.close();
-                return;
-            }
-            if (typeof data.progress === 'number') {
-                progress.value = data.progress;
-            } else {
-                progress.value += 1;
-            }
-            if (plan.length && plan[0] === data.stage) {
-                plan.shift();
-            }
-            const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : '';
-            msg.textContent = `Scanning ${data.stage} (${data.count} found)...` +
-                (plan.length ? ` Next: ${plan[0]}` : '') + eta;
-            if (data.cameras) {
-                data.cameras.forEach(addRow);
-            }
+            return;
+          }
+          if (data.done) {
+            msg.textContent = `Found ${known.size} cameras.`;
+            progress.style.display = "none";
+            source.close();
+            return;
+          }
+          if (typeof data.progress === "number") {
+            progress.value = data.progress;
+          } else {
+            progress.value += 1;
+          }
+          if (plan.length && plan[0] === data.stage) {
+            plan.shift();
+          }
+          const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : "";
+          msg.textContent =
+            `Scanning ${data.stage} (${data.count} found)...` +
+            (plan.length ? ` Next: ${plan[0]}` : "") +
+            eta;
+          if (data.cameras) {
+            data.cameras.forEach(addRow);
+          }
         };
         source.onerror = (e) => {
-            console.error('Discovery error', e);
-            let text = 'Error discovering cameras';
-            if (e && e.message) {
-                text += `: ${e.message}`;
-            }
-            msg.textContent = text;
-            progress.style.display = 'none';
-            source.close();
+          console.error("Discovery error", e);
+          let text = "Error discovering cameras";
+          if (e && e.message) {
+            text += `: ${e.message}`;
+          }
+          msg.textContent = text;
+          progress.style.display = "none";
+          source.close();
         };
-    });
-}
+      });
+    }
 
-const exportData = (fmt) => {
-    fetch(`/discover/export?format=${fmt}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(results)
-    }).then(r => r.blob()).then(blob => {
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = fmt === 'csv' ? 'discovery.csv' : 'discovery.json';
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
-    });
-};
-  if (exportJson) exportJson.addEventListener('click', () => exportData('json'));
-  if (exportCsv) exportCsv.addEventListener('click', () => exportData('csv'));
-});
+    const exportData = (fmt) => {
+      fetch(`/discover/export?format=${fmt}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(results),
+      })
+        .then((r) => r.blob())
+        .then((blob) => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = fmt === "csv" ? "discovery.csv" : "discovery.json";
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        });
+    };
+    if (exportJson)
+      exportJson.addEventListener("click", () => exportData("json"));
+    if (exportCsv) exportCsv.addEventListener("click", () => exportData("csv"));
+  });
 </script>
-<script type="module" src="{{ url_for('static', filename='js/url_test.js') }}"></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/url_test.js') }}"
+></script>

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -8,7 +8,7 @@ The scheduling call now triggers discovery in a background thread so the UI neve
 The page now polls `/discovery_status` every 30 seconds so the background state
 is always visible, including the remaining time until the next run.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
-discovered camera. The previous hop is stored in the ``upstream`` field so you
+discovered camera. The previous hop is stored in the `upstream` field so you
 can see which router or switch connects the device. Each progress message now
 includes a completion percentage and an estimated time remaining so you know how
 long the scan will take.
@@ -31,9 +31,9 @@ def discover_cameras_scan_stream():
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
 ```
 
-When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message now includes the list of subnets that will be scanned and the full plan of discovery stages. The progress bar is initialized with the total number of stages. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with ``{"done": true}`` simply signals completion. Discovery results now display firmware details along with the reported manufacturer and model when available. These fields are pulled from the camera's ONVIF device service. The page also offers buttons to export the table as CSV or JSON.
+When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message now includes the list of subnets that will be scanned and the full plan of discovery stages. The progress bar is initialized with the total number of stages. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with `{"done": true}` simply signals completion. Discovery results now display firmware details along with the reported manufacturer and model when available. These fields are pulled from the camera's ONVIF device service. The page also offers buttons to export the table as CSV or JSON.
 
-An optional CIDR can be supplied via the new input field to restrict discovery to a specific Class C network. The value is sent as the ``cidr`` query parameter and parsed by ``discover_cameras()``.
+The network field offers a dropdown of detected local subnets. You can pick one of these values or type your own CIDR range. Whatever you enter is sent as the `cidr` query parameter and parsed by `discover_cameras()`.
 
 During the scan you will see messages like `Scanning onvif (3 found)...`. The stage name shows which discovery method just finished, while the number in parentheses reflects how many cameras have been detected so far.
 
@@ -162,11 +162,11 @@ details such as a camera's name, ONVIF address, or HTTP path instead of showing
 the raw JSON dictionary.
 
 Each camera is now also checked for commonly used service ports. Any detected
-ports are listed in the ``open_ports`` field so you can quickly see which
+ports are listed in the `open_ports` field so you can quickly see which
 services are reachable (for example, 80 for HTTP or 554 for RTSP). This scan
 is lightweight and runs after the main discovery steps finish.
 If a camera responds to ICMP echo requests, Glimpser measures the round-trip
-latency and reports the value in the ``ping_ms`` field. This extra check runs in
+latency and reports the value in the `ping_ms` field. This extra check runs in
 parallel with other metadata gathering so it does not slow down discovery.
 If an HTTP port responds, Glimpser also fetches the web page banner to capture
 the `Server` header, authentication realm, and page title when present. These
@@ -175,9 +175,9 @@ values populate the **Info** column so you can quickly identify each device.
 Each result now tries to classify the kind of hardware discovered. Devices with
 RTSP ports or ONVIF data are labeled as **camera** while models referencing DVR
 or NVR become **nvr**. Routers and switches are recognized when their metadata
-contains those keywords. The detected type appears in the ``device_type`` field.
+contains those keywords. The detected type appears in the `device_type` field.
 
-Discovered entries also include a suggested ``url`` built from the protocol and
+Discovered entries also include a suggested `url` built from the protocol and
 port. This makes the "Add" action work immediately without manual edits.
 
 You can then add a discovered camera to your configuration directly from the Discover tab.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Dependencies fail to install
 
 -**Solution:**
+
 - Ensure you're using Python 3.8 or newer (tested up to 3.13): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
@@ -18,6 +19,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Can't connect to data sources
 
 **Solution:**
+
 - Check your internet connection
 - Verify the URL of the data source
 - Ensure you have the necessary permissions to access the data source
@@ -27,12 +29,14 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: API key not working
 
 **Solution:**
+
 - Regenerate your API key in the Glimpser web interface
 - Ensure you're using the correct API key format in your requests
 
 ### Problem: Invalid proxy values
 
 **Solution:**
+
 - Ensure the proxy string begins with `http://` or `https://`.
 - Blank or malformed proxy values are ignored by Glimpser.
 
@@ -41,14 +45,16 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: High CPU usage
 
 **Solution:**
+
 - Reduce the number of concurrent data sources
 - Increase the refresh interval for less critical sources
 - Check the `MAX_WORKERS` setting and adjust if necessary
-- Open the *System Status* tab under Settings to watch CPU and memory usage in real time
+- Open the _System Status_ tab under Settings to watch CPU and memory usage in real time
 
 ### Problem: Out of memory errors
 
 **Solution:**
+
 - Reduce the `MAX_RAW_DATA_SIZE` setting
 - Increase the system's available memory
 - Consider using a database instead of in-memory storage for large datasets
@@ -59,6 +65,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Inaccurate or missing captions
 
 **Solution:**
+
 - Check the `LLM_CAPTION_PROMPT` setting and adjust if necessary
 - Ensure your CHATGPT_KEY is valid and has sufficient credits
 - Verify that the image data is being correctly captured and processed
@@ -66,6 +73,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Summaries not generating
 
 **Solution:**
+
 - Check the `LLM_SUMMARY_PROMPT` setting
 - Ensure there's enough data collected to generate a meaningful summary
 - Verify that the CHATGPT_KEY is working correctly
@@ -79,6 +87,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Web interface not loading
 
 **Solution:**
+
 - Check if the Glimpser server is running
 - Verify you're using the correct port (default is 8082)
 - Ensure the `HOST` setting is `0.0.0.0` so the server is reachable from other devices
@@ -88,6 +97,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Can't log in to the web interface
 
 **Solution:**
+
 - Ensure you're using the correct username and password
 - Verify that the account exists in the `users` table
 - Try resetting your password through the recovery process
@@ -99,7 +109,6 @@ This guide addresses common issues that users might encounter while using Glimps
   cookie is missing. Running without HTTPS? Disable `SESSION_COOKIE_SECURE` so
   your browser accepts the cookie. See [Startup Tips](startup_tips.md) for a
   quick reminder of this and other common gotchas.
-
 
 ## Getting Further Help
 
@@ -117,6 +126,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Unable to connect to the database
 
 **Solution:**
+
 - Ensure the database path in `GLIMPSER_DB` is correct.
 - Check file permissions so the process can read and write to the database.
 - For remote servers verify network connectivity and credentials.
@@ -124,6 +134,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Database locked errors
 
 **Solution:**
+
 - Stop other Glimpser instances that might be using the same database file.
 - If using SQLite, ensure the volume is mounted with proper locking support.
 - Consider switching to a server database like PostgreSQL for multi‑user setups.
@@ -135,6 +146,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Containers fail to start
 
 **Solution:**
+
 - Build images again with `docker compose build --no-cache`.
 - Inspect the container logs with `docker compose logs` for errors.
 - Confirm that environment variables in `docker-compose.yaml` match your setup.
@@ -142,12 +154,14 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Port conflicts
 
 **Solution:**
+
 - Make sure no other service is using port 8082.
 - Change the `ports` mapping in `docker-compose.yaml` if needed.
 
 ### Problem: Permission denied on volumes
 
 **Solution:**
+
 - Verify that the host directories mapped as volumes are writable by Docker.
 - On Linux you may need to adjust ownership with `chown` or use Docker's `user` option.
 
@@ -156,18 +170,21 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Settings not loading
 
 **Solution:**
+
 - Confirm variables are defined in your shell or `.env` file before starting.
 - Use `printenv | grep GLIMPSER` to check that values are present.
 
 ### Problem: Missing secrets
 
 **Solution:**
+
 - Ensure `CHATGPT_KEY` and any other credentials are exported in your environment.
 - When running under Docker, set these values in `docker-compose.yaml`.
 
 ## 9. Logging and Debugging Tips
 
-Glimpser writes logs to the console and exposes them via the *System Status* tab. If something goes wrong:
+Glimpser writes logs to the console and exposes them via the _System Status_ tab. If something goes wrong:
+
 - Use the **System Monitoring and Logs** guide to access live logs.
 - Increase the `LOG_LEVEL` or `FLASK_LOG_LEVEL` environment variable to `DEBUG` for more details.
 - Review recent entries for stack traces or connection errors.
@@ -179,6 +196,7 @@ Glimpser writes logs to the console and exposes them via the *System Status* tab
 ### Problem: Errors after pulling a new version
 
 **Solution:**
+
 - Run `pip install -r requirements.txt --upgrade` to update dependencies.
 - Apply any new database migrations as described in the release notes.
 - The `capture_failed` column is added automatically if missing.
@@ -187,6 +205,7 @@ Glimpser writes logs to the console and exposes them via the *System Status* tab
 ### Problem: Search bar does not filter templates
 
 **Solution:**
+
 - Ensure you are running the latest Glimpser version.
 - Refresh the page to load the updated JavaScript.
 
@@ -199,6 +218,7 @@ If the logs repeat messages like `No frames captured from stream` or
 snapshot image rather than a true video stream.
 
 **Solution:**
+
 - Use the camera's RTSP or HTTP video stream URL when available.
 - Snapshot-only URLs now fall back to an MJPEG feed so the live view
   behaves like a regular video stream.
@@ -221,6 +241,7 @@ Older versions kept preloading the previous stream when you changed the video
 source. That could cause extra network requests and confusing behavior.
 
 **Solution:**
+
 - Update to the latest version.
 - The player now destroys any active HLS or looping handlers before starting the
   new stream, so switching sources cleanly stops the old one.
@@ -228,10 +249,11 @@ source. That could cause extra network requests and confusing behavior.
 ### Problem: Loop video or the "All" camera shows `Format error`
 
 This typically happens when Glimpser cannot locate a recent MP4 clip for a
-camera. The player attempts to load the file and the browser reports a *Format
-error* because the response is missing or invalid.
+camera. The player attempts to load the file and the browser reports a _Format
+error_ because the response is missing or invalid.
 
 **Solution:**
+
 - Ensure the `compile_to_teaser` job is running so group videos are generated.
 - When a clip fails to load, the live player now skips to the next camera
   instead of stalling on the error message.
@@ -243,6 +265,7 @@ camera. If the newest PNG is corrupt or missing the placeholder image is shown
 instead.
 
 **Solution:**
+
 - Ensure each camera is capturing screenshots in `data/screenshots`.
 - Remove any zero-byte or invalid PNG files. Glimpser now skips corrupt images
   when choosing the latest shot.
@@ -257,6 +280,7 @@ could overlap the last buttons. The site now calculates the footer height and
 sets a `--footer-space` CSS variable so mobile views always leave enough room.
 
 **Solution:**
+
 - Glimpser now adds extra padding to the `main` element so page content scrolls
   fully above the footer. Update to the latest version or mimic this logic in
   your custom CSS.
@@ -266,7 +290,8 @@ sets a `--footer-space` CSS variable so mobile views always leave enough room.
 ### Problem: Discovery page times out or stops on "Scanning SSDP"
 
 **Solution:**
-- Networks with many SSDP devices can delay this step. Wait a little longer or restrict scanning using the CIDR field (e.g., `192.168.1.0/24`).
+
+- Networks with many SSDP devices can delay this step. Wait a little longer or restrict scanning using the network dropdown (e.g., `192.168.1.0/24`).
 - Since v0.9.1 SSDP scanning stops after five seconds so discovery continues even on busy networks.
 - Ensure UDP multicast traffic is allowed; blocked multicast causes timeouts.
 - Check `logs/glimpser.log` for `SSDP probe error` messages if the scan never finishes.
@@ -278,6 +303,7 @@ sets a `--footer-space` CSS variable so mobile views always leave enough room.
 If shutdown is interrupted it can leave background threads running.
 
 **Solution:**
+
 - Glimpser now manages cleanup through `CleanupManager`, ensuring shutdown only runs once.
 - Calling `main.shutdown_manager.cleanup()` manually will join any remaining threads.
 - If threads still refuse to exit, call `app.utils.scheduling.stop_background_tasks()` to signal the

--- a/tests/js/subnet_input.test.js
+++ b/tests/js/subnet_input.test.js
@@ -1,0 +1,46 @@
+import { jest } from "@jest/globals";
+
+let initSubnetInput;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/discovery.js");
+  initSubnetInput = mod.initSubnetInput;
+});
+
+beforeEach(() => {
+  document.body.innerHTML =
+    '<input id="cidr-input"><datalist id="cidr-options"></datalist>';
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(["192.168.0.0/24"]) }),
+  );
+  HTMLInputElement.prototype.setCustomValidity = jest.fn();
+});
+
+test("populates subnet options", async () => {
+  initSubnetInput();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith("/discover/subnets");
+  const options = document.querySelectorAll("#cidr-options option");
+  expect(options).toHaveLength(1);
+  expect(options[0].value).toBe("192.168.0.0/24");
+});
+
+test("validates CIDR input", async () => {
+  initSubnetInput();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  await Promise.resolve();
+  const input = document.getElementById("cidr-input");
+  input.value = "bad";
+  input.dispatchEvent(new Event("input"));
+  expect(HTMLInputElement.prototype.setCustomValidity).toHaveBeenCalledWith(
+    "Invalid CIDR",
+  );
+  input.value = "192.168.1.0/24";
+  input.dispatchEvent(new Event("input"));
+  expect(HTMLInputElement.prototype.setCustomValidity).toHaveBeenLastCalledWith(
+    "",
+  );
+});

--- a/tests/test_discover_subnets_endpoint.py
+++ b/tests/test_discover_subnets_endpoint.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestDiscoverSubnetsEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch(
+        "app.routes.camera_discovery._local_subnets", return_value=["192.168.0.0/24"]
+    )
+    def test_returns_subnets(self, mock_subnets):
+        resp = self.client.get("/discover/subnets")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), ["192.168.0.0/24"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support fetching local network ranges via `/discover/subnets`
- provide LAN suggestions in discovery tab
- validate custom CIDR input on the page
- wire subnet initializer in script.js
- document new dropdown behaviour
- update troubleshooting tips
- test subnet route and UI script

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845d062ce68833396a35d015b10be36