### PR TITLE
Improve scheduler reliability with backoff

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -78,6 +78,13 @@ logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
 clip_processor, clip_model = None, None
 
+# Track currently running jobs to avoid launching duplicates.
+active_jobs: dict[str, multiprocessing.Process] = {}
+active_jobs_lock = threading.Lock()
+# Track failures and backoff time to slow down flapping jobs.
+job_failures: dict[str, int] = {}
+job_backoff_until: dict[str, float] = {}
+
 
 class GracefulAPScheduler(APScheduler):
     def __init__(self):
@@ -147,8 +154,25 @@ def run_with_timeout(func, args=(), timeout=300):
             session.close()
         return
 
+    # Determine key for tracking active jobs. For camera updates the first
+    # argument is the camera name; otherwise fall back to function name.
+    key = getattr(func, "__name__", "job")
+    if args and isinstance(args[0], str):
+        key = args[0]
+
     try:
-        process = multiprocessing.Process(target=func, args=args)
+        with active_jobs_lock:
+            now = time.time()
+            backoff_until = job_backoff_until.get(key, 0)
+            if now < backoff_until:
+                logging.info("backing off job %s for %.1fs", key, backoff_until - now)
+                return
+            existing = active_jobs.get(key)
+            if existing and existing.is_alive():
+                logging.info("job already running")
+                return
+            process = multiprocessing.Process(target=func, args=args)
+            active_jobs[key] = process
         process.start()
     except OSError as exc:
         logging.error(
@@ -161,13 +185,17 @@ def run_with_timeout(func, args=(), timeout=300):
                 mark_offline(args[0])
             except Exception:
                 pass
+        with active_jobs_lock:
+            active_jobs.pop(key, None)
         return
 
     process.join(timeout)
+    success = True
     if process.is_alive():
         process.terminate()
         process.join()
         logging.warning("Process terminated due to timeout")
+        success = False
         if args and isinstance(args[0], str):
             try:
                 mark_offline(args[0])
@@ -180,6 +208,18 @@ def run_with_timeout(func, args=(), timeout=300):
                         cas_error(url)
             except Exception:
                 pass
+    elif process.exitcode and process.exitcode != 0:
+        success = False
+
+    with active_jobs_lock:
+        active_jobs.pop(key, None)
+        if success:
+            job_failures.pop(key, None)
+            job_backoff_until.pop(key, None)
+        else:
+            fails = job_failures.get(key, 0) + 1
+            job_failures[key] = fails
+            job_backoff_until[key] = time.time() + min(2**fails, 300)
 
 
 MAX_IMAGE_TIME_DIFF = datetime.timedelta(minutes=5)

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -1,0 +1,7 @@
+# Performance Tuning
+
+Glimpser avoids launching duplicate capture jobs to reduce CPU load. Each running job is tracked in `app/utils/scheduling.py` via the global `active_jobs` dictionary guarded by a lock. When a job is already active for a camera, new requests are skipped.
+
+If a capture job repeatedly fails or times out, the scheduler backs off before
+retrying. The delay grows exponentially up to five minutes, preventing the
+system from thrashing when a camera remains offline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Clock Settings: clock_settings.md
       - Configuration Management: config_management.md
       - System Monitoring: system_monitoring.md
+      - Performance Tuning: performance_tuning.md
       - Telemetry: telemetry.md
       - Testing: testing.md
       - Tooltips: tooltips.md

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -29,6 +29,9 @@ def dummy_job(arg):
 
 
 class TestRunWithTimeout(unittest.TestCase):
+    def setUp(self):
+        scheduling.active_jobs.clear()
+
     @patch("app.utils.scheduling.is_system_online", return_value=True)
     def test_run_completes_before_timeout(self, _online):
         manager = multiprocessing.Manager()
@@ -66,6 +69,30 @@ class TestRunWithTimeout(unittest.TestCase):
         )
         mock_offline.assert_called_once_with("cam1")
         mock_cas_error.assert_called_once_with("http://ex")
+
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    def test_skip_if_active(self, _online):
+        class DummyProc:
+            def is_alive(self):
+                return True
+
+        scheduling.active_jobs["cam1"] = DummyProc()
+        with patch("app.utils.scheduling.multiprocessing.Process") as mock_proc:
+            run_with_timeout(lambda name: None, args=("cam1",), timeout=1)
+            mock_proc.assert_not_called()
+
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    def test_backoff_on_failure(self, _online):
+        def bad_job():
+            raise RuntimeError("boom")
+
+        run_with_timeout(bad_job, timeout=1)
+        backoff = scheduling.job_backoff_until.get("bad_job")
+        self.assertIsNotNone(backoff)
+
+        with patch("app.utils.scheduling.multiprocessing.Process") as mock_proc:
+            run_with_timeout(bad_job, timeout=1)
+            mock_proc.assert_not_called()
 
 
 class TestAddMotionAndCaption(unittest.TestCase):
@@ -124,6 +151,9 @@ class TestGetSystemMetrics(unittest.TestCase):
 
 
 class TestOfflineJobQueue(unittest.TestCase):
+    def setUp(self):
+        scheduling.active_jobs.clear()
+
     @patch("app.utils.scheduling.multiprocessing.Process")
     @patch("app.utils.scheduling.SessionLocal")
     @patch("app.utils.scheduling.is_system_online", return_value=False)


### PR DESCRIPTION
## Summary
- track job failures and back off before retrying
- describe the new backoff behavior in the docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d31eb6248333a531bf4b78fbc1dd