### PR TITLE
Show port usage when startup fails

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -157,6 +157,8 @@ Remember to always include relevant log files, error messages, and your Glimpser
 **Solution:**
 
 - Make sure no other service is using port 8082.
+- Glimpser now prints which process is using the port when startup fails.
+- You can still run `lsof -i :8082` or `fuser -n tcp 8082` manually.
 - Change the `ports` mapping in `docker-compose.yaml` if needed.
 
 ### Problem: Permission denied on volumes

--- a/main.py
+++ b/main.py
@@ -362,6 +362,20 @@ def is_port_in_use(port):
         return s.connect_ex(("localhost", port)) == 0
 
 
+def get_port_usage(port: int) -> str:
+    """Return any process details using ``port`` or an empty string."""
+    commands = [["lsof", "-i", f":{port}"], ["fuser", "-n", "tcp", str(port)]]
+    for cmd in commands:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            output = result.stdout.strip() or result.stderr.strip()
+            if output:
+                return output
+        except FileNotFoundError:
+            continue
+    return ""
+
+
 def main(argv=None):
     """Entry point for the ``glimpser`` command."""
     # Clear the console before starting
@@ -384,6 +398,14 @@ def main(argv=None):
             "Error: Port %s is already in use. Please choose a different port.",
             config.PORT,
         )
+        usage = get_port_usage(config.PORT)
+        if usage:
+            logging.error("Processes using port %s:\n%s", config.PORT, usage)
+        else:
+            logging.error(
+                "Could not determine which process is using port %s.",
+                config.PORT,
+            )
         sys.exit(1)
 
     try:

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -2,7 +2,7 @@ import sys
 import os
 import unittest
 import signal
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -120,6 +120,58 @@ class TestMainUtilities(unittest.TestCase):
             mock_socket.assert_not_called()
         finally:
             os.environ.pop("IN_DOCKER")
+
+    @patch("main.subprocess.run")
+    def test_get_port_usage_lsof(self, mock_run):
+        result = MagicMock(stdout="lsof output", stderr="")
+        mock_run.return_value = result
+
+        output = main.get_port_usage(8082)
+
+        mock_run.assert_called_once_with(
+            [
+                "lsof",
+                "-i",
+                ":8082",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(output, "lsof output")
+
+    @patch("main.subprocess.run")
+    def test_get_port_usage_fuser_fallback(self, mock_run):
+        result = MagicMock(stdout="fuser output", stderr="")
+        mock_run.side_effect = [FileNotFoundError, result]
+
+        output = main.get_port_usage(8082)
+
+        expected_calls = [
+            call(
+                [
+                    "lsof",
+                    "-i",
+                    ":8082",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            ),
+            call(
+                [
+                    "fuser",
+                    "-n",
+                    "tcp",
+                    "8082",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            ),
+        ]
+        self.assertEqual(mock_run.call_args_list, expected_calls)
+        self.assertEqual(output, "fuser output")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display processes using the configured port when Glimpser can't bind
- document automatic port usage output in troubleshooting guide
- test `get_port_usage` helper

## Testing
- `pre-commit run --files main.py docs/troubleshooting.md tests/test_main_utilities.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846e2dee7048333bfd45d4ae18930fd