### PR TITLE
Implement offline reconnect skeleton

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -251,10 +251,10 @@ function showError(message) {
   }, 5000);
 }
 
-function showOfflineIndicator(cameraName) {
+function showOfflineIndicator(message) {
   videoOverlay.style.display = "block";
   offlineIndicator.style.display = "block";
-  offlineMessage.textContent = `Camera ${cameraName} is currently offline`;
+  offlineMessage.textContent = message;
   loadingIndicator.style.display = "none";
   playPauseIndicator.style.display = "none";
 }
@@ -439,7 +439,7 @@ function changeCamera() {
   localStorage.setItem("liveCamera", currentCamera);
 
   if (!isConnected) {
-    showOfflineIndicator(currentCamera);
+    showOfflineIndicator(`Camera ${currentCamera} is currently offline`);
     hideLoadingIndicator();
     video.pause();
     video.src = "";
@@ -488,7 +488,7 @@ function updateFeed() {
   hideStreamErrorIndicator();
 
   if (!isConnected) {
-    showOfflineIndicator(currentCamera);
+    showOfflineIndicator(`Camera ${currentCamera} is currently offline`);
     hideCaptureErrorIndicator();
     hideLoadingIndicator();
     video.pause();
@@ -1357,6 +1357,46 @@ if (playButton) {
   playButton.addEventListener("click", togglePlayback);
 }
 
+// --- Offline handling ---
+let reconnectTimer = null;
+let resumeTime = 0;
+let wasPlaying = false;
+
+async function attemptReconnect() {
+  try {
+    const res = await fetch("/network_status");
+    const data = await res.json();
+    if (data.online) {
+      clearInterval(reconnectTimer);
+      reconnectTimer = null;
+      hideOfflineIndicator();
+      video.currentTime = resumeTime;
+      if (wasPlaying) {
+        safePlay(video);
+      }
+    }
+  } catch {
+    // still offline
+  }
+}
+
+function handleNetworkOffline() {
+  wasPlaying = !video.paused;
+  resumeTime = video.currentTime;
+  video.pause();
+  showOfflineIndicator("Offline. Reconnecting...");
+  if (!reconnectTimer) {
+    reconnectTimer = setInterval(attemptReconnect, 5000);
+  }
+}
+
+async function handleNetworkOnline() {
+  await attemptReconnect();
+}
+
+window.addEventListener("offline", handleNetworkOffline);
+window.addEventListener("online", handleNetworkOnline);
+
 // Allow pausing/resuming the video by clicking anywhere on the player
 video.addEventListener("click", togglePlayback);
 
@@ -1402,4 +1442,9 @@ function handleTouchEnd(event) {
 document.addEventListener("touchstart", handleTouchStart, { passive: true });
 document.addEventListener("touchend", handleTouchEnd, { passive: true });
 
-export { updateFrameTimestamp, getCameraNames };
+export {
+  updateFrameTimestamp,
+  getCameraNames,
+  handleNetworkOffline,
+  handleNetworkOnline,
+};

--- a/tests/js/network_reconnect.test.js
+++ b/tests/js/network_reconnect.test.js
@@ -1,0 +1,72 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container"></div>
+  <video id="live-video"></video>
+  <img id="live-image" />
+  <div id="template-details"></div>
+  <div id="speed-container"></div>
+  <input id="speed-slider" value="0" />
+  <span id="speed-value"></span>
+  <div id="video-overlay"></div>
+  <div id="loading-indicator"></div>
+  <div id="play-pause-indicator"></div>
+  <div id="offline-indicator"></div>
+  <div id="offline-message"></div>
+  <div id="capture-error-indicator"></div>
+  <div id="capture-error-message"></div>
+  <div id="stream-error-indicator"></div>
+  <div id="stream-error-message"></div>
+  <div id="error-message"></div>
+  <button id="play-pause"></button>
+  <div id="toggle-details"></div>
+  <input id="seek-bar" />
+  <div id="jog-shuttle"></div>
+  <select id="group-selector"></select>
+  <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
+`;
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: jest.fn(),
+});
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: jest.fn(() => Promise.resolve()),
+});
+
+let handleNetworkOffline;
+let handleNetworkOnline;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/live.js");
+  handleNetworkOffline = mod.handleNetworkOffline;
+  handleNetworkOnline = mod.handleNetworkOnline;
+});
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({ json: () => Promise.resolve({ online: true }) }),
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.getElementById("offline-indicator").style.display = "none";
+  document.getElementById("offline-message").textContent = "";
+});
+
+test("shows offline overlay and resumes when back online", async () => {
+  const video = document.getElementById("live-video");
+  video.currentTime = 5;
+  handleNetworkOffline();
+  expect(document.getElementById("offline-indicator").style.display).toBe(
+    "block",
+  );
+  expect(document.getElementById("offline-message").textContent).toBe(
+    "Offline. Reconnecting...",
+  );
+  await handleNetworkOnline();
+  expect(fetch).toHaveBeenCalledWith("/network_status");
+  expect(document.getElementById("offline-indicator").style.display).toBe(
+    "none",
+  );
+});


### PR DESCRIPTION
## Summary
- handle offline events in the live view
- reconnect the video player once network returns
- test reconnect logic

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea995720833391951b8552bab2e4