### PR TITLE
Update tiles to use clip endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Live video retries now use exponential backoff to reduce repeated ffmpeg errors
 - Template toolbar now anchors to the lower left of detail pages
 - Image thumbnails show captions in their tooltips
+- Dashboard tiles now use the `/clip` endpoint to loop the last two minutes of footage
 
 ### Fixed
 

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -673,7 +673,7 @@ function playLoop() {
         cameraIndex = 0; // Reset the index to loop through the cameras again
       }
       const cameraName = groupCameras[cameraIndex];
-      video.src = `/last_video/${cameraName}`; // Update the video source with the current camera
+      video.src = `/clip/${cameraName}`; // Update the video source with the current camera
       video.load();
       safePlay(video);
       cameraIndex++; // Move to the next camera
@@ -683,7 +683,7 @@ function playLoop() {
     video.addEventListener("ended", loopHandler); // Continue the loop when the video ends
   } else {
     // Handling for individual cameras
-    video.src = `/last_video/${currentCamera}`;
+    video.src = `/clip/${currentCamera}`;
     video.load();
     safePlay(video);
   }
@@ -777,7 +777,7 @@ function handleVideoEnded() {
     const currentIndex = groupCameras.indexOf(video.dataset.currentCamera);
     const nextIndex = (currentIndex + 1) % groupCameras.length;
     const nextCamera = groupCameras[nextIndex];
-    video.src = "/last_video/" + nextCamera;
+    video.src = `/clip/${nextCamera}`;
     video.dataset.currentCamera = nextCamera;
   }
   video.load();

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -51,7 +51,7 @@ export function initVideoControls() {
           videos.forEach((video) => {
             const name = video.getAttribute("data-name");
             const src = video.querySelector("source");
-            src.src = `/last_video/${name}`;
+            src.src = `/clip/${name}`;
             video.removeAttribute("src");
             video.poster = `/last_screenshot/${name}`;
             playAllObserver.observe(video);
@@ -96,7 +96,7 @@ export function updateVideoSources() {
   videos.forEach((video) => {
     const name = video.getAttribute("data-name");
     const timestamp = new Date().getTime();
-    video.querySelector("source").src = `/last_video/${name}?t=${timestamp}`;
+    video.querySelector("source").src = `/clip/${name}?t=${timestamp}`;
     video.poster = `/last_screenshot/${name}?t=${timestamp}`;
   });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -146,7 +146,7 @@ block content %}
                     muted
                     poster="/last_screenshot/{{ camera }}"
                   >
-                    <source src="/last_video/{{ camera }}" type="video/mp4" />
+                    <source src="/clip/{{ camera }}" type="video/mp4" />
                     Your browser does not support the video tag.
                   </video>
                 </div>

--- a/app/templates/player.html
+++ b/app/templates/player.html
@@ -18,7 +18,7 @@
 		const cameraNameElement = document.getElementById('camera-name');
             if (cameras.length > 0) {
                 const currentCamera = cameras[currentCameraIndex];
-                videoElement.src = `/last_video/${currentCamera}`;
+                videoElement.src = `/clip/${currentCamera}`;
                 videoElement.load();
                 videoElement.playbackRate = 0.25;
                 videoElement.play();

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -653,7 +653,7 @@ block content %}
     const endpoints = {
       "Camera Name": templateName,
       "Last Screenshot URL": `${baseUrl}/last_screenshot/${templateName}`,
-      "Last Video URL": `${baseUrl}/last_video/${templateName}`,
+      "Recent Clip URL": `${baseUrl}/clip/${templateName}`,
       "Stream URL": `${baseUrl}/stream.mjpg?group=${templateName}`,
       "Motion Stream URL": `${baseUrl}/motion.mjpg?group=${templateName}`,
       "Caption Stream URL": `${baseUrl}/caption.mjpg?group=${templateName}`,

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,7 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. Use the optional `duration` query parameter to set the length in seconds (defaults to `DEFAULT_CLIP_DURATION`).
+- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. Use the optional `duration` query parameter to set the length in seconds (defaults to `DEFAULT_CLIP_DURATION`). This endpoint now powers the dashboard thumbnail loops.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 


### PR DESCRIPTION
## Summary
- switch dashboard tiles from `/last_video` to `/clip`
- adjust camera details modal text
- document new endpoint usage

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e485ec30833390770ba89c19368e