### PR TITLE
Improve control bar UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -212,7 +212,7 @@ h2 {
 
 #controls-wrapper {
   position: fixed;
-  bottom: 0.5rem;
+  bottom: calc(var(--footer-space, 60px) + 0.5rem);
   left: 0.5rem;
   background-color: rgba(0, 0, 0, 0.7);
   color: #fff;

--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -15,10 +15,16 @@ export function initControlsDropdown() {
       fadeTimeout = setTimeout(() => wrapper.classList.add("fade-out"), 3000);
     };
 
+    const pauseFade = () => {
+      wrapper.classList.remove("fade-out");
+      clearTimeout(fadeTimeout);
+    };
+
     ["mousemove", "scroll"].forEach((evt) => {
       document.addEventListener(evt, showControls);
     });
-    wrapper.addEventListener("mouseover", showControls);
+    wrapper.addEventListener("mouseenter", pauseFade);
+    wrapper.addEventListener("mouseleave", showControls);
 
     showControls();
   });

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -14,6 +14,13 @@ function safePlay(el) {
 
 let captionsVisible = localStorage.getItem("showCaptions") !== "false";
 
+export function setCaptionsVisibility(value) {
+  const slider = document.getElementById("grid-width-slider");
+  captionsVisible = value;
+  localStorage.setItem("showCaptions", value.toString());
+  applyCaptionVisibility(parseFloat(slider?.value || "0"));
+}
+
 export function applyCaptionVisibility(width) {
   const templateList = document.getElementById("template-list");
   const captionToggle = document.getElementById("caption-toggle");
@@ -27,6 +34,11 @@ export function applyCaptionVisibility(width) {
     captionToggle.classList.toggle("disabled", !enabled);
     captionToggle.classList.toggle("active", captionsVisible && enabled);
     captionToggle.classList.toggle("off", !captionsVisible && enabled);
+    captionToggle.title = enabled
+      ? captionsVisible
+        ? "Hide caption overlays"
+        : "Show caption overlays"
+      : "Increase tile size to enable captions";
   }
 }
 
@@ -133,6 +145,10 @@ export function initTemplates() {
         localStorage.setItem("showCaptions", captionsVisible.toString());
         applyCaptionVisibility(parseFloat(slider?.value || "0"));
       });
+      setTimeout(() => {
+        captionToggle.classList.add("flash-caption");
+        setTimeout(() => captionToggle.classList.remove("flash-caption"), 4000);
+      }, 500);
     }
 
     function autofillGroup() {

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -1,3 +1,5 @@
+import { setCaptionsVisibility } from "./templates.js";
+
 function safePlay(el) {
   const promise = el.play();
   if (promise && typeof promise.catch === "function") {
@@ -61,6 +63,7 @@ export function initVideoControls() {
             video.load();
             safePlay(video);
           });
+          setCaptionsVisibility(false);
           playAllButton.textContent = "Pause All";
           if (liveAllButton) liveAllButton.style.display = "inline-block";
         }

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
 block content %}
 <div id="controls-wrapper" class="closed">
-  <button id="controls-toggle" type="button">Controls</button>
   <div id="template-controls">
     <div id="search-container">
       <input
@@ -26,9 +25,17 @@ block content %}
       aria-label="Toggle caption overlays"
       title="Toggle caption overlays"
     >
-      <svg width="20" height="20">
-        <use
-          href="{{ url_for('static', filename='icons/sprite.svg') }}#closed-caption"
+      <svg
+        class="w-5 h-5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1Zm-11 8.5h-2v3h2a1.5 1.5 0 1 0 0-3Zm7 0h-2v3h2a1.5 1.5 0 1 0 0-3Z"
         />
       </svg>
     </button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,9 +26,17 @@ block content %}
       aria-label="Toggle caption overlays"
       title="Toggle caption overlays"
     >
-      <svg width="20" height="20">
-        <use
-          href="{{ url_for('static', filename='icons/sprite.svg') }}#closed-caption"
+      <svg
+        class="w-5 h-5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1Zm-11 8.5h-2v3h2a1.5 1.5 0 1 0 0-3Zm7 0h-2v3h2a1.5 1.5 0 1 0 0-3Z"
         />
       </svg>
     </button>

--- a/tests/js/caption_toggle.test.js
+++ b/tests/js/caption_toggle.test.js
@@ -10,11 +10,13 @@ document.body.innerHTML = `
 
 let initTemplates;
 let applyCaptionVisibility;
+let setCaptionsVisibility;
 
 beforeAll(async () => {
   const mod = await import("../../app/static/js/templates.js");
   initTemplates = mod.initTemplates;
   applyCaptionVisibility = mod.applyCaptionVisibility;
+  setCaptionsVisibility = mod.setCaptionsVisibility;
 });
 
 describe("caption toggle", () => {
@@ -28,6 +30,7 @@ describe("caption toggle", () => {
     applyCaptionVisibility(100);
     const btn = document.getElementById("caption-toggle");
     expect(btn.classList.contains("disabled")).toBe(true);
+    expect(btn.title).toMatch(/increase tile size/i);
   });
 
   test("click toggles visibility", () => {
@@ -45,5 +48,12 @@ describe("caption toggle", () => {
       false,
     );
     expect(btn.classList.contains("active")).toBe(true);
+  });
+
+  test("setCaptionsVisibility hides captions", () => {
+    setCaptionsVisibility(false);
+    expect(document.documentElement.classList.contains("hide-captions")).toBe(
+      true,
+    );
   });
 });

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -41,4 +41,13 @@ describe("controls dropdown", () => {
     jest.advanceTimersByTime(5000);
     expect(wrapper.classList.contains("fade-out")).toBe(false);
   });
+
+  test("stays visible when hovered", () => {
+    const wrapper = document.getElementById("controls-wrapper");
+    initControlsDropdown();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    wrapper.dispatchEvent(new Event("mouseenter"));
+    jest.advanceTimersByTime(5000);
+    expect(wrapper.classList.contains("fade-out")).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- adjust footer space so controls clear the footer
- change captions icon to Material Symbol markup
- remove unused Controls button
- stop fading controls when hovered
- highlight captions toggle and add API for programmatic control
- hide captions when Play All pressed
- update JS tests for new behaviours

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Could not install dependencies)*
- `pytest`
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d8ee589083338bf2cc83dd11339b