### PR TITLE
Add developer setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test test-js precommit
+.PHONY: format lint test test-js precommit setup
 
 format:
 	black .
@@ -15,4 +15,7 @@ test-js:
 	npm test
 
 precommit:
-	pre-commit run --all-files
+        pre-commit run --all-files
+
+setup:
+        ./scripts/setup_env.sh

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ The web interface will be available at [http://localhost:8082](http://localhost:
 
 If you cannot log in or see video feeds, double-check that your `.env` file matches the configuration values in the database. Missing `SECRET_KEY` or API credentials often cause startup failures. Refer to [Troubleshooting](docs/troubleshooting.md) for more solutions.
 
+### Developer Dependencies
+
+To install Python packages required for development, run:
+
+```sh
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+```
+
+Then install linters and JavaScript tools with `make setup` (or `scripts/setup_env.sh`).
+
 ## Usage
 
 ### Configuration
@@ -192,19 +203,22 @@ To set up the project for development:
    source env/bin/activate  # On Windows, use `env\Scripts\activate`
    ```
 
-3. Install the package in editable mode with development dependencies:
+3. Install Python dependencies:
 
    ```sh
-   pip install -e ".[dev]"
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
    ```
 
-4. Run tests:
+4. Install developer tooling:
+
+   ```sh
+   make setup  # runs scripts/setup_env.sh
+   ```
+
+5. Run tests:
    ```sh
    pytest
-   ```
-5. Install Node packages for linting and JS tests:
-   ```sh
-   npm install
    ```
 6. Run JavaScript tests with coverage:
    ```sh
@@ -224,7 +238,7 @@ To set up the project for development:
 
 From [Developer Guide](docs/developer_guide.md):
 
-1. Install the tooling and Git hooks:
+1. Install the tooling and Git hooks (or run `make setup`):
    ```sh
    pip install pre-commit black flake8
    npm install

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -11,15 +11,14 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    python -m venv env
    source env/bin/activate
    ```
-2. Install the package in editable mode with development dependencies:
+2. Install Python dependencies:
    ```sh
-   pip install -e ".[dev]"
+   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
    ```
-3. Install tooling before network access is disabled:
+3. Set up tooling:
    ```sh
-   pip install pre-commit black flake8
-   npm install
-   pre-commit install
+   make setup  # installs flake8, pre-commit and JS packages
    ```
    After installation, verify hooks:
    ```sh
@@ -38,6 +37,7 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    ```
 
 ## Understanding the Architecture
+
 Before diving into new features, read
 [Architecture Overview](architecture_overview.md). It describes how Flask routes,
 background jobs and utility modules cooperate. The "Data Flow from Camera to UI"
@@ -47,10 +47,12 @@ to the web interface.
 ## Running Tests
 
 The project uses `pytest` for testing and `flake8` for linting. After activating your environment, run:
+
 ```sh
 flake8
 pytest
 ```
+
 Running the full test suite helps ensure that your changes do not introduce regressions.
 
 ## Contribution Workflow
@@ -71,6 +73,7 @@ For more details, see [CONTRIBUTING.md](https://github.com/KristopherKubicki/gli
 - Configuration defaults are defined in `app/config.py`.
 
 When adding new features, include corresponding tests under the `tests/` directory.
+
 - Utilities for network testing now have dedicated tests in `tests/test_network_testing_utils.py`.
 - Configuration lookup logic is verified by `tests/test_config_get_setting.py`.
 - Scheduler helpers are tested in `tests/test_scheduling_more.py`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Additional developer dependencies
+pre-commit>=3.6
+flake8>=7.0
+black>=25.1
+mypy>=1.10
+isort>=5.13
+pytest>=8.3

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Set up local development environment
+set -e
+
+pip install -r requirements.txt
+if [ -f requirements-dev.txt ]; then
+    pip install -r requirements-dev.txt
+fi
+pip install flake8 pre-commit
+npm install
+pre-commit install


### PR DESCRIPTION
## Summary
- document developer dependencies in README and developer guide
- add `requirements-dev.txt` and setup script
- add `make setup` target

## Testing
- `flake8`
- `pre-commit run --all-files` *(with black, isort, mypy skipped)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846f7e51cc88333b608b207660d4b3b