### PR TITLE
Extend network banner event handling

### DIFF
--- a/app/static/js/network_banner.js
+++ b/app/static/js/network_banner.js
@@ -7,22 +7,29 @@ export function initNetworkBanner() {
     const banner = document.getElementById("network-banner");
     if (!banner) return;
 
-    const checkStatus = async () => {
-      try {
-        const res = await fetch("/network_status");
-        const data = await res.json();
-        if (data.online) {
-          banner.classList.remove("show");
-          banner.textContent = "";
-        } else {
-          banner.textContent = "Offline mode";
-          banner.classList.add("show");
-        }
-      } catch {
+    const updateBanner = (isOnline) => {
+      if (isOnline) {
+        banner.classList.remove("show");
+        banner.textContent = "";
+      } else {
         banner.textContent = "Offline mode";
         banner.classList.add("show");
       }
     };
+
+    const checkStatus = async () => {
+      try {
+        const res = await fetch("/network_status");
+        const data = await res.json();
+        updateBanner(data.online);
+      } catch {
+        updateBanner(false);
+      }
+    };
+
+    updateBanner(navigator.onLine);
+    window.addEventListener("online", () => updateBanner(true));
+    window.addEventListener("offline", () => updateBanner(false));
 
     checkStatus();
     setInterval(checkStatus, 10000);

--- a/tests/js/network_banner.test.js
+++ b/tests/js/network_banner.test.js
@@ -36,3 +36,21 @@ test("shows banner when offline", async () => {
   expect(banner.classList.contains("show")).toBe(true);
   expect(banner.textContent).toBe("Offline mode");
 });
+
+test("updates banner on online/offline events", async () => {
+  global.fetch.mockResolvedValue({
+    json: () => Promise.resolve({ online: true }),
+  });
+  initNetworkBanner();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  const banner = document.getElementById("network-banner");
+
+  window.dispatchEvent(new Event("offline"));
+  expect(banner.classList.contains("show")).toBe(true);
+  expect(banner.textContent).toBe("Offline mode");
+
+  window.dispatchEvent(new Event("online"));
+  expect(banner.classList.contains("show")).toBe(false);
+  expect(banner.textContent).toBe("");
+});


### PR DESCRIPTION
## Summary
- update `network_banner.js` to react to browser online/offline events
- add unit test for immediate banner updates on those events

## Testing
- `pre-commit run --files app/static/js/network_banner.js tests/js/network_banner.test.js` *(fails: `npm` not found)*
- `npm test` *(fails: command not found)*
- `pytest -k network_banner -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e38334248333a87a540363752734