### PR TITLE
Lazy load high quality clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API discovery and paginated log view
 - LLM summary generation with email alerts
 - Capture time tracking for templates
+- Template tiles lazy load high-quality clips with a two-minute cache
 - FFprobe path configuration
 - Live video streaming endpoint `/live_video`
 - Python 3.11 compatibility

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -1,5 +1,25 @@
 export const NO_TIMESTAMP_PLACEHOLDER = "no timestamp";
 
+// Cache high-definition clips for two minutes to limit network load
+const CLIP_CACHE_DURATION_MS = 2 * 60 * 1000;
+const clipCache = new Map();
+
+function fetchCachedClip(name, src) {
+  const now = Date.now();
+  const cached = clipCache.get(name);
+  if (cached && now < cached.expire) {
+    return Promise.resolve(cached.url);
+  }
+  return fetch(src)
+    .then((r) => r.blob())
+    .then((blob) => {
+      const url = URL.createObjectURL(blob);
+      if (cached) URL.revokeObjectURL(cached.url);
+      clipCache.set(name, { url, expire: now + CLIP_CACHE_DURATION_MS });
+      return url;
+    });
+}
+
 let captionsVisible = localStorage.getItem("showCaptions") !== "false";
 
 export function applyCaptionVisibility(width) {
@@ -497,6 +517,30 @@ export async function loadTemplates() {
       { threshold: 0.5 },
     );
 
+    const clipObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const video = entry.target;
+          if (video.dataset.clipLoaded === "true") return;
+          const hd = video.dataset.clipSrc;
+          if (hd) {
+            const name = video.dataset.name;
+            fetchCachedClip(name, hd)
+              .then((url) => {
+                const source = video.querySelector("source");
+                source.src = url;
+                video.load();
+                video.dataset.clipLoaded = "true";
+                clipObserver.unobserve(video);
+              })
+              .catch((err) => console.error("clip load failed", err));
+          }
+        });
+      },
+      { threshold: 0.25 },
+    );
+
     let hasTemplates = false;
     let templateCount = 0;
     Object.entries(templates).forEach(([name, template], index) => {
@@ -537,7 +581,7 @@ export async function loadTemplates() {
             <a href='/templates/${name}'>
               <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                 <div class="camera-name">${name}</div>
-                <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none">
+                <video data-name="${name}" data-clip-src="/clip/${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none">
                   <source src="/last_video/${name}" type="video/mp4">
                   Your browser does not support the video tag.
                 </video>
@@ -557,6 +601,7 @@ export async function loadTemplates() {
 
           const video = templateDiv.querySelector("video");
           observer.observe(video);
+          clipObserver.observe(video);
 
           video.addEventListener("mouseenter", () => {
             video.playbackRate = 2.0;

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Video Archiver](video_archiver.md)
 - [Live All Playback](live_all.md)
 - [Live View Scrubbing](live_scrub.md)
+- [Template Clip Caching](template_clip_cache.md)
 - [Jog-Shuttle Control](jog_shuttle.md)
 - [Developer Guide](developer_guide.md)
 - [Testing and Coverage](testing.md)

--- a/docs/template_clip_cache.md
+++ b/docs/template_clip_cache.md
@@ -1,0 +1,3 @@
+# Template Clip Caching
+
+Template thumbnails load a short preview video when visible. The high-quality clip from `/clip/<template>` now downloads only once every two minutes. A small client-side cache stores the clip so revisiting the tile won't hit the server again until the cache expires.


### PR DESCRIPTION
## Summary
- lazy load clips for template tiles
- cache /clip responses for 2 minutes

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846e9b00f948333aac9b459c806e558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Template tiles now lazy load high-quality video clips with a two-minute cache to improve performance and reduce network usage.

- **Documentation**
  - Added a new guide explaining the template clip caching mechanism.
  - Updated the documentation index to include the new caching guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->