### PR TITLE
Unify control panels and update captions filters

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1782,7 +1782,7 @@ details > summary {
 }
 
 .caption-filters input[type="search"],
-.caption-filters input[type="date"] {
+.caption-filters input[type="range"] {
   margin-right: 0.5rem;
   padding: 4px;
 }

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -882,8 +882,8 @@ export function sortCameraTable(option) {
 
 export function setupCaptionsFilter() {
   const searchInput = document.getElementById("captions-search");
-  const startInput = document.getElementById("caption-start");
-  const endInput = document.getElementById("caption-end");
+  const rangeInput = document.getElementById("caption-range");
+  const rangeLabel = document.getElementById("caption-range-label");
   const clearBtn = document.getElementById("caption-clear");
   const rows = document.querySelectorAll("#captions-table tbody tr");
 
@@ -914,9 +914,10 @@ export function setupCaptionsFilter() {
 
   const filter = () => {
     const term = searchInput.value.toLowerCase().trim();
-    const start =
-      startInput && startInput.value ? new Date(startInput.value) : null;
-    const end = endInput && endInput.value ? new Date(endInput.value) : null;
+    const days = rangeInput ? parseInt(rangeInput.value, 10) : NaN;
+    const start = Number.isFinite(days)
+      ? new Date(Date.now() - days * 86400000)
+      : null;
 
     rows.forEach((row) => {
       const timeElem = row.querySelector("td:first-child span");
@@ -925,8 +926,6 @@ export function setupCaptionsFilter() {
       let show = true;
       if (term && !text.includes(term)) show = false;
       if (start && rowDate && rowDate < start) show = false;
-      if (end && rowDate && rowDate > new Date(end.getTime() + 86400000 - 1))
-        show = false;
       row.style.display = show ? "" : "none";
       const captionCell = row.querySelector("td:nth-child(2)");
       if (show) highlight(captionCell, term);
@@ -937,13 +936,16 @@ export function setupCaptionsFilter() {
   };
 
   searchInput.addEventListener("input", filter);
-  if (startInput) startInput.addEventListener("change", filter);
-  if (endInput) endInput.addEventListener("change", filter);
+  if (rangeInput) {
+    rangeInput.addEventListener("input", () => {
+      if (rangeLabel) rangeLabel.textContent = `Last ${rangeInput.value} days`;
+    });
+    rangeInput.addEventListener("change", filter);
+  }
   if (clearBtn)
     clearBtn.addEventListener("click", () => {
       searchInput.value = "";
-      if (startInput) startInput.value = "";
-      if (endInput) endInput.value = "";
+      if (rangeInput) rangeInput.value = "7";
       filter();
     });
 }

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -39,70 +39,16 @@ block content %}
   </div>
 
   <div id="prompts-tab" class="tab-content active">
-    <div id="controls-wrapper" class="filter-controls closed">
-      <button id="controls-toggle" type="button">Search &amp; Filters</button>
-      <div class="controls-inner">
-        <label for="search-input" title="Search by name or group"
-          >Search:</label
-        >
-        <input
-          type="search"
-          id="search-input"
-          placeholder="Search cameras or groups"
-          title="Enter search terms"
-        />
-
-        <label for="filter-column" title="Metric to filter by">Metric:</label>
-        <select id="filter-column" title="Select metric">
-          <option value="">All</option>
-          <option value="screenshot_count">Shots</option>
-          <option value="video_count">Videos</option>
-          <option value="storage_usage">Storage</option>
-          <option value="llm_response_count">LLM Resp</option>
-          <option value="llm_cost_estimate">LLM Cost</option>
-        </select>
-        <input
-          type="text"
-          id="filter-value"
-          placeholder="Minimum"
-          title="Minimum value or text"
-        />
-        <label for="cost-start" title="Start date for cost">From:</label>
-        <input
-          type="date"
-          id="cost-start"
-          title="Cost start"
-          value="{{ cost_start or '' }}"
-        />
-        <label for="cost-end" title="End date for cost">To:</label>
-        <input
-          type="date"
-          id="cost-end"
-          title="Cost end"
-          value="{{ cost_end or '' }}"
-        />
-        <button id="apply-filter" type="button" title="Filter table rows">
-          Filter
-        </button>
-        <input
-          type="range"
-          id="grid-width-slider"
-          min="50"
-          max="3840"
-          value="360"
-          title="Adjust thumbnail width"
-        />
-        {{ status_legend() }}
-        <label for="sort-date" title="Sort camera table">Sort:</label>
-        <select id="sort-date" title="Sort camera table">
-          <option value="">Default</option>
-          <option value="last_desc">Last &darr;</option>
-          <option value="last_asc">Last &uarr;</option>
-          <option value="next_asc">Next &uarr;</option>
-          <option value="next_desc">Next &darr;</option>
-        </select>
-      </div>
-    </div>
+    {% call template_controls() %}
+    <label for="sort-date" title="Sort camera table">Sort:</label>
+    <select id="sort-date" title="Sort camera table">
+      <option value="">Default</option>
+      <option value="last_desc">Last &darr;</option>
+      <option value="last_asc">Last &uarr;</option>
+      <option value="next_asc">Next &uarr;</option>
+      <option value="next_desc">Next &darr;</option>
+    </select>
+    {% endcall %}
 
     <h2>Camera Notes</h2>
     <div id="template-list">
@@ -196,10 +142,9 @@ block content %}
         placeholder="Search captions or time"
         title="Filter captions"
       />
-      <label for="caption-start">From:</label>
-      <input type="date" id="caption-start" title="Start date" />
-      <label for="caption-end">To:</label>
-      <input type="date" id="caption-end" title="End date" />
+      <label for="caption-range">Range:</label>
+      <input type="range" id="caption-range" min="1" max="30" value="7" />
+      <span id="caption-range-label">Last 7 days</span>
       <button id="caption-clear" type="button" title="Clear filters">
         Clear
       </button>

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -30,4 +30,53 @@ confirm='Confirm', cancel='Cancel') -%}
   <div class="card-header">{{ title }}</div>
   <div class="card-body">{{ caller() }}</div>
 </div>
+{%- endmacro %} {%- macro template_controls() -%}
+<div id="controls-wrapper">
+  <section id="template-controls">
+    {{ caller() }}
+    <input
+      type="text"
+      id="search-input"
+      placeholder="Search cameras"
+      title="Enter search terms"
+    />
+    <input
+      type="range"
+      id="grid-width-slider"
+      min="50"
+      max="3840"
+      value="360"
+      title="Adjust the width of the template grid"
+    />
+    {{ status_legend() }}
+    <button
+      id="caption-toggle"
+      class="settings-icon"
+      aria-label="Toggle caption overlays"
+      title="Toggle caption overlays"
+    >
+      <svg
+        class="w-5 h-5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1Zm-11 8.5h-2v3h2a1.5 1.5 0 1 0 0-3Zm7 0h-2v3h2a1.5 1.5 0 1 0 0-3Z"
+        />
+      </svg>
+    </button>
+    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
+    <button
+      id="live-all-button"
+      class="hidden"
+      title="Return to latest screenshot"
+    >
+      Live
+    </button>
+  </section>
+</div>
 {%- endmacro %}

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,54 +1,5 @@
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
-block content %}
-<div id="controls-wrapper" class="closed">
-  <div id="template-controls">
-    <div id="search-container">
-      <input
-        type="text"
-        id="search-input"
-        placeholder="Search cameras"
-        title="Enter search terms"
-      />
-    </div>
-    <input
-      type="range"
-      id="grid-width-slider"
-      min="50"
-      max="3840"
-      value="360"
-      title="Adjust the width of the template grid"
-    />
-    {{ status_legend() }}
-    <button
-      id="caption-toggle"
-      class="settings-icon"
-      aria-label="Toggle caption overlays"
-      title="Toggle caption overlays"
-    >
-      <svg
-        class="w-5 h-5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        aria-hidden="true"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1Zm-11 8.5h-2v3h2a1.5 1.5 0 1 0 0-3Zm7 0h-2v3h2a1.5 1.5 0 1 0 0-3Z"
-        />
-      </svg>
-    </button>
-    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-    <button
-      id="live-all-button"
-      style="display: none"
-      title="Return to latest screenshot"
-    >
-      Live
-    </button>
-  </div>
-</div>
+{% extends 'base.html' %} {% from 'components.html' import template_controls %}
+{% block content %} {% call template_controls() %}{% endcall %}
 <div
   id="template-list"
   title="List of all templates"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,55 +1,7 @@
 <!-- app/templates/index.html -->
 
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
-block content %}
-
-<div id="controls-wrapper">
-  <section id="template-controls">
-    <input
-      type="text"
-      id="search-input"
-      placeholder="Search cameras"
-      title="Enter search terms"
-    />
-    <input
-      type="range"
-      id="grid-width-slider"
-      min="50"
-      max="3840"
-      value="360"
-      title="Adjust the width of the template grid"
-    />
-    {{ status_legend() }}
-    <button
-      id="caption-toggle"
-      class="settings-icon"
-      aria-label="Toggle caption overlays"
-      title="Toggle caption overlays"
-    >
-      <svg
-        class="w-5 h-5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.5"
-        aria-hidden="true"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M21 4H3a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V5a1 1 0 0 0-1-1Zm-11 8.5h-2v3h2a1.5 1.5 0 1 0 0-3Zm7 0h-2v3h2a1.5 1.5 0 1 0 0-3Z"
-        />
-      </svg>
-    </button>
-    <button id="play-all-button" title="Play/Stop all videos">Play All</button>
-    <button
-      id="live-all-button"
-      style="display: none"
-      title="Return to latest screenshot"
-    >
-      Live
-    </button>
-  </section>
-</div>
+{% extends 'base.html' %} {% from 'components.html' import template_controls %}
+{% block content %} {% call template_controls() %}{% endcall %}
 
 <section id="template-list-section">
   <div


### PR DESCRIPTION
## Summary
- add `template_controls` macro for shared panel
- use the macro on index, groups and captions page
- swap captions date fields for a range slider
- handle range slider in JS
- adjust caption filter styles

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68461ce1b5908333b4a5a45e4e06c136