### PR TITLE
Fix nav settings icon position

### DIFF
--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -90,16 +90,6 @@
         />
       </svg>
     </a>
-    <a
-      href="/settings"
-      class="settings-icon"
-      title="Update settings"
-      aria-label="Update settings"
-    >
-      <svg width="20" height="20">
-        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
-      </svg>
-    </a>
     <div class="caption-container">
       <a
         href="/captions"
@@ -132,6 +122,16 @@
           <div class="digital-clock"></div>
         </div>
       </div>
+    </a>
+    <a
+      href="/settings"
+      class="settings-icon"
+      title="Update settings"
+      aria-label="Update settings"
+    >
+      <svg width="20" height="20">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#gear" />
+      </svg>
     </a>
     {# login link removed from nav bar #}
   </div>


### PR DESCRIPTION
## Summary
- place Settings gear at the end of the nav-right container

## Testing
- `pre-commit run --all-files` *(fails: `npm` not found)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462bb6a1748333bf9eb5cb8ae9465c