### PR TITLE
Remove redundant caption time

### DIFF
--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -766,8 +766,9 @@ block content %}
   <button onclick="openModal('edit-template-modal')" title="Edit this template">
     Edit Template
   </button>
-  <p><strong>Last Caption:</strong> {{ template_details.last_caption }}</p>
-  <p><strong>Caption Time:</strong> {{ template_details.last_caption_time }}</p>
+  <p title="{{ template_details.last_caption_time }}">
+    <strong>Last Caption:</strong> {{ template_details.last_caption }}
+  </p>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- eliminate duplicate caption time from template actions bar
- show caption timestamp as tooltip on last caption

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dfda395c83339ddf6d3b9f62f34a