### PR TITLE
docs: fix Flax version in install guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,7 @@ pip install -r requirements.txt
 ```
 
 The `requirements.txt` file now includes the CPU builds of **JAX 0.6.1** and
-**Flax 0.2.0**, along with updated `scikit-image` (0.25.0) and
+**Flax 0.8.5**, along with updated `scikit-image` (0.25.0) and
 `numpy` (1.25.0).
 
 ### 6. (Optional) Configure Environment Variables

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -102,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png?group=g1")
         with open(img1, "rb") as f:
             self.assertEqual(resp.data, f.read())
-            
+
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
         img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")


### PR DESCRIPTION
## Summary
- correct the Flax version number in the installation guide
- run code formatters which cleaned trailing whitespace in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b7b2a62c83339a3ad6ac78ba7c77