### PR TITLE
Add clip endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -350,6 +350,9 @@ LIVE_MAX_RETRY_DELAY = int(get_setting("LIVE_MAX_RETRY_DELAY", 30))
 # the banner remains visible after a caption arrives.
 CHYRON_SPEED = int(get_setting("CHYRON_SPEED", 0))
 
+# Length in seconds returned by the `/clip/<template>` endpoint.
+DEFAULT_CLIP_DURATION = int(get_setting("DEFAULT_CLIP_DURATION", 120))
+
 # Whether the System Performance icon in the navigation bar should remain
 # visible even when the application reports healthy status. When set to
 # ``False`` the icon hides itself if all metrics look nominal to reduce

--- a/app/routes.py
+++ b/app/routes.py
@@ -2568,6 +2568,57 @@ def init_routes(app: Flask) -> None:
 
         abort(404)
 
+    @app.route("/clip/<string:template_name>")
+    @login_required
+    def serve_clip(template_name: TemplateName):
+        """Compile and return a short clip from archived footage."""
+
+        template_name = validate_template_name(template_name)
+        if template_name is None:
+            abort(404)
+
+        duration = (
+            request.args.get("duration", type=int) or config.DEFAULT_CLIP_DURATION
+        )
+        if duration <= 0:
+            abort(400, "Invalid duration")
+
+        path = os.path.join(
+            os.path.dirname(os.path.join(__file__)),
+            "..",
+            VIDEO_DIRECTORY,
+            template_name,
+        )
+        if not os.path.exists(path):
+            abort(404)
+
+        video_files = sorted(
+            glob.glob(os.path.join(path, "final_*.mp4")),
+            key=os.path.getmtime,
+            reverse=True,
+        )
+
+        accumulated = 0.0
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_list:
+            for vf in video_files:
+                dur = video_archiver.get_video_duration(vf)
+                if dur:
+                    temp_list.write(f"file '{os.path.abspath(vf)}'\n")
+                    accumulated += dur
+                    if accumulated >= duration:
+                        break
+            temp_list_path = temp_list.name
+
+        output_tmp = os.path.join(path, "clip.mp4.tmp")
+        output_final = os.path.join(path, "clip.mp4")
+        video_archiver.compile_videos(temp_list_path, output_tmp)
+        os.unlink(temp_list_path)
+
+        if os.path.exists(output_final):
+            return send_file(output_final)
+
+        abort(404)
+
     @app.route("/last_screenshot/<string:template_name>")
     @login_required
     def serve_screenshot(template_name: TemplateName):

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,6 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
+- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. Use the optional `duration` query parameter to set the length in seconds (defaults to `DEFAULT_CLIP_DURATION`).
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 
 ### 6. Trigger Screenshot Capture

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -128,6 +128,7 @@ Settings controlling how frames are captured from video sources:
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
 - `LIVE_BACKOFF_MAX` – maximum seconds between live stream restart attempts (default `30`)
 - `CHYRON_SPEED` – seconds the caption chyron scrolls; set to `0` to disable (default `0`)
+- `DEFAULT_CLIP_DURATION` – seconds returned by the `/clip` endpoint when no `duration` query is provided (default `120`)
 - `HEALTH_STATUS_ALWAYS_VISIBLE` – keep the System Performance icon visible even when the system is healthy (default `False`)
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
 - `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.routes as routes
+from app.routes import init_routes
+import app.config as config
+
+
+class TestClipRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.video_archiver.compile_videos")
+    @patch("app.routes.video_archiver.get_video_duration", return_value=60)
+    @patch("glob.glob", return_value=["v1.mp4", "v2.mp4"])
+    @patch("os.path.getmtime", side_effect=[2, 1])
+    @patch("os.path.exists", return_value=True)
+    @patch("app.routes.send_file")
+    def test_clip_default(
+        self,
+        mock_send,
+        mock_exists,
+        mock_getmtime,
+        mock_glob,
+        mock_duration,
+        mock_compile,
+    ):
+        resp = self.client.get("/clip/cam1")
+        self.assertEqual(resp.status_code, 200)
+        expected = os.path.join(
+            os.path.dirname(routes.__file__),
+            "..",
+            config.VIDEO_DIRECTORY,
+            "cam1",
+            "clip.mp4",
+        )
+        mock_compile.assert_called_once()
+        mock_send.assert_called_with(expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/clip/<template>` endpoint to compile recent video
- document new API endpoint and configuration
- include DEFAULT_CLIP_DURATION setting
- test clip endpoint

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845dd0201f88333ae06841bace7d7dd