### PR TITLE
Add Makefile with helper tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: format lint test test-js precommit
+
+format:
+	black .
+	prettier --write app/static/js/**/*.js app/static/css/**/*.css
+
+lint:
+	flake8
+	eslint 'app/static/js/**/*.js'
+
+test:
+	pytest
+
+test-js:
+	npm test
+
+precommit:
+	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -210,6 +210,14 @@ To set up the project for development:
    ```sh
    npm test -- --coverage
    ```
+7. Use the Makefile for common tasks:
+   ```sh
+   make format   # format code
+   make lint     # run linters
+   make test     # run Python tests
+   make test-js  # run JavaScript tests
+   make precommit
+   ```
    See [Developer Guide](docs/developer_guide.md) for details.
 
 ## Releases


### PR DESCRIPTION
## Summary
- add a Makefile with common development targets
- document Makefile usage in the README

## Testing
- `pytest -q`
- `npm test`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6846e19aaa0483339b12fb862ef9983f