### PR TITLE
Add custom navigation logo upload

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
@@ -2692,6 +2693,55 @@ def init_routes(app: Flask) -> None:
                 "message": f"Screenshot for {template_name} uploaded",
             }
         )
+
+    @app.route("/upload_nav_icon", methods=["POST"])
+    @login_required
+    def upload_nav_icon():
+        """Upload or choose a navigation logo."""
+
+        choice = request.form.get("logo_choice")
+        if choice in {"img/glimpser_small.png", "img/glimpser.png"}:
+            update_setting("NAV_ICON", choice)
+            flash("Navigation logo updated", "success")
+            return redirect(url_for("settings"))
+
+        if "logo_file" not in request.files:
+            flash("No logo file provided", "error")
+            return redirect(url_for("settings")), 400
+
+        logo_file = request.files["logo_file"]
+        if logo_file.filename == "":
+            flash("No logo file provided", "error")
+            return redirect(url_for("settings")), 400
+
+        if not allowed_filename(
+            logo_file.filename
+        ) or not logo_file.filename.lower().endswith(".png"):
+            flash("Invalid file name", "error")
+            return redirect(url_for("settings")), 400
+
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            logo_file.save(temp_file.name)
+            try:
+                img = Image.open(temp_file.name)
+                w, h = img.size
+                if h == 0 or not 2 <= w / h <= 10:
+                    os.unlink(temp_file.name)
+                    flash("Invalid aspect ratio", "error")
+                    return redirect(url_for("settings")), 400
+            except Exception:
+                os.unlink(temp_file.name)
+                flash("Invalid image file", "error")
+                return redirect(url_for("settings")), 400
+
+            dest_dir = os.path.join(app.static_folder, "img")
+            os.makedirs(dest_dir, exist_ok=True)
+            dest_name = secure_filename(logo_file.filename)
+            dest_path = os.path.join(dest_dir, dest_name)
+            shutil.move(temp_file.name, dest_path)
+            update_setting("NAV_ICON", f"img/{dest_name}")
+        flash("Navigation logo uploaded", "success")
+        return redirect(url_for("settings"))
 
     @app.route("/take_screenshot/<string:template_name>", methods=["POST", "GET"])
     @login_required

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -47,15 +47,19 @@
     </a>
   </div>
 
-  <form method="POST" action="{{ url_for('settings') }}" id="settings-form">
+  <form
+    method="POST"
+    action="{{ url_for('settings') }}"
+    id="settings-form"
+    enctype="multipart/form-data"
+  >
     {% for name, opts in choices.items() %}
     <datalist id="{{ name }}-list">
       {% for opt in opts %}
       <option value="{{ opt }}"></option>
       {% endfor %}
     </datalist>
-    {% endfor %}
-    {% for group, items in grouped_settings.items() %}
+    {% endfor %} {% for group, items in grouped_settings.items() %}
     <div
       id="{{ group|replace(' ', '-') }}-tab"
       class="tab-content{% if loop.first %} active{% endif %}"
@@ -111,7 +115,15 @@
                 name="{{ setting.name }}"
                 value="{{ setting.value }}"
                 title="Edit value for {{ setting.name }}"
-                {% if setting.name in choices %}list="{{ setting.name }}-list"{% endif %}
+                {%
+                if
+                setting.name
+                in
+                choices
+                %}list="{{ setting.name }}-list"
+                {%
+                endif
+                %}
                 {%
                 if
                 setting.name
@@ -218,6 +230,31 @@
       >
         Update Chrome Shortcut
       </button>
+
+      {% call card('Navigation Logo') %}
+      <form
+        action="{{ url_for('upload_nav_icon') }}"
+        method="post"
+        enctype="multipart/form-data"
+      >
+        <label for="logo-choice" class="sr-only">Built-in logo</label>
+        <select
+          name="logo_choice"
+          id="logo-choice"
+          title="Select built-in logo"
+        >
+          <option value="img/glimpser_small.png">Default Small</option>
+          <option value="img/glimpser.png">Large</option>
+        </select>
+        <input
+          type="file"
+          name="logo_file"
+          accept="image/png"
+          title="Upload custom logo"
+        />
+        <button type="submit" title="Update navigation logo">Save Logo</button>
+      </form>
+      {% endcall %}
       <input
         type="hidden"
         id="name_to_delete"

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -28,7 +28,7 @@ Below are key settings loaded from the database with their default values. You
 can modify them in the application interface or directly in the database.
 
 - `NAME` – application name (default `glimpser`)
-- `NAV_ICON` – navigation logo path relative to the `static` directory. Set to an empty string to hide the logo (default `img/glimpser_small.png`)
+- `NAV_ICON` – navigation logo path relative to the `static` directory. Set to an empty string to hide the logo (default `img/glimpser_small.png`). The settings page now includes a form to upload a custom PNG logo or choose from the bundled options.
 - `VERSION` – application version (defaults to the installed package version and
   is updated automatically when it changes)
 - `LANG` – default language (default `en-US`). The settings page lists common language codes such as `en-US`, `es-ES`, `fr-FR`, `de-DE`, `zh-CN`, `ja-JP`, `pt-BR`, `hi-IN`, `ar-SA`, and `ru-RU`.

--- a/tests/test_upload_nav_icon.py
+++ b/tests/test_upload_nav_icon.py
@@ -1,0 +1,46 @@
+import os
+import io
+import shutil
+import unittest
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+from app.routes import init_routes
+
+
+class TestUploadNavIcon(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.static_dir = os.path.join(self.repo_root, "test_static")
+        os.makedirs(os.path.join(self.static_dir, "img"), exist_ok=True)
+        self.app = Flask(__name__, static_folder=self.static_dir)
+        self.app.config["SECRET_KEY"] = "test"
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.update_patch = patch("app.routes.update_setting")
+        self.login_patch.start()
+        self.mock_update = self.update_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.update_patch.stop()
+        shutil.rmtree(self.static_dir, ignore_errors=True)
+
+    def test_upload_nav_icon(self):
+        img_bytes = io.BytesIO()
+        Image.new("RGB", (150, 22)).save(img_bytes, format="PNG")
+        img_bytes.seek(0)
+        data = {"logo_file": (img_bytes, "logo.png")}
+        resp = self.client.post(
+            "/upload_nav_icon", data=data, content_type="multipart/form-data"
+        )
+        self.assertEqual(resp.status_code, 302)
+        saved = os.path.join(self.static_dir, "img", "logo.png")
+        self.assertTrue(os.path.exists(saved))
+        self.mock_update.assert_called_with("NAV_ICON", "img/logo.png")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow uploading a custom PNG logo or choosing a built-in one
- document NAV_ICON upload support
- add tests for the new upload route

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845ded4d4d88333b390cd1d639048d3