### PR TITLE
Add host loopback warning

### DIFF
--- a/docs/startup_tips.md
+++ b/docs/startup_tips.md
@@ -11,6 +11,7 @@ This page lists quick reminders that appear when Glimpser starts.
   ```
 - **Port already in use?** Make sure another process isn't bound to the configured port before starting Glimpser.
 - **Need more logging?** Start the app with `--console-log` to mirror log output to your terminal.
+- **Can't reach the server?** Binding `HOST` to `127.0.0.1` or `localhost` makes it invisible to other machines.
 
 Refer to this file any time you hit a startup issue.
 

--- a/main.py
+++ b/main.py
@@ -271,6 +271,13 @@ def display_startup_tips():
     for tip in STARTUP_TIPS:
         logging.info("* %s", tip)
     logging.info(border)
+    # Warn when the server binds to a loopback address. Remote
+    # clients cannot reach 127.x or localhost hosts.
+    if config.HOST.startswith("127.") or config.HOST in {"localhost", "::1"}:
+        logging.warning(
+            "HOST %s is only reachable locally; remote clients may not connect.",
+            config.HOST,
+        )
     if config.SESSION_COOKIE_SECURE:
         logging.warning(
             "SESSION_COOKIE_SECURE is enabled; browsers only send the login cookie over HTTPS."

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -184,6 +184,18 @@ class TestMain(unittest.TestCase):
         main.display_startup_tips()
         mock_info.assert_any_call("Startup Tips")
 
+    @patch("logging.warning")
+    def test_display_startup_tips_warns_on_local_host(self, mock_warn):
+        with (
+            patch.object(config, "HOST", "127.0.0.1"),
+            patch.object(config, "SESSION_COOKIE_SECURE", False),
+        ):
+            main.display_startup_tips()
+        mock_warn.assert_any_call(
+            "HOST %s is only reachable locally; remote clients may not connect.",
+            "127.0.0.1",
+        )
+
     @patch("main.get_system_metrics")
     @patch("logging.info")
     def test_display_startup_info(self, mock_info, mock_metrics):


### PR DESCRIPTION
## Summary
- warn when HOST is configured to a loopback address
- mention loopback bind caveat in Startup Tips
- test HOST warning logic

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e5c7a2208333b0fcef779aba3306