### PR TITLE
Add macOS build automation

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -78,3 +78,25 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           files: dist/Glimpser.exe
+
+  build_macos:
+    runs-on: macos-latest
+    needs: build_debian
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PyInstaller
+        run: python -m pip install --upgrade pip && pip install pyinstaller
+      - name: Build macOS executable
+        run: python build_macos.py
+      - name: Upload macOS archive
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/Glimpser

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ To set up the project for development:
 
 Release packages are built automatically when a version tag is pushed.
 The workflow runs tests and creates the Debian package on an Ubuntu runner.
-The Windows executable is built separately on a Windows runner using
-`build_windows.py`. When both steps finish, the resulting Debian package and
-Windows binary are uploaded to the GitHub release for that tag.
+The Windows executable is built on a Windows runner with `build_windows.py`, and
+a macOS archive is produced with `build_macos.py`. When all steps finish, the
+resulting Debian package and platform binaries are uploaded to the GitHub
+release for that tag.
 If the repository contains a `PYPI_API_TOKEN` secret, the workflow also
 builds Python distributions and publishes them to PyPI. These files can be
 downloaded from the Releases page or installed with `pip`.

--- a/build_macos.py
+++ b/build_macos.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Build a macOS bundle using PyInstaller."""
+import os
+import PyInstaller.__main__
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+PyInstaller.__main__.run(
+    [
+        "app/__init__.py",
+        "--name=Glimpser",
+        "--onefile",
+        "--windowed",
+        "--add-data=app/templates:templates",
+        "--add-data=app/static:static",
+        "--hidden-import=flask",
+        "--hidden-import=flask_apscheduler",
+        "--hidden-import=sqlalchemy",
+        "--hidden-import=werkzeug",
+        "--hidden-import=jinja2",
+        "--hidden-import=PIL",
+        "--hidden-import=numpy",
+        "--hidden-import=selenium",
+        "--hidden-import=undetected_chromedriver",
+        "--hidden-import=yt_dlp",
+        "--hidden-import=pdf2image",
+        "--hidden-import=pyvirtualdisplay",
+        "--icon=app/static/favicon.ico",
+    ]
+)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -1,12 +1,13 @@
 # Release Workflow
 
 Glimpser packages are generated automatically when a version tag is pushed to the repository.
-The process is split across two runners:
+The process is split across multiple runners:
 
 - **Ubuntu** builds the Debian package and runs the test suite. The packaging
   script now uses `rsync` to copy directories so unchanged files are skipped,
   speeding up repeated builds.
 - **Windows** builds the standalone executable using `build_windows.py`.
+- **macOS** builds a self-contained application with `build_macos.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists
 status badges for the current tag.  This file becomes the body of the GitHub

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -102,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png?group=g1")
         with open(img1, "rb") as f:
             self.assertEqual(resp.data, f.read())
-            
+
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
         img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")


### PR DESCRIPTION
## Summary
- build macOS executable with PyInstaller
- include macOS job in release workflow
- document macOS step in README and release docs
- fix trailing whitespace in test

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b62bdb848333812cdcc237d14a5d