### PR TITLE
Add live preview in edit template modal

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1817,6 +1817,25 @@ details > summary {
   width: 80%;
   border-radius: 8px;
 }
+
+.edit-template-modal-content {
+  position: relative;
+}
+
+.edit-template-preview {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 240px;
+  height: 180px;
+}
+
+.edit-template-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 4px;
+}
 #chat-modal .modal-content {
   width: 90%;
   max-width: 600px;

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -869,7 +869,7 @@ block content %}
 </div>
 
 <div id="edit-template-modal" class="modal">
-  <div class="modal-content">
+  <div class="modal-content edit-template-modal-content">
     <span
       onclick="closeGenericModal('edit-template-modal')"
       class="close-icon"
@@ -877,6 +877,13 @@ block content %}
       >&times;</span
     >
     <div class="edit-template-container">
+      <div class="edit-template-preview">
+        <img
+          id="mini-live-preview"
+          src="/stream.mjpg?camera={{ template_name }}"
+          alt="Live preview"
+        />
+      </div>
       <h3>Edit Template Details</h3>
       <form
         id="edit-template-form"

--- a/docs/edit_template_preview.md
+++ b/docs/edit_template_preview.md
@@ -1,0 +1,3 @@
+# Edit Template Preview
+
+The edit template dialog now shows a mini live view of the camera in the top-right corner. This MJPEG stream lets you verify the feed while tweaking settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Live All: live_all.md
       - Live Scrub: live_scrub.md
       - Rotate Button: rotate_button.md
+      - Edit Template Preview: edit_template_preview.md
       - MCP Integration: mcp_integration.md
       - Onboarding Guide: onboarding.md
       - Scorecard: scorecard.md


### PR DESCRIPTION
## Summary
- show a live camera preview in the edit-template dialog
- style the preview with new CSS
- document the feature and add navigation entry

## Testing
- `pre-commit run --files app/templates/template_details.html app/static/css/style.css mkdocs.yml docs/edit_template_preview.md`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845dfaec5d88333b990847888fa0107