### PR TITLE
Add tests for push alerts and oui map

### DIFF
--- a/tests/test_oui_map.py
+++ b/tests/test_oui_map.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+
+
+from app.utils.oui_map import OUI_MAP
+
+
+class TestOUIMap(unittest.TestCase):
+    def test_known_ouis(self):
+        expected = {
+            "000c29": "VMware",
+            "001c42": "Apple",
+            "0023ae": "Nintendo",
+        }
+        for prefix, vendor in expected.items():
+            self.assertEqual(OUI_MAP.get(prefix), vendor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_push_alerts.py
+++ b/tests/test_push_alerts.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import unittest
+
+from unittest.mock import patch, call
+
+from app.utils.push_alerts import send_push_alert
+
+
+class DummySub:
+    def __init__(self, endpoint: str, p256dh: str, auth: str) -> None:
+        self.endpoint = endpoint
+        self.p256dh = p256dh
+        self.auth = auth
+
+
+class DummySession:
+    def __init__(self, subs):
+        self.subs = subs
+        self.closed = False
+
+    def query(self, model):
+        return self
+
+    def all(self):
+        return self.subs
+
+    def close(self):
+        self.closed = True
+
+
+class TestPushAlerts(unittest.TestCase):
+    def test_send_push_alert_success(self):
+        subs = [DummySub("e1", "k1", "a1"), DummySub("e2", "k2", "a2")]
+        session = DummySession(subs)
+        with (
+            patch("app.utils.push_alerts.VAPID_PRIVATE_KEY", "priv"),
+            patch("app.utils.push_alerts.VAPID_PUBLIC_KEY", "pub"),
+            patch(
+                "app.utils.push_alerts.SessionLocal", return_value=session
+            ) as mock_sess,
+            patch("app.utils.push_alerts.webpush") as mock_webpush,
+        ):
+            send_push_alert("T", "B")
+            mock_sess.assert_called_once()
+            self.assertTrue(session.closed)
+            self.assertEqual(mock_webpush.call_count, 2)
+            calls = [call.kwargs for call in mock_webpush.call_args_list]
+            self.assertEqual(calls[0]["subscription_info"]["endpoint"], "e1")
+            self.assertEqual(calls[1]["subscription_info"]["endpoint"], "e2")
+
+    def test_send_push_alert_disabled(self):
+        with (
+            patch("app.utils.push_alerts.VAPID_PRIVATE_KEY", None),
+            patch("app.utils.push_alerts.VAPID_PUBLIC_KEY", None),
+            patch("app.utils.push_alerts.SessionLocal") as mock_sess,
+            patch("app.utils.push_alerts.webpush") as mock_webpush,
+        ):
+            send_push_alert("T", "B")
+            mock_sess.assert_not_called()
+            mock_webpush.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- test push notifications with and without VAPID keys
- verify vendor names in the OUI map

## Testing
- `pre-commit run --all-files` *(fails: `npm` not found)*
- `pytest -q tests/test_push_alerts.py tests/test_oui_map.py`
- `python -m coverage run -m pytest tests/test_push_alerts.py tests/test_oui_map.py`

------
https://chatgpt.com/codex/tasks/task_e_6846e1947f3083339bdce358d39f3e62