### PR TITLE
Add discovery status icon and tooltips

### DIFF
--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -4,6 +4,14 @@ export function initDiscoveryToggle() {
   document.addEventListener("DOMContentLoaded", () => {
     const stopBtn = document.getElementById("stop-discovery");
     const statusSpan = document.getElementById("discovery-bg-status");
+    const statusIcon = document.getElementById("discovery-bg-icon");
+    let iconBase = "";
+    if (statusIcon) {
+      const useEl = statusIcon.querySelector("use");
+      if (useEl) {
+        iconBase = useEl.getAttribute("href").split("#")[0];
+      }
+    }
     if (!statusSpan) return;
 
     const minutes = (s) => `${Math.round(s / 60)}m`;
@@ -20,6 +28,25 @@ export function initDiscoveryToggle() {
       return text;
     };
 
+    const updateIcon = (d) => {
+      if (!statusIcon) return;
+      const useEl = statusIcon.querySelector("use");
+      const colorMap = {
+        none: "grey",
+        running: "orange",
+        ready: "green",
+        error: "red",
+        stale: "grey",
+      };
+      statusIcon.style.color = colorMap[d.status] || "grey";
+      if (useEl) {
+        let symbol = "search";
+        if (d.status === "ready") symbol = "check";
+        if (d.status === "error") symbol = "alert";
+        useEl.setAttribute("href", `${iconBase}#${symbol}`);
+      }
+    };
+
     if (stopBtn) {
       stopBtn.addEventListener("click", async () => {
         const confirmStop = confirm(
@@ -29,10 +56,12 @@ export function initDiscoveryToggle() {
         try {
           const data = await fetchJson("/toggle_discovery", { method: "POST" });
           statusSpan.textContent = formatStatus(data);
+          updateIcon(data);
           stopBtn.style.display =
             data.status === "running" ? "inline-block" : "none";
         } catch (err) {
           statusSpan.textContent = "error";
+          if (statusIcon) statusIcon.style.color = "red";
           alert("Unable to stop discovery.");
         }
       });
@@ -42,6 +71,7 @@ export function initDiscoveryToggle() {
       fetchJson("/discovery_status")
         .then((data) => {
           statusSpan.textContent = formatStatus(data);
+          updateIcon(data);
           if (stopBtn) {
             stopBtn.style.display =
               data.status === "running" ? "inline-block" : "none";
@@ -49,6 +79,7 @@ export function initDiscoveryToggle() {
         })
         .catch(() => {
           statusSpan.textContent = "error";
+          if (statusIcon) statusIcon.style.color = "red";
         });
 
     refreshStatus();

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -1,279 +1,484 @@
 <div class="discovery-page">
-    {% call card('Background Discovery') %}
-    <div class="discovery-controls" title="Manage background discovery">
-        <button id="stop-discovery" class="btn btn-primary" title="Stop background discovery" style="display: none;">Stop Discovery</button>
-        <span id="discovery-bg-status" title="Current background discovery status">Checking...</span>
+  {% call card('Background Discovery', 'Status of hourly background discovery
+  task') %}
+  <div class="discovery-controls" title="Manage background discovery">
+    <button
+      id="stop-discovery"
+      class="btn btn-primary"
+      title="Stop background discovery"
+      style="display: none"
+    >
+      Stop Discovery
+    </button>
+    <span
+      id="discovery-bg-icon"
+      class="status-indicator"
+      title="Background discovery status"
+    >
+      <svg width="18" height="18">
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#search"
+        />
+      </svg>
+    </span>
+    <span
+      id="discovery-bg-status"
+      class="status-text"
+      title="Background discovery status text"
+      >Checking...</span
+    >
+  </div>
+  <div class="wizard-step" title="Enter an optional network range">
+    <input
+      id="cidr-input"
+      type="text"
+      placeholder="192.168.1.0/24"
+      title="Optional CIDR to scan"
+    />
+    <button
+      id="discover-btn"
+      class="btn btn-primary"
+      title="Scan the network for cameras"
+    >
+      Discover
+    </button>
+  </div>
+  {% endcall %} {% call card('Scan Progress', 'Shows current scanning stage and
+  ETA') %}
+  <div class="wizard-step" title="Progress of the discovery scan">
+    <progress
+      id="discover-progress"
+      class="discovery-progress hidden"
+      max="100"
+      title="Discovery progress"
+    ></progress>
+    <span id="discover-message" title="Status messages">&nbsp;</span>
+  </div>
+  {% endcall %} {% call card('Results', 'List of discovered cameras') %}
+  <div class="wizard-step" title="Review results and export if desired">
+    <div class="export-buttons">
+      <button
+        id="export-json"
+        class="btn btn-primary"
+        title="Download results as JSON"
+      >
+        Export JSON
+      </button>
+      <button
+        id="export-csv"
+        class="btn btn-primary"
+        title="Download results as CSV"
+      >
+        Export CSV
+      </button>
     </div>
-    <div class="wizard-step" title="Enter an optional network range">
-        <input id="cidr-input" type="text" placeholder="192.168.1.0/24" title="Optional CIDR to scan">
-        <button id="discover-btn" class="btn btn-primary" title="Scan the network for cameras">Discover</button>
-    </div>
-    {% endcall %}
+    <table class="camera-table">
+      <thead>
+        <tr>
+          <th title="Camera IP address">IP</th>
+          <th title="Protocol type">Protocol</th>
+          <th title="Port number">Port</th>
+          <th title="MAC address">MAC</th>
+          <th title="Device manufacturer">Manufacturer</th>
+          <th title="Additional information">Info</th>
+          <th title="Add camera"></th>
+        </tr>
+      </thead>
+      <tbody id="discover-body">
+        {% for cam in cameras %}
+        <tr>
+          <td>{{ cam.ip }}</td>
+          <td>{{ cam.protocol }}</td>
+          <td>{{ cam.port }}</td>
+          <td>{{ cam.info.mac }}</td>
+          <td>{{ cam.info.manufacturer }}</td>
+          <td>{{ show_info(cam.info) }}</td>
+          <td>
+            <form action="/discover/add" method="post">
+              <input type="hidden" name="ip" value="{{ cam.ip }}" />
+              <input type="hidden" name="protocol" value="{{ cam.protocol }}" />
+              <input type="hidden" name="port" value="{{ cam.port }}" />
+              {% if cam.url %}
+              <input type="hidden" name="url" value="{{ cam.url }}" />
+              {% endif %}
+              <input type="hidden" name="name" value="{{ cam.ip }}" />
+              <button type="submit" title="Add this camera">Add</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endcall %} {% call card('Add Camera', 'Create a new camera template') %}
+  <div class="wizard-step" title="Form to add a new camera">
+    <details title="Expand to add a new camera">
+      <summary>Add Camera</summary>
+      <div id="template-form" title="Form to add a new template">
+        <h3>Add Camera</h3>
+        <form
+          id="add-template-form"
+          action="/templates"
+          method="post"
+          onsubmit="return validateForm()"
+          title="Enter details for the new template"
+        >
+          <div>
+            <label for="name" title="Name of the template"
+              >Template Name:</label
+            >
+            <input
+              type="text"
+              id="name"
+              name="name"
+              required
+              title="Enter a unique name for this template"
+            />
 
-    {% call card('Scan Progress') %}
-    <div class="wizard-step" title="Progress of the discovery scan">
-        <progress id="discover-progress" class="discovery-progress hidden" max="100" title="Discovery progress"></progress>
-        <span id="discover-message" title="Status messages"></span>
-    </div>
-    {% endcall %}
+            <label for="url" title="URL to monitor">URL:</label>
+            <input
+              type="url"
+              id="url"
+              name="url"
+              required
+              title="Enter the URL to monitor"
+            />
 
-    {% call card('Results') %}
-    <div class="wizard-step" title="Review results and export if desired">
-        <div class="export-buttons">
-            <button id="export-json" class="btn btn-primary" title="Download results as JSON">Export JSON</button>
-            <button id="export-csv" class="btn btn-primary" title="Download results as CSV">Export CSV</button>
-        </div>
-        <table class="camera-table">
-            <thead>
-                <tr>
-                    <th title="Camera IP address">IP</th>
-                    <th title="Protocol type">Protocol</th>
-                    <th title="Port number">Port</th>
-                    <th title="MAC address">MAC</th>
-                    <th title="Device manufacturer">Manufacturer</th>
-                    <th title="Additional information">Info</th>
-                    <th title="Add camera"></th>
-                </tr>
-            </thead>
-            <tbody id="discover-body">
-            {% for cam in cameras %}
-            <tr>
-                <td>{{ cam.ip }}</td>
-                <td>{{ cam.protocol }}</td>
-                <td>{{ cam.port }}</td>
-                <td>{{ cam.info.mac }}</td>
-                <td>{{ cam.info.manufacturer }}</td>
-                <td>{{ show_info(cam.info) }}</td>
-                <td>
-                    <form action="/discover/add" method="post">
-                        <input type="hidden" name="ip" value="{{ cam.ip }}">
-                        <input type="hidden" name="protocol" value="{{ cam.protocol }}">
-                        <input type="hidden" name="port" value="{{ cam.port }}">
-                        {% if cam.url %}
-                        <input type="hidden" name="url" value="{{ cam.url }}">
-                        {% endif %}
-                        <input type="hidden" name="name" value="{{ cam.ip }}">
-                        <button type="submit" title="Add this camera">Add</button>
-                    </form>
-                </td>
-            </tr>
-            {% endfor %}
-            </tbody>
-</table>
-    </div>
-    {% endcall %}
+            <label for="frequency" title="How often to check the URL"
+              >Frequency (minutes):</label
+            >
+            <input
+              type="number"
+              id="frequency"
+              name="frequency"
+              value="30"
+              min="1"
+              required
+              title="Enter how often to check the URL (in minutes)"
+            />
 
-    {% call card('Add Camera') %}
-    <div class="wizard-step" title="Form to add a new camera">
-        <details title="Expand to add a new camera">
-            <summary>Add Camera</summary>
-            <div id="template-form" title="Form to add a new template">
-                <h3>Add Camera</h3>
-                <form id="add-template-form" action="/templates" method="post" onsubmit="return validateForm()" title="Enter details for the new template">
-                    <div>
-                        <label for="name" title="Name of the template">Template Name:</label>
-                        <input type="text" id="name" name="name" required title="Enter a unique name for this template">
+            <label for="timeout" title="Maximum time to wait for a response"
+              >Timeout (seconds):</label
+            >
+            <input
+              type="number"
+              id="timeout"
+              name="timeout"
+              value="10"
+              min="1"
+              required
+              title="Enter the maximum time to wait for a response (in seconds)"
+            />
 
-                        <label for="url" title="URL to monitor">URL:</label>
-                        <input type="url" id="url" name="url" required title="Enter the URL to monitor">
+            <label for="notes" title="Additional notes">Notes:</label>
+            <textarea
+              id="notes"
+              name="notes"
+              title="Enter any additional notes or comments"
+            ></textarea>
 
-                        <label for="frequency" title="How often to check the URL">Frequency (minutes):</label>
-                        <input type="number" id="frequency" name="frequency" value="30" min="1" required title="Enter how often to check the URL (in minutes)">
+            <label for="object_filter" title="Filter for specific objects"
+              >Object Filter:</label
+            >
+            <input
+              type="text"
+              id="object_filter"
+              name="object_filter"
+              title="Enter object types to filter (e.g., 'person,car')"
+            />
 
-                        <label for="timeout" title="Maximum time to wait for a response">Timeout (seconds):</label>
-                        <input type="number" id="timeout" name="timeout" value="10" min="1" required title="Enter the maximum time to wait for a response (in seconds)">
+            <label
+              for="object_confidence"
+              title="Minimum confidence for object detection"
+              >Object Confidence:</label
+            >
+            <input
+              type="number"
+              id="object_confidence"
+              name="object_confidence"
+              min="0"
+              max="1"
+              step="0.01"
+              title="Enter the minimum confidence level for object detection (0-1)"
+            />
 
-                        <label for="notes" title="Additional notes">Notes:</label>
-                        <textarea id="notes" name="notes" title="Enter any additional notes or comments"></textarea>
-
-                        <label for="object_filter" title="Filter for specific objects">Object Filter:</label>
-                        <input type="text" id="object_filter" name="object_filter" title="Enter object types to filter (e.g., 'person,car')">
-
-                        <label for="object_confidence" title="Minimum confidence for object detection">Object Confidence:</label>
-                        <input type="number" id="object_confidence" name="object_confidence" min="0" max="1" step="0.01" title="Enter the minimum confidence level for object detection (0-1)">
-
-                        <label for="popup_xpath">Popup XPath:</label>
-                        <div class="xpath-input-container">
-                            <input type="text" id="popup_xpath" name="popup_xpath">
-                            <button type="button" onclick="showStructuredInput('popup_xpath')" title="Open structured XPath editor">Structured</button>
-                        </div>
-
-                        <label for="dedicated_xpath">Dedicated XPath:</label>
-                        <div class="xpath-input-container">
-                            <input type="text" id="dedicated_xpath" name="dedicated_xpath">
-                            <button type="button" onclick="showStructuredInput('dedicated_xpath')" title="Open structured XPath editor">Structured</button>
-                        </div>
-
-                        <label for="callback_url" title="URL for notifications">Callback URL:</label>
-                        <input type="url" id="callback_url" name="callback_url" title="Enter URL to receive notifications">
-
-                        <label for="proxy" title="Proxy server address">Proxy:</label>
-                        <input type="text" id="proxy" name="proxy" title="Enter proxy server address (optional)">
-
-                        <label for="auth_username" title="Username for camera authentication">Username:</label>
-                        <input type="text" id="auth_username" name="auth_username" title="Camera username">
-
-                        <label for="auth_password" title="Password for camera authentication">Password:</label>
-                        <input type="password" id="auth_password" name="auth_password" title="Camera password">
-
-                        <label for="groups" title="Groups for the template, comma separated ">Groups:</label>
-                        <input type="text" id="groups" name="groups" title="Enter comma-separated group names">
-
-                        <label for="rollback_frames" title="Number of frames to rollback">Rollback Frames:</label>
-                        <input type="number" id="rollback_frames" name="rollback_frames" value="0" min="0" title="Enter number of frames to rollback">
-                    </div>
-                    <br/>
-
-                    <div class="checkbox-row">
-                        <label for="invert" title="Invert image colors">
-                            <input type="checkbox" id="invert" name="invert" title="Invert colors of the captured image"> Invert
-                        </label>
-                        <label for="dark" title="Use dark mode">
-                            <input type="checkbox" id="dark" name="dark" checked title="Enable dark mode for the captured page"> Dark Mode
-                        </label>
-                        <label for="headless" title="Run in headless mode">
-                            <input type="checkbox" id="headless" name="headless" checked title="Run browser in headless mode"> Headless
-                        </label>
-                        <label for="stealth" title="Use stealth mode">
-                            <input type="checkbox" id="stealth" name="stealth" title="Use stealth mode to avoid detection"> Stealth
-                        </label>
-                    </div>
-                    <br/>
-
-                    <div class="form-actions">
-                        <input type="submit" value="Submit" title="Submit the template">
-                    </div>
-                </form>
+            <label for="popup_xpath">Popup XPath:</label>
+            <div class="xpath-input-container">
+              <input type="text" id="popup_xpath" name="popup_xpath" />
+              <button
+                type="button"
+                onclick="showStructuredInput('popup_xpath')"
+                title="Open structured XPath editor"
+              >
+                Structured
+              </button>
             </div>
-        </details>
-    </div>
-    {% endcall %}
+
+            <label for="dedicated_xpath">Dedicated XPath:</label>
+            <div class="xpath-input-container">
+              <input type="text" id="dedicated_xpath" name="dedicated_xpath" />
+              <button
+                type="button"
+                onclick="showStructuredInput('dedicated_xpath')"
+                title="Open structured XPath editor"
+              >
+                Structured
+              </button>
+            </div>
+
+            <label for="callback_url" title="URL for notifications"
+              >Callback URL:</label
+            >
+            <input
+              type="url"
+              id="callback_url"
+              name="callback_url"
+              title="Enter URL to receive notifications"
+            />
+
+            <label for="proxy" title="Proxy server address">Proxy:</label>
+            <input
+              type="text"
+              id="proxy"
+              name="proxy"
+              title="Enter proxy server address (optional)"
+            />
+
+            <label
+              for="auth_username"
+              title="Username for camera authentication"
+              >Username:</label
+            >
+            <input
+              type="text"
+              id="auth_username"
+              name="auth_username"
+              title="Camera username"
+            />
+
+            <label
+              for="auth_password"
+              title="Password for camera authentication"
+              >Password:</label
+            >
+            <input
+              type="password"
+              id="auth_password"
+              name="auth_password"
+              title="Camera password"
+            />
+
+            <label
+              for="groups"
+              title="Groups for the template, comma separated "
+              >Groups:</label
+            >
+            <input
+              type="text"
+              id="groups"
+              name="groups"
+              title="Enter comma-separated group names"
+            />
+
+            <label for="rollback_frames" title="Number of frames to rollback"
+              >Rollback Frames:</label
+            >
+            <input
+              type="number"
+              id="rollback_frames"
+              name="rollback_frames"
+              value="0"
+              min="0"
+              title="Enter number of frames to rollback"
+            />
+          </div>
+          <br />
+
+          <div class="checkbox-row">
+            <label for="invert" title="Invert image colors">
+              <input
+                type="checkbox"
+                id="invert"
+                name="invert"
+                title="Invert colors of the captured image"
+              />
+              Invert
+            </label>
+            <label for="dark" title="Use dark mode">
+              <input
+                type="checkbox"
+                id="dark"
+                name="dark"
+                checked
+                title="Enable dark mode for the captured page"
+              />
+              Dark Mode
+            </label>
+            <label for="headless" title="Run in headless mode">
+              <input
+                type="checkbox"
+                id="headless"
+                name="headless"
+                checked
+                title="Run browser in headless mode"
+              />
+              Headless
+            </label>
+            <label for="stealth" title="Use stealth mode">
+              <input
+                type="checkbox"
+                id="stealth"
+                name="stealth"
+                title="Use stealth mode to avoid detection"
+              />
+              Stealth
+            </label>
+          </div>
+          <br />
+
+          <div class="form-actions">
+            <input type="submit" value="Submit" title="Submit the template" />
+          </div>
+        </form>
+      </div>
+    </details>
+  </div>
+  {% endcall %}
 </div>
 <script>
-const button = document.getElementById('discover-btn');
-const msg = document.getElementById('discover-message');
-const progress = document.getElementById('discover-progress');
-const body = document.getElementById('discover-body');
-const exportJson = document.getElementById('export-json');
-const exportCsv = document.getElementById('export-csv');
-const renderInfo = (info) => {
-    if (!info) return '';
+  const button = document.getElementById("discover-btn");
+  const msg = document.getElementById("discover-message");
+  const progress = document.getElementById("discover-progress");
+  const body = document.getElementById("discover-body");
+  const exportJson = document.getElementById("export-json");
+  const exportCsv = document.getElementById("export-csv");
+  const renderInfo = (info) => {
+    if (!info) return "";
     const pieces = [];
     if (info.name) pieces.push(info.name);
     if (info.xaddr) pieces.push(info.xaddr);
     if (info.path) pieces.push(info.path);
-    if (info.sdp) pieces.push('SDP available');
+    if (info.sdp) pieces.push("SDP available");
     Object.entries(info).forEach(([k, v]) => {
-        if (!['name', 'xaddr', 'path', 'sdp', 'mac', 'manufacturer'].includes(k)) {
-            pieces.push(`${k}: ${v}`);
-        }
+      if (
+        !["name", "xaddr", "path", "sdp", "mac", "manufacturer"].includes(k)
+      ) {
+        pieces.push(`${k}: ${v}`);
+      }
     });
-    return pieces.join(' ');
-};
-let results = [];
-if (button) {
-    button.addEventListener('click', async () => {
-        msg.textContent = 'Searching...';
-        try {
-            const res = await fetch('/discovery_status');
-            const data = await res.json();
-            if (data.status !== 'running') {
-                await fetch('/toggle_discovery', { method: 'POST' });
-            }
-        } catch (e) {
-            console.warn('Unable to start background discovery', e);
+    return pieces.join(" ");
+  };
+  let results = [];
+  if (button) {
+    button.addEventListener("click", async () => {
+      msg.textContent = "Searching...";
+      try {
+        const res = await fetch("/discovery_status");
+        const data = await res.json();
+        if (data.status !== "running") {
+          await fetch("/toggle_discovery", { method: "POST" });
         }
-        progress.style.display = 'inline';
-        progress.value = 0;
-        body.innerHTML = '';
-        results = [];
-        const cidr = document.getElementById('cidr-input').value.trim();
-        const url = cidr ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}` : '/discover/scan_stream';
-        const source = new EventSource(url);
-        const known = new Set();
-        const addRow = (cam) => {
-            const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
-            if (known.has(key)) return;
-            known.add(key);
-            results.push(cam);
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
+      } catch (e) {
+        console.warn("Unable to start background discovery", e);
+      }
+      progress.style.display = "inline";
+      progress.value = 0;
+      body.innerHTML = "";
+      results = [];
+      const cidr = document.getElementById("cidr-input").value.trim();
+      const url = cidr
+        ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}`
+        : "/discover/scan_stream";
+      const source = new EventSource(url);
+      const known = new Set();
+      const addRow = (cam) => {
+        const key = `${cam.ip}-${cam.protocol}-${cam.port}`;
+        if (known.has(key)) return;
+        known.add(key);
+        results.push(cam);
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
                     <td>${cam.port}</td>
-                    <td>${cam.info.mac || ''}</td>
-                    <td>${cam.info.manufacturer || ''}</td>
+                    <td>${cam.info.mac || ""}</td>
+                    <td>${cam.info.manufacturer || ""}</td>
                     <td>${renderInfo(cam.info)}</td>
                     <td>
                         <form action="/discover/add" method="post">
                             <input type="hidden" name="ip" value="${cam.ip}">
                             <input type="hidden" name="protocol" value="${cam.protocol}">
                             <input type="hidden" name="port" value="${cam.port}">
-                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ''}
+                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ""}
                             <input type="hidden" name="name" value="${cam.ip}">
                             <button type="submit" title="Add this camera">Add</button>
                         </form>
                     </td>`;
-            body.appendChild(tr);
-        };
-        let plan = [];
-        source.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            if (data.total) {
-                progress.max = 100;
-                progress.value = 0;
-                plan = data.stages || [];
-                if (data.subnets) {
-                    msg.textContent = `Scanning networks: ${data.subnets.join(', ')}. Plan: ${plan.join(', ')}`;
-                }
-                return;
-            }
-            if (data.done) {
-                msg.textContent = `Found ${known.size} cameras.`;
-                progress.style.display = 'none';
-                source.close();
-                return;
-            }
-            if (typeof data.progress === 'number') {
-                progress.value = data.progress;
-            } else {
-                progress.value += 1;
-            }
-            if (plan.length && plan[0] === data.stage) {
-                plan.shift();
-            }
-            const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : '';
-            msg.textContent = `Scanning ${data.stage} (${data.count} found)...` +
-                (plan.length ? ` Next: ${plan[0]}` : '') + eta;
-            if (data.cameras) {
-                data.cameras.forEach(addRow);
-            }
-        };
-        source.onerror = (e) => {
-            console.error('Discovery error', e);
-            msg.textContent = 'Error discovering cameras';
-            progress.style.display = 'none';
-            source.close();
-        };
+        body.appendChild(tr);
+      };
+      let plan = [];
+      source.onmessage = (event) => {
+        const data = JSON.parse(event.data);
+        if (data.total) {
+          progress.max = 100;
+          progress.value = 0;
+          plan = data.stages || [];
+          if (data.subnets) {
+            msg.textContent = `Scanning networks: ${data.subnets.join(", ")}. Plan: ${plan.join(", ")}`;
+          }
+          return;
+        }
+        if (data.done) {
+          msg.textContent = `Found ${known.size} cameras.`;
+          progress.style.display = "none";
+          source.close();
+          return;
+        }
+        if (typeof data.progress === "number") {
+          progress.value = data.progress;
+        } else {
+          progress.value += 1;
+        }
+        if (plan.length && plan[0] === data.stage) {
+          plan.shift();
+        }
+        const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : "";
+        msg.textContent =
+          `Scanning ${data.stage} (${data.count} found)...` +
+          (plan.length ? ` Next: ${plan[0]}` : "") +
+          eta;
+        if (data.cameras) {
+          data.cameras.forEach(addRow);
+        }
+      };
+      source.onerror = (e) => {
+        console.error("Discovery error", e);
+        msg.textContent = "Error discovering cameras";
+        progress.style.display = "none";
+        source.close();
+      };
     });
-}
+  }
 
-const exportData = (fmt) => {
+  const exportData = (fmt) => {
     fetch(`/discover/export?format=${fmt}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(results)
-    }).then(r => r.blob()).then(blob => {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(results),
+    })
+      .then((r) => r.blob())
+      .then((blob) => {
         const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
+        const a = document.createElement("a");
         a.href = url;
-        a.download = fmt === 'csv' ? 'discovery.csv' : 'discovery.json';
+        a.download = fmt === "csv" ? "discovery.csv" : "discovery.json";
         document.body.appendChild(a);
         a.click();
         a.remove();
         URL.revokeObjectURL(url);
-    });
-};
-if (exportJson) exportJson.addEventListener('click', () => exportData('json'));
-if (exportCsv) exportCsv.addEventListener('click', () => exportData('csv'));
+      });
+  };
+  if (exportJson)
+    exportJson.addEventListener("click", () => exportData("json"));
+  if (exportCsv) exportCsv.addEventListener("click", () => exportData("csv"));
 </script>

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -1,20 +1,24 @@
-{# Shared UI components #}
-{% macro confirm_modal(name, message='Are you sure?', confirm='Confirm', cancel='Cancel') -%}
+{# Shared UI components #} {% macro confirm_modal(name, message='Are you sure?',
+confirm='Confirm', cancel='Cancel') -%}
 <div id="{{ name }}-modal" class="modal">
   <div class="modal-content">
-    <span id="{{ name }}-close" class="close-icon" title="Close dialog">&times;</span>
+    <span id="{{ name }}-close" class="close-icon" title="Close dialog"
+      >&times;</span
+    >
     <p id="{{ name }}-modal-message">{{ message }}</p>
-    <button id="{{ name }}-confirm" title="Confirm this action">{{ confirm }}</button>
-    <button id="{{ name }}-cancel" title="Cancel and close">{{ cancel }}</button>
+    <button id="{{ name }}-confirm" title="Confirm this action">
+      {{ confirm }}
+    </button>
+    <button id="{{ name }}-cancel" title="Cancel and close">
+      {{ cancel }}
+    </button>
   </div>
 </div>
-{%- endmacro %}
-
-{% macro card(title) -%}
+{%- endmacro %} {% macro card(title, tooltip='') -%}
 <div class="card">
-  <div class="card-header">{{ title }}</div>
-  <div class="card-body">
-    {{ caller() }}
+  <div class="card-header" {% if tooltip %} title="{{ tooltip }}" {% endif %}>
+    {{ title }}
   </div>
+  <div class="card-body">{{ caller() }}</div>
 </div>
 {%- endmacro %}

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -7,8 +7,12 @@ Background discovery can run automatically every hour when the `DISCOVERY_AUTOST
 The scheduling call now triggers discovery in a background thread so the UI never hangs when you enable it.
 The page now polls `/discovery_status` every 30 seconds so the background state
 is always visible, including the remaining time until the next run.
+The **Background Discovery** card now shows a small search icon next to the
+status text. The icon changes color based on the current state: orange while
+scanning, green when the last scan succeeded and gray when disabled. Hovering
+over the icon or any field reveals a tooltip explaining its purpose.
 After all scanning steps finish, Glimpser performs a two-hop traceroute to each
-discovered camera. The previous hop is stored in the ``upstream`` field so you
+discovered camera. The previous hop is stored in the `upstream` field so you
 can see which router or switch connects the device. Each progress message now
 includes a completion percentage and an estimated time remaining so you know how
 long the scan will take.
@@ -31,9 +35,9 @@ def discover_cameras_scan_stream():
     return Response(stream_with_context(generate()), mimetype='text/event-stream')
 ```
 
-When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message now includes the list of subnets that will be scanned and the full plan of discovery stages. The progress bar is initialized with the total number of stages. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with ``{"done": true}`` simply signals completion. Discovery results now display firmware details along with the reported manufacturer and model when available. These fields are pulled from the camera's ONVIF device service. The page also offers buttons to export the table as CSV or JSON.
+When you visit `/discover`, the page loads instantly with an empty list. Clicking the **Discover** button opens an EventSource to `/discover/scan_stream`. The first message now includes the list of subnets that will be scanned and the full plan of discovery stages. The progress bar is initialized with the total number of stages. Each subsequent message indicates which stage has finished, how many cameras have been found so far, and includes any new cameras discovered during that stage. These cameras appear in the table immediately. A final event with `{"done": true}` simply signals completion. Discovery results now display firmware details along with the reported manufacturer and model when available. These fields are pulled from the camera's ONVIF device service. The page also offers buttons to export the table as CSV or JSON.
 
-An optional CIDR can be supplied via the new input field to restrict discovery to a specific Class C network. The value is sent as the ``cidr`` query parameter and parsed by ``discover_cameras()``.
+An optional CIDR can be supplied via the new input field to restrict discovery to a specific Class C network. The value is sent as the `cidr` query parameter and parsed by `discover_cameras()`.
 
 During the scan you will see messages like `Scanning onvif (3 found)...`. The stage name shows which discovery method just finished, while the number in parentheses reflects how many cameras have been detected so far.
 
@@ -157,11 +161,11 @@ details such as a camera's name, ONVIF address, or HTTP path instead of showing
 the raw JSON dictionary.
 
 Each camera is now also checked for commonly used service ports. Any detected
-ports are listed in the ``open_ports`` field so you can quickly see which
+ports are listed in the `open_ports` field so you can quickly see which
 services are reachable (for example, 80 for HTTP or 554 for RTSP). This scan
 is lightweight and runs after the main discovery steps finish.
 If a camera responds to ICMP echo requests, Glimpser measures the round-trip
-latency and reports the value in the ``ping_ms`` field. This extra check runs in
+latency and reports the value in the `ping_ms` field. This extra check runs in
 parallel with other metadata gathering so it does not slow down discovery.
 If an HTTP port responds, Glimpser also fetches the web page banner to capture
 the `Server` header, authentication realm, and page title when present. These
@@ -170,9 +174,9 @@ values populate the **Info** column so you can quickly identify each device.
 Each result now tries to classify the kind of hardware discovered. Devices with
 RTSP ports or ONVIF data are labeled as **camera** while models referencing DVR
 or NVR become **nvr**. Routers and switches are recognized when their metadata
-contains those keywords. The detected type appears in the ``device_type`` field.
+contains those keywords. The detected type appears in the `device_type` field.
 
-Discovered entries also include a suggested ``url`` built from the protocol and
+Discovered entries also include a suggested `url` built from the protocol and
 port. This makes the "Add" action work immediately without manual edits.
 
 You can then add a discovered camera to your configuration directly from the Discover tab.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -10,7 +10,7 @@ This document lists the main tooltips available in the Glimpser interface. Hover
 - **System Performance icon** – shows CPU, memory and other metrics. It hides
   when the system is healthy unless `HEALTH_STATUS_ALWAYS_VISIBLE` is set.
 - **Danger Mode icon** – appears only when Danger mode is available. Hovering over it explains why the feature may be disabled.
- - **Discover Cameras icon** – opens the Settings page to the Discover tab.
+- **Discover Cameras icon** – opens the Settings page to the Discover tab.
 - **Captions icon** – reads and updates camera language models. The icon flashes
   with the latest caption when group messages arrive. After a short period of
   inactivity the newest global summary slowly scrolls across the top in gray text.
@@ -43,6 +43,7 @@ Interactive forms now include additional tooltips:
 - **Live video player** – tooltip now refreshes with the full caption as it updates.
 - **Info icon** – toggles camera metadata on the live page.
 - **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
+- **Background Discovery icon** – on the Discover tab, a colored search icon shows whether automatic scanning is running, idle or failed.
 
 ## Dynamic Tooltips
 

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- show an icon for background discovery status with color states
- add tooltips across the discovery page
- document the new icon and tooltips

## Testing
- `flake8`
- `black --check .`
- `npx prettier --check app/static/js/discovery.js app/templates/_discover_tab.html app/templates/components.html docs/camera_discovery.md docs/tooltips.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462cfd0e808333a4ffd1bd5a748d2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual status icon to the Background Discovery card that changes color and symbol based on discovery status.
  - Introduced an "Add Camera" card with a comprehensive form for creating new camera templates.

- **Enhancements**
  - Improved UI structure and accessibility in the Discover tab, including clearer card organization and semantic HTML.
  - Cards now support optional tooltips for additional context.

- **Documentation**
  - Updated documentation to describe the new status icon and tooltip features, and improved formatting for clarity.

- **Style**
  - Reformatted modal and card components for improved readability and consistency.

- **Tests**
  - Minor code cleanup in test setup without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->