### PR TITLE
Add tooltips across UI templates

### DIFF
--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -1,7 +1,14 @@
 {% call card('LLM Cost Summary') %}
 <div id="cost-controls">
   <label for="cost-range">Range:</label>
-  <input type="range" id="cost-range" min="1" max="30" value="7" />
+  <input
+    type="range"
+    id="cost-range"
+    min="1"
+    max="30"
+    value="7"
+    title="Select cost range"
+  />
   <span id="cost-range-label">Last 7 days</span>
 </div>
 <canvas id="costChart" width="200" height="200"></canvas>

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -209,13 +209,17 @@ template_controls %} {% block content %}
     </table>
     <div id="chat-modal" class="modal">
       <div class="modal-content">
-        <span id="chat-close" class="close-icon">&times;</span>
+        <span id="chat-close" class="close-icon" title="Close chat"
+          >&times;</span
+        >
         <textarea
           id="chat-question"
           class="prompt-textarea"
           placeholder="Ask a question..."
         ></textarea>
-        <button id="chat-submit" type="button">Ask</button>
+        <button id="chat-submit" type="button" title="Submit question">
+          Ask
+        </button>
         <div id="chat-answer" class="chat-answer"></div>
       </div>
     </div>

--- a/app/templates/cost_summary.html
+++ b/app/templates/cost_summary.html
@@ -4,11 +4,13 @@ content %}
 {% call card('Select Range') %}
 <form id="cost-form" class="cost-form">
   <label for="start-date">From:</label>
-  <input type="date" id="start-date" name="start" />
+  <input type="date" id="start-date" name="start" title="Select start date" />
   <label for="end-date">To:</label>
-  <input type="date" id="end-date" name="end" />
-  <button type="button" id="since-restart">Since Last Restart</button>
-  <button type="button" id="load-cost">Load</button>
+  <input type="date" id="end-date" name="end" title="Select end date" />
+  <button type="button" id="since-restart" title="Use start time from restart">
+    Since Last Restart
+  </button>
+  <button type="button" id="load-cost" title="Load cost data">Load</button>
 </form>
 {% endcall %}
 <canvas id="costChart" width="400" height="300"></canvas>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -3,10 +3,26 @@ content %}
 <main class="container help-page">
   <h2 class="page-title">Glimpser Help</h2>
   <div class="tabs">
-    <button class="tab-link active" data-tab="basics-tab">Basics</button>
-    <button class="tab-link" data-tab="usage-tab">Usage</button>
-    <button class="tab-link" data-tab="advanced-tab">Advanced</button>
-    <button class="tab-link" data-tab="support-tab">Support</button>
+    <button
+      class="tab-link active"
+      data-tab="basics-tab"
+      title="Overview of key features"
+    >
+      Basics
+    </button>
+    <button class="tab-link" data-tab="usage-tab" title="How to use Glimpser">
+      Usage
+    </button>
+    <button
+      class="tab-link"
+      data-tab="advanced-tab"
+      title="Advanced options and offline access"
+    >
+      Advanced
+    </button>
+    <button class="tab-link" data-tab="support-tab" title="Help resources">
+      Support
+    </button>
   </div>
 
   <div id="basics-tab" class="tab-content active">
@@ -54,7 +70,9 @@ content %}
       Control Glimpser from the command line. Run
       <code>glimpser --help</code> to list all commands.
     </p>
-    <button id="load-cli-help" class="btn">Show CLI Help</button>
+    <button id="load-cli-help" class="btn" title="Show CLI help output">
+      Show CLI Help
+    </button>
     <pre id="cli-help" class="cli-help hidden" aria-live="polite"></pre>
     {% endcall %}
   </div>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -15,17 +15,35 @@ template_form %} {% block content %}
       type="button"
       class="tab-link{% if loop.first %} active{% endif %}"
       data-tab="{{ 'management-tab' if group == 'Credentials & Management' else group|replace(' ', '-') ~ '-tab' }}"
+      title="Open {{ group }} tab"
     >
       {{ group }}
     </button>
     {% if loop.first %}
-    <button type="button" class="tab-link" data-tab="discover-tab">
+    <button
+      type="button"
+      class="tab-link"
+      data-tab="discover-tab"
+      title="Open Discover tab"
+    >
       Discover
     </button>
-    <button type="button" class="tab-link" data-tab="status-tab">
+    <button
+      type="button"
+      class="tab-link"
+      data-tab="status-tab"
+      title="Open System Status tab"
+    >
       System Status
     </button>
-    <button type="button" class="tab-link" data-tab="costs-tab">Costs</button>
+    <button
+      type="button"
+      class="tab-link"
+      data-tab="costs-tab"
+      title="Open Costs tab"
+    >
+      Costs
+    </button>
     {% endif %} {% endfor %}
     <a
       href="{{ url_for('logout') }}"

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -47,6 +47,10 @@ Interactive forms now include additional tooltips:
 - **Info icon** – toggles camera metadata on the live page.
 - **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
 - **Camera type icons** – small symbols next to each feed name show whether the capture runs in a full browser, headless mode, or uses stealth.
+- **Chat modal controls** – the close icon and submit button now describe their actions.
+- **Help page tabs** – each tab button explains what information the section contains.
+- **Settings tabs** – hovering shows which category will open.
+- **Cost dashboards** – date selectors, the Load buttons and range slider include titles.
 
 ## Dynamic Tooltips
 


### PR DESCRIPTION
## Summary
- add tooltips to chat modal buttons
- describe help tab buttons and CLI loader
- show tab descriptions on the settings page
- label date inputs and sliders in cost templates
- document new tooltips

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846493b17348333b81ab0aed6cc0ff5