### PR TITLE
Fix captions template import

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -1,5 +1,5 @@
-{% extends 'base.html' %} {% from 'components.html' import status_legend %} {%
-block content %}
+{% extends 'base.html' %} {% from 'components.html' import status_legend,
+template_controls %} {% block content %}
 <div class="captions-page" data-latest-caption="{{ latest_caption }}">
   <script>
     function updateTemplate(templateName) {


### PR DESCRIPTION
## Summary
- ensure captions page imports the `template_controls` macro

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846247b2c2c83338ec249b237764e51