### PR TITLE
Fix system metrics display and GPU indicator

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1874,6 +1874,8 @@ details > summary {
 }
 
 .metrics-list li {
+  display: flex;
+  align-items: center;
   margin-bottom: 0.25rem;
 }
 

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -10,32 +10,49 @@ function setProgress(el, value) {
   }
 }
 
+function setStatus(el, status) {
+  if (!el) return;
+  el.classList.remove("ok", "slow", "error");
+  el.classList.add(status);
+}
+
 export function updatePerformanceMetrics() {
   return fetch("/health")
     .then((response) => response.json())
     .then((data) => {
+      const metrics = data.metrics || data;
+
       const cpuVal = document.getElementById("cpu-value");
-      if (cpuVal) cpuVal.textContent = `${data.cpu_usage}%`;
-      setProgress(document.getElementById("cpu-bar"), data.cpu_usage);
+      if (cpuVal) cpuVal.textContent = `${metrics.cpu_usage}%`;
+      setProgress(document.getElementById("cpu-bar"), metrics.cpu_usage);
 
       const memoryVal = document.getElementById("memory-value");
-      if (memoryVal) memoryVal.textContent = `${data.memory_usage}%`;
-      setProgress(document.getElementById("memory-bar"), data.memory_usage);
+      if (memoryVal) memoryVal.textContent = `${metrics.memory_usage}%`;
+      setProgress(document.getElementById("memory-bar"), metrics.memory_usage);
 
       const diskVal = document.getElementById("disk-value");
-      if (diskVal) diskVal.textContent = `${data.disk_usage}%`;
-      setProgress(document.getElementById("disk-bar"), data.disk_usage);
+      if (diskVal) diskVal.textContent = `${metrics.disk_usage}%`;
+      setProgress(document.getElementById("disk-bar"), metrics.disk_usage);
 
       const openFiles = document.getElementById("open-files");
-      if (openFiles) openFiles.textContent = data.open_files;
+      if (openFiles) openFiles.textContent = metrics.open_files;
 
       const threadCount = document.getElementById("thread-count");
-      if (threadCount) threadCount.textContent = data.thread_count;
+      if (threadCount) threadCount.textContent = metrics.thread_count;
 
       const uptimeVal = document.getElementById("uptime-value");
-      if (uptimeVal) uptimeVal.textContent = data.uptime;
+      if (uptimeVal) uptimeVal.textContent = metrics.uptime;
 
-      updateCPUSparkline(data.cpu_usage);
+      const gpuStatus = document.getElementById("gpu-status");
+      if (metrics.ffmpeg_gpu_enabled) {
+        setStatus(gpuStatus, "ok");
+      } else if (metrics.gpu_support) {
+        setStatus(gpuStatus, "slow");
+      } else {
+        setStatus(gpuStatus, "error");
+      }
+
+      updateCPUSparkline(metrics.cpu_usage);
     });
 }
 

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -53,6 +53,13 @@
   <li title="System uptime">
     Uptime: <span id="uptime-value">{{ metrics.uptime }}</span>
   </li>
+  <li title="GPU acceleration status">
+    GPU:
+    <span
+      id="gpu-status"
+      class="status-dot {{ 'ok' if metrics.ffmpeg_gpu_enabled else ('slow' if metrics.gpu_support else 'error') }}"
+    ></span>
+  </li>
 </ul>
 {% endcall %} {% call card('Feed Status') %}
 <table id="feed-status" class="feed-status">

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -56,7 +56,9 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
   <li title="Number of active threads">
     Thread Count: <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
-  <li title="System uptime">Uptime: <span id="uptime-value">{{ metrics.uptime }}</span></li>
+  <li title="System uptime">
+    Uptime: <span id="uptime-value">{{ metrics.uptime }}</span>
+  </li>
   <li title="Installed ffmpeg version">
     FFmpeg: {{ metrics.ffmpeg_version }} ({{ metrics.ffmpeg_path }})
   </li>
@@ -76,6 +78,13 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
     HW Accel Enabled:
     <span
       class="status-dot {{ 'ok' if metrics.hwaccel_enabled else 'error' }}"
+    ></span>
+  </li>
+  <li title="GPU acceleration status">
+    GPU:
+    <span
+      id="gpu-status"
+      class="status-dot {{ 'ok' if metrics.ffmpeg_gpu_enabled else ('slow' if metrics.gpu_support else 'error') }}"
     ></span>
   </li>
   <li title="Danger mode enabled setting">
@@ -175,4 +184,9 @@ content %} {% include '_status_tab.html' %} {% endblock %} {% extends
 </table>
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>
-{% endcall %} {% include 'logs.html' %} {% endblock %}
+{% endcall %} {% include 'logs.html' %}
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/performance.js') }}"
+></script>
+{% endblock %}

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -46,7 +46,8 @@ name, last image time, last caption time, any KPI column, or status.
 - **Danger Mode Enabled** – whether the DANGER_MODE setting is on
 
 Boolean metrics now display a green dot when enabled and a red dot when
-disabled to make the status easier to scan.
+disabled to make the status easier to scan. GPU acceleration uses a yellow dot
+when hardware is available but not currently active.
 
 ## Streaming Logs
 


### PR DESCRIPTION
## Summary
- show GPU status with new indicator
- fetch nested metric properties in performance.js
- align metric rows with flexbox
- auto-refresh metrics on System Status page
- document GPU indicator behavior

## Testing
- `pre-commit run --all-files` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest`
- `npm test`
- `npm run size-audit`

------
https://chatgpt.com/codex/tasks/task_e_6845d0dc590483338022e4ffe0041d70