### PR TITLE
Fix LLM optional handling

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -16,7 +16,9 @@ last_429_error_time = None
 
 
 class ChatGPTImageComparison:
-    def __init__(self):
+    """Helper for caption prompts using the ChatGPT vision API."""
+
+    def __init__(self) -> None:
         self.api_key = CHATGPT_KEY
         self.headers = {"Authorization": f"Bearer {self.api_key}"}
         self.url = "https://api.openai.com/v1/chat/completions"
@@ -26,6 +28,9 @@ class ChatGPTImageComparison:
     ):
 
         global last_429_error_time
+
+        if not self.api_key:
+            return None, 0
         # Check if a 429 error occurred in the last 30 minutes
         if last_429_error_time and (
             datetime.datetime.now() - last_429_error_time

--- a/app/utils/prompt_optimizer.py
+++ b/app/utils/prompt_optimizer.py
@@ -2,7 +2,7 @@
 
 import os
 
-from app.config import SCREENSHOT_DIRECTORY
+from app.config import SCREENSHOT_DIRECTORY, CHATGPT_KEY
 from .template_manager import get_screenshots_for_template
 from .image_processing import ChatGPTImageComparison
 import app.utils.image_processing as img_proc
@@ -10,6 +10,9 @@ import app.utils.image_processing as img_proc
 
 def generate_prompt(template_name: str, num_images: int = 3) -> str:
     """Return a suggested caption prompt for ``template_name``."""
+
+    if not CHATGPT_KEY:
+        return ""
 
     screenshots = get_screenshots_for_template(template_name)[:num_images]
     if not screenshots:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,6 +68,7 @@ This guide addresses common issues that users might encounter while using Glimps
 
 - Check the `LLM_CAPTION_PROMPT` setting and adjust if necessary
 - Ensure your CHATGPT_KEY is valid and has sufficient credits
+- Leave `CHATGPT_KEY` empty to disable ChatGPT features gracefully
 - Verify that the image data is being correctly captured and processed
 
 ### Problem: Summaries not generating

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -106,6 +106,7 @@ class TestImageProcessing(unittest.TestCase):
 
 class TestChatGPTImageComparison(unittest.TestCase):
     @patch("app.utils.image_processing.requests.post")
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
     def test_compare_images(self, mock_post):
         # Create a ChatGPTImageComparison instance
         comparison = ChatGPTImageComparison()

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -13,6 +13,7 @@ class TestPromptOptimizer(unittest.TestCase):
     @patch("app.utils.prompt_optimizer.ChatGPTImageComparison.compare_images")
     @patch("app.utils.prompt_optimizer.os.path.exists")
     @patch("app.utils.prompt_optimizer.get_screenshots_for_template")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "k")
     def test_generate_prompt_returns_caption(self, mock_get, mock_exists, mock_compare):
         mock_get.return_value = ["shot1.png", "shot2.png"]
         mock_exists.return_value = True
@@ -28,9 +29,25 @@ class TestPromptOptimizer(unittest.TestCase):
     @patch("app.utils.prompt_optimizer.ChatGPTImageComparison.compare_images")
     @patch("app.utils.prompt_optimizer.os.path.exists")
     @patch("app.utils.prompt_optimizer.get_screenshots_for_template")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "k")
     def test_generate_prompt_no_images(self, mock_get, mock_exists, mock_compare):
         mock_get.return_value = ["shot1.png"]
         mock_exists.return_value = False
+
+        original = img_proc.LLM_CAPTION_PROMPT
+        result = prompt_optimizer.generate_prompt("cam1")
+
+        self.assertEqual(result, "")
+        self.assertEqual(img_proc.LLM_CAPTION_PROMPT, original)
+        mock_compare.assert_not_called()
+
+    @patch("app.utils.prompt_optimizer.ChatGPTImageComparison.compare_images")
+    @patch("app.utils.prompt_optimizer.os.path.exists")
+    @patch("app.utils.prompt_optimizer.get_screenshots_for_template")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "")
+    def test_generate_prompt_no_key(self, mock_get, mock_exists, mock_compare):
+        mock_get.return_value = ["shot1.png"]
+        mock_exists.return_value = True
 
         original = img_proc.LLM_CAPTION_PROMPT
         result = prompt_optimizer.generate_prompt("cam1")


### PR DESCRIPTION
## Summary
- skip prompt optimization when LLM key is missing
- ensure ChatGPT image comparison handles missing key
- document that CHATGPT_KEY can be left empty
- adjust tests for new behaviour

## Testing
- `pre-commit run --all-files` *(fails: KeyboardInterrupt)*
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6845e1fde6d483338897ab53e9d805bd