### PR TITLE
Add in-app docs viewer

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,8 @@ from datetime import datetime, timedelta
 from functools import wraps
 from threading import Lock, Thread
 import queue
+from markupsafe import Markup
+from markdown import markdown
 
 from flask import (
     abort,
@@ -1346,6 +1348,21 @@ def init_routes(app: Flask) -> None:
     @login_required
     def help_page():
         return render_template("help.html", page_title="Help")
+
+    @app.route("/docs/<path:filename>")
+    @login_required
+    def doc_viewer(filename: str):
+        """Render a documentation file from the docs directory."""
+        docs_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "docs")
+        )
+        doc_path = os.path.abspath(os.path.join(docs_dir, filename))
+        if not doc_path.startswith(docs_dir) or not os.path.isfile(doc_path):
+            abort(404)
+        with open(doc_path, "r", encoding="utf-8") as fh:
+            md_text = fh.read()
+        html = Markup(markdown(md_text, extensions=["extra", "toc"]))
+        return render_template("doc_view.html", content=html, page_title=filename)
 
     @app.route("/settings_help")
     @login_required

--- a/app/templates/doc_view.html
+++ b/app/templates/doc_view.html
@@ -1,0 +1,7 @@
+{% extends 'base.html' %}
+{% block content %}
+<main class="container doc-view">
+    {{ content|safe }}
+    <p><a href="{{ url_for('help_page') }}">Back to Help</a></p>
+</main>
+{% endblock %}

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -12,6 +12,7 @@
             <span class="footer-copy">&copy; <span id="current-year"></span> Glimpser. All rights reserved.</span>
             <a href='https://github.com/KristopherKubicki/glimpser/releases'>v{{VERSION}}{% if VERSION_OUTDATED %}<span title="Update available">&#9888;</span>{% endif %}</a>
             <a href="/help" title="View help documentation">Help</a>
+            <a href="/docs/index.md" title="View documentation">Docs</a>
             <a href="https://glimpser.net" target="_blank" title="Project website">About</a>
             <a href="https://github.com/KristopherKubicki/glimpser/blob/main/LICENSE.md" target="_blank" title="Software license">License</a>
         </nav>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -93,7 +93,7 @@
 
         <section class="help-section">
             <h3 class="section-title">Documentation</h3>
-            <p>See the <a href="../docs/index.md" target="_blank">docs/</a> directory for detailed guides.</p>
+            <p>Browse the <a href="{{ url_for('doc_viewer', filename='index.md') }}">in-app documentation</a> or see the <a href="../docs/index.md" target="_blank">docs/</a> directory for detailed guides.</p>
         </section>
 
         <section class="help-section">

--- a/docs/doc_viewer.md
+++ b/docs/doc_viewer.md
@@ -1,0 +1,8 @@
+# In-App Documentation Viewer
+
+You can read any guide from the `docs/` directory without leaving Glimpser.
+After logging in, visit `/docs/<filename>` in the browser. For example,
+`/docs/index.md` opens the documentation index.
+
+The viewer converts the Markdown file to HTML so you can browse the
+documentation while offline or without opening the raw files.

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -4,6 +4,8 @@ The built-in help page is accessible at the `/help` route once you log in.
 It provides step-by-step instructions for adding templates, managing
 captures, and using the command line interface. The help page is cached
 locally after you view it online so you can reference it offline.
+You can also view any guide from the `docs/` directory directly in the
+application by visiting `/docs/<filename>`.
 
 Key topics covered include:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
 - [API Resilience](api_resilience.md)
 - [OpenSSF Scorecard](scorecard.md)
+- [In-App Documentation Viewer](doc_viewer.md)
 
 ## Dashboard Time
 


### PR DESCRIPTION
## Summary
- add a `/docs/<file>` route for reading documentation in-app
- link the new route from the help page and footer
- document how to view guides using the new viewer

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462c1a6f788333944563987486c30c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an in-app documentation viewer, allowing authenticated users to browse Markdown documentation directly within the application.
  - Added a new "Docs" link to the footer for quick access to documentation.
- **Documentation**
  - Updated help and documentation pages to reference the new in-app documentation viewer and provide usage instructions.
  - Added new and updated documentation files to support the viewer and guide users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->