### PR TITLE
Fix Doppler spelling

### DIFF
--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -207,7 +207,7 @@ well to the existing discovery methods:
 Locally attached USB webcams (for example, Logitech devices) will appear under
 `/dev/video*`.
 
-Remote sources such as **GOES16**, **ZoomEarth**, and **Dopler** can be added
+Remote sources such as **GOES16**, **ZoomEarth**, and **Doppler** can be added
 manually, but they are not discovered automatically because they are hosted
 outside the local network.
 

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -6,7 +6,7 @@ Glimpser is a powerful monitoring and data aggregation tool that can be used for
 
 Glimpser's ability to aggregate data from multiple sources makes it an excellent tool for comprehensive weather and environmental monitoring.
 
-- **Local Weather Tracking**: Use cameras like ["GOES16"](https://www.goes-r.gov/), ["ZoomEarth"](https://zoom.earth/), and ["Dopler"](https://weather.com/maps/current-weather) to get real-time updates on local weather conditions.
+- **Local Weather Tracking**: Use cameras like ["GOES16"](https://www.goes-r.gov/), ["ZoomEarth"](https://zoom.earth/), and ["Doppler"](https://weather.com/maps/current-weather) to get real-time updates on local weather conditions.
 - **Air Quality Monitoring**: The "AQI" camera can help track air quality, allowing users to make informed decisions about outdoor activities.
 - **Natural Disaster Preparedness**: Utilize ["Lightning"](https://www.lightningmaps.org/), ["Storms"](https://www.nhc.noaa.gov/), and ["NOAA"](https://www.noaa.gov/) feeds to stay ahead of severe weather events.
 - **Climate Change Research**: Long-term data from "Drought" and "Groundwater" cameras can contribute to climate change studies.

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -102,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png?group=g1")
         with open(img1, "rb") as f:
             self.assertEqual(resp.data, f.read())
-            
+
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
         img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")


### PR DESCRIPTION
## Summary
- fix Doppler spelling in documentation
- remove stray whitespace in test to satisfy lint

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b7bc5be483338f16e4af49e07990