### PR TITLE
Add pie chart and range slider to costs tab

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3569,12 +3569,15 @@ def init_routes(app: Flask) -> None:
     def api_llm_cost_summary():
         start = request.args.get("start")
         end = request.args.get("end")
-        templates = template_manager.get_templates()
+        summary, _, _ = template_manager.get_llm_cost_summary(
+            start_date=start, end_date=end
+        )
         costs = {
-            name: template_manager.get_llm_cost_estimate(
-                name, start_date=start, end_date=end
-            )
-            for name in templates
+            entry["name"]: {
+                "tokens": entry["tokens"],
+                "cost": entry["cost"],
+            }
+            for entry in summary
         }
         return jsonify(costs)
 

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -1,43 +1,31 @@
+import { setupTableSorting } from "./templates.js";
+
 export function initCosts() {
   document.addEventListener("DOMContentLoaded", () => {
     const dataEl = document.getElementById("cost-data");
     if (!dataEl) return;
-    const data = JSON.parse(dataEl.textContent);
-    const groupSel = document.getElementById("cost-group");
-    const camSel = document.getElementById("cost-camera");
+    const range = document.getElementById("cost-range");
+    const label = document.getElementById("cost-range-label");
     const tbody = document.querySelector("#cost-table tbody");
     const ctx = document.getElementById("costChart");
     let chart;
 
-    const filterData = () => {
-      const g = groupSel.value;
-      const c = camSel.value;
-      return data.filter((d) => (!g || d.group === g) && (!c || d.name === c));
-    };
-
-    const renderTable = () => {
+    const render = (rows) => {
       tbody.innerHTML = "";
-      for (const row of filterData()) {
+      const labels = [];
+      const values = [];
+      for (const row of rows) {
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${row.name}</td><td>${row.tokens}</td><td>$${row.cost.toFixed(2)}</td>`;
+        tr.innerHTML = `<td>${row.name}</td><td data-value="${row.tokens}">${row.tokens}</td><td data-value="${row.cost}">$${row.cost.toFixed(2)}</td>`;
         tbody.appendChild(tr);
+        labels.push(row.name);
+        values.push(row.cost);
       }
-    };
-
-    const renderChart = () => {
       if (!ctx) return;
-      const rows = filterData();
-      const labels = rows.map((r) => r.name);
-      const values = rows.map((r) => r.cost);
-      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360}, 70%, 60%)`);
+      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
       const chartData = {
         labels,
-        datasets: [
-          {
-            data: values,
-            backgroundColor: bg,
-          },
-        ],
+        datasets: [{ data: values, backgroundColor: bg }],
       };
       if (chart) {
         chart.data = chartData;
@@ -47,17 +35,35 @@ export function initCosts() {
       }
     };
 
-    groupSel.addEventListener("change", () => {
-      renderTable();
-      renderChart();
-    });
-    camSel.addEventListener("change", () => {
-      renderTable();
-      renderChart();
-    });
+    const fetchData = async () => {
+      if (!range) {
+        render(JSON.parse(dataEl.textContent));
+        return;
+      }
+      const days = parseInt(range.value, 10);
+      const end = new Date().toISOString().slice(0, 10);
+      const start = new Date(Date.now() - days * 86400000)
+        .toISOString()
+        .slice(0, 10);
+      const resp = await fetch(
+        `/api/llm_cost_summary?start=${start}&end=${end}`,
+      );
+      const data = await resp.json();
+      const rows = Object.entries(data).map(([name, info]) => ({
+        name,
+        tokens: info.tokens,
+        cost: parseFloat(info.cost.replace("$", "")),
+      }));
+      render(rows);
+    };
 
-    renderTable();
-    renderChart();
+    range?.addEventListener("input", () => {
+      if (label) label.textContent = `Last ${range.value} days`;
+    });
+    range?.addEventListener("change", fetchData);
+
+    setupTableSorting("cost-table");
+    fetchData();
   });
 }
 
@@ -77,11 +83,12 @@ export function initCostSummary(startTime) {
       const labels = [];
       const values = [];
       for (const name in data) {
+        const info = data[name];
         const row = document.createElement("tr");
-        row.innerHTML = `<td>${name}</td><td>${data[name]}</td>`;
+        row.innerHTML = `<td>${name}</td><td>${info.cost}</td>`;
         tbody.appendChild(row);
         labels.push(name);
-        values.push(parseFloat(data[name].replace("$", "")));
+        values.push(parseFloat(info.cost.replace("$", "")));
       }
       if (!ctx) return;
       const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -1,10 +1,16 @@
 {% call card('LLM Cost Summary') %}
-<table class="cost-table">
+<div id="cost-controls">
+  <label for="cost-range">Range:</label>
+  <input type="range" id="cost-range" min="1" max="30" value="7" />
+  <span id="cost-range-label">Last 7 days</span>
+</div>
+<canvas id="costChart" width="200" height="200"></canvas>
+<table id="cost-table" class="cost-table">
   <thead>
     <tr>
-      <th>Template</th>
-      <th>Tokens</th>
-      <th>Cost</th>
+      <th class="sortable">Template</th>
+      <th class="sortable" data-type="number">Tokens</th>
+      <th class="sortable" data-type="number">Cost</th>
     </tr>
   </thead>
   <tbody>
@@ -24,4 +30,8 @@
     </tr>
   </tfoot>
 </table>
+<script id="cost-data" type="application/json">
+  {{ cost_summary | tojson }}
+</script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 {% endcall %}

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -4,7 +4,9 @@ Glimpser now records the number of tokens used when generating captions.
 Token counts are stored in `data/llm_usage.json` keyed by template name.
 Costs are calculated at `$0.005` per thousand tokens.
 Use the captions page to view each template's estimated cost.
-An overall cost summary now appears under **Settings → Costs**.
+An overall cost summary now appears under **Settings → Costs**. This tab now
+includes a small pie chart and sortable columns. Adjust the date range with the
+slider to view recent spending.
 
 An additional **LLM Cost Summary** page now provides a date range picker to
 review costs for a specific period. Use the **Since Last Restart** shortcut to

--- a/tests/js/cost_summary.test.js
+++ b/tests/js/cost_summary.test.js
@@ -17,7 +17,7 @@ beforeAll(async () => {
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({ cam1: "$1.00" }),
+    json: () => Promise.resolve({ cam1: { cost: "$1.00", tokens: 1 } }),
   }),
 );
 

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -1,0 +1,38 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <input id="cost-range" type="range" value="7">
+  <span id="cost-range-label"></span>
+  <table id="cost-table"><tbody></tbody></table>
+  <canvas id="costChart"></canvas>
+  <script id="cost-data" type="application/json">[]</script>
+`;
+
+let initCosts;
+
+beforeAll(async () => {
+  ({ initCosts } = await import("../../app/static/js/costs.js"));
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ cam1: { cost: "$1.00", tokens: 1 } }),
+  }),
+);
+
+global.Chart = jest.fn(function () {
+  this.update = jest.fn();
+});
+
+test("slider triggers fetch", async () => {
+  initCosts();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledTimes(1);
+  const slider = document.getElementById("cost-range");
+  fetch.mockClear();
+  slider.value = "10";
+  slider.dispatchEvent(new Event("change"));
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
- show cost pie chart with slider to select date range
- allow sorting columns in the costs table
- update API to return tokens and cost
- document updated costs tab
- add tests for new cost tab behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`
- `npm run size-audit`

------
https://chatgpt.com/codex/tasks/task_e_6845e60ac6648333935b37ed042e468c