### PR TITLE
Add view link for known cameras

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3124,6 +3124,9 @@ def init_routes(app: Flask) -> None:
             "running": is_chrome_debug_port_open("127.0.0.1", 9222),
         }
 
+        templates = template_manager.get_templates()
+        existing_urls = {t.get("url"): n for n, t in templates.items() if t.get("url")}
+
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
@@ -3142,6 +3145,7 @@ def init_routes(app: Flask) -> None:
             email_fields=EMAIL_FIELDS,
             locked_settings=LOCKED_SETTINGS,
             file_info=file_info,
+            existing_urls=existing_urls,
             page_title="Settings",
         )
 
@@ -3246,8 +3250,17 @@ def init_routes(app: Flask) -> None:
     @app.route("/discover", methods=["GET"])
     @login_required
     def discover_cameras_route():
+        templates = template_manager.get_templates()
+        existing_urls = {}
+        for name, t in templates.items():
+            url = t.get("url")
+            if url:
+                existing_urls[url] = name
         return render_template(
-            "discover.html", cameras=[], page_title="Discover Cameras"
+            "discover.html",
+            cameras=[],
+            existing_urls=existing_urls,
+            page_title="Discover Cameras",
         )
 
     @app.route("/discover/scan", methods=["POST"])

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -71,7 +71,8 @@
         </tr>
       </thead>
       <tbody id="discover-body">
-        {% for cam in cameras %}
+        {% for cam in cameras %} {% set url = cam.url or (cam.protocol ~ '://' ~
+        cam.ip ~ ':' ~ cam.port) %}
         <tr>
           <td>{{ cam.ip }}</td>
           <td>{{ cam.protocol }}</td>
@@ -80,6 +81,14 @@
           <td>{{ cam.info.manufacturer }}</td>
           <td>{{ show_info(cam.info) }}</td>
           <td>
+            {% if url in existing_urls %}
+            <a
+              href="{{ url_for('template_details', template_name=existing_urls[url]) }}"
+              class="btn btn-primary"
+              title="View this camera"
+              >View</a
+            >
+            {% else %}
             <form action="/discover/add" method="post">
               <input type="hidden" name="ip" value="{{ cam.ip }}" />
               <input type="hidden" name="protocol" value="{{ cam.protocol }}" />
@@ -90,6 +99,7 @@
               <input type="hidden" name="name" value="{{ cam.ip }}" />
               <button type="submit" title="Add this camera">Add</button>
             </form>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}
@@ -337,6 +347,7 @@
 </div>
 <script>
   document.addEventListener("DOMContentLoaded", () => {
+    const existingMap = {{ existing_urls | tojson | safe }};
     const button = document.getElementById("discover-btn");
     const msg = document.getElementById("discover-message");
     const progress = document.getElementById("discover-progress");
@@ -391,6 +402,18 @@
           known.add(key);
           results.push(cam);
           const tr = document.createElement("tr");
+          const url = cam.url || `${cam.protocol}://${cam.ip}:${cam.port}`;
+          const existing = existingMap[url];
+          const action = existing
+            ? `<a href="/templates/${existing}" class="btn btn-primary" title="View this camera">View</a>`
+            : `<form action="/discover/add" method="post">
+                            <input type="hidden" name="ip" value="${cam.ip}">
+                            <input type="hidden" name="protocol" value="${cam.protocol}">
+                            <input type="hidden" name="port" value="${cam.port}">
+                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ""}
+                            <input type="hidden" name="name" value="${cam.ip}">
+                            <button type="submit" title="Add this camera">Add</button>
+                        </form>`;
           tr.innerHTML = `
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
@@ -398,16 +421,7 @@
                     <td>${cam.info.mac || ""}</td>
                     <td>${cam.info.manufacturer || ""}</td>
                     <td>${renderInfo(cam.info)}</td>
-                    <td>
-                        <form action="/discover/add" method="post">
-                            <input type="hidden" name="ip" value="${cam.ip}">
-                            <input type="hidden" name="protocol" value="${cam.protocol}">
-                            <input type="hidden" name="port" value="${cam.port}">
-                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ""}
-                            <input type="hidden" name="name" value="${cam.ip}">
-                            <button type="submit" title="Add this camera">Add</button>
-                        </form>
-                    </td>`;
+                    <td>${action}</td>`;
           body.appendChild(tr);
         };
         let plan = [];

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -76,6 +76,11 @@ class TestHtmlTemplates(unittest.TestCase):
         required = {"name", "url", "frequency", "timeout"}
         self.assertTrue(required.issubset(inputs))
 
+    def test_discover_has_existing_map_variable(self):
+        with open("app/templates/_discover_tab.html", encoding="utf-8") as f:
+            html = f.read()
+        self.assertIn("existingMap", html)
+
     def test_header_preloads_sprite(self):
         parser = parse_template(Path("app/templates/header.html"))
         expected_href = "{{ url_for('static', filename='icons/sprite.svg') }}"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -461,7 +461,7 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         mock_discover.assert_not_called()
         mock_render_template.assert_called_with(
-            "discover.html", cameras=[], page_title="Discover Cameras"
+            "discover.html", cameras=[], existing_urls={}, page_title="Discover Cameras"
         )
 
     @patch("app.routes.SessionLocal")


### PR DESCRIPTION
## Summary
- show "View" link instead of Add button when a discovered camera already exists
- expose existing template URLs to discovery and settings pages
- update discovery template tests
- adjust expected arguments in discovery route test

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Could not install build dependencies)*
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845d74776e483338ac892fe7b4c2c13