### PR TITLE
Refactor clip endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2702,7 +2702,7 @@ def init_routes(app: Flask) -> None:
     @login_required
     @limit_rate(30)
     def serve_clip(template_name: TemplateName):
-        """Return a short clip built from recent finalized segments."""
+        """Return a short clip built from recent footage."""
 
         template_name = validate_template_name(template_name)
         if template_name is None:
@@ -2722,8 +2722,13 @@ def init_routes(app: Flask) -> None:
 
         clip_path = root / "clip.mp4"
 
+        in_process = root / "in_process.mp4"
+        sources = list(root.glob("final_*.mp4"))
+        if in_process.exists():
+            sources.append(in_process)
+
         newest_src = max(
-            root.glob("final_*.mp4"),
+            sources,
             key=lambda p: p.stat().st_mtime,
             default=None,
         )
@@ -2736,29 +2741,33 @@ def init_routes(app: Flask) -> None:
         ):
             return send_file(clip_path, conditional=True)
 
-        needed = math.ceil(duration / SEGMENT_SEC)
-        parts = sorted(
-            root.glob("final_*.mp4"),
-            key=lambda p: p.stat().st_mtime,
-            reverse=True,
-        )[:needed]
-        parts = sorted(parts, key=lambda p: p.stat().st_mtime)
-
-        blank_duration = duration - len(parts) * SEGMENT_SEC
-        blank_path = root / "blank_tmp.mp4"
-        blank_width, blank_height = (
-            video_archiver.get_video_resolution(newest_src)
-            if newest_src
-            else (None, None)
-        )
-        if blank_duration > 0:
-            video_archiver.create_blank_video(
-                blank_duration,
-                blank_path.as_posix(),
-                width=blank_width,
-                height=blank_height,
+        parts: list[Path] = []
+        in_process_len = 0
+        if in_process.exists():
+            in_process_len = int(
+                video_archiver.get_video_duration(in_process.as_posix()) or 0
             )
-            parts = [blank_path] + parts
+
+        remaining = duration - in_process_len
+        if remaining > 0:
+            final_parts = [
+                p
+                for p in sorted(
+                    root.glob("final_*.mp4"),
+                    key=lambda p: p.stat().st_mtime,
+                    reverse=True,
+                )
+                if p.stat().st_size > 0
+            ]
+            total = 0
+            for part in final_parts:
+                parts.insert(0, part)
+                total += SEGMENT_SEC
+                if total >= remaining:
+                    break
+
+        if in_process.exists():
+            parts.append(in_process)
 
         lock_path = root / ".clip.lock"
         with lock_path.open("w") as lock_fd:
@@ -2770,18 +2779,10 @@ def init_routes(app: Flask) -> None:
             ):
                 return send_file(clip_path, conditional=True)
 
-            if parts and _concat_copy(clip_path, parts, duration):
-                pass
-            else:
-                video_archiver.create_blank_video(
-                    duration,
-                    clip_path.as_posix(),
-                    width=blank_width,
-                    height=blank_height,
-                )
-
-        if blank_path.exists():
-            blank_path.unlink(missing_ok=True)
+            if not parts:
+                video_archiver.create_blank_video(duration, clip_path.as_posix())
+            elif not _concat_copy(clip_path, parts, duration):
+                video_archiver.create_blank_video(duration, clip_path.as_posix())
 
         if clip_path.exists():
             return send_file(clip_path, conditional=True)

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,7 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /clip/<template_name>** – Concatenate the latest finalized segments into a fresh clip. The response always spans the requested `duration` (default `DEFAULT_CLIP_DURATION`). When no footage exists the server returns a blank video of that length. Subsequent requests within a few seconds reuse the cached clip for speed.
+- **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests within a few seconds reuse the cached clip for speed.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -37,19 +37,14 @@ class TestClipRoute(unittest.TestCase):
             f2 = os.path.join(camera_path, "final_2.mp4")
             open(f1, "w").close()
             open(f2, "w").close()
+            in_proc = os.path.join(camera_path, "in_process.mp4")
+            open(in_proc, "w").close()
             os.utime(f1, (1, 1))
             os.utime(f2, (2, 2))
             with (
                 patch("app.routes.VIDEO_DIRECTORY", tmpdir),
                 patch("app.routes.send_file") as mock_send,
             ):
-
-                def fake_blank(duration, output, width=None, height=None):
-                    with open(output, "w"):
-                        pass
-                    return True
-
-                mock_blank.side_effect = fake_blank
 
                 def fake_concat(out, parts, clip_len):
                     with open(out, "w"):
@@ -63,7 +58,7 @@ class TestClipRoute(unittest.TestCase):
         expected = Path(tmpdir, "cam1", "clip.mp4")
         mock_send.assert_called_with(expected, conditional=True)
         mock_concat.assert_called_once()
-        mock_blank.assert_called_once()
+        mock_blank.assert_not_called()
 
     @patch("app.routes._concat_copy", return_value=False)
     @patch("app.routes.video_archiver.create_blank_video")
@@ -87,7 +82,7 @@ class TestClipRoute(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         expected = Path(tmpdir, "cam1", "clip.mp4")
         mock_send.assert_called_with(expected, conditional=True)
-        self.assertEqual(mock_blank.call_count, 2)
+        mock_blank.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_throttle_routes.py
+++ b/tests/test_throttle_routes.py
@@ -41,7 +41,8 @@ class TestHeavyRouteThrottle(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             camera_path = os.path.join(tmpdir, "cam1")
             os.makedirs(camera_path)
-            open(os.path.join(camera_path, "final_1.mp4"), "w").close()
+            with open(os.path.join(camera_path, "final_1.mp4"), "wb") as f:
+                f.write(b"0")
             with (
                 patch("app.routes.VIDEO_DIRECTORY", tmpdir),
                 patch("app.routes.send_file") as mock_send,
@@ -67,7 +68,7 @@ class TestHeavyRouteThrottle(unittest.TestCase):
         self.assertEqual(resp2.status_code, 429)
         mock_send.assert_called_once()
         mock_concat.assert_called_once()
-        self.assertGreaterEqual(mock_blank.call_count, 1)
+        mock_blank.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include `in_process.mp4` when building `/clip` response
- update API docs
- adjust clip route tests
- revise throttle route test

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c985e8688333989a3d1e8bb10bfd