### PR TITLE
Improve offline checks for screenshots

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -46,6 +46,7 @@ from selenium.common.exceptions import TimeoutException, WebDriverException
 from webdriver_manager.chrome import ChromeDriverManager
 import threading
 from typing import Dict
+from .network import is_system_online
 
 try:
     from pynput import mouse, keyboard
@@ -187,9 +188,16 @@ _driver_local = threading.local()
 def get_driver(opts):
     driver = getattr(_driver_local, "driver", None)
     if driver is None:
-        service = Service(ChromeDriverManager().install())
-        driver = webdriver.Chrome(service=service, options=opts)
-        _driver_local.driver = driver
+        if not is_system_online():
+            logging.warning("System offline; skipping driver setup")
+            return None
+        try:
+            service = Service(ChromeDriverManager().install())
+            driver = webdriver.Chrome(service=service, options=opts)
+            _driver_local.driver = driver
+        except Exception as exc:
+            logging.error("Failed to launch driver: %s", exc)
+            return None
     return driver
 
 
@@ -2435,6 +2443,10 @@ def capture_screenshot_and_har(
     # Quick sanity check
     if not re.match(r"^https?://", url, flags=re.IGNORECASE):
         logging.error(f"[capture_screenshot_and_har] Not a valid http/https URL: {url}")
+        return False
+
+    if not is_system_online():
+        logging.warning("System offline; skipping capture for %s", url)
         return False
 
     if timeout < 30:

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -9,3 +9,5 @@ This approach keeps the application responsive even when external services are s
 The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond.
 
 Skipped jobs are stored in the `offline_jobs` table. A background task checks connectivity every 30 seconds and re-runs any queued tasks once the system comes back online.
+
+Screenshot capture routines now call `is_system_online` before trying to download a browser driver. When offline the capture is skipped and a warning is logged instead of raising network errors.

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -30,8 +30,9 @@ class TestScreenshotCapture(unittest.TestCase):
     @patch("app.utils.screenshots.launch_headless_chrome")
     @patch("app.utils.screenshots.get_chrome_version", return_value=120)
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
     def test_capture_screenshot_success(
-        self, mock_path, mock_version, mock_launch, mock_finalize
+        self, mock_online, mock_path, mock_version, mock_launch, mock_finalize
     ):
         mock_driver = MagicMock()
         mock_launch.return_value = mock_driver
@@ -49,8 +50,9 @@ class TestScreenshotCapture(unittest.TestCase):
     @patch("app.utils.screenshots.launch_headless_chrome")
     @patch("app.utils.screenshots.get_chrome_version", return_value=120)
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
     def test_capture_screenshot_with_popup(
-        self, mock_path, mock_version, mock_launch, mock_finalize
+        self, mock_online, mock_path, mock_version, mock_launch, mock_finalize
     ):
         mock_driver = MagicMock()
         mock_launch.return_value = mock_driver
@@ -69,7 +71,8 @@ class TestScreenshotCapture(unittest.TestCase):
         mock_finalize.assert_called_once()
 
     @patch("app.utils.screenshots.webdriver.Chrome")
-    def test_capture_screenshot_failure(self, mock_chrome):
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
+    def test_capture_screenshot_failure(self, mock_online, mock_chrome):
         # Mock the Chrome driver to raise an exception
         mock_chrome.side_effect = Exception("Browser error")
 
@@ -85,8 +88,15 @@ class TestScreenshotCapture(unittest.TestCase):
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.utils.screenshots.create_placeholder")
     @patch("app.utils.screenshots.is_mostly_blank", return_value=True)
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
     def test_capture_screenshot_blank_image(
-        self, mock_blank, mock_placeholder, mock_get_path, mock_get_version, mock_launch
+        self,
+        mock_online,
+        mock_blank,
+        mock_placeholder,
+        mock_get_path,
+        mock_get_version,
+        mock_launch,
     ):
         mock_driver = MagicMock()
         mock_launch.return_value = mock_driver
@@ -116,8 +126,9 @@ class TestScreenshotCapture(unittest.TestCase):
     @patch("app.utils.screenshots.launch_headless_chrome")
     @patch("app.utils.screenshots.get_chrome_version", return_value=120)
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
     def test_capture_screenshot_with_dark_mode(
-        self, mock_path, mock_version, mock_launch, mock_finalize
+        self, mock_online, mock_path, mock_version, mock_launch, mock_finalize
     ):
         mock_driver = MagicMock()
         mock_launch.return_value = mock_driver

--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -47,6 +47,7 @@ class TestGetDriver(unittest.TestCase):
                 "app.utils.screenshots.webdriver.Chrome",
                 return_value=sentinel.driver,
             ) as mock_chrome,
+            patch("app.utils.screenshots.is_system_online", return_value=True),
         ):
             driver1 = ss.get_driver(sentinel.options)
             driver2 = ss.get_driver(sentinel.options)


### PR DESCRIPTION
## Summary
- skip driver download when system offline
- exit screenshot capture early if offline
- document offline driver handling
- update tests for offline-aware functions

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846197d7da48333ac0ff38635505f02