### PR TITLE
Improve management tab layout

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -60,7 +60,7 @@
     </datalist>
     {% endfor %} {% for group, items in grouped_settings.items() %}
     <div
-      id="{{ group|replace(' ', '-') }}-tab"
+      id="{{ 'management-tab' if group == 'Credentials & Management' else group|replace(' ', '-') ~ '-tab' }}"
       class="tab-content{% if loop.first %} active{% endif %}"
     >
       {% call card(group) %}
@@ -151,8 +151,8 @@
           {% endfor %}
         </tbody>
       </table>
-      {% endcall %} {% if group == 'Credentials & Management' %}
-      <h3>Configuration Management</h3>
+      {% endcall %} {% if group == 'Credentials & Management' %} {% call
+      card('Configuration Management') %}
       <div class="checkbox-row">
         <span>Advanced Options</span>
         <label class="switch" title="Toggle advanced options">
@@ -191,16 +191,14 @@
       >
         Upload Configuration
       </button>
-
-      <h3>
-        Danger Mode
-        <a
-          href="../docs/danger_mode.md"
-          target="_blank"
-          title="Open Danger Mode documentation"
-          >docs</a
-        >
-      </h3>
+      {% endcall %} {% call card('Danger Mode') %}
+      <a
+        href="../docs/danger_mode.md"
+        target="_blank"
+        title="Open Danger Mode documentation"
+        class="doc-link"
+        >docs</a
+      >
       <ul class="danger-info">
         <li>Browser: {{ danger_info.browser }}</li>
         <li>Path: {{ danger_info.path }}</li>
@@ -229,8 +227,7 @@
       >
         Update Chrome Shortcut
       </button>
-
-      {% call card('Navigation Logo') %}
+      {% endcall %} {% call card('Navigation Logo') %}
       <form
         action="{{ url_for('upload_nav_icon') }}"
         method="post"
@@ -271,7 +268,9 @@
         aria-label="Unsaved changes"
         title="Unsaved changes"
       >
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+        />
       </svg>
     </div>
     {% if loop.first %}

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -7,6 +7,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Add New Setting** – quickly create additional key/value pairs.
 - **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
+- **Credentials & Management** – buttons are organized into cards for a cleaner layout.
 - **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.


### PR DESCRIPTION
## Summary
- organize the Credentials & Management tab using cards
- ensure CSS hooks apply by setting `id="management-tab"`
- document new layout in the settings page guide

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845e63b9d1c8333b78ba13f63fe4094