### PR TITLE
Use clip endpoint for preview video

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -624,10 +624,21 @@ export async function loadTemplates() {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (isMobile() && entry.isIntersecting) {
-            safePlay(entry.target);
+          const video = entry.target;
+          if (entry.isIntersecting) {
+            if (video.dataset.hdSrc && !video.dataset.hdLoaded) {
+              const source = video.querySelector("source");
+              if (source) {
+                source.src = video.dataset.hdSrc;
+                video.dataset.hdLoaded = "true";
+                video.load();
+              }
+            }
+            if (isMobile()) {
+              safePlay(video);
+            }
           } else {
-            entry.target.pause();
+            video.pause();
           }
         });
       },
@@ -681,7 +692,7 @@ export async function loadTemplates() {
               <a href='/templates/${name}'>
                 <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                   <div class="camera-name">${name}</div>
-                  <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback>
+                  <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback data-hd-src="/clip/${name}">
                     <source src="/last_video/${name}" type="video/mp4">
                     Your browser does not support the video tag.
                   </video>

--- a/tests/js/hd_clip_switch.test.js
+++ b/tests/js/hd_clip_switch.test.js
@@ -1,0 +1,50 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="template-list"></div>
+  <select id="group-dropdown"></select>
+  <input id="grid-width-slider" type="range">
+`;
+
+let loadTemplates;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/templates.js");
+  loadTemplates = mod.loadTemplates;
+});
+
+test("loads clip when video becomes visible", async () => {
+  let callback;
+  window.IntersectionObserver = class {
+    constructor(cb) {
+      callback = cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => "application/json" },
+    json: () =>
+      Promise.resolve({
+        cam1: {
+          url: "#",
+          capture_failed: false,
+          last_caption: "",
+          last_screenshot_time: 0,
+        },
+      }),
+  });
+
+  await loadTemplates();
+  const video = document.querySelector("video");
+  const source = video.querySelector("source");
+  expect(source.src).toMatch(/\/last_video\/cam1$/);
+  expect(video.dataset.hdSrc).toBe("/clip/cam1");
+
+  callback([{ target: video, isIntersecting: true }]);
+
+  expect(source.src).toMatch(/\/clip\/cam1$/);
+});


### PR DESCRIPTION
## Summary
- switch hover video from `/last_video` to `/clip`
- only load `/clip` when a tile becomes visible
- test HD clip source swap logic

## Testing
- `flake8`
- `pytest -k placeholder -q`
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470f7c73e88333a0cd2069eb17b172