### PR TITLE
Add isort and mypy to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,13 @@ repos:
         entry: black
         language: system
         types: [python]
+  - repo: local
+    hooks:
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        types: [python]
 
   # keep flake8 (example)
   - repo: local
@@ -16,6 +23,13 @@ repos:
       - id: flake8
         name: flake8
         entry: flake8
+        language: system
+        types: [python]
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
         language: system
         types: [python]
 

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -4,7 +4,7 @@ Glimpser runs automated quality checks on every push and pull request.
 The workflow located at `.github/workflows/python-app.yml` performs the
 following tasks:
 
-- Formats Python code with `black` and lints with `flake8`.
+- Formats Python code with `black`, sorts imports with `isort`, and lints with `flake8`.
 - Checks type hints with `mypy`.
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites and uploads coverage.
@@ -13,5 +13,5 @@ following tasks:
 - Caches Python and Node dependencies to speed up builds.
 
 Running `pre-commit run --all-files` locally will execute the same Black,
-Flake8, and mypy checks before they fail in CI. These checks help catch
+isort, Flake8, and mypy checks before they fail in CI. These checks help catch
 regressions and security issues before code is merged.


### PR DESCRIPTION
## Summary
- add isort and mypy hooks to pre-commit
- note new hooks in CI docs

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/ci_checks.md` *(fails: KeyboardInterrupt)*
- `flake8`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846e183dd248333884a85494ff7adab