### PR TITLE
Improve logout behavior and login UI

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1834,7 +1834,8 @@ def init_routes(app: Flask) -> None:
     def logout():
         session.pop("user_id", None)
         flash("You have been logged out successfully.", "success")
-        return redirect(url_for("login"))
+        # add query flag so client can clear persistent credentials
+        return redirect(url_for("login", logout="1"))
 
     @app.route("/")
     @login_required

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1084,8 +1084,8 @@ a {
 
 .checkbox-row {
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 /* Toggle switch styling for boolean settings */
@@ -1463,7 +1463,7 @@ footer.fade-out {
   border-radius: 5px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   display: inline-block;
-  max-width: 400px;
+  max-width: 340px;
   width: 100%;
   margin: 20px auto;
 }
@@ -1479,6 +1479,10 @@ footer.fade-out {
   color: var(--primary-color);
   margin-bottom: 0.5rem;
 }
+.login-icon svg {
+  width: 32px;
+  height: 32px;
+}
 .security-note {
   text-align: center;
   font-size: 0.85rem;
@@ -1487,7 +1491,7 @@ footer.fade-out {
 }
 
 .warning {
-  color: #b80000;
+  color: var(--danger-on-color);
 }
 
 input[type="text"],
@@ -1918,7 +1922,7 @@ details > summary {
 }
 
 .form-error {
-  color: red;
+  color: var(--danger-on-color);
   font-size: 0.9rem;
   margin-top: 4px;
 }

--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -1,5 +1,9 @@
 export function initLogin() {
   document.addEventListener("DOMContentLoaded", () => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("logout")) {
+      localStorage.removeItem("autoLogin");
+    }
     const form = document.getElementById("login-form");
     const noteEl = document.getElementById("security-note");
     attemptAutoLogin();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,7 +3,7 @@ content %}
 <div class="login-wrapper">
   {% call card('Secure Sign In') %}
   <div class="login-icon" aria-hidden="true">
-    <svg width="40" height="40">
+    <svg width="32" height="32">
       <use href="{{ url_for('static', filename='icons/sprite.svg') }}#lock" />
     </svg>
   </div>
@@ -40,10 +40,8 @@ content %}
     <div id="login-error" class="form-error hidden"></div>
 
     <div class="checkbox-row">
-      <label for="remember">
-        <input id="remember" type="checkbox" name="remember" />
-        Remember me
-      </label>
+      <input id="remember" type="checkbox" name="remember" />
+      <label for="remember">Remember me</label>
     </div>
 
     {% with messages = get_flashed_messages(with_categories=true) %} {% if

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -18,6 +18,7 @@ Key topics covered include:
 - System Status metrics, feed dashboard, and live log viewer.
 - Offline preview of recent snapshots and locally hosted fonts.
 - "Remember me" option on the login page for automatic sign in.
+- Logging out now clears any saved credentials so shared devices stay secure.
 - Links to the rest of the documentation under `docs/`.
 - Tooltips across the interface for quick explanations.
 - Inline viewing of command-line help via the **Show CLI Help** button.


### PR DESCRIPTION
## Summary
- clear any autoLogin credentials when logging out
- tighten login card layout and smaller icon
- make warning/error colors more accessible
- align the remember-me checkbox label
- document logout security improvement

## Testing
- `flake8`
- `pytest -q tests/test_authentication.py::test_login_form_inputs` *(fails: KeyboardInterrupt)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846eac2190c83338538cec56233be07