### PR TITLE
Handle clip padding with blank video

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2673,6 +2673,13 @@ def init_routes(app: Flask) -> None:
             key=lambda p: p.stat().st_mtime,
             reverse=True,
         )[:needed]
+        parts = sorted(parts, key=lambda p: p.stat().st_mtime)
+
+        blank_duration = duration - len(parts) * SEGMENT_SEC
+        blank_path = root / "blank_tmp.mp4"
+        if blank_duration > 0:
+            video_archiver.create_blank_video(blank_duration, blank_path.as_posix())
+            parts = [blank_path] + parts
 
         lock_path = root / ".clip.lock"
         with lock_path.open("w") as lock_fd:
@@ -2688,6 +2695,9 @@ def init_routes(app: Flask) -> None:
                 pass
             else:
                 video_archiver.create_blank_video(duration, clip_path.as_posix())
+
+        if blank_path.exists():
+            blank_path.unlink(missing_ok=True)
 
         if clip_path.exists():
             return send_file(clip_path, conditional=True)

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -24,8 +24,9 @@ class TestClipRoute(unittest.TestCase):
     def tearDown(self):
         self.login_patch.stop()
 
+    @patch("app.routes.video_archiver.create_blank_video")
     @patch("app.routes._concat_copy")
-    def test_clip_default(self, mock_concat):
+    def test_clip_default(self, mock_concat, mock_blank):
         with tempfile.TemporaryDirectory() as tmpdir:
             camera_path = os.path.join(tmpdir, "cam1")
             os.makedirs(camera_path)
@@ -40,6 +41,13 @@ class TestClipRoute(unittest.TestCase):
                 patch("app.routes.send_file") as mock_send,
             ):
 
+                def fake_blank(duration, output):
+                    with open(output, "w"):
+                        pass
+                    return True
+
+                mock_blank.side_effect = fake_blank
+
                 def fake_concat(out, parts, clip_len):
                     with open(out, "w"):
                         pass
@@ -52,6 +60,7 @@ class TestClipRoute(unittest.TestCase):
         expected = Path(tmpdir, "cam1", "clip.mp4")
         mock_send.assert_called_with(expected, conditional=True)
         mock_concat.assert_called_once()
+        mock_blank.assert_called_once()
 
     @patch("app.routes._concat_copy", return_value=False)
     @patch("app.routes.video_archiver.create_blank_video")
@@ -75,7 +84,7 @@ class TestClipRoute(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         expected = Path(tmpdir, "cam1", "clip.mp4")
         mock_send.assert_called_with(expected, conditional=True)
-        mock_blank.assert_called_once()
+        self.assertEqual(mock_blank.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prepend blank video before recent segments for `/clip` route
- adjust tests for new behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68462047b18c8333837b73cda59853b2