### PR TITLE
Fix tile layout height calc

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -63,6 +63,18 @@ export function initTemplates() {
         // Iterate over possible column counts to find the largest
         // tile width that fits the viewport both horizontally and vertically.
         let bestWidth = 50;
+        const headerHeight =
+          document.querySelector("header")?.offsetHeight || 0;
+        const bannerHeight =
+          document.getElementById("network-banner")?.offsetHeight || 0;
+        const footerSpace = parseFloat(
+          getComputedStyle(document.documentElement).getPropertyValue(
+            "--footer-space",
+          ) || "0",
+        );
+        const availableHeight =
+          window.innerHeight - headerHeight - bannerHeight - footerSpace;
+
         for (let cols = 1; cols <= templateCount; cols++) {
           const maxWidthForCols = Math.floor(
             (window.innerWidth - gap * (cols - 1)) / cols,
@@ -71,10 +83,7 @@ export function initTemplates() {
           const rows = Math.ceil(templateCount / cols);
           const tileHeight = maxWidthForCols * ASPECT_RATIO;
           const totalHeight = rows * tileHeight + gap * (rows - 1);
-          if (
-            totalHeight <= window.innerHeight &&
-            maxWidthForCols > bestWidth
-          ) {
+          if (totalHeight <= availableHeight && maxWidthForCols > bestWidth) {
             bestWidth = maxWidthForCols;
           }
         }

--- a/tests/js/slider_init.test.js
+++ b/tests/js/slider_init.test.js
@@ -3,9 +3,12 @@ import { jest } from "@jest/globals";
 // tests/js/slider_init.test.js
 
 document.body.innerHTML = `
+  <header></header>
+  <div id="network-banner" class="network-banner"></div>
   <div id="template-list" style="gap:0"></div>
   <div id="camera-table"></div>
   <input id="grid-width-slider" type="range" value="360">
+  <footer></footer>
 `;
 
 let initTemplates;
@@ -21,12 +24,25 @@ describe("slider initialization", () => {
     const list = document.getElementById("template-list");
     list.innerHTML = "";
     list.style.gap = "0px";
+    Object.defineProperty(document.querySelector("header"), "offsetHeight", {
+      configurable: true,
+      value: 40,
+    });
+    Object.defineProperty(
+      document.getElementById("network-banner"),
+      "offsetHeight",
+      {
+        configurable: true,
+        value: 10,
+      },
+    );
+    document.documentElement.style.setProperty("--footer-space", "50px");
   });
 
   test.each([
-    [1920, 1080, 4, 960],
+    [1920, 1080, 4, 640],
     [1920, 1080, 2, 960],
-    [1280, 720, 4, 640],
+    [1280, 720, 4, 426],
   ])(
     "computes min width %ipx x %ipx with %i cameras",
     (width, height, count, expected) => {


### PR DESCRIPTION
## Summary
- adjust tile grid calculations for header, footer and banner
- set proper offsets in slider init test

## Testing
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d3e5085c8333a5e9d0d0720dcdc0