### PR TITLE
Improve edit template modal layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1040,6 +1040,7 @@ a {
 #template-form label,
 #edit-template label {
   color: var(--form-text-color);
+  font-weight: 600;
 }
 
 #template-form input[type="text"],
@@ -1051,6 +1052,10 @@ a {
 #edit-template input[type="number"],
 #edit-template textarea {
   padding: 5px;
+  background-color: var(--secondary-bg-color);
+  border: 1px solid var(--accent-color);
+  border-radius: 4px;
+  color: var(--text-color);
 }
 
 .form-row {
@@ -1820,14 +1825,18 @@ details > summary {
 
 .edit-template-modal-content {
   position: relative;
+  margin-top: 5vh;
+}
+
+.edit-template-container {
+  display: flow-root;
 }
 
 .edit-template-preview {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
+  float: right;
   width: 240px;
   height: 180px;
+  margin-left: 1rem;
 }
 
 .edit-template-preview img {
@@ -1835,6 +1844,7 @@ details > summary {
   height: 100%;
   object-fit: contain;
   border-radius: 4px;
+  border: 1px solid var(--accent-color);
 }
 #chat-modal .modal-content {
   width: 90%;


### PR DESCRIPTION
## Summary
- polish edit-template modal styles
- float preview thumbnail so form wraps around it
- style form controls for better visual polish

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845eafc3f5c8333bab38dd28d2ea433