### PR TITLE
Add recent clip endpoint for tiles

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -350,6 +350,9 @@ LIVE_MAX_RETRY_DELAY = int(get_setting("LIVE_MAX_RETRY_DELAY", 30))
 # the banner remains visible after a caption arrives.
 CHYRON_SPEED = int(get_setting("CHYRON_SPEED", 0))
 
+# Length in seconds for clips returned by the /recent_clip endpoint.
+RECENT_CLIP_DURATION = int(get_setting("RECENT_CLIP_DURATION", 120))
+
 # Whether the System Performance icon in the navigation bar should remain
 # visible even when the application reports healthy status. When set to
 # ``False`` the icon hides itself if all metrics look nominal to reduce

--- a/app/routes.py
+++ b/app/routes.py
@@ -2568,6 +2568,23 @@ def init_routes(app: Flask) -> None:
 
         abort(404)
 
+    @app.route("/recent_clip/<string:template_name>")
+    @login_required
+    def recent_clip(template_name: TemplateName):
+        """Return a concatenated clip from the last few minutes."""
+
+        template_name = validate_template_name(template_name)
+        if template_name is None:
+            abort(404)
+
+        clip = video_archiver.assemble_recent_clip(
+            template_name, config.RECENT_CLIP_DURATION
+        )
+        if clip and os.path.exists(clip):
+            return send_file(clip)
+
+        abort(404)
+
     @app.route("/last_screenshot/<string:template_name>")
     @login_required
     def serve_screenshot(template_name: TemplateName):

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -673,7 +673,7 @@ function playLoop() {
         cameraIndex = 0; // Reset the index to loop through the cameras again
       }
       const cameraName = groupCameras[cameraIndex];
-      video.src = `/last_video/${cameraName}`; // Update the video source with the current camera
+      video.src = `/recent_clip/${cameraName}`; // Update the video source with the current camera
       video.load();
       safePlay(video);
       cameraIndex++; // Move to the next camera
@@ -683,7 +683,7 @@ function playLoop() {
     video.addEventListener("ended", loopHandler); // Continue the loop when the video ends
   } else {
     // Handling for individual cameras
-    video.src = `/last_video/${currentCamera}`;
+    video.src = `/recent_clip/${currentCamera}`;
     video.load();
     safePlay(video);
   }
@@ -777,7 +777,7 @@ function handleVideoEnded() {
     const currentIndex = groupCameras.indexOf(video.dataset.currentCamera);
     const nextIndex = (currentIndex + 1) % groupCameras.length;
     const nextCamera = groupCameras[nextIndex];
-    video.src = "/last_video/" + nextCamera;
+    video.src = "/recent_clip/" + nextCamera;
     video.dataset.currentCamera = nextCamera;
   }
   video.load();

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -673,7 +673,7 @@ export async function loadTemplates() {
               <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                 <div class="camera-name">${name}</div>
                 <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback>
-                  <source src="/last_video/${name}" type="video/mp4">
+                  <source src="/recent_clip/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
                 <div class="caption-overlay">${template.last_caption || ""}</div>

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -56,7 +56,7 @@ export function initVideoControls() {
           videos.forEach((video) => {
             const name = video.getAttribute("data-name");
             const src = video.querySelector("source");
-            src.src = `/last_video/${name}`;
+            src.src = `/recent_clip/${name}`;
             video.removeAttribute("src");
             video.poster = `/last_screenshot/${name}`;
             playAllObserver.observe(video);
@@ -101,7 +101,7 @@ export function updateVideoSources() {
   videos.forEach((video) => {
     const name = video.getAttribute("data-name");
     const timestamp = new Date().getTime();
-    video.querySelector("source").src = `/last_video/${name}?t=${timestamp}`;
+    video.querySelector("source").src = `/recent_clip/${name}?t=${timestamp}`;
     video.poster = `/last_screenshot/${name}?t=${timestamp}`;
   });
 }

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -279,6 +279,57 @@ def get_video_duration(video_path):
     return duration
 
 
+def assemble_recent_clip(template_name: str, duration: int) -> str | None:
+    """Return a concatenated clip of recent footage.
+
+    Parameters
+    ----------
+    template_name : str
+        Name of the camera template to process.
+    duration : int
+        Length of the clip in seconds.
+
+    Returns
+    -------
+    str | None
+        Path to the assembled clip or ``None`` if unavailable.
+    """
+
+    name = validate_template_name(template_name)
+    if name is None:
+        return None
+    base_path = os.path.join(VIDEO_DIRECTORY, name)
+    if not os.path.isdir(base_path):
+        return None
+
+    files = sorted(
+        glob.glob(os.path.join(base_path, "*.mp4")), key=os.path.getmtime, reverse=True
+    )
+    selected: list[str] = []
+    total = 0.0
+    for f in files:
+        if total >= duration:
+            break
+        d = get_video_duration(f)
+        if d:
+            selected.append(f)
+            total += d
+
+    if not selected:
+        return None
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".txt", delete=False) as fh:
+        for f in reversed(selected):
+            fh.write(f"file '{os.path.abspath(f)}'\n")
+        fh.flush()
+        output_file = os.path.join(base_path, "recent_clip.mp4")
+        compile_videos(fh.name, output_file + ".tmp")
+
+    if os.path.exists(output_file):
+        return output_file
+    return None
+
+
 def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> bool:
     """Concatenate the temporary video with the existing in-process video."""
     file_updated = False

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -131,6 +131,7 @@ Several other routes provide streaming functionality:
   Optional `camera` or `group` query parameters filter the playlist to a
   single camera or group of cameras.
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
+- **GET /recent_clip/<template_name>** – Concatenate archived segments to create a clip of length `RECENT_CLIP_DURATION` seconds (default 120).
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -128,6 +128,7 @@ Settings controlling how frames are captured from video sources:
 - `LIVE_MAX_FAILURES` – maximum consecutive ffmpeg failures before live view stops (default `10`)
 - `LIVE_BACKOFF_MAX` – maximum seconds between live stream restart attempts (default `30`)
 - `CHYRON_SPEED` – seconds the caption chyron scrolls; set to `0` to disable (default `0`)
+- `RECENT_CLIP_DURATION` – seconds of footage stitched together for `/recent_clip` (default `120`)
 - `HEALTH_STATUS_ALWAYS_VISIBLE` – keep the System Performance icon visible even when the system is healthy (default `False`)
 - `WATCHDOG_FAILURE_THRESHOLD` – number of failed health checks before a restart (default `3`)
 - `WATCHDOG_RESTART_COOLDOWN` – cooldown period between restarts in seconds (default `900`)

--- a/tests/test_recent_clip_route.py
+++ b/tests/test_recent_clip_route.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.routes as routes
+from app.routes import init_routes
+import app.config as config
+
+
+class TestRecentClipRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.clip_patch = patch("app.routes.video_archiver.assemble_recent_clip")
+        self.send_patch = patch("app.routes.send_file")
+        self.exists_patch = patch("os.path.exists", return_value=True)
+        self.login_patch.start()
+        self.mock_clip = self.clip_patch.start()
+        self.mock_send = self.send_patch.start()
+        self.exists_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.clip_patch.stop()
+        self.send_patch.stop()
+        self.exists_patch.stop()
+
+    def test_recent_clip_success(self):
+        self.mock_clip.return_value = "/tmp/clip.mp4"
+        resp = self.client.get("/recent_clip/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.mock_clip.assert_called_with("cam1", config.RECENT_CLIP_DURATION)
+        self.mock_send.assert_called_with("/tmp/clip.mp4")
+
+    def test_recent_clip_missing(self):
+        self.mock_clip.return_value = None
+        resp = self.client.get("/recent_clip/cam1")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `RECENT_CLIP_DURATION` setting
- implement `/recent_clip/<template_name>` route
- stitch recent footage via `assemble_recent_clip`
- use the new endpoint in JS tiles
- document new API and setting
- test recent clip route

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Executable `npm` not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dd2244f483339482710ded5e1ac6