### PR TITLE
Add unsaved changes alert to settings page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1917,6 +1917,12 @@ details > summary {
   color: orange;
 }
 
+.unsaved-icon {
+  vertical-align: middle;
+  margin-left: 0.25rem;
+  color: orange;
+}
+
 .feed-status tr.danger-disabled {
   opacity: 0.5;
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -21,6 +21,7 @@ import { initCosts } from "./costs.js";
 import { initAdvanced } from "./advanced.js";
 import { initCliHelp } from "./cli_help.js";
 import { initNetworkBanner } from "./network_banner.js";
+import { initUnsavedIndicator } from "./unsaved.js";
 
 initTemplates();
 initVideoControls();
@@ -46,4 +47,5 @@ initControlsDropdown();
 initAutocomplete();
 initCosts();
 initAdvanced();
+initUnsavedIndicator();
 initCliHelp();

--- a/app/static/js/unsaved.js
+++ b/app/static/js/unsaved.js
@@ -1,0 +1,13 @@
+export function initUnsavedIndicator() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const form = document.getElementById("settings-form");
+    const icon = document.getElementById("unsaved-icon");
+    if (!form || !icon) return;
+    form.addEventListener("input", () => {
+      icon.classList.remove("hidden");
+    });
+    form.addEventListener("submit", () => {
+      icon.classList.add("hidden");
+    });
+  });
+}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -3,7 +3,6 @@
 <main class="container settings-page">
   {# Help content now appears directly in the table, so the collapsible menu was
   removed #}
-  <h2 class="page-title">Settings</h2>
 
   <div id="settings-search" class="hidden">
     <label for="search-input" title="Filter the selected column">Search:</label>
@@ -227,6 +226,16 @@
       />
       {% endif %}
       <button type="submit" title="Save all changes">Save Changes</button>
+      <svg
+        id="unsaved-icon"
+        width="16"
+        height="16"
+        class="unsaved-icon hidden"
+        aria-label="Unsaved changes"
+        title="Unsaved changes"
+      >
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
+      </svg>
     </div>
     {% if loop.first %}
     <div id="discover-tab" class="tab-content">

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -12,6 +12,8 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.
 - **Tab headers removed** – the active tab is highlighted, freeing space.
+- **Unsaved Changes Indicator** – a small alert icon appears next to the Save
+  Changes button when edits haven't been saved.
 - **System Status** – view CPU, memory, disk usage, and live logs.
 - **Certain tabs start collapsed** – Capture, Credentials & Management, and
   Integrations & Other appear collapsed until expanded.

--- a/tests/js/unsaved.test.js
+++ b/tests/js/unsaved.test.js
@@ -1,0 +1,26 @@
+import { jest } from "@jest/globals";
+
+let initUnsavedIndicator;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/unsaved.js");
+  initUnsavedIndicator = mod.initUnsavedIndicator;
+});
+
+test("icon shows on input and hides on submit", () => {
+  document.body.innerHTML = `
+    <form id="settings-form">
+      <input id="foo" />
+    </form>
+    <svg id="unsaved-icon" class="hidden"></svg>
+  `;
+  initUnsavedIndicator();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const input = document.getElementById("foo");
+  const icon = document.getElementById("unsaved-icon");
+  input.value = "bar";
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  expect(icon.classList.contains("hidden")).toBe(false);
+  document.getElementById("settings-form").dispatchEvent(new Event("submit"));
+  expect(icon.classList.contains("hidden")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- show icon beside 'Save Changes' when form inputs change
- remove redundant header from settings page
- document unsaved change indicator in settings page docs
- include unsaved indicator init in script loader
- style unsaved icon and add tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`
- `npm run size-audit --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845de7730cc833384881ffc5b4b4a62