### PR TITLE
Add doc for X display errors

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -404,14 +404,32 @@ def check_user_activity(timeout=10):
         return user_active
 
     # Create listeners for keyboard and mouse
-    mouse_listener = mouse.Listener(
-        on_move=on_move, on_click=on_click, on_scroll=on_scroll
-    )
-    keyboard_listener = keyboard.Listener(on_press=on_press)
+    mouse_listener = None
+    keyboard_listener = None
+    try:
+        mouse_listener = mouse.Listener(
+            on_move=on_move, on_click=on_click, on_scroll=on_scroll
+        )
+        keyboard_listener = keyboard.Listener(on_press=on_press)
 
-    # Start listeners
-    mouse_listener.start()
-    keyboard_listener.start()
+        # Start listeners
+        mouse_listener.start()
+        keyboard_listener.start()
+    except Exception as e:  # pragma: no cover - best effort
+        logging.debug(f"pynput listener failed: {e}")
+        if mouse_listener:
+            try:
+                mouse_listener.stop()
+                mouse_listener.join()
+            except Exception:
+                pass
+        if keyboard_listener:
+            try:
+                keyboard_listener.stop()
+                keyboard_listener.join()
+            except Exception:
+                pass
+        return user_active
 
     # Monitor for a defined timeout
     start_time = time.time()
@@ -421,12 +439,16 @@ def check_user_activity(timeout=10):
         time.sleep(0.1)
 
     # Stop listeners
-    mouse_listener.stop()
-    keyboard_listener.stop()
+    if mouse_listener:
+        mouse_listener.stop()
+    if keyboard_listener:
+        keyboard_listener.stop()
 
     # Ensure threads close their X connections before returning
-    mouse_listener.join()
-    keyboard_listener.join()
+    if mouse_listener:
+        mouse_listener.join()
+    if keyboard_listener:
+        keyboard_listener.join()
 
     return user_active
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -310,3 +310,18 @@ If shutdown is interrupted it can leave background threads running.
 - Calling `main.shutdown_manager.cleanup()` manually will join any remaining threads.
 - If threads still refuse to exit, call `app.utils.scheduling.stop_background_tasks()` to signal the
   metrics and logging loops to terminate.
+
+## 15. Display Connection Errors
+
+### Problem: "pynput not available" or "failed to acquire X connection"
+
+This happens when Glimpser cannot open an X display. The logs may show
+`Maximum number of clients reached` or `Can't connect to display`.
+
+**Solution:**
+
+- Ensure an X server is running and `$DISPLAY` points to it.
+- Close stray X applications or restart the display if the client limit is hit.
+- On headless systems run Glimpser with `xvfb-run` to start a temporary virtual display, e.g.
+  `xvfb-run --server-args="-screen 0 1280x720x24" python main.py`.
+- If the connection still fails, Glimpser will log the error and skip activity detection so the server stays online.


### PR DESCRIPTION
## Summary
- catch pynput errors when X display can't open
- document that Glimpser skips user activity detection if display fails

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684618d1d2048333aa4e61da2bc6fa9c