### PR TITLE
Simplify clip player

### DIFF
--- a/app/static/js/clip_player.js
+++ b/app/static/js/clip_player.js
@@ -1,0 +1,54 @@
+export function initClipPlayer(options = {}) {
+  const {
+    videoId = "live-video",
+    posterId = "live-image",
+    cameras = [],
+    refresh = 60,
+    playbackRate = 0.25,
+  } = options;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const video = document.getElementById(videoId);
+    if (!video) return;
+    const posterEl = posterId ? document.getElementById(posterId) : null;
+    let camList = cameras.slice();
+    if (camList.length === 0) {
+      const data = video.dataset.camera || "";
+      if (data) camList = [data];
+    }
+    if (camList.length === 0) return;
+    let index = 0;
+
+    function updatePoster(cam) {
+      if (!posterEl) return;
+      const ts = Date.now();
+      posterEl.src = `/last_screenshot/${cam}?t=${ts}`;
+      video.poster = posterEl.src;
+    }
+
+    function playNext() {
+      const cam = camList[index];
+      const ts = Date.now();
+      video.src = `/clip/${cam}?t=${ts}`;
+      updatePoster(cam);
+      video.load();
+      video.playbackRate = playbackRate;
+      const p = video.play();
+      if (p && typeof p.catch === "function") {
+        p.catch(() => {});
+      }
+      index = (index + 1) % camList.length;
+    }
+
+    video.addEventListener("ended", playNext);
+    playNext();
+
+    if (refresh > 0 && posterEl) {
+      setInterval(
+        () =>
+          updatePoster(camList[(index + camList.length - 1) % camList.length]),
+        refresh * 1000,
+      );
+    }
+  });
+}

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -375,4 +375,10 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
     </div>
   </form>
 </div>
+{%- endmacro %} {%- macro clip_player(video_id='live-video',
+poster_id='live-image') -%}
+<div class="video-container full-height">
+  <img id="{{ poster_id }}" loading="lazy" alt="Latest frame" />
+  <video id="{{ video_id }}" autoplay muted controls></video>
+</div>
 {%- endmacro %}

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -9,181 +9,30 @@
   href="{{ url_for('static', filename='css/player.css') }}"
 />
 
+{{ clip_player() }} {% if CLOCK_OVERLAY %}
 <div
-  class="video-container full-height"
-  role="region"
-  aria-label="Live video feed"
+  id="overlayClock"
+  class="cool-clock clock-overlay"
+  data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
 >
-  <img
-    id="live-image"
-    loading="lazy"
-    alt="Live feed frame"
-    title="Current frame from the live feed"
-  />
-  <video id="live-video" class="hidden" autoplay muted tabindex="0">
-    <source src="" type="video/mp4" />
-    Your browser does not support the video tag.
-  </video>
-  <video id="preload-video" class="hidden" muted preload="auto"></video>
-  <div class="video-controls">
-    <input type="range" id="seek-bar" value="0" />
-
-    <div class="control-row">
-      <button
-        id="play-pause"
-        title="play/pause"
-        aria-label="Play or pause video"
-      >
-        <i class="fa-play-pause"></i>
-      </button>
-      <div id="speed-container">
-        <input
-          type="range"
-          id="speed-slider"
-          min="-3"
-          max="4"
-          value="0"
-          step="0.1"
-          oninput="updatePlaybackSpeed()"
-        />
-        <label for="speed-slider"
-          >Speed: <span id="speed-value">1x</span></label
-        >
-      </div>
-      <div id="jog-shuttle" title="Jog shuttle control"></div>
-
-      <!-- <button id="cast-button">Cast</button> -->
-      <button
-        id="full-screen"
-        title="fullscreen"
-        aria-label="Toggle fullscreen"
-      >
-        <i class="fas fa-expand"></i>
-      </button>
-      <button
-        id="toggle-details"
-        title="Show details"
-        aria-label="Toggle details"
-      >
-        <i class="fas fa-info-circle"></i>
-      </button>
-      <button id="rotate-video" title="Rotate 90°" aria-label="Rotate video">
-        <i class="fas fa-sync-alt"></i>
-      </button>
-
-      <select id="video-source" onchange="changeVideoSource()">
-        <option value="png" title="View a series of PNG images">
-          PNG Stream
-        </option>
-        <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
-        <option value="loop" title="Loop through available video clips">
-          Loop Videos
-        </option>
-        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
-        <option value="live" title="View the direct live stream">
-          Live Video
-        </option>
-        <option value="motion" title="View motion-detected frames">
-          Motion
-        </option>
-        <option
-          value="mjpg"
-          selected
-          title="View an MJPEG (Motion JPEG) stream"
-        >
-          MJPG
-        </option>
-      </select>
-
-      <select id="group-selector" onchange="changeGroup()">
-        <option value="all" title="View all groups">All</option>
-        {% set all_groups = [] %} {% for camera, details in
-        template_details.items() %} {% if details.groups %} {% for group in
-        details.groups.split(',') %} {% if group %} {% set _ =
-        all_groups.append(group|trim) %} {% endif %} {% endfor %} {% endif %} {%
-        endfor %} {% for group in all_groups|unique|sort %}
-        <option value="{{ group }}" title="View group {{ group }}">
-          {{ group }}
-        </option>
-        {% endfor %}
-      </select>
-
-      <select
-        id="camera-selector"
-        onchange="changeCamera()"
-        style="display: none"
-      >
-        {% for camera in template_details.keys()|sort %}
-        <option value="{{ camera }}" title="View camera {{ camera }}">
-          Camera: {{ camera }}
-        </option>
-        {% endfor %}
-      </select>
+  <div class="clock-face">
+    <div class="clock-hands">
+      <div class="hand hour-hand"></div>
+      <div class="hand minute-hand"></div>
+      <div class="hand second-hand"></div>
     </div>
+    <div class="digital-clock"></div>
   </div>
-  <div
-    id="video-overlay"
-    class="video-overlay"
-    role="region"
-    aria-live="polite"
-  >
-    <div id="loading-indicator" class="hidden" role="status">Loading...</div>
-    <div id="play-pause-indicator" class="video-icon hidden" aria-hidden="true">
-      ▶
-    </div>
-    <div
-      id="offline-indicator"
-      class="offline-indicator hidden"
-      role="alert"
-      title="Camera offline"
-    >
-      <i class="fas fa-video-slash video-icon" aria-hidden="true"></i>
-      <p id="offline-message"></p>
-    </div>
-    <div
-      id="capture-error-indicator"
-      class="error-indicator hidden"
-      role="alert"
-      title="Capture error"
-    >
-      <i class="fas fa-exclamation-triangle video-icon" aria-hidden="true"></i>
-      <p id="capture-error-message"></p>
-    </div>
-    <div
-      id="stream-error-indicator"
-      class="error-indicator hidden"
-      role="alert"
-      title="Streaming error"
-    >
-      <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
-      <p id="stream-error-message"></p>
-    </div>
-  </div>
-  {% if CLOCK_OVERLAY %}
-  <div
-    id="overlayClock"
-    class="cool-clock clock-overlay"
-    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-  >
-    <div class="clock-face">
-      <div class="clock-hands">
-        <div class="hand hour-hand"></div>
-        <div class="hand minute-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
-      <div class="digital-clock"></div>
-    </div>
-  </div>
-  {% endif %}
-  <div id="error-message" role="alert"></div>
 </div>
+{% endif %}
+<div id="error-message" role="alert"></div>
 
 <div id="template-details" role="region" aria-live="polite"></div>
 
 <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
-<script
-  type="module"
-  src="{{ url_for('static', filename='js/live.js') }}"
-></script>
+<script type="module">
+  import { initClipPlayer } from '{{ url_for('static', filename='js/clip_player.js') }}';
+  initClipPlayer({ cameras: {{ template_details.keys()|list|tojson }} });
+</script>
 
 {% endblock %}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -16,109 +16,30 @@ template_form %} {% block content %}
   href="{{ url_for('static', filename='css/player.css') }}"
 />
 
-<div class="video-container full-height">
-  <img
-    id="live-image"
-    loading="lazy"
-    alt="Live feed frame"
-    title="Current frame from the live feed"
-  />
-  <video id="live-video" class="hidden" autoplay muted>
-    <source src="" type="video/mp4" />
-    Your browser does not support the video tag.
-  </video>
-  <video id="preload-video" class="hidden" muted preload="auto"></video>
-  <div class="video-controls">
-    <input type="range" id="seek-bar" value="0" title="Seek position" />
-
-    <div class="control-row">
-      <button id="play-pause" title="play/pause">
-        <i class="fa-play-pause"></i>
-      </button>
-      <div id="speed-container">
-        <input
-          type="range"
-          id="speed-slider"
-          min="-3"
-          max="4"
-          value="0"
-          step="0.1"
-          oninput="updatePlaybackSpeed()"
-          title="Adjust playback speed"
-        />
-        <label for="speed-slider"
-          >Speed: <span id="speed-value">1x</span></label
-        >
-      </div>
-      <button id="full-screen" title="fullscreen">
-        <i class="fas fa-expand"></i>
-      </button>
-      <select id="video-source" onchange="changeVideoSource()">
-        <option value="png" title="View a series of PNG images">
-          PNG Stream
-        </option>
-        <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
-        <option value="loop" title="Loop through available video clips">
-          Loop Videos
-        </option>
-        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
-        <option value="live" title="View the direct live stream">
-          Live Video
-        </option>
-        <option value="motion" title="View motion-detected frames">
-          Motion
-        </option>
-        <option
-          value="mjpg"
-          selected
-          title="View an MJPEG (Motion JPEG) stream"
-        >
-          MJPG
-        </option>
-      </select>
+{{ clip_player() }} {% if CLOCK_OVERLAY %}
+<div
+  id="overlayClock"
+  class="cool-clock clock-overlay"
+  data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
+>
+  <div class="clock-face">
+    <div class="clock-hands">
+      <div class="hand hour-hand"></div>
+      <div class="hand minute-hand"></div>
+      <div class="hand second-hand"></div>
     </div>
+    <div class="digital-clock"></div>
   </div>
-  <div id="video-overlay" class="video-overlay">
-    <div id="loading-indicator" class="hidden">Loading...</div>
-    <div id="play-pause-indicator" class="video-icon hidden">▶</div>
-    <div id="offline-indicator" class="offline-indicator hidden">
-      <i class="fas fa-video-slash video-icon"></i>
-      <p id="offline-message"></p>
-    </div>
-    <div id="capture-error-indicator" class="error-indicator hidden">
-      <i class="fas fa-exclamation-triangle video-icon"></i>
-      <p id="capture-error-message"></p>
-    </div>
-    <div id="stream-error-indicator" class="error-indicator hidden">
-      <i class="fas fa-times-circle video-icon"></i>
-      <p id="stream-error-message"></p>
-    </div>
-  </div>
-  {% if CLOCK_OVERLAY %}
-  <div
-    id="overlayClock"
-    class="cool-clock clock-overlay"
-    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-  >
-    <div class="clock-face">
-      <div class="clock-hands">
-        <div class="hand hour-hand"></div>
-        <div class="hand minute-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
-      <div class="digital-clock"></div>
-    </div>
-  </div>
-  {% endif %}
-  <div id="error-message"></div>
 </div>
+{% endif %}
+<div id="error-message"></div>
 
 <div id="template-details"></div>
 <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
-<script
-  type="module"
-  src="{{ url_for('static', filename='js/live.js') }}"
-></script>
+<script type="module">
+  import { initClipPlayer } from '{{ url_for('static', filename='js/clip_player.js') }}';
+  initClipPlayer({ cameras: ['{{ template_name }}'] });
+</script>
 
 <script>
   function takeInstantScreenshot(templateName) {

--- a/docs/clip_player.md
+++ b/docs/clip_player.md
@@ -1,0 +1,7 @@
+# Clip Player
+
+The new player loads short clips from each camera using the `/clip` endpoint.
+When playback ends the next clip automatically begins. The poster image
+refreshes every minute so the player always shows the latest frame.
+This simplified player is used across the live view, template details and
+group pages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Video Archiver](video_archiver.md)
 - [Dashboard Live Button](live_all.md)
 - [Live View Scrubbing](live_scrub.md)
+- [Clip Player](clip_player.md)
 - [Search Bar Autocomplete](search_autocomplete.md)
 - [Jog-Shuttle Control](jog_shuttle.md)
 - [Developer Guide](developer_guide.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Jog-Shuttle Control: jog_shuttle.md
       - Live All Playback: live_all.md
       - Live View Scrubbing: live_scrub.md
+      - Clip Player: clip_player.md
       - MCP Integration: mcp_integration.md
       - In-App Onboarding: onboarding.md
       - OpenSSF Scorecard: scorecard.md

--- a/tests/js/clip_player.test.js
+++ b/tests/js/clip_player.test.js
@@ -1,0 +1,44 @@
+import { jest } from "@jest/globals";
+
+// setup DOM
+Document.prototype.createRange = function () {
+  return {
+    setStart: () => {},
+    setEnd: () => {},
+    commonAncestorContainer: document.createElement("div"),
+  };
+};
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "load", {
+  configurable: true,
+  value: jest.fn(),
+});
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: jest.fn(() => Promise.resolve()),
+});
+
+document.body.innerHTML = `
+  <video id="vid"></video>
+  <img id="img" />
+`;
+
+jest.useFakeTimers();
+
+describe("initClipPlayer", () => {
+  test("sets clip and poster", async () => {
+    const mod = await import("../../app/static/js/clip_player.js");
+    mod.initClipPlayer({
+      cameras: ["cam1"],
+      videoId: "vid",
+      posterId: "img",
+      refresh: 0,
+    });
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.runAllTimers();
+    const vid = document.getElementById("vid");
+    const img = document.getElementById("img");
+    expect(vid.src).toContain("/clip/cam1");
+    expect(img.src).toContain("/last_screenshot/cam1");
+  });
+});


### PR DESCRIPTION
## Summary
- add `clip_player` macro
- add new `clip_player.js` for looping `/clip` playback
- update live and template details pages to use the new player
- document the clip player
- add jest test for clip player

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68464ab3d244833386070a64aed671af