### PR TITLE
Add status legend filtering and responsive search

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -232,7 +232,13 @@ h2 {
 }
 
 #search-input {
-  width: clamp(120px, 15vw, 180px);
+  width: clamp(80px, 10vw, 140px);
+  transition: width 0.2s;
+}
+
+#search-input:focus,
+#search-input:not(:placeholder-shown) {
+  width: clamp(120px, 15vw, 200px);
 }
 
 #play-all-button,
@@ -549,6 +555,16 @@ body.dark-mode {
   display: flex;
   align-items: center;
   gap: 5px;
+  cursor: pointer;
+}
+
+.status-item.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.status-item.active .status-box {
+  box-shadow: 0 0 0 2px currentcolor;
 }
 
 .status-box {

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -267,6 +267,7 @@ export function initTemplates() {
     setupSorting();
     setupSortMenu();
     setupCaptionsFilter();
+    setupStatusFilter();
     updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
     applyCaptionVisibility(parseFloat(slider?.value || "0"));
@@ -796,6 +797,8 @@ export async function loadTemplates() {
     window.dispatchEvent(
       new CustomEvent("templatesLoaded", { detail: { count: templateCount } }),
     );
+    updateStatusCounts();
+    applyStatusFilter();
     applyCaptionVisibility(parseFloat(sliderElement?.value || "0"));
   } catch (error) {
     console.error("Error loading templates:", error);
@@ -934,4 +937,64 @@ export function setupCaptionsFilter() {
       if (endInput) endInput.value = "";
       filter();
     });
+}
+
+let activeStatus = null;
+
+export function applyStatusFilter() {
+  document
+    .querySelectorAll("#template-list .video-container")
+    .forEach((box) => {
+      const wrapper = box.closest(".templateDiv");
+      if (!wrapper) return;
+      const isRecent = box.classList.contains("recent-screenshot");
+      const isError = box.classList.contains("template-error");
+      let show = true;
+      if (activeStatus === "recent") show = isRecent;
+      else if (activeStatus === "error") show = isError;
+      wrapper.style.display = show ? "" : "none";
+    });
+}
+
+export function updateStatusCounts() {
+  const legend = document.getElementById("status-legend");
+  if (!legend) return;
+  const recent = document.querySelectorAll(
+    "#template-list .video-container.recent-screenshot",
+  ).length;
+  const error = document.querySelectorAll(
+    "#template-list .video-container.template-error",
+  ).length;
+  legend
+    .querySelector('[data-status="recent"]')
+    ?.classList.toggle("disabled", recent === 0);
+  legend
+    .querySelector('[data-status="error"]')
+    ?.classList.toggle("disabled", error === 0);
+}
+
+export function setupStatusFilter() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const legend = document.getElementById("status-legend");
+    if (!legend) return;
+    legend.querySelectorAll(".status-item").forEach((item) => {
+      item.dataset.status ||= item.textContent.trim().toLowerCase();
+      item.addEventListener("click", () => {
+        if (item.classList.contains("disabled")) return;
+        const status = item.dataset.status;
+        if (activeStatus === status) {
+          activeStatus = null;
+          item.classList.remove("active");
+        } else {
+          activeStatus = status;
+          legend
+            .querySelectorAll(".status-item")
+            .forEach((i) => i.classList.toggle("active", i === item));
+        }
+        applyStatusFilter();
+      });
+    });
+    updateStatusCounts();
+    window.addEventListener("templatesLoaded", updateStatusCounts);
+  });
 }

--- a/docs/border_legend.md
+++ b/docs/border_legend.md
@@ -16,3 +16,6 @@ Search, width slider and legend controls now start collapsed in a dropdown to ke
 The dropdown closes automatically after a few seconds without mouse or scroll activity.
 On desktop screens the **Controls** button itself stays hidden until you move the
 mouse, fading out again when idle just like the toolbar on template pages.
+
+Clicking **Recent** or **Error** in the legend now filters the dashboard to only show
+those cameras. The legend entries gray out when no tiles match.

--- a/tests/js/status_filter.test.js
+++ b/tests/js/status_filter.test.js
@@ -1,0 +1,55 @@
+import { jest } from "@jest/globals";
+
+const html = `
+  <div id="status-legend">
+    <span class="status-item" data-status="recent"><span class="status-box recent"></span>Recent</span>
+    <span class="status-item" data-status="error"><span class="status-box error"></span>Error</span>
+  </div>
+  <div id="template-list">
+    <div class="templateDiv"><div class="video-container recent-screenshot"></div></div>
+    <div class="templateDiv"><div class="video-container template-error"></div></div>
+    <div class="templateDiv"><div class="video-container"></div></div>
+  </div>
+`;
+
+document.body.innerHTML = html;
+
+let setupStatusFilter;
+let applyStatusFilter;
+let updateStatusCounts;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/templates.js");
+  setupStatusFilter = mod.setupStatusFilter;
+  applyStatusFilter = mod.applyStatusFilter;
+  updateStatusCounts = mod.updateStatusCounts;
+});
+
+describe("status legend filter", () => {
+  beforeEach(() => {
+    document.body.innerHTML = html;
+  });
+
+  test("updateStatusCounts disables entries with no matches", () => {
+    document
+      .querySelectorAll(".video-container")
+      .forEach((c) => (c.className = "video-container"));
+    updateStatusCounts();
+    const recent = document.querySelector('[data-status="recent"]');
+    const error = document.querySelector('[data-status="error"]');
+    expect(recent.classList.contains("disabled")).toBe(true);
+    expect(error.classList.contains("disabled")).toBe(true);
+  });
+
+  test("click filters visible templates", () => {
+    setupStatusFilter();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    const recentItem = document.querySelector('[data-status="recent"]');
+    recentItem.click();
+    const visible = Array.from(
+      document.querySelectorAll(".templateDiv"),
+    ).filter((d) => d.style.display !== "none");
+    expect(visible).toHaveLength(1);
+    expect(visible[0].querySelector(".recent-screenshot")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- filter dashboard cameras when clicking Recent or Error in the legend
- animate search input width when focused
- document new legend behaviour
- test status legend filtering

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e9433ce8833380262d097da47ef6