### PR TITLE
Enhance template form

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -40,6 +40,7 @@ from flask import (
     stream_with_context,
     Flask,
 )
+from collections import deque
 
 from PIL import Image, ImageDraw, ImageFont
 import textwrap
@@ -3554,6 +3555,15 @@ def init_routes(app: Flask) -> None:
 
         return Response(stream_with_context(generate()), mimetype="text/event-stream")
 
+    @app.route("/telemetry", methods=["POST"])
+    @login_required
+    def collect_telemetry():
+        """Collect lightweight UI events for diagnostics."""
+        data = request.get_json(force=True)
+        telemetry_events.append({"ts": int(time.time()), "data": data})
+        logging.info("telemetry: %s", data)
+        return jsonify({"status": "ok"})
+
     @app.route("/discover/add", methods=["POST"])
     @login_required
     def add_discovered_camera():
@@ -3780,6 +3790,8 @@ def init_routes(app: Flask) -> None:
 
     notifications = []
     MAX_NOTIFICATIONS = 100
+
+    telemetry_events = deque(maxlen=1000)
 
     @app.route("/send_notification", methods=["POST"])
     @login_required

--- a/app/static/js/telemetry.js
+++ b/app/static/js/telemetry.js
@@ -1,0 +1,7 @@
+export function sendTelemetry(event, data = {}) {
+  fetch("/telemetry", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event, data }),
+  }).catch(() => {});
+}

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -1,3 +1,5 @@
+import { sendTelemetry } from "./telemetry.js";
+
 export function initUrlTester() {
   document.addEventListener("DOMContentLoaded", () => {
     const input = document.getElementById("url");
@@ -30,10 +32,12 @@ export function initUrlTester() {
           status.textContent = "✗";
           status.classList.add("bad");
         }
+        sendTelemetry("url_test", { url, ok: data.ok });
       } catch {
         if (controller.signal.aborted) return;
         status.textContent = "✗";
         status.classList.add("bad");
+        sendTelemetry("url_test", { url, ok: false });
       }
     };
 

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -101,7 +101,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
     id="{{ form_id }}"
     action="{{ action }}"
     method="post"
-    onsubmit="return validateForm()"
+    onsubmit="window.sendTelemetry && sendTelemetry('template_submit'); return validateForm()"
     title="Enter template details"
   >
     <div>
@@ -113,6 +113,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         name="name"
         value="{{ template.name if template else '' }}"
         required
+        placeholder="My Camera"
         title="Enter a unique name for this template"
       />
       {% endif %}
@@ -124,6 +125,8 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         name="url"
         value="{{ template.url if template else '' }}"
         required
+        pattern="https?://.+"
+        placeholder="https://example.com/video"
         title="Enter the URL to monitor"
       />
       <span id="url-status" class="url-status" title="URL test result"></span>
@@ -139,6 +142,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         min="0.1"
         step="0.1"
         required
+        placeholder="30"
         title="Enter how often to check the URL (in minutes)"
       />
 
@@ -152,6 +156,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         value="{{ template.timeout if template else 10 }}"
         min="1"
         required
+        placeholder="10"
         title="Enter the maximum time to wait for a response (in seconds)"
       />
 
@@ -159,6 +164,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
       <textarea
         id="notes"
         name="notes"
+        placeholder="Optional notes"
         title="Enter any additional notes or comments"
       >
 {{ template.notes if template else '' }}</textarea
@@ -172,6 +178,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="object_filter"
         name="object_filter"
         value="{{ template.object_filter if template else '' }}"
+        placeholder="person,car"
         title="Enter object types to filter (e.g., 'person,car')"
       />
 
@@ -188,6 +195,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         min="0"
         max="1"
         step="0.01"
+        placeholder="0.5"
         title="Enter the minimum confidence level for object detection (0-1)"
       />
 
@@ -233,6 +241,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="callback_url"
         name="callback_url"
         value="{{ template.callback_url if template else '' }}"
+        placeholder="https://example.com/callback"
         title="Enter URL to receive notifications"
       />
 
@@ -242,6 +251,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="proxy"
         name="proxy"
         value="{{ template.proxy if template else '' }}"
+        placeholder="proxy.example.com:8080"
         title="Enter proxy server address (optional)"
       />
 
@@ -253,6 +263,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="auth_username"
         name="auth_username"
         value="{{ template.auth_username if template else '' }}"
+        placeholder="user"
         title="Camera username"
       />
 
@@ -264,6 +275,7 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="auth_password"
         name="auth_password"
         value="{{ template.auth_password if template else '' }}"
+        placeholder="pass"
         title="Camera password"
       />
 
@@ -275,6 +287,8 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
         id="groups"
         name="groups"
         value="{{ template.groups if template else '' }}"
+        pattern="[\w,\- ]*"
+        placeholder="group1,group2"
         title="Enter comma-separated group names"
       />
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,5 @@
+# Telemetry
+
+The interface now records lightweight usage events. When you test a URL or submit the template form,
+a small JSON payload is POSTed to `/telemetry`. The server keeps the last
+1000 events in memory and logs them for diagnostics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Clock Settings: clock_settings.md
       - Configuration Management: config_management.md
       - System Monitoring: system_monitoring.md
+      - Telemetry: telemetry.md
       - Testing: testing.md
       - Tooltips: tooltips.md
       - SEO Metadata: seo_metadata.md

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -10,19 +10,24 @@ beforeAll(async () => {
 
 describe("url_test", () => {
   test("shows status after fetch", async () => {
-    global.fetch = jest.fn(() =>
+    const responses = [
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ ok: true }),
       }),
-    );
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ status: "ok" }),
+      }),
+    ];
+    global.fetch = jest.fn(() => responses.shift());
     initUrlTester();
     document.dispatchEvent(new Event("DOMContentLoaded"));
     const input = document.getElementById("url");
     input.value = "http://example.com";
     input.dispatchEvent(new Event("change"));
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(fetch).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(2);
     const status = document.getElementById("url-status");
     expect(status.textContent).toBe("✓");
     expect(status.classList.contains("ok")).toBe(true);


### PR DESCRIPTION
## Summary
- improve form placeholders and add client-side validation
- record telemetry events client-side and server-side
- update docs with telemetry info

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68464eaf26648333a28d4adc84552898