### PR TITLE
Fix configuration download

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3045,6 +3045,11 @@ def init_routes(app: Flask) -> None:
                 else:
                     flash("Failed to backup configuration", "error")
             elif action == "download":
+                # Always create a fresh backup before serving the file so the
+                # user gets the most up‐to‐date configuration. If the file did
+                # not exist previously ``backup_config`` will create it.
+                backup_config()
+
                 if os.path.exists(BACKUP_PATH):
                     return send_file(
                         BACKUP_PATH,

--- a/docs/config_management.md
+++ b/docs/config_management.md
@@ -6,8 +6,8 @@ Glimpser allows you to export and restore configuration data from the web interf
 
 1. Open the **Settings** page from the navigation bar.
 2. Switch to the **Credentials & Management** tab.
-3. Click **Backup Configuration** to create a JSON snapshot if one does not already exist.
-4. Click **Download Configuration** to save the backup file locally.
+3. Click **Download Configuration** to save the current settings as a JSON backup.
+   A new backup is created automatically before the file is served.
 
 The downloaded file contains every setting and camera template defined in the database.
 

--- a/tests/test_settings_download_route.py
+++ b/tests/test_settings_download_route.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import unittest
+import tempfile
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestSettingsDownloadRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.backup_path = os.path.join(self.temp_dir.name, "config.json")
+        self.path_patch = patch("app.routes.BACKUP_PATH", self.backup_path)
+        self.path_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.path_patch.stop()
+        self.temp_dir.cleanup()
+
+    @patch("app.routes.send_file")
+    @patch("app.routes.backup_config", return_value=True)
+    @patch("app.routes.os.path.exists", return_value=True)
+    def test_download_triggers_backup(self, mock_exists, mock_backup, mock_send):
+        resp = self.client.post("/settings", data={"action": "download"})
+        self.assertEqual(resp.status_code, 200)
+        mock_backup.assert_called_once()
+        mock_send.assert_called_once_with(
+            self.backup_path,
+            as_attachment=True,
+            download_name="config_backup.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -179,7 +179,7 @@ class TestSettingsRoute(unittest.TestCase):
             patch("app.routes.login_required", lambda x: x),
         ):
             response = self.client.post("/settings", data={"action": "download"})
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 200)
 
     def test_notification_tests(self):
         with (


### PR DESCRIPTION
## Summary
- create a fresh backup each time the configuration is downloaded
- clarify docs for automatic backup
- update settings download tests
- add test covering download action

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845e17a1fe88333a24d28f8ba0dda91