### PR TITLE
feat(discovery): add test frame camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 
 - **Auto-summarization**: Summarizes data from multiple sources into a coherent and concise format, highlighting the most important information.
 - **RTSP Streaming**: Exposes a basic RTSP endpoint (`/test.rtsp`) so external NVRs can ingest the MJPEG stream. Supported verbs are `OPTIONS`, `DESCRIBE`, `SETUP`, `PLAY`, `PAUSE`, `GET_PARAMETER`, and `TEARDOWN`.
+- **MJPG Test Stream**: Provides `/test.mjpg` for clients that lack RTSP support.
 
 - **Customizable Configuration**: Easily configure different data sources and processing rules through the user-friendly interface. Glimpser’s configuration is fully database-driven, ensuring flexibility and ease of use.
 
@@ -158,6 +159,7 @@ Glimpser can summarize data from multiple sources into a coherent and concise fo
 ### RTSP Streaming
 
 Glimpser exposes a simple RTSP endpoint at `/test.rtsp`. When a client issues the standard RTSP verbs, the `/rtsp_stream` route serves MJPEG frames packetized with RTP headers.
+An equivalent MJPEG feed is available at `/test.mjpg` for quick testing or clients without RTSP support.
 
 Typical sequence:
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -1965,6 +1965,20 @@ def init_routes(app: Flask) -> None:
 
         return "Method Not Allowed", 405
 
+    @app.route("/test.mjpg", methods=["GET"])
+    @login_required
+    def test_mjpg():
+        group = request.args.get("group")
+        camera = request.args.get("camera")
+        if group == "all":
+            group = None
+        if camera == "all":
+            camera = None
+        return Response(
+            generate(group=group, camera=camera, filename="latest_camera.png"),
+            mimetype="multipart/x-mixed-replace; boundary=frame",
+        )
+
     @app.route("/stream.mjpg", methods=["GET"])
     @login_required
     def stream_mjpg():

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -995,6 +995,16 @@ def discover_cameras(progress_callback=None, subnets=None):
         }
     )
 
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "rtsp",
+            "port": PORT,
+            "info": {"name": "Test Frame"},
+            "url": f"rtsp://127.0.0.1:{PORT}/test.rtsp",
+        }
+    )
+
     # remove duplicates but keep distinct URLs
     unique = {}
     for cam in cameras:

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -134,6 +134,7 @@ Several other routes provide streaming functionality:
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
+- **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 
 ### 6. Trigger Screenshot Capture
 

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -189,6 +189,8 @@ item like any other camera to have Glimpser periodically capture screenshots of
 its own metrics tab.
 It now also includes an **Internal Caption** entry streaming `/internal_caption.mjpg`,
 which loops recent caption text for convenient review.
+A **Test Frame** entry is also available, streaming `/test.mjpg` so you can quickly
+verify connectivity without adding a real camera.
 
 ## Common cameras to try
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -282,6 +282,12 @@ class TestCameraDiscovery(unittest.TestCase):
                 "port": 8082,
                 "info": {"name": "System Status"},
             },
+            {
+                "ip": "127.0.0.1",
+                "protocol": "rtsp",
+                "port": 8082,
+                "info": {"name": "Test Frame"},
+            },
         ]
         # convert to set of tuples for comparison ignoring order
         self.assertEqual(

--- a/tests/test_test_mjpg_route.py
+++ b/tests/test_test_mjpg_route.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+
+
+class TestTestMjpg(unittest.TestCase):
+    def setUp(self):
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        self.app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.app_context.pop()
+
+    def _check_call(self, url, expected_camera, expected_group):
+        with patch("app.routes.generate") as mock_gen:
+            mock_gen.return_value = iter([b"TEST"])
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 200)
+            mock_gen.assert_called_with(
+                group=expected_group,
+                camera=expected_camera,
+                filename="latest_camera.png",
+            )
+            next(resp.response)
+
+    def test_camera_query(self):
+        self._check_call("/test.mjpg?camera=cam1", "cam1", None)
+
+    def test_group_query(self):
+        self._check_call("/test.mjpg?group=front", None, "front")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/test.mjpg` endpoint for an MJPEG test feed
- expose test frame in camera discovery results
- document new feed and discovery entry
- update tests for discovery and new route

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845de2865bc8333b8cc814a4b3fb013