### PR TITLE
Integrate docs with search

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3725,8 +3725,13 @@ def init_routes(app: Flask) -> None:
         names = [t.get("name", "") for t in templates.values()]
         groups = get_active_groups()
 
+        docs_path = Path(__file__).resolve().parent.parent / "docs"
+        doc_names = [
+            f.stem for f in docs_path.glob("*.md") if f.name.lower() != "readme.md"
+        ]
+
         suggestions: list[str] = []
-        for item in names + groups:
+        for item in names + groups + doc_names:
             if query and query not in item.lower():
                 continue
             if item not in suggestions:

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -38,7 +38,7 @@ confirm='Confirm', cancel='Cancel') -%}
       type="text"
       id="search-input"
       placeholder="Search cameras"
-      title="Enter search terms"
+      title="Enter search terms or docs keywords"
     />
     <input
       type="range"

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -6,7 +6,7 @@ The help content is organized into **Basics**, **Usage**, **Advanced** and **Sup
 
 Key topics covered include:
 
-- Guided setup when you first launch the app.
+- [Guided setup](guided_setup.md) when you first launch the app.
 - Adding templates with field descriptions and sample prompts.
 - Viewing screenshots, archived video, and real-time streams.
 - Managing templates and groups, including editing and deletion.

--- a/docs/search_autocomplete.md
+++ b/docs/search_autocomplete.md
@@ -9,3 +9,6 @@ input field queries a new `/search_suggestions` endpoint and displays up to ten
 matching results. This makes locating specific cameras much faster on large
 installations.
 
+Documentation titles are now included in these suggestions as well. Typing a
+topic like "offline" will show the matching docs page in addition to any camera
+or group names. Selecting the doc entry takes you straight to `/docs/<page>.md`.

--- a/tests/test_search_suggestions.py
+++ b/tests/test_search_suggestions.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from flask import Flask
 from unittest.mock import patch
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -20,9 +21,10 @@ class TestSearchSuggestionsEndpoint(unittest.TestCase):
     def tearDown(self):
         self.login_patch.stop()
 
+    @patch("app.routes.Path.glob", return_value=[])
     @patch("app.routes.get_active_groups")
     @patch("app.routes.template_manager.get_templates")
-    def test_search_suggestions(self, mock_get_templates, mock_get_groups):
+    def test_search_suggestions(self, mock_get_templates, mock_get_groups, mock_glob):
         mock_get_templates.return_value = {
             "Cam1": {"name": "Cam1"},
             "Cam2": {"name": "Cam2"},
@@ -32,6 +34,23 @@ class TestSearchSuggestionsEndpoint(unittest.TestCase):
         resp = self.client.get("/search_suggestions?q=cam")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.get_json(), ["Cam1", "Cam2"])
+
+    @patch("app.routes.Path.glob")
+    @patch("app.routes.get_active_groups")
+    @patch("app.routes.template_manager.get_templates")
+    def test_search_suggestions_docs(
+        self, mock_get_templates, mock_get_groups, mock_glob
+    ):
+        mock_get_templates.return_value = {}
+        mock_get_groups.return_value = []
+        mock_glob.return_value = [
+            Path("docs/usage.md"),
+            Path("docs/faq.md"),
+        ]
+
+        resp = self.client.get("/search_suggestions?q=faq")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), ["faq"])
 
 
 if __name__ == "__main__":

--- a/tests/test_throttle_routes.py
+++ b/tests/test_throttle_routes.py
@@ -47,7 +47,7 @@ class TestHeavyRouteThrottle(unittest.TestCase):
                 patch("app.routes.send_file") as mock_send,
             ):
 
-                def fake_blank(duration, output):
+                def fake_blank(duration, output, **_):
                     with open(output, "w"):
                         pass
                     return True


### PR DESCRIPTION
## Summary
- offer docs filenames in search_suggestions
- hint about docs in search tooltip
- link to guided setup from help page
- document docs autocomplete behavior
- update tests for docs suggestions and throttle route

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684634be214883338baf781bd560fe42