### PR TITLE
Add Python versions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Docs Build](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/glimpser)](https://github.com/KristopherKubicki/glimpser/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+[![Python versions](https://img.shields.io/pypi/pyversions/glimpser.svg)](https://pypi.org/project/glimpser/)
 [![Coverage](https://codecov.io/gh/KristopherKubicki/glimpser/branch/main/graph/badge.svg)](https://codecov.io/gh/KristopherKubicki/glimpser)
 
 ## Introduction


### PR DESCRIPTION
## Summary
- add a badge for supported Python versions in `README.md`

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68464d6bc4808333beafdfbab6a8cb61