### PR TITLE
Add persistent notifications

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 from .user import User
 from .summary import Summary
 from .offline_job import OfflineJob
+from .notification import Notification
 
-__all__ = ["User", "Summary", "OfflineJob"]
+__all__ = ["User", "Summary", "OfflineJob", "Notification"]

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String, Text, Boolean
+
+from app.utils.db import Base
+
+
+class Notification(Base):
+    """User-facing notification stored in the database."""
+
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(Integer, nullable=False)
+    title = Column(String, nullable=False)
+    body = Column(Text, nullable=False)
+    viewed = Column(Boolean, default=False)
+
+    def __repr__(self) -> str:
+        return f"<Notification id={self.id} title={self.title}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -76,7 +76,7 @@ from app.config import (
     CLOCK_DIGITAL,
     CLOCK_NAVBAR,
 )
-from app.models import User, Summary
+from app.models import User, Summary, Notification
 from app.utils import (
     scheduling,
     template_manager,
@@ -3848,9 +3848,16 @@ def init_routes(app: Flask) -> None:
     @login_required
     def send_notification():
         data = request.get_json(force=True)
-        notifications.append(
-            {"title": data.get("title", "Notification"), "body": data.get("body", "")}
-        )
+        title = data.get("title", "Notification")
+        body = data.get("body", "")
+        ts = int(time.time())
+        session_db = SessionLocal()
+        try:
+            session_db.add(Notification(timestamp=ts, title=title, body=body))
+            session_db.commit()
+        finally:
+            session_db.close()
+        notifications.append({"title": title, "body": body})
         if len(notifications) > MAX_NOTIFICATIONS:
             notifications.pop(0)
         return jsonify({"status": "queued"})
@@ -3867,3 +3874,63 @@ def init_routes(app: Flask) -> None:
                 time.sleep(1)
 
         return Response(stream_with_context(generate()), mimetype="text/event-stream")
+
+    @app.route("/notifications")
+    @login_required
+    def notifications_page():
+        page = max(int(request.args.get("page", 1)), 1)
+        per_page = 20
+        session_db = SessionLocal()
+        try:
+            query = session_db.query(Notification).order_by(
+                Notification.timestamp.desc()
+            )
+            total = query.count()
+            notes = query.offset((page - 1) * per_page).limit(per_page).all()
+        finally:
+            session_db.close()
+        display = [
+            {
+                "id": n.id,
+                "title": n.title,
+                "body": n.body,
+                "viewed": n.viewed,
+                "timestamp": datetime.utcfromtimestamp(n.timestamp).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            }
+            for n in notes
+        ]
+        return render_template(
+            "notifications.html",
+            notifications=display,
+            page=page,
+            total=total,
+            per_page=per_page,
+        )
+
+    @app.route("/notifications/read/<int:note_id>", methods=["POST"])
+    @login_required
+    def mark_notification_read(note_id: int):
+        session_db = SessionLocal()
+        try:
+            note = session_db.query(Notification).get(note_id)
+            if note:
+                note.viewed = True
+                session_db.commit()
+        finally:
+            session_db.close()
+        return redirect(url_for("notifications_page", page=request.args.get("page", 1)))
+
+    @app.route("/notifications/delete/<int:note_id>", methods=["POST"])
+    @login_required
+    def delete_notification(note_id: int):
+        session_db = SessionLocal()
+        try:
+            note = session_db.query(Notification).get(note_id)
+            if note:
+                session_db.delete(note)
+                session_db.commit()
+        finally:
+            session_db.close()
+        return redirect(url_for("notifications_page", page=request.args.get("page", 1)))

--- a/app/templates/notifications.html
+++ b/app/templates/notifications.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% from 'components.html' import card %}
+{% block content %}
+<h1>Notifications</h1>
+{% call card('Recent Notifications') %}
+<table class="notification-table">
+  <thead>
+    <tr><th>Time</th><th>Title</th><th>Body</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {% for n in notifications %}
+    <tr>
+      <td>{{ n.timestamp }}</td>
+      <td>{{ n.title }}</td>
+      <td>{{ n.body }}</td>
+      <td>{{ 'Read' if n.viewed else 'Unread' }}</td>
+      <td>
+        <form action="{{ url_for('mark_notification_read', note_id=n.id, page=page) }}" method="post" style="display:inline">
+          <button type="submit" {% if n.viewed %}disabled{% endif %}>Mark Read</button>
+        </form>
+        <form action="{{ url_for('delete_notification', note_id=n.id, page=page) }}" method="post" style="display:inline">
+          <button type="submit">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<div class="pagination">
+{% if page > 1 %}
+  <a href="{{ url_for('notifications_page', page=page-1) }}" title="Previous page">Previous</a>
+{% endif %}
+{% if page * per_page < total %}
+  <a href="{{ url_for('notifications_page', page=page+1) }}" title="Next page">Next</a>
+{% endif %}
+</div>
+{% endcall %}
+{% endblock %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Configuration Management](config_management.md)
 - [Offline Preview](offline_preview.md)
 - [Web Notifications](web_notifications.md)
+- [Notifications Page](notifications_page.md)
 - [Nginx HTTP/2 Push](nginx_http2_push.md)
 - [API Resilience](api_resilience.md)
 - [OpenSSF Scorecard](scorecard.md)

--- a/docs/notifications_page.md
+++ b/docs/notifications_page.md
@@ -1,0 +1,5 @@
+# Notifications Page
+
+Glimpser stores browser notifications in a new `notifications` table. The `/notifications` route lists recent messages with controls to mark each one as read or delete it. Entries show the timestamp, title and body.
+
+Use `/send_notification` to queue a message for connected browsers. Every POST creates a record in the database so alerts can be reviewed later.

--- a/docs/web_notifications.md
+++ b/docs/web_notifications.md
@@ -8,6 +8,9 @@ Send a POST request to `/send_notification` with a JSON body containing
 `title` and `body` fields. Connected browsers display the message using the
 standard Notification API.
 
+All notifications are stored in the database and can be reviewed on the
+`/notifications` page.
+
 ```bash
 curl -X POST -H "Content-Type: application/json" \
      -d '{"title": "Update", "body": "Motion detected"}' \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Offline Preview: offline_preview.md
       - Pylint Checks: pylint_checks.md
       - Web Notifications: web_notifications.md
+      - Notifications Page: notifications_page.md
       - Search Autocomplete: search_autocomplete.md
       - Recommendations: recommendations.md
       - Release Workflow: release_workflow.md

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import importlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app import create_app
+import app.config as config
+import app.utils.db as db
+import app.routes as routes
+from app.models import Notification
+from app.utils.scheduling import scheduler
+
+
+class TestNotifications(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.temp_dir.name, "test.db")
+        self.env_patch = patch.dict(
+            os.environ, {"GLIMPSER_DATABASE_PATH": self.db_path}
+        )
+        self.env_patch.start()
+
+        importlib.reload(config)
+        importlib.reload(db)
+        import app.models as models
+
+        importlib.reload(models)
+        importlib.reload(models.notification)
+        db.init_db()
+        self.orig_session_local = routes.SessionLocal
+        self.orig_notification = routes.Notification
+        routes.Notification = models.notification.Notification
+        routes.SessionLocal = db.SessionLocal
+
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        from flask import Flask
+
+        self.app = Flask(__name__)
+        routes.init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.env_patch.stop()
+        import app
+
+        importlib.reload(config)
+        importlib.reload(db)
+        importlib.reload(app)
+        routes.SessionLocal = self.orig_session_local
+        routes.Notification = self.orig_notification
+        import app.models as models
+
+        importlib.reload(models)
+        importlib.reload(models.notification)
+        self.temp_dir.cleanup()
+        scheduler.shutdown(wait=False)
+
+    def test_table_created(self):
+        from sqlalchemy import inspect
+
+        inspector = inspect(db.engine)
+        self.assertIn("notifications", inspector.get_table_names())
+
+    def test_send_and_manage_notifications(self):
+        resp = self.client.post(
+            "/send_notification", json={"title": "Hello", "body": "World"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        session = db.SessionLocal()
+        try:
+            note = session.query(Notification).first()
+            self.assertIsNotNone(note)
+            note_id = note.id
+        finally:
+            session.close()
+
+        self.client.post(f"/notifications/read/{note_id}")
+        session = db.SessionLocal()
+        try:
+            note = session.query(Notification).get(note_id)
+            self.assertTrue(note.viewed)
+        finally:
+            session.close()
+
+        self.client.post(f"/notifications/delete/{note_id}")
+        session = db.SessionLocal()
+        try:
+            note = session.query(Notification).get(note_id)
+            self.assertIsNone(note)
+        finally:
+            session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -102,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
         resp = self.client.get("/stream.png?group=g1")
         with open(img1, "rb") as f:
             self.assertEqual(resp.data, f.read())
-            
+
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
         img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")


### PR DESCRIPTION
## Summary
- add Notification SQLAlchemy model
- persist `/send_notification` messages
- list notifications with management actions
- document notifications page
- test notification model and endpoints

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_notifications.py tests/test_scheduler_start_once.py::test_scheduler_starts_once tests/test_routes.py::TestRoutes::test_captions_status -q`


------
https://chatgpt.com/codex/tasks/task_e_6846b5d53af8833383598a67bf277095