### PR TITLE
Decouple overlay clock from controls

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -158,23 +158,23 @@
       <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
       <p id="stream-error-message"></p>
     </div>
-    {% if CLOCK_OVERLAY %}
-    <div
-      id="overlayClock"
-      class="cool-clock clock-overlay"
-      data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-    >
-      <div class="clock-face">
-        <div class="clock-hands">
-          <div class="hand hour-hand"></div>
-          <div class="hand minute-hand"></div>
-          <div class="hand second-hand"></div>
-        </div>
-        <div class="digital-clock"></div>
-      </div>
-    </div>
-    {% endif %}
   </div>
+  {% if CLOCK_OVERLAY %}
+  <div
+    id="overlayClock"
+    class="cool-clock clock-overlay"
+    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
+  >
+    <div class="clock-face">
+      <div class="clock-hands">
+        <div class="hand hour-hand"></div>
+        <div class="hand minute-hand"></div>
+        <div class="hand second-hand"></div>
+      </div>
+      <div class="digital-clock"></div>
+    </div>
+  </div>
+  {% endif %}
   <div id="error-message" role="alert"></div>
 </div>
 

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -93,23 +93,23 @@ block content %}
       <i class="fas fa-times-circle video-icon"></i>
       <p id="stream-error-message"></p>
     </div>
-    {% if CLOCK_OVERLAY %}
-    <div
-      id="overlayClock"
-      class="cool-clock clock-overlay"
-      data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-    >
-      <div class="clock-face">
-        <div class="clock-hands">
-          <div class="hand hour-hand"></div>
-          <div class="hand minute-hand"></div>
-          <div class="hand second-hand"></div>
-        </div>
-        <div class="digital-clock"></div>
-      </div>
-    </div>
-    {% endif %}
   </div>
+  {% if CLOCK_OVERLAY %}
+  <div
+    id="overlayClock"
+    class="cool-clock clock-overlay"
+    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
+  >
+    <div class="clock-face">
+      <div class="clock-hands">
+        <div class="hand hour-hand"></div>
+        <div class="hand minute-hand"></div>
+        <div class="hand second-hand"></div>
+      </div>
+      <div class="digital-clock"></div>
+    </div>
+  </div>
+  {% endif %}
   <div id="error-message"></div>
 </div>
 


### PR DESCRIPTION
## Summary
- keep the overlay clock visible even when controls are hidden

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845dde5b92c8333ab6d466160a7dd72