### PR TITLE
Add auto login option

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -259,6 +259,7 @@ FLASK_LOG_LEVEL = get_setting("FLASK_LOG_LEVEL", LOG_LEVEL)
 SESSION_COOKIE_SECURE = get_setting("SESSION_COOKIE_SECURE", "True") == "True"
 SESSION_COOKIE_HTTPONLY = get_setting("SESSION_COOKIE_HTTPONLY", "True") == "True"
 SESSION_TIMEOUT_MINUTES = int(get_setting("SESSION_TIMEOUT_MINUTES", 30))
+AUTO_LOGIN_DAYS = int(get_setting("AUTO_LOGIN_DAYS", 30))
 
 # Clock configuration
 CLOCK_OVERLAY = get_setting("CLOCK_OVERLAY", "False") == "True"

--- a/app/routes.py
+++ b/app/routes.py
@@ -39,6 +39,7 @@ from flask import (
     make_response,
     stream_with_context,
     Flask,
+    current_app,
 )
 from collections import deque
 
@@ -311,9 +312,12 @@ def login_required(f: Callable) -> Callable:
                 return redirect(url_for("login", next=request.url))
 
             # Refresh expiry so the timeout is based on inactivity
-            session["expiry"] = (
-                datetime.now() + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
-            ).strftime("%Y-%m-%d %H:%M:%S")
+            timeout = (
+                timedelta(days=config.AUTO_LOGIN_DAYS)
+                if session.get("remember")
+                else timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
+            )
+            session["expiry"] = (datetime.now() + timeout).strftime("%Y-%m-%d %H:%M:%S")
 
             db_session = SessionLocal()
             try:
@@ -1577,6 +1581,7 @@ def init_routes(app: Flask) -> None:
         if request.method == "POST":
             username = (request.form.get("username") or "").strip()
             password = (request.form.get("password") or "").strip()
+            remember = request.form.get("remember") == "on"
             if not username or not password:
                 flash("Username and password are required", "error")
                 return render_template("login.html", page_title="Login"), 400
@@ -1589,9 +1594,19 @@ def init_routes(app: Flask) -> None:
 
             if user and check_password_hash(user.password_hash, password):
                 session["user_id"] = user.id
-                session["expiry"] = (
-                    now + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
-                ).strftime("%Y-%m-%d %H:%M:%S")
+                if remember:
+                    current_app.permanent_session_lifetime = timedelta(
+                        days=config.AUTO_LOGIN_DAYS
+                    )
+                    session["remember"] = True
+                    timeout = timedelta(days=config.AUTO_LOGIN_DAYS)
+                else:
+                    current_app.permanent_session_lifetime = timedelta(
+                        minutes=config.SESSION_TIMEOUT_MINUTES
+                    )
+                    session.pop("remember", None)
+                    timeout = timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
+                session["expiry"] = (now + timeout).strftime("%Y-%m-%d %H:%M:%S")
                 session.permanent = True
                 login_attempts.pop(
                     ip_address, None

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1,4 +1,5 @@
 import { timeAgo, formatExactTime } from "./templates.js";
+import { attemptAutoLogin } from "./login.js";
 
 const video = document.getElementById("live-video");
 
@@ -1197,6 +1198,13 @@ async function fetchLatestCaptions() {
     const resp = await fetch("/templates");
     if (!resp.ok) return;
     const data = await resp.json();
+    if (data.error === "unauthorized") {
+      const ok = await attemptAutoLogin();
+      if (ok) {
+        fetchLatestCaptions();
+      }
+      return;
+    }
     for (const name in templateDetails) {
       if (data[name]) {
         templateDetails[name].last_caption = data[name].last_caption;
@@ -1377,6 +1385,13 @@ async function attemptReconnect() {
   try {
     const res = await fetch("/network_status");
     const data = await res.json();
+    if (data.error === "unauthorized") {
+      const ok = await attemptAutoLogin();
+      if (ok) {
+        return attemptReconnect();
+      }
+      return;
+    }
     if (data.online) {
       clearInterval(reconnectTimer);
       reconnectTimer = null;

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -2,6 +2,7 @@ export function initLogin() {
   document.addEventListener("DOMContentLoaded", () => {
     const form = document.getElementById("login-form");
     const noteEl = document.getElementById("security-note");
+    attemptAutoLogin();
     if (!form) return;
     if (noteEl) {
       if (location.protocol === "https:") {
@@ -15,6 +16,7 @@ export function initLogin() {
     form.addEventListener("submit", (e) => {
       const user = form.elements["username"].value.trim();
       const pass = form.elements["password"].value.trim();
+      const remember = form.elements["remember"].checked;
       const error = document.getElementById("login-error");
       if (!user || !pass) {
         e.preventDefault();
@@ -22,9 +24,46 @@ export function initLogin() {
           error.textContent = "Username and password are required.";
           error.classList.remove("hidden");
         }
+        return;
+      }
+      if (remember) {
+        localStorage.setItem(
+          "autoLogin",
+          JSON.stringify({ username: user, password: pass }),
+        );
+      } else {
+        localStorage.removeItem("autoLogin");
       }
     });
   });
+}
+
+export async function attemptAutoLogin() {
+  if (window.IS_LOGGED_IN) return false;
+  const stored = localStorage.getItem("autoLogin");
+  if (!stored) return false;
+  try {
+    const creds = JSON.parse(stored);
+    const resp = await fetch("/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        username: creds.username,
+        password: creds.password,
+        remember: "on",
+      }),
+    });
+    if (resp.redirected || resp.url.endsWith("/")) {
+      window.IS_LOGGED_IN = true;
+      if (window.location.pathname === "/login") {
+        window.location.href = "/";
+      }
+      return true;
+    }
+  } catch (err) {
+    console.error("Auto login failed", err);
+  }
+  return false;
 }
 
 initLogin();

--- a/app/static/js/logs.js
+++ b/app/static/js/logs.js
@@ -1,3 +1,5 @@
+import { attemptAutoLogin } from "./login.js";
+
 export function updateTable(logs) {
   const tbody = document.querySelector("#log-table tbody");
   if (!tbody) return;
@@ -68,8 +70,14 @@ export function initLogs() {
       };
 
       eventSource.onmessage = (event) => {
-        const logs = JSON.parse(event.data);
-        updateTable(logs);
+        const data = JSON.parse(event.data);
+        if (data.error === "unauthorized") {
+          attemptAutoLogin().then((ok) => {
+            if (ok) startEventStream();
+          });
+          return;
+        }
+        updateTable(data);
       };
 
       eventSource.onerror = (error) => {

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -19,6 +19,7 @@ export function initNav() {
     const cameraDropdown = document.getElementById("nav-camera-dropdown");
     const currentGroup = window.currentGroup || null;
     const currentCamera = window.currentCamera || null;
+    const menuToggle = document.getElementById("menu-toggle");
 
     if (nav && menuToggle) {
       menuToggle.addEventListener("click", () => {

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -39,6 +39,13 @@ content %}
     </div>
     <div id="login-error" class="form-error hidden"></div>
 
+    <div class="checkbox-row">
+      <label for="remember">
+        <input id="remember" type="checkbox" name="remember" />
+        Remember me
+      </label>
+    </div>
+
     {% with messages = get_flashed_messages(with_categories=true) %} {% if
     messages %}
     <div class="flash-messages">

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -62,6 +62,8 @@ updated with `generate_credentials.py` or through the web interface.
   session cookie (default `True`)
 - `SESSION_TIMEOUT_MINUTES` – session timeout after this many minutes of
   inactivity (default `30`)
+- `AUTO_LOGIN_DAYS` – days the session persists when "Remember me" is checked
+  (default `30`)
 
 User accounts are stored in the `users` table. Each record contains the
 `username`, `password_hash`, and an optional `role` that can be used for future

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -17,6 +17,7 @@ Key topics covered include:
 - Dark mode toggle and mobile-friendly responsive layout.
 - System Status metrics, feed dashboard, and live log viewer.
 - Offline preview of recent snapshots and locally hosted fonts.
+- "Remember me" option on the login page for automatic sign in.
 - Links to the rest of the documentation under `docs/`.
 - Tooltips across the interface for quick explanations.
 - Inline viewing of command-line help via the **Show CLI Help** button.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -13,6 +13,7 @@ import unittest
 from unittest.mock import patch
 from types import SimpleNamespace
 from app.config import USER_NAME
+import time
 from app.routes import login_required
 from app import create_app
 
@@ -413,6 +414,60 @@ class TestAuthentication(unittest.TestCase):
             response = self.client.get("/sso?token=wrong")
             self.assertEqual(response.status_code, 302)
             self.assertIn("/login", response.headers["Location"])
+
+    def test_remember_me_session_persistent(self):
+        login_attempts = {}
+        with (
+            patch("app.routes.SessionLocal") as mock_session_local,
+            patch("app.routes.login_attempts", login_attempts),
+            patch("app.routes.check_password_hash", return_value=True),
+            patch("app.routes.config.AUTO_LOGIN_DAYS", 10),
+        ):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+            response = self.client.post(
+                "/login",
+                data={
+                    "username": USER_NAME,
+                    "password": "correct_password",
+                    "remember": "on",
+                },
+            )
+            self.assertEqual(response.status_code, 302)
+            cookie_header = response.headers.get("Set-Cookie")
+            self.assertIsNotNone(cookie_header)
+            parts = cookie_header.split("Expires=")
+            self.assertEqual(len(parts), 2)
+            expiry_str = parts[1].split(";")[0]
+            expiry = datetime.datetime.strptime(expiry_str, "%a, %d %b %Y %H:%M:%S GMT")
+            self.assertGreater(
+                expiry, datetime.datetime.utcnow() + datetime.timedelta(days=1)
+            )
+
+    def test_sse_unauthorized_message(self):
+        login_attempts = {}
+        response = self.client.get(
+            "/stream_logs",
+            headers={"Accept": "text/event-stream"},
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.mimetype, "text/event-stream")
+        self.assertIn(b'{"error": "unauthorized"}', response.data)
 
 
 if __name__ == "__main__":

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -102,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png?group=g1")
         with open(img1, "rb") as f:
             self.assertEqual(resp.data, f.read())
-            
+
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
         img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")


### PR DESCRIPTION
## Summary
- add remember-me checkbox to login template
- store credentials in localStorage and auto-login
- extend logs and live scripts to retry when unauthorized
- support persistent sessions in login route
- document `AUTO_LOGIN_DAYS` and new login option
- ensure nav toggle element exists for tests
- test persistent session and SSE unauthorized handling

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_authentication.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b5f470dc83338045ded457dcabee