### PR TITLE
Add Jinja macro tests

### DIFF
--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -1,0 +1,29 @@
+import unittest
+from jinja2 import Environment, FileSystemLoader
+
+
+class TestJinjaMacros(unittest.TestCase):
+    """Ensure Jinja macros render expected markup."""
+
+    def setUp(self):
+        self.env = Environment(loader=FileSystemLoader("app/templates"))
+
+    def test_confirm_modal_ids(self):
+        template = self.env.get_template("components.html")
+        html = template.module.confirm_modal("remove")
+        self.assertIn('id="remove-modal"', html)
+        self.assertIn('id="remove-confirm"', html)
+        self.assertIn('id="remove-cancel"', html)
+
+    def test_card_wraps_content(self):
+        tmpl = self.env.from_string(
+            '{% from "components.html" import card %}{% call card("Title") %}Body{% endcall %}'
+        )
+        html = tmpl.render()
+        self.assertIn('<div class="card">', html)
+        self.assertIn('<div class="card-header">Title</div>', html)
+        self.assertIn('<div class="card-body">Body</div>', html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for Jinja macros to verify markup IDs
- ensure card macro wraps content

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846243de5588333a85e91322e0105f1