### PR TITLE
Improve clip endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -14,6 +14,9 @@ import tempfile
 import time
 import uuid
 import requests
+import fcntl
+import math
+from pathlib import Path
 from datetime import datetime, timedelta
 from dateutil import tz
 
@@ -115,6 +118,50 @@ from app.utils.db import SessionLocal, engine
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 import sqlite3
 from typing import Any, Callable, Generator, Optional, List, Dict
+
+# Clip caching constants
+CACHE_TTL_SEC = 5
+SEGMENT_SEC = 10
+
+
+def _concat_copy(out: Path, parts: list[Path], clip_len: int) -> bool:
+    """Concatenate ``parts`` into ``out`` using ffmpeg copy mode."""
+
+    out_tmp = out.with_suffix(".tmp")
+    concat_payload = "\n".join(f"file '{p.as_posix()}'" for p in parts).encode()
+
+    cmd = [
+        config.FFMPEG_PATH,
+        "-nostdin",
+        "-loglevel",
+        "error",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-protocol_whitelist",
+        "file,pipe",
+        "-i",
+        "-",
+        "-t",
+        str(clip_len),
+        "-c",
+        "copy",
+        "-movflags",
+        "+faststart",
+        "-y",
+        out_tmp.as_posix(),
+    ]
+
+    try:
+        subprocess.run(cmd, input=concat_payload, timeout=20, check=True)
+        out_tmp.rename(out)
+        return True
+    except Exception as exc:  # pragma: no cover - ffmpeg failures logged
+        logging.error("FFmpeg concat failed: %s", exc)
+        out_tmp.unlink(missing_ok=True)
+        return False
+
 
 try:
     COMMIT_HASH = (
@@ -2587,7 +2634,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/clip/<string:template_name>")
     @login_required
     def serve_clip(template_name: TemplateName):
-        """Compile and return a short clip from archived footage."""
+        """Return a short clip built from recent finalized segments."""
 
         template_name = validate_template_name(template_name)
         if template_name is None:
@@ -2599,44 +2646,54 @@ def init_routes(app: Flask) -> None:
         if duration <= 0:
             abort(400, "Invalid duration")
 
-        path = os.path.join(
-            os.path.dirname(os.path.join(__file__)),
-            "..",
-            VIDEO_DIRECTORY,
-            template_name,
-        )
-        if not os.path.exists(path):
+        root = (
+            Path(__file__).resolve().parent / ".." / VIDEO_DIRECTORY / template_name
+        ).resolve()
+        if not root.is_dir():
             abort(404)
 
-        video_files = sorted(
-            glob.glob(os.path.join(path, "final_*.mp4")),
-            key=os.path.getmtime,
-            reverse=True,
+        clip_path = root / "clip.mp4"
+
+        newest_src = max(
+            root.glob("final_*.mp4"),
+            key=lambda p: p.stat().st_mtime,
+            default=None,
         )
 
-        accumulated = 0.0
-        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_list:
-            for vf in video_files:
-                dur = video_archiver.get_video_duration(vf)
-                if dur:
-                    temp_list.write(f"file '{os.path.abspath(vf)}'\n")
-                    accumulated += dur
-                    if accumulated >= duration:
-                        break
-            temp_list_path = temp_list.name
+        if (
+            clip_path.exists()
+            and newest_src
+            and clip_path.stat().st_mtime > newest_src.stat().st_mtime
+            and (time.time() - clip_path.stat().st_mtime) < CACHE_TTL_SEC
+        ):
+            return send_file(clip_path, conditional=True)
 
-        output_tmp = os.path.join(path, "clip.mp4.tmp")
-        output_final = os.path.join(path, "clip.mp4")
-        video_archiver.compile_videos(temp_list_path, output_tmp)
-        os.unlink(temp_list_path)
+        needed = math.ceil(duration / SEGMENT_SEC)
+        parts = sorted(
+            root.glob("final_*.mp4"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:needed]
 
-        if not os.path.exists(output_final):
-            video_archiver.create_blank_video(duration, output_final)
+        lock_path = root / ".clip.lock"
+        with lock_path.open("w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            if (
+                clip_path.exists()
+                and newest_src
+                and clip_path.stat().st_mtime > newest_src.stat().st_mtime
+            ):
+                return send_file(clip_path, conditional=True)
 
-        if os.path.exists(output_final):
-            return send_file(output_final)
+            if parts and _concat_copy(clip_path, parts, duration):
+                pass
+            else:
+                video_archiver.create_blank_video(duration, clip_path.as_posix())
 
-        abort(404)
+        if clip_path.exists():
+            return send_file(clip_path, conditional=True)
+
+        abort(500, "Could not create clip")
 
     @app.route("/last_screenshot/<string:template_name>")
     @login_required

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,7 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /clip/<template_name>** – Stitch together recent MP4 segments into a clip. If no footage exists a blank clip of `DEFAULT_CLIP_DURATION` seconds is returned. Use the optional `duration` query parameter to override the length. This endpoint powers the dashboard thumbnail loops.
+- **GET /clip/<template_name>** – Concatenate the latest finalized segments into a fresh clip. The response always spans the requested `duration` (default `DEFAULT_CLIP_DURATION`). When no footage exists the server returns a blank video of that length. Subsequent requests within a few seconds reuse the cached clip for speed.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 import tempfile
+from pathlib import Path
 from flask import Flask
 from unittest.mock import patch
 
@@ -23,49 +24,43 @@ class TestClipRoute(unittest.TestCase):
     def tearDown(self):
         self.login_patch.stop()
 
-    @patch("app.routes.video_archiver.compile_videos")
-    @patch("app.routes.video_archiver.get_video_duration", return_value=60)
-    @patch("glob.glob", return_value=["v1.mp4", "v2.mp4"])
-    @patch("os.path.getmtime", side_effect=[2, 1])
-    @patch("os.path.exists", return_value=True)
-    @patch("app.routes.send_file")
-    def test_clip_default(
-        self,
-        mock_send,
-        mock_exists,
-        mock_getmtime,
-        mock_glob,
-        mock_duration,
-        mock_compile,
-    ):
-        resp = self.client.get("/clip/cam1")
-        self.assertEqual(resp.status_code, 200)
-        expected = os.path.join(
-            os.path.dirname(routes.__file__),
-            "..",
-            config.VIDEO_DIRECTORY,
-            "cam1",
-            "clip.mp4",
-        )
-        mock_compile.assert_called_once()
-        mock_send.assert_called_with(expected)
+    @patch("app.routes._concat_copy")
+    def test_clip_default(self, mock_concat):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            camera_path = os.path.join(tmpdir, "cam1")
+            os.makedirs(camera_path)
+            f1 = os.path.join(camera_path, "final_1.mp4")
+            f2 = os.path.join(camera_path, "final_2.mp4")
+            open(f1, "w").close()
+            open(f2, "w").close()
+            os.utime(f1, (1, 1))
+            os.utime(f2, (2, 2))
+            with (
+                patch("app.routes.VIDEO_DIRECTORY", tmpdir),
+                patch("app.routes.send_file") as mock_send,
+            ):
 
+                def fake_concat(out, parts, clip_len):
+                    with open(out, "w"):
+                        pass
+                    return True
+
+                mock_concat.side_effect = fake_concat
+                resp = self.client.get("/clip/cam1")
+
+        self.assertEqual(resp.status_code, 200)
+        expected = Path(tmpdir, "cam1", "clip.mp4")
+        mock_send.assert_called_with(expected, conditional=True)
+        mock_concat.assert_called_once()
+
+    @patch("app.routes._concat_copy", return_value=False)
     @patch("app.routes.video_archiver.create_blank_video")
-    @patch("app.routes.video_archiver.compile_videos", return_value=None)
-    @patch("app.routes.video_archiver.get_video_duration", return_value=60)
-    def test_clip_blank_fallback(
-        self,
-        mock_duration,
-        mock_compile,
-        mock_blank,
-    ):
+    def test_clip_blank_fallback(self, mock_blank, mock_concat):
         with tempfile.TemporaryDirectory() as tmpdir:
             camera_path = os.path.join(tmpdir, "cam1")
             os.makedirs(camera_path)
             with (
                 patch("app.routes.VIDEO_DIRECTORY", tmpdir),
-                patch("glob.glob", return_value=[]),
-                patch("os.path.getmtime", return_value=1),
                 patch("app.routes.send_file") as mock_send,
             ):
 
@@ -78,8 +73,8 @@ class TestClipRoute(unittest.TestCase):
                 resp = self.client.get("/clip/cam1")
 
         self.assertEqual(resp.status_code, 200)
-        expected = os.path.join(tmpdir, "cam1", "clip.mp4")
-        mock_send.assert_called_with(expected)
+        expected = Path(tmpdir, "cam1", "clip.mp4")
+        mock_send.assert_called_with(expected, conditional=True)
         mock_blank.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- implement new clip generation logic with caching and blank fallback
- update tests for refreshed clip endpoint
- document updated `/clip` route behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845efc4638c8333a2cb8513c424d143