### PR TITLE
Fix caption timestamps timezone

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1316,7 +1316,7 @@ def init_routes(app: Flask) -> None:
                 except Exception:
                     caption = rec.content
                 timestamp = datetime.utcfromtimestamp(rec.timestamp).strftime(
-                    "%Y-%m-%d %H:%M:%S"
+                    "%Y-%m-%dT%H:%M:%SZ"
                 )
         except Exception as e:  # pragma: no cover - unexpected DB errors
             logging.error("error retrieving captions status: %s", e)
@@ -2244,7 +2244,7 @@ def init_routes(app: Flask) -> None:
                         for ts, text in data.items():
                             try:
                                 dt = datetime.utcfromtimestamp(int(ts))
-                                iso_ts = dt.strftime("%Y-%m-%d %H:%M:%S")
+                                iso_ts = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
                             except Exception:
                                 iso_ts = ts
                             entries.append({iso_ts: text})

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -221,13 +221,12 @@ block content %}
         <tr>
           <th class="sortable" data-type="date">Timestamp</th>
           <th class="sortable" data-type="string">Caption</th>
-          <th>Play</th>
         </tr>
       </thead>
       <tbody>
         {% if not lcaptions %}
         <tr class="no-data">
-          <td colspan="3">No captions available</td>
+          <td colspan="2">No captions available</td>
         </tr>
         {% else %} {% for caption in lcaptions %} {% for lc in caption %} {% if
         caption[lc] != "" %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -631,7 +631,7 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.get_json(),
-            {"caption": "hello", "timestamp": "1970-01-01 00:00:00"},
+            {"caption": "hello", "timestamp": "1970-01-01T00:00:00Z"},
         )
 
 


### PR DESCRIPTION
## Summary
- fix caption timezone for `captions_status`
- update captions table header
- adjust tests for new timestamp format

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e86fca4083339e697c52b0c2417e