### PR TITLE
UI tweaks for settings and discovery

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -381,7 +381,7 @@ EMAIL_SMTP_SERVER = get_setting("EMAIL_SMTP_SERVER", "")
 EMAIL_SMTP_PORT = get_setting("EMAIL_SMTP_PORT", "587")
 EMAIL_SMTP_TIMEOUT = int(get_setting("EMAIL_SMTP_TIMEOUT", 10))
 EMAIL_USE_TLS = get_setting("EMAIL_USE_TLS", "True")
-EMAIL_USERNAME = get_setting("EMAIL_USERNAME", "your-username")
+EMAIL_USERNAME = get_setting("EMAIL_USERNAME", "")
 EMAIL_PASSWORD = get_setting("EMAIL_PASSWORD", "")
 EMAIL_SMTP_TIMEOUT = int(get_setting("EMAIL_SMTP_TIMEOUT", "5"))
 

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -108,240 +108,229 @@
   </div>
   {% endcall %} {% call card('Add Camera') %}
   <div class="wizard-step" title="Form to add a new camera">
-    <details title="Expand to add a new camera">
-      <summary>Add Camera</summary>
-      <div id="template-form" title="Form to add a new template">
-        <form
-          id="add-template-form"
-          action="/templates"
-          method="post"
-          onsubmit="return validateForm()"
-          title="Enter details for the new template"
-        >
-          <div>
-            <label for="name" title="Name of the template"
-              >Template Name:</label
+    <div id="template-form" title="Form to add a new template">
+      <form
+        id="add-template-form"
+        action="/templates"
+        method="post"
+        onsubmit="return validateForm()"
+        title="Enter details for the new template"
+      >
+        <div>
+          <label for="name" title="Name of the template">Template Name:</label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            title="Enter a unique name for this template"
+          />
+
+          <label for="url" title="URL to monitor">URL:</label>
+          <input
+            type="url"
+            id="url"
+            name="url"
+            required
+            title="Enter the URL to monitor"
+          />
+          <span
+            id="url-status"
+            class="url-status"
+            title="URL test result"
+          ></span>
+
+          <label for="frequency" title="How often to check the URL"
+            >Frequency (minutes):</label
+          >
+          <input
+            type="number"
+            id="frequency"
+            name="frequency"
+            value="30"
+            min="1"
+            required
+            title="Enter how often to check the URL (in minutes)"
+          />
+
+          <label for="timeout" title="Maximum time to wait for a response"
+            >Timeout (seconds):</label
+          >
+          <input
+            type="number"
+            id="timeout"
+            name="timeout"
+            value="10"
+            min="1"
+            required
+            title="Enter the maximum time to wait for a response (in seconds)"
+          />
+
+          <label for="notes" title="Additional notes">Notes:</label>
+          <textarea
+            id="notes"
+            name="notes"
+            title="Enter any additional notes or comments"
+          ></textarea>
+
+          <label for="object_filter" title="Filter for specific objects"
+            >Object Filter:</label
+          >
+          <input
+            type="text"
+            id="object_filter"
+            name="object_filter"
+            title="Enter object types to filter (e.g., 'person,car')"
+          />
+
+          <label
+            for="object_confidence"
+            title="Minimum confidence for object detection"
+            >Object Confidence:</label
+          >
+          <input
+            type="number"
+            id="object_confidence"
+            name="object_confidence"
+            min="0"
+            max="1"
+            step="0.01"
+            title="Enter the minimum confidence level for object detection (0-1)"
+          />
+
+          <label for="popup_xpath">Popup XPath:</label>
+          <div class="xpath-input-container">
+            <input type="text" id="popup_xpath" name="popup_xpath" />
+            <button
+              type="button"
+              onclick="showStructuredInput('popup_xpath')"
+              title="Open structured XPath editor"
             >
-            <input
-              type="text"
-              id="name"
-              name="name"
-              required
-              title="Enter a unique name for this template"
-            />
-
-            <label for="url" title="URL to monitor">URL:</label>
-            <input
-              type="url"
-              id="url"
-              name="url"
-              required
-              title="Enter the URL to monitor"
-            />
-            <span
-              id="url-status"
-              class="url-status"
-              title="URL test result"
-            ></span>
-
-            <label for="frequency" title="How often to check the URL"
-              >Frequency (minutes):</label
-            >
-            <input
-              type="number"
-              id="frequency"
-              name="frequency"
-              value="30"
-              min="1"
-              required
-              title="Enter how often to check the URL (in minutes)"
-            />
-
-            <label for="timeout" title="Maximum time to wait for a response"
-              >Timeout (seconds):</label
-            >
-            <input
-              type="number"
-              id="timeout"
-              name="timeout"
-              value="10"
-              min="1"
-              required
-              title="Enter the maximum time to wait for a response (in seconds)"
-            />
-
-            <label for="notes" title="Additional notes">Notes:</label>
-            <textarea
-              id="notes"
-              name="notes"
-              title="Enter any additional notes or comments"
-            ></textarea>
-
-            <label for="object_filter" title="Filter for specific objects"
-              >Object Filter:</label
-            >
-            <input
-              type="text"
-              id="object_filter"
-              name="object_filter"
-              title="Enter object types to filter (e.g., 'person,car')"
-            />
-
-            <label
-              for="object_confidence"
-              title="Minimum confidence for object detection"
-              >Object Confidence:</label
-            >
-            <input
-              type="number"
-              id="object_confidence"
-              name="object_confidence"
-              min="0"
-              max="1"
-              step="0.01"
-              title="Enter the minimum confidence level for object detection (0-1)"
-            />
-
-            <label for="popup_xpath">Popup XPath:</label>
-            <div class="xpath-input-container">
-              <input type="text" id="popup_xpath" name="popup_xpath" />
-              <button
-                type="button"
-                onclick="showStructuredInput('popup_xpath')"
-                title="Open structured XPath editor"
-              >
-                Structured
-              </button>
-            </div>
-
-            <label for="dedicated_xpath">Dedicated XPath:</label>
-            <div class="xpath-input-container">
-              <input type="text" id="dedicated_xpath" name="dedicated_xpath" />
-              <button
-                type="button"
-                onclick="showStructuredInput('dedicated_xpath')"
-                title="Open structured XPath editor"
-              >
-                Structured
-              </button>
-            </div>
-
-            <label for="callback_url" title="URL for notifications"
-              >Callback URL:</label
-            >
-            <input
-              type="url"
-              id="callback_url"
-              name="callback_url"
-              title="Enter URL to receive notifications"
-            />
-
-            <label for="proxy" title="Proxy server address">Proxy:</label>
-            <input
-              type="text"
-              id="proxy"
-              name="proxy"
-              title="Enter proxy server address (optional)"
-            />
-
-            <label
-              for="auth_username"
-              title="Username for camera authentication"
-              >Username:</label
-            >
-            <input
-              type="text"
-              id="auth_username"
-              name="auth_username"
-              title="Camera username"
-            />
-
-            <label
-              for="auth_password"
-              title="Password for camera authentication"
-              >Password:</label
-            >
-            <input
-              type="password"
-              id="auth_password"
-              name="auth_password"
-              title="Camera password"
-            />
-
-            <label
-              for="groups"
-              title="Groups for the template, comma separated "
-              >Groups:</label
-            >
-            <input
-              type="text"
-              id="groups"
-              name="groups"
-              title="Enter comma-separated group names"
-            />
-
-            <label for="rollback_frames" title="Number of frames to rollback"
-              >Rollback Frames:</label
-            >
-            <input
-              type="number"
-              id="rollback_frames"
-              name="rollback_frames"
-              value="0"
-              min="0"
-              title="Enter number of frames to rollback"
-            />
+              Structured
+            </button>
           </div>
-          <br />
 
-          <div class="checkbox-row">
-            <label for="invert" title="Invert image colors">
-              <input
-                type="checkbox"
-                id="invert"
-                name="invert"
-                title="Invert colors of the captured image"
-              />
-              Invert
-            </label>
-            <label for="dark" title="Use dark mode">
-              <input
-                type="checkbox"
-                id="dark"
-                name="dark"
-                checked
-                title="Enable dark mode for the captured page"
-              />
-              Dark Mode
-            </label>
-            <label for="headless" title="Run in headless mode">
-              <input
-                type="checkbox"
-                id="headless"
-                name="headless"
-                checked
-                title="Run browser in headless mode"
-              />
-              Headless
-            </label>
-            <label for="stealth" title="Use stealth mode">
-              <input
-                type="checkbox"
-                id="stealth"
-                name="stealth"
-                title="Use stealth mode to avoid detection"
-              />
-              Stealth
-            </label>
+          <label for="dedicated_xpath">Dedicated XPath:</label>
+          <div class="xpath-input-container">
+            <input type="text" id="dedicated_xpath" name="dedicated_xpath" />
+            <button
+              type="button"
+              onclick="showStructuredInput('dedicated_xpath')"
+              title="Open structured XPath editor"
+            >
+              Structured
+            </button>
           </div>
-          <br />
 
-          <div class="form-actions">
-            <input type="submit" value="Submit" title="Submit the template" />
-          </div>
-        </form>
-      </div>
-    </details>
+          <label for="callback_url" title="URL for notifications"
+            >Callback URL:</label
+          >
+          <input
+            type="url"
+            id="callback_url"
+            name="callback_url"
+            title="Enter URL to receive notifications"
+          />
+
+          <label for="proxy" title="Proxy server address">Proxy:</label>
+          <input
+            type="text"
+            id="proxy"
+            name="proxy"
+            title="Enter proxy server address (optional)"
+          />
+
+          <label for="auth_username" title="Username for camera authentication"
+            >Username:</label
+          >
+          <input
+            type="text"
+            id="auth_username"
+            name="auth_username"
+            title="Camera username"
+          />
+
+          <label for="auth_password" title="Password for camera authentication"
+            >Password:</label
+          >
+          <input
+            type="password"
+            id="auth_password"
+            name="auth_password"
+            title="Camera password"
+          />
+
+          <label for="groups" title="Groups for the template, comma separated "
+            >Groups:</label
+          >
+          <input
+            type="text"
+            id="groups"
+            name="groups"
+            title="Enter comma-separated group names"
+          />
+
+          <label for="rollback_frames" title="Number of frames to rollback"
+            >Rollback Frames:</label
+          >
+          <input
+            type="number"
+            id="rollback_frames"
+            name="rollback_frames"
+            value="0"
+            min="0"
+            title="Enter number of frames to rollback"
+          />
+        </div>
+        <br />
+
+        <div class="checkbox-row">
+          <label for="invert" title="Invert image colors">
+            <input
+              type="checkbox"
+              id="invert"
+              name="invert"
+              title="Invert colors of the captured image"
+            />
+            Invert
+          </label>
+          <label for="dark" title="Use dark mode">
+            <input
+              type="checkbox"
+              id="dark"
+              name="dark"
+              checked
+              title="Enable dark mode for the captured page"
+            />
+            Dark Mode
+          </label>
+          <label for="headless" title="Run in headless mode">
+            <input
+              type="checkbox"
+              id="headless"
+              name="headless"
+              checked
+              title="Run browser in headless mode"
+            />
+            Headless
+          </label>
+          <label for="stealth" title="Use stealth mode">
+            <input
+              type="checkbox"
+              id="stealth"
+              name="stealth"
+              title="Use stealth mode to avoid detection"
+            />
+            Stealth
+          </label>
+        </div>
+        <br />
+
+        <div class="form-actions">
+          <input type="submit" value="Submit" title="Submit the template" />
+        </div>
+      </form>
+    </div>
   </div>
   {% endcall %}
 </div>

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -90,6 +90,16 @@
         />
       </svg>
     </a>
+    <a
+      href="/settings"
+      class="settings-icon"
+      title="Update settings"
+      aria-label="Update settings"
+    >
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
+      </svg>
+    </a>
     <div class="caption-container">
       <a
         href="/captions"
@@ -122,16 +132,6 @@
           <div class="digital-clock"></div>
         </div>
       </div>
-    </a>
-    <a
-      href="/settings"
-      class="settings-icon"
-      title="Update settings"
-      aria-label="Update settings"
-    >
-      <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
-      </svg>
     </a>
     {# login link removed from nav bar #}
   </div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -52,6 +52,16 @@
     id="settings-form"
     enctype="multipart/form-data"
   >
+    <svg
+      id="unsaved-icon"
+      width="16"
+      height="16"
+      class="unsaved-icon hidden"
+      aria-label="Unsaved changes"
+      title="Unsaved changes"
+    >
+      <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
+    </svg>
     {% for name, opts in choices.items() %}
     <datalist id="{{ name }}-list">
       {% for opt in opts %}
@@ -114,9 +124,16 @@
                 name="{{ setting.name }}"
                 value="{{ setting.value }}"
                 title="Edit value for {{ setting.name }}"
-                {% if setting.name in placeholders %}
+                {%
+                if
+                setting.name
+                in
+                placeholders
+                %}
                 placeholder="{{ placeholders[setting.name] }}"
-                {% endif %}
+                {%
+                endif
+                %}
                 {%
                 if
                 setting.name
@@ -263,18 +280,6 @@
       />
       {% endif %}
       <button type="submit" title="Save all changes">Save Changes</button>
-      <svg
-        id="unsaved-icon"
-        width="16"
-        height="16"
-        class="unsaved-icon hidden"
-        aria-label="Unsaved changes"
-        title="Unsaved changes"
-      >
-        <use
-          href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
-        />
-      </svg>
     </div>
     {% if loop.first %}
     <div id="discover-tab" class="tab-content">

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -180,6 +180,7 @@ SETTINGS_PLACEHOLDERS = {
     "EMAIL_SENDER": "your-email@example.com",
     "EMAIL_RECIPIENTS": "recipient1@example.com,recipient2@example.com",
     "EMAIL_SMTP_SERVER": "smtp.example.com",
+    "EMAIL_USERNAME": "your-username",
     "CAP_ENDPOINT": "https://alert.example.com",
     "CAP_SENDER": "glimpser@example.com",
 }

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -276,6 +276,8 @@ BOOLEAN_SETTINGS = {
     "DISCOVERY_AUTOSTART",
     "EMAIL_ENABLED",
     "EMAIL_USE_TLS",
+    "ENFORCE_DOMAIN_IN_HOST",
+    "FFMPEG_HWACCEL",
 }
 
 
@@ -306,6 +308,13 @@ def validate_setting(name: str, value: str) -> str | None:
         if level in {"DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"}:
             return level
         return None
+
+    if key == "FFMPEG_HWACCEL":
+        return (
+            "auto"
+            if val.lower() in {"true", "1", "t", "y", "yes", "on", "auto"}
+            else "False"
+        )
 
     if key in BOOLEAN_SETTINGS:
         return (


### PR DESCRIPTION
## Summary
- move unsaved indicator to top of settings form
- expose placeholders for more email fields
- support toggling domain enforcement and HW accel
- open Add Camera form by default
- place settings icon higher in the navigation

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684622ad748c8333a805fa306ba21c78