### PR TITLE
Fix timestamp overlay toggle

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -711,6 +711,16 @@ function updateFrameTimestamp() {
   );
 }
 
+function setTimestampVisibility(show) {
+  const container = document.querySelector(".video-container");
+  if (!container) return;
+  if (show) {
+    updateFrameTimestamp();
+  } else {
+    container.removeAttribute("data-timestamp");
+  }
+}
+
 function refreshPNG() {
   image.src =
     "/last_screenshot/" +
@@ -1140,6 +1150,7 @@ function updateSeekBar() {
     seekBar.max = video.duration || 0;
     seekBar.value = video.currentTime || 0;
   }
+  setTimestampVisibility(show);
 }
 
 function updateJogShuttle() {


### PR DESCRIPTION
## Summary
- hide timestamp overlay when scrub bar is hidden

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68461ac5f1e4833392c55667215c9ea8