### PR TITLE
Add blank clip fallback

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2629,6 +2629,9 @@ def init_routes(app: Flask) -> None:
         video_archiver.compile_videos(temp_list_path, output_tmp)
         os.unlink(temp_list_path)
 
+        if not os.path.exists(output_final):
+            video_archiver.create_blank_video(duration, output_final)
+
         if os.path.exists(output_final):
             return send_file(output_final)
 

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -252,6 +252,34 @@ def compile_videos(input_file, output_file):
             os.unlink(output_file)
 
 
+def create_blank_video(duration: int, output_file: str) -> bool:
+    """Create a blank MP4 video of ``duration`` seconds."""
+
+    command = [
+        FFMPEG_PATH,
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=black:s=640x360:d={duration}",
+        "-c:v",
+        "libx264",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        "-y",
+        os.path.abspath(output_file),
+    ]
+    try:
+        run_ffmpeg(command)
+        return os.path.exists(output_file) and os.path.getsize(output_file) > 0
+    except Exception as e:  # pragma: no cover - ffmpeg errors logged
+        logging.error("Failed to create blank video: %s", e)
+        if os.path.exists(output_file):
+            os.unlink(output_file)
+    return False
+
+
 def get_video_duration(video_path):
 
     if not os.path.exists(video_path):  # raise?

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,7 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. Use the optional `duration` query parameter to set the length in seconds (defaults to `DEFAULT_CLIP_DURATION`). This endpoint now powers the dashboard thumbnail loops.
+- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. If no footage exists a blank clip of `DEFAULT_CLIP_DURATION` seconds is returned. Use the optional `duration` query parameter to override the length. This endpoint powers the dashboard thumbnail loops.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,8 +249,9 @@ source. That could cause extra network requests and confusing behavior.
 ### Problem: Loop video or the "All" camera shows `Format error`
 
 This typically happens when Glimpser cannot locate a recent MP4 clip for a
-camera. The player attempts to load the file and the browser reports a _Format
-error_ because the response is missing or invalid.
+camera. The player attempts to load the file and the browser reports a
+_Format error_ because the response is missing or invalid. The server now
+falls back to a two‑minute blank clip so playback never fails entirely.
 
 **Solution:**
 

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+import tempfile
 from flask import Flask
 from unittest.mock import patch
 
@@ -48,6 +49,38 @@ class TestClipRoute(unittest.TestCase):
         )
         mock_compile.assert_called_once()
         mock_send.assert_called_with(expected)
+
+    @patch("app.routes.video_archiver.create_blank_video")
+    @patch("app.routes.video_archiver.compile_videos", return_value=None)
+    @patch("app.routes.video_archiver.get_video_duration", return_value=60)
+    def test_clip_blank_fallback(
+        self,
+        mock_duration,
+        mock_compile,
+        mock_blank,
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            camera_path = os.path.join(tmpdir, "cam1")
+            os.makedirs(camera_path)
+            with (
+                patch("app.routes.VIDEO_DIRECTORY", tmpdir),
+                patch("glob.glob", return_value=[]),
+                patch("os.path.getmtime", return_value=1),
+                patch("app.routes.send_file") as mock_send,
+            ):
+
+                def fake_blank(duration, output):
+                    with open(output, "w"):
+                        pass
+                    return True
+
+                mock_blank.side_effect = fake_blank
+                resp = self.client.get("/clip/cam1")
+
+        self.assertEqual(resp.status_code, 200)
+        expected = os.path.join(tmpdir, "cam1", "clip.mp4")
+        mock_send.assert_called_with(expected)
+        mock_blank.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return blank clip when no footage exists
- document blank clip behavior
- test the `/clip` blank fallback

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e7e867488333a4e58e62ddd59124