### PR TITLE
Improve prompt accessibility

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -156,12 +156,24 @@ block content %}
               <form id="form-{{ camera }}" class="notes-form caption-box">
                 <div class="chat-box">
                   <div class="chat-prompt">
-                    <textarea id="notes-{{ camera }}" class="notes-textarea">
+                    <label for="notes-{{ camera }}">Prompt</label>
+                    <textarea
+                      id="notes-{{ camera }}"
+                      class="notes-textarea"
+                      placeholder="Edit caption prompt"
+                    >
 {{ template_details[camera]['notes'] }}</textarea
                     >
                   </div>
                   <div class="chat-response">
-                    <div class="last-caption">
+                    <label id="last-caption-label-{{ camera }}"
+                      >Last caption</label
+                    >
+                    <div
+                      id="last-caption-{{ camera }}"
+                      class="last-caption"
+                      aria-labelledby="last-caption-label-{{ camera }}"
+                    >
                       {{ template_details[camera]['last_caption'] }}
                     </div>
                   </div>

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -19,4 +19,6 @@ the dark background.
 
 The captions page uses the same theme variables. Prompt and response fields now
 inherit `--form-bg-color` and `--form-text-color` so text remains legible when
-switching themes.
+switching themes. Each caption row labels the prompt and last caption so the
+conversation thread is obvious, and the prompt textarea shows a placeholder to
+encourage editing.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -103,6 +103,12 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIsNotNone(advanced, "advanced-toggle missing")
         self.assertEqual(advanced.get("type"), "checkbox")
 
+    def test_captions_prompt_label(self):
+        """Captions page prompt textarea should have a visible label."""
+        html = Path("app/templates/captions.html").read_text(encoding="utf-8")
+        self.assertIn("Prompt</label>", html)
+        self.assertIn("Last caption", html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show visible labels for prompt and last caption on the Captions page
- document the new caption labels in the dark mode guide
- test that labels appear in `captions.html`

## Testing
- `pre-commit run --files app/templates/captions.html docs/dark_mode.md tests/test_html_templates.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68461ebbdd4483339e9f11c84d04c4ac