### PR TITLE
Improve cost screen layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1721,7 +1721,8 @@ body.advanced-enabled .advanced-only {
 
 .captions-table,
 .camera-table,
-.settings-table {
+.settings-table,
+.cost-table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 20px;
@@ -1732,27 +1733,32 @@ body.advanced-enabled .advanced-only {
 .camera-table th,
 .camera-table td,
 .settings-table th,
-.settings-table td {
+.settings-table td,
+.cost-table th,
+.cost-table td {
   padding: 8px;
   border: 1px solid var(--table-border-color);
 }
 
 .captions-table th,
 .camera-table th,
-.settings-table th {
+.settings-table th,
+.cost-table th {
   background-color: var(--table-header-bg-color);
 }
 
 /* Indicate sortable KPI columns */
 .camera-table th.sortable,
 .feed-status th.sortable,
-.captions-table th.sortable {
+.captions-table th.sortable,
+.cost-table th.sortable {
   cursor: pointer;
 }
 
 .camera-table th.sortable::after,
 .feed-status th.sortable::after,
-.captions-table th.sortable::after {
+.captions-table th.sortable::after,
+.cost-table th.sortable::after {
   content: " \2195";
   font-size: 0.8em;
   opacity: 0.6;
@@ -1764,11 +1770,13 @@ details > summary {
   margin: 1rem 0;
 }
 
-.captions-table tr:nth-child(even) {
+.captions-table tr:nth-child(even),
+.cost-table tr:nth-child(even) {
   background-color: var(--table-row-alt-bg-color);
 }
 
-.captions-table tr:hover {
+.captions-table tr:hover,
+.cost-table tr:hover {
   background-color: var(--table-hover-bg-color);
 }
 

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -1,5 +1,21 @@
 import { setupTableSorting } from "./templates.js";
 
+export function groupSmallValues(rows, limit = 15) {
+  if (rows.length <= limit) return rows;
+  const sorted = [...rows].sort((a, b) => a.cost - b.cost);
+  const bottom = sorted.slice(0, limit);
+  const other = bottom.reduce(
+    (acc, r) => {
+      acc.tokens += r.tokens;
+      acc.cost += r.cost;
+      return acc;
+    },
+    { name: "Other", tokens: 0, cost: 0 },
+  );
+  const remaining = sorted.slice(limit).sort((a, b) => b.cost - a.cost);
+  return [...remaining, other];
+}
+
 export function initCosts() {
   document.addEventListener("DOMContentLoaded", () => {
     const dataEl = document.getElementById("cost-data");
@@ -12,16 +28,15 @@ export function initCosts() {
 
     const render = (rows) => {
       tbody.innerHTML = "";
-      const labels = [];
-      const values = [];
       for (const row of rows) {
         const tr = document.createElement("tr");
         tr.innerHTML = `<td>${row.name}</td><td data-value="${row.tokens}">${row.tokens}</td><td data-value="${row.cost}">$${row.cost.toFixed(2)}</td>`;
         tbody.appendChild(tr);
-        labels.push(row.name);
-        values.push(row.cost);
       }
       if (!ctx) return;
+      const grouped = groupSmallValues(rows);
+      const labels = grouped.map((r) => r.name);
+      const values = grouped.map((r) => r.cost);
       const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
       const chartData = {
         labels,
@@ -80,17 +95,23 @@ export function initCostSummary(startTime) {
 
     const render = (data) => {
       tbody.innerHTML = "";
-      const labels = [];
-      const values = [];
+      const rows = [];
       for (const name in data) {
         const info = data[name];
-        const row = document.createElement("tr");
-        row.innerHTML = `<td>${name}</td><td>${info.cost}</td>`;
-        tbody.appendChild(row);
-        labels.push(name);
-        values.push(parseFloat(info.cost.replace("$", "")));
+        const row = {
+          name,
+          tokens: info.tokens ?? 0,
+          cost: parseFloat(info.cost.replace("$", "")),
+        };
+        rows.push(row);
+        const tr = document.createElement("tr");
+        tr.innerHTML = `<td>${name}</td><td>${info.cost}</td>`;
+        tbody.appendChild(tr);
       }
       if (!ctx) return;
+      const grouped = groupSmallValues(rows);
+      const labels = grouped.map((r) => r.name);
+      const values = grouped.map((r) => r.cost);
       const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
       const chartData = {
         labels,

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -11,7 +11,9 @@ slider to view recent spending.
 An additional **LLM Cost Summary** page now provides a date range picker to
 review costs for a specific period. Use the **Since Last Restart** shortcut to
 fill the start date with the server start time. A pie chart shows how costs are
-distributed across templates.
+distributed across templates. When more than 15 templates are present, the chart
+automatically groups the least expensive templates into a single **Other** slice
+to remain legible.
 
 ## LLM Response Cache
 

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -9,9 +9,12 @@ document.body.innerHTML = `
 `;
 
 let initCosts;
+let groupSmallValues;
 
 beforeAll(async () => {
-  ({ initCosts } = await import("../../app/static/js/costs.js"));
+  ({ initCosts, groupSmallValues } = await import(
+    "../../app/static/js/costs.js"
+  ));
 });
 
 global.fetch = jest.fn(() =>
@@ -35,4 +38,17 @@ test("slider triggers fetch", async () => {
   slider.dispatchEvent(new Event("change"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("groups bottom rows", () => {
+  const rows = Array.from({ length: 20 }, (_, i) => ({
+    name: `cam${i}`,
+    tokens: 1,
+    cost: i,
+  }));
+  const grouped = groupSmallValues(rows, 15);
+  expect(grouped.length).toBe(6); // 5 top + Other
+  const other = grouped[grouped.length - 1];
+  expect(other.name).toBe("Other");
+  expect(other.cost).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- group low-cost entries under 'Other' for charts
- keep cost table sortable and style it like other tables
- document new grouping behaviour
- add tests for grouping

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68461df3a380833384faa54590f4ec21