### PR TITLE
Improve feed status layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1763,6 +1763,7 @@ body.advanced-enabled .advanced-only {
   content: " \2195";
   font-size: 0.8em;
   opacity: 0.6;
+  padding-left: 2px;
 }
 
 details > summary {
@@ -1945,6 +1946,13 @@ details > summary {
 .feed-status td {
   padding: 6px 8px;
   border: 1px solid var(--table-border-color);
+  white-space: nowrap;
+}
+.feed-status thead th {
+  position: sticky;
+  top: 0;
+  background-color: var(--table-header-bg-color);
+  z-index: 1;
 }
 .feed-status a {
   color: var(--text-color);
@@ -1979,6 +1987,28 @@ details > summary {
 }
 .danger-icon.user {
   color: orange;
+}
+
+.danger-icon-inline,
+.camera-icon {
+  vertical-align: middle;
+  margin-right: 0.25rem;
+}
+
+.camera-icon.browser {
+  color: dodgerblue;
+}
+.camera-icon.headless-stealth,
+.camera-icon.stealth {
+  color: orange;
+}
+.camera-icon.headless {
+  color: gray;
+}
+
+.status-col {
+  width: 4rem;
+  text-align: center;
 }
 
 .unsaved-icon {

--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -208,4 +208,18 @@
     <path d="M9.5 15a2.5 2.5 0 110-6" fill="none" stroke="currentColor" stroke-width="2" />
     <path d="M14.5 15a2.5 2.5 0 110-6" fill="none" stroke="currentColor" stroke-width="2" />
   </symbol>
+  <symbol id="camera" viewBox="0 0 24 24">
+    <rect x="3" y="7" width="18" height="14" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none" />
+    <circle cx="12" cy="14" r="3" stroke="currentColor" stroke-width="2" fill="none" />
+    <rect x="7" y="3" width="10" height="4" stroke="currentColor" stroke-width="2" fill="none" />
+  </symbol>
+  <symbol id="browser" viewBox="0 0 24 24">
+    <rect x="2" y="4" width="20" height="16" rx="2" ry="2" stroke="currentColor" stroke-width="2" fill="none" />
+    <line x1="2" y1="8" x2="22" y2="8" stroke="currentColor" stroke-width="2" />
+  </symbol>
+  <symbol id="mask" viewBox="0 0 24 24">
+    <path d="M2 7s5 5 10 5 10-5 10-5v6c0 5-5 9-10 9S2 18 2 13V7z" stroke="currentColor" stroke-width="2" fill="none" />
+    <circle cx="9" cy="12" r="1" fill="currentColor" />
+    <circle cx="15" cy="12" r="1" fill="currentColor" />
+  </symbol>
 </svg>

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -78,15 +78,15 @@
 <table id="feed-status" class="feed-status">
   <thead>
     <tr>
-      <th class="sortable" data-type="string">Feed</th>
-      <th class="sortable" data-type="date">Last Image</th>
-      <th class="sortable" data-type="date">Last Caption</th>
-      <th class="sortable" data-type="number">Shots</th>
-      <th class="sortable" data-type="number">Videos</th>
-      <th class="sortable" data-type="number">Storage</th>
-      <th class="sortable" data-type="number">LLM Resp</th>
-      <th class="sortable" data-type="number">LLM Cost</th>
-      <th class="sortable" data-type="string">Status</th>
+      <th class="sortable" data-type="string" title="Camera name">Feed</th>
+      <th class="sortable" data-type="date" title="Most recent screenshot time">Last Image</th>
+      <th class="sortable" data-type="date" title="Most recent caption time">Last Caption</th>
+      <th class="sortable" data-type="number" title="Total screenshots">Shots</th>
+      <th class="sortable" data-type="number" title="Total videos">Videos</th>
+      <th class="sortable" data-type="number" title="Disk usage">Storage</th>
+      <th class="sortable" data-type="number" title="LLM responses">LLM Resp</th>
+      <th class="sortable" data-type="number" title="Estimated LLM cost">LLM Cost</th>
+      <th class="sortable status-col" data-type="string" title="Current feed status">Status</th>
     </tr>
   </thead>
   <tbody>
@@ -95,9 +95,27 @@
       class="{{ feed.status }}{% if feed.danger_reason %} danger-{{ feed.danger_reason }}{% endif %}"
     >
       <td data-label="Feed" data-value="{{ feed.name }}">
-        <a href="{{ url_for('template_details', template_name=feed.name) }}"
-          >{{ feed.name }}</a
+        <svg
+          width="12"
+          height="12"
+          class="camera-icon {{ feed.camera_type }}"
+          aria-label="{{ feed.camera_tooltip }}"
+          title="{{ feed.camera_tooltip }}"
         >
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#{% if feed.camera_type == 'browser' %}browser{% elif 'stealth' in feed.camera_type %}mask{% else %}camera{% endif %}" />
+        </svg>
+        {% if feed.danger %}
+        <svg
+          width="12"
+          height="12"
+          class="danger-icon-inline {{ feed.danger_reason or '' }}"
+          aria-label="Danger mode"
+          title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'Danger mode user active' if feed.danger_reason == 'user' else 'Danger mode' }}"
+        >
+          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
+        </svg>
+        {% endif %}
+        <a href="{{ url_for('template_details', template_name=feed.name) }}" title="View template details">{{ feed.name }}</a>
       </td>
       <td
         data-label="Last Image"
@@ -142,7 +160,7 @@
       <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
         {{ feed.llm_cost_estimate }}
       </td>
-      <td data-label="Status" data-value="{{ feed.status }}">
+      <td class="status-col" data-label="Status" data-value="{{ feed.status }}">
         {% if feed.danger_reason %}
         <svg
           width="12"

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1217,6 +1217,28 @@ def get_feed_status():
         storage_bytes = get_storage_usage_bytes(name)
         llm_responses = get_llm_response_count(name)
         llm_cost = get_llm_cost_estimate(name)
+        headless = bool(template.get("headless", True))
+        stealth = bool(template.get("stealth", False))
+        browser = bool(template.get("browser", False))
+
+        if browser:
+            camera_type = "browser"
+        elif headless and stealth:
+            camera_type = "headless-stealth"
+        elif headless:
+            camera_type = "headless"
+        elif stealth:
+            camera_type = "stealth"
+        else:
+            camera_type = "standard"
+
+        camera_tooltip = {
+            "browser": "Full browser",
+            "headless-stealth": "Headless with stealth",
+            "headless": "Headless",
+            "stealth": "Stealth",
+            "standard": "Standard",
+        }[camera_type]
 
         status = "ok"
         tooltip_parts: list[str] = []
@@ -1276,6 +1298,8 @@ def get_feed_status():
                 "last_caption_display": _humanize(last_caption),
                 "status": status,
                 "tooltip": tooltip,
+                "camera_type": camera_type,
+                "camera_tooltip": camera_tooltip,
                 "screenshot_count": shot_count,
                 "video_count": video_count,
                 "storage_usage": storage,

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -777,7 +777,7 @@ def get_llm_cost_estimate(
         tokens = entry if isinstance(entry, int) else 0
 
     cost = tokens * LLM_COST_PER_TOKEN
-    return f"${cost:.2f}"
+    return f"${cost:.3f}"
 
 
 def get_llm_cost_summary(
@@ -824,10 +824,10 @@ def get_llm_cost_summary(
                 tokens = entry
         total_tokens += tokens
         cost = tokens * LLM_COST_PER_TOKEN
-        summary.append({"name": name, "tokens": tokens, "cost": f"${cost:.2f}"})
+        summary.append({"name": name, "tokens": tokens, "cost": f"${cost:.3f}"})
 
     total_cost = total_tokens * LLM_COST_PER_TOKEN
-    return summary, total_tokens, f"${total_cost:.2f}"
+    return summary, total_tokens, f"${total_cost:.3f}"
 
 
 def update_last_screenshot_time(name: str) -> None:

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -25,7 +25,9 @@ same table appears on the _System Status_ tab under Settings so you can review
 usage metrics without leaving the configuration interface.
 
 Additional KPI columns track the number of screenshots, videos, total storage
-used, LLM responses, and estimated LLM cost for each feed.
+used, LLM responses, and estimated LLM cost for each feed. Costs now display three decimal places.
+
+The header row stays visible while scrolling so column names are always accessible.
 
 The table headers are sortable. Click a column name to reorder feeds by feed
 name, last image time, last caption time, any KPI column, or status.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -46,6 +46,7 @@ Interactive forms now include additional tooltips:
 - **Group selector** – choose a group on the live page. Selecting one reveals a second dropdown for cameras and syncs with the navigation bar.
 - **Info icon** – toggles camera metadata on the live page.
 - **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
+- **Camera type icons** – small symbols next to each feed name show whether the capture runs in a full browser, headless mode, or uses stealth.
 
 ## Dynamic Tooltips
 

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -21,8 +21,8 @@ class TestLLMCostTracking(unittest.TestCase):
     def test_record_and_get_cost(self):
         record_llm_usage("cam1", 2000)
         cost = get_llm_cost_estimate("cam1")
-        expected = 2000 * LLM_COST_PER_TOKEN
-        self.assertAlmostEqual(float(cost.strip("$")), expected, places=2)
+        expected = round(2000 * LLM_COST_PER_TOKEN, 3)
+        self.assertEqual(float(cost.strip("$")), expected)
 
     def test_cost_date_range(self):
         record_llm_usage("cam1", 1000)
@@ -35,8 +35,8 @@ class TestLLMCostTracking(unittest.TestCase):
 
         record_llm_usage("cam1", 500)
         cost = get_llm_cost_estimate("cam1", start_date="2020-01-01")
-        expected = 500 * LLM_COST_PER_TOKEN
-        self.assertAlmostEqual(float(cost.strip("$")), expected, places=2)
+        expected = round(500 * LLM_COST_PER_TOKEN, 3)
+        self.assertEqual(float(cost.strip("$")), expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_cost_summary.py
+++ b/tests/test_llm_cost_summary.py
@@ -22,8 +22,8 @@ class TestLLMCostSummary(unittest.TestCase):
             json.dump({"cam1": 500, "cam2": 1500}, f)
         summary, tokens, cost = get_llm_cost_summary()
         self.assertEqual(tokens, 2000)
-        expected_cost = 2000 * LLM_COST_PER_TOKEN
-        self.assertEqual(cost, f"${expected_cost:.2f}")
+        expected_cost = round(2000 * LLM_COST_PER_TOKEN, 3)
+        self.assertEqual(cost, f"${expected_cost:.3f}")
         self.assertEqual(len(summary), 2)
 
 


### PR DESCRIPTION
## Summary
- tweak cost formatting to show 3 decimal places
- add camera type icons and tooltips on feed status table
- make table header sticky and adjust styling
- document the new UI details
- update tests for 3-decimal costs

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684628ea660483339d66e23c6e5305ea