### PR TITLE
Fix pause all button

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -40,12 +40,7 @@ export function initVideoControls() {
         if (playAllActive) {
           if (playAllObserver) playAllObserver.disconnect();
           videos.forEach((video) => {
-            const name = video.getAttribute("data-name");
             video.pause();
-            //video.src = "";
-            video.removeAttribute("src");
-            video.poster = `/last_screenshot/${name}?t=${Date.now()}`;
-            video.load();
           });
           playAllButton.textContent = "Play All";
           if (liveAllButton) liveAllButton.style.display = "none";


### PR DESCRIPTION
## Summary
- fix the Pause All handler so it actually pauses videos instead of resetting to live screenshots

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845ddd9bef48333822e57b83d36e365