### PR TITLE
Improve offline browsing

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1829,6 +1829,12 @@ def init_routes(app: Flask) -> None:
         """Redirect old help route to the main settings page."""
         return redirect(url_for("settings"))
 
+    @app.route("/offline")
+    @login_required
+    def offline_page():
+        """Render a fallback page when offline."""
+        return render_template("offline.html", page_title="Offline")
+
     @app.route("/logout")
     @login_required
     def logout():

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -6,6 +6,7 @@ const OFFLINE_URLS = [
   "/discover",
   "/settings",
   "/templates",
+  "/offline",
   "/static/css/style.css",
   "/static/css/player.css",
   "/static/js/script.js",
@@ -23,6 +24,13 @@ self.addEventListener("fetch", (event) => {
 
   if (OFFLINE_URLS.includes(url.pathname)) {
     event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      networkFirst(request).then((res) => res || caches.match("/offline")),
+    );
     return;
   }
 

--- a/app/templates/offline.html
+++ b/app/templates/offline.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %} {% from 'components.html' import card %} {% block
+content %}
+<div class="offline-container container">
+  {% call card('Offline Mode') %}
+  <p>You are offline. Cached pages and images are still available.</p>
+  <p>Reconnect to regain full functionality.</p>
+  {% endcall %}
+  <a
+    href="{{ url_for('index') }}"
+    class="btn btn-primary"
+    title="Return to dashboard"
+    >Return to Dashboard</a
+  >
+</div>
+{% endblock %}

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -11,3 +11,6 @@ or reports the system is offline, a banner appears below the navigation bar to
 indicate Glimpser is running in offline mode. The banner has the
 `network-banner` class and is hidden until the `show` class is added. It
 disappears automatically once connectivity is restored.
+
+Navigation requests that miss the cache now fall back to `/offline`, so users
+see a friendly message instead of a blank page when connectivity drops.

--- a/tests/js/offline_sw.test.js
+++ b/tests/js/offline_sw.test.js
@@ -1,0 +1,8 @@
+import fs from "fs";
+import path from "path";
+
+test("service worker caches offline page", () => {
+  const swPath = path.join("app", "static", "sw.js");
+  const swText = fs.readFileSync(swPath, "utf8");
+  expect(swText.includes("/offline")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add dedicated offline fallback route and template
- extend service worker to serve `/offline`
- ensure new URL is cached and tested
- document offline fallback behavior

## Testing
- `pytest -q`
- `npm test --silent`
- `pre-commit run --all-files` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb3054b88333ad390bfb6ae67fb7