### PR TITLE
Fix tile videos to use /clip endpoint

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -673,7 +673,7 @@ function playLoop() {
         cameraIndex = 0; // Reset the index to loop through the cameras again
       }
       const cameraName = groupCameras[cameraIndex];
-      video.src = `/last_video/${cameraName}`; // Update the video source with the current camera
+      video.src = `/clip/${cameraName}`; // Update the video source with the current camera
       video.load();
       safePlay(video);
       cameraIndex++; // Move to the next camera
@@ -683,7 +683,7 @@ function playLoop() {
     video.addEventListener("ended", loopHandler); // Continue the loop when the video ends
   } else {
     // Handling for individual cameras
-    video.src = `/last_video/${currentCamera}`;
+    video.src = `/clip/${currentCamera}`;
     video.load();
     safePlay(video);
   }
@@ -777,7 +777,7 @@ function handleVideoEnded() {
     const currentIndex = groupCameras.indexOf(video.dataset.currentCamera);
     const nextIndex = (currentIndex + 1) % groupCameras.length;
     const nextCamera = groupCameras[nextIndex];
-    video.src = "/last_video/" + nextCamera;
+    video.src = "/clip/" + nextCamera;
     video.dataset.currentCamera = nextCamera;
   }
   video.load();

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -673,7 +673,7 @@ export async function loadTemplates() {
               <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                 <div class="camera-name">${name}</div>
                 <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback>
-                  <source src="/last_video/${name}" type="video/mp4">
+                  <source src="/clip/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
                 <div class="caption-overlay">${template.last_caption || ""}</div>

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -51,7 +51,7 @@ export function initVideoControls() {
           videos.forEach((video) => {
             const name = video.getAttribute("data-name");
             const src = video.querySelector("source");
-            src.src = `/last_video/${name}`;
+            src.src = `/clip/${name}`;
             video.removeAttribute("src");
             video.poster = `/last_screenshot/${name}`;
             playAllObserver.observe(video);
@@ -96,7 +96,7 @@ export function updateVideoSources() {
   videos.forEach((video) => {
     const name = video.getAttribute("data-name");
     const timestamp = new Date().getTime();
-    video.querySelector("source").src = `/last_video/${name}?t=${timestamp}`;
+    video.querySelector("source").src = `/clip/${name}?t=${timestamp}`;
     video.poster = `/last_screenshot/${name}?t=${timestamp}`;
   });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -146,7 +146,7 @@ block content %}
                     muted
                     poster="/last_screenshot/{{ camera }}"
                   >
-                    <source src="/last_video/{{ camera }}" type="video/mp4" />
+                    <source src="/clip/{{ camera }}" type="video/mp4" />
                     Your browser does not support the video tag.
                   </video>
                 </div>

--- a/app/templates/player.html
+++ b/app/templates/player.html
@@ -18,7 +18,7 @@
 		const cameraNameElement = document.getElementById('camera-name');
             if (cameras.length > 0) {
                 const currentCamera = cameras[currentCameraIndex];
-                videoElement.src = `/last_video/${currentCamera}`;
+                videoElement.src = `/clip/${currentCamera}`;
                 videoElement.load();
                 videoElement.playbackRate = 0.25;
                 videoElement.play();

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -654,6 +654,7 @@ block content %}
       "Camera Name": templateName,
       "Last Screenshot URL": `${baseUrl}/last_screenshot/${templateName}`,
       "Last Video URL": `${baseUrl}/last_video/${templateName}`,
+      "Clip URL": `${baseUrl}/clip/${templateName}`,
       "Stream URL": `${baseUrl}/stream.mjpg?group=${templateName}`,
       "Motion Stream URL": `${baseUrl}/motion.mjpg?group=${templateName}`,
       "Caption Stream URL": `${baseUrl}/caption.mjpg?group=${templateName}`,


### PR DESCRIPTION
## Summary
- use `/clip/<template>` when loading dashboard video tiles
- show clip URL in template details

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845e594b5fc83338fb56fcd10d57996