### PR TITLE
Improve first run experience

### DIFF
--- a/docs/startup_tips.md
+++ b/docs/startup_tips.md
@@ -11,6 +11,7 @@ This page lists quick reminders that appear when Glimpser starts.
   ```
 - **Port already in use?** Make sure another process isn't bound to the configured port before starting Glimpser.
 - **Need more logging?** Start the app with `--console-log` to mirror log output to your terminal.
+- **First time running?** After credentials are generated, the log prints a link to open in your browser and complete setup.
 - **Can't reach the server?** Binding `HOST` to `127.0.0.1` or `localhost` makes it invisible to other machines.
 
 Refer to this file any time you hit a startup issue.

--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 # generate_credentials.py
 
+import argparse
+import getpass
+import logging
 import secrets
 import sqlite3
-import getpass
-import argparse
 import sys
 
-import app.config
-import logging
 from werkzeug.security import generate_password_hash
+
+import app.config
 
 
 def upsert_setting(name, value, conn):
@@ -122,6 +123,11 @@ def generate_credentials(args):
     conn.close()
 
     logging.info("Credentials and settings updated in the database.")
+    logging.info(
+        "Open http://%s:%s in your browser after starting Glimpser to finish setup.",
+        app.config.HOST,
+        app.config.PORT,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_generate_credentials.py
+++ b/tests/test_generate_credentials.py
@@ -1,15 +1,15 @@
-import sys
-import os
-import unittest
-from unittest.mock import patch
-import tempfile
-import sqlite3
 import argparse
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from unittest.mock import call, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-import generate_credentials  # noqa: E402
 import app.config as config  # noqa: E402
+import generate_credentials  # noqa: E402
 
 
 class TestGenerateCredentials(unittest.TestCase):
@@ -121,8 +121,15 @@ class TestGenerateCredentials(unittest.TestCase):
         )
         self.assertEqual(cur.fetchone(), ("testuser", "hashed_password"))
 
-        mock_log.assert_called_once_with(
-            "Credentials and settings updated in the database."
+        mock_log.assert_has_calls(
+            [
+                call("Credentials and settings updated in the database."),
+                call(
+                    "Open http://%s:%s in your browser after starting Glimpser to finish setup.",
+                    config.HOST,
+                    config.PORT,
+                ),
+            ]
         )
 
     @patch("generate_credentials.generate_password_hash", return_value="h")


### PR DESCRIPTION
## Summary
- log instructions to visit the setup URL after credentials are generated
- mention first-run message in `startup_tips.md`
- update tests for new log message

## Testing
- `pre-commit run --files generate_credentials.py docs/startup_tips.md tests/test_generate_credentials.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470fe7f2848333ae4979b5716b4314