### PR TITLE
Add request throttling for heavy routes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -103,6 +103,7 @@ from app.utils.screenshots import (
     capture_frame_from_stream,
 )
 from app.utils.network import is_system_online
+from app.utils import limit_rate
 
 # Names of settings that store file paths.
 FILE_LOCATION_NAMES = [
@@ -2632,6 +2633,7 @@ def init_routes(app: Flask) -> None:
 
     @app.route("/clip/<string:template_name>")
     @login_required
+    @limit_rate(30)
     def serve_clip(template_name: TemplateName):
         """Return a short clip built from recent finalized segments."""
 
@@ -2762,6 +2764,7 @@ def init_routes(app: Flask) -> None:
 
     @app.route("/compile_teaser", methods=["POST"])
     @login_required
+    @limit_rate(30)
     def take_compile():
         video_archiver.compile_to_teaser()
         return jsonify({"status": "success", "message": "Compilation taken"})

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,3 +3,5 @@
 This package collects modules for network checks, camera interaction,
 scheduling tasks, alerting, and other supporting functionality.
 """
+
+from .throttle import limit_rate, clear as clear_throttle

--- a/app/utils/throttle.py
+++ b/app/utils/throttle.py
@@ -1,0 +1,39 @@
+"""Simple request throttling utilities."""
+
+from __future__ import annotations
+
+import time
+import logging
+from functools import wraps
+from typing import Callable, Dict, Tuple
+
+from flask import request, abort
+
+# Map of (IP address, endpoint) to last access timestamp
+_last_calls: Dict[Tuple[str, str], float] = {}
+
+
+def clear() -> None:
+    """Clear all stored throttle information."""
+    _last_calls.clear()
+
+
+def limit_rate(seconds: int) -> Callable[[Callable], Callable]:
+    """Limit calls from a single IP to once every ``seconds`` seconds."""
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            ip = request.remote_addr or "unknown"
+            key = (ip, func.__name__)
+            now = time.time()
+            last = _last_calls.get(key, float("-inf"))
+            if now - last < seconds:
+                logging.warning("Throttled %s from %s", func.__name__, ip)
+                abort(429)
+            _last_calls[key] = now
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -17,12 +17,15 @@ class TestClipRoute(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
         self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.throttle_patch = patch("app.utils.throttle._last_calls", {})
         self.login_patch.start()
+        self.throttle_patch.start()
         init_routes(self.app)
         self.client = self.app.test_client()
 
     def tearDown(self):
         self.login_patch.stop()
+        self.throttle_patch.stop()
 
     @patch("app.routes.video_archiver.create_blank_video")
     @patch("app.routes._concat_copy")

--- a/tests/test_compile_teaser_route.py
+++ b/tests/test_compile_teaser_route.py
@@ -14,14 +14,17 @@ class TestCompileTeaserRoute(unittest.TestCase):
         self.app = Flask(__name__)
         self.login_patch = patch("app.routes.login_required", lambda x: x)
         self.compile_patch = patch("app.routes.video_archiver.compile_to_teaser")
+        self.throttle_patch = patch("app.utils.throttle._last_calls", {})
         self.login_patch.start()
         self.mock_compile = self.compile_patch.start()
+        self.throttle_patch.start()
         init_routes(self.app)
         self.client = self.app.test_client()
 
     def tearDown(self):
         self.login_patch.stop()
         self.compile_patch.stop()
+        self.throttle_patch.stop()
 
     def test_compile_teaser_post(self):
         resp = self.client.post("/compile_teaser")

--- a/tests/test_throttle_routes.py
+++ b/tests/test_throttle_routes.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import tempfile
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestHeavyRouteThrottle(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        self.throttle_patch = patch("app.utils.throttle._last_calls", {})
+        self.throttle_patch.start()
+        self.time_patch = patch("app.utils.throttle.time.time", return_value=0)
+        self.time_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.throttle_patch.stop()
+        self.time_patch.stop()
+
+    @patch("app.routes.video_archiver.compile_to_teaser")
+    def test_compile_teaser_throttled(self, mock_compile):
+        resp1 = self.client.post("/compile_teaser")
+        self.assertEqual(resp1.status_code, 200)
+        resp2 = self.client.post("/compile_teaser")
+        self.assertEqual(resp2.status_code, 429)
+        mock_compile.assert_called_once()
+
+    @patch("app.routes._concat_copy")
+    @patch("app.routes.video_archiver.create_blank_video")
+    def test_clip_throttled(self, mock_blank, mock_concat):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            camera_path = os.path.join(tmpdir, "cam1")
+            os.makedirs(camera_path)
+            open(os.path.join(camera_path, "final_1.mp4"), "w").close()
+            with (
+                patch("app.routes.VIDEO_DIRECTORY", tmpdir),
+                patch("app.routes.send_file") as mock_send,
+            ):
+
+                def fake_blank(duration, output):
+                    with open(output, "w"):
+                        pass
+                    return True
+
+                mock_blank.side_effect = fake_blank
+
+                def fake_concat(out, parts, clip_len):
+                    with open(out, "w"):
+                        pass
+                    return True
+
+                mock_concat.side_effect = fake_concat
+
+                resp1 = self.client.get("/clip/cam1")
+                resp2 = self.client.get("/clip/cam1")
+        self.assertEqual(resp1.status_code, 200)
+        self.assertEqual(resp2.status_code, 429)
+        mock_send.assert_called_once()
+        mock_concat.assert_called_once()
+        self.assertGreaterEqual(mock_blank.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- throttle heavy routes with new `limit_rate` decorator
- enforce throttling on clip and teaser compilation endpoints
- ensure tests reset throttle state
- add new tests covering throttled behavior

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629bf21408333bef04e832da701d6