### PR TITLE
Improve settings tab persistence

### DIFF
--- a/app/static/js/tabs.js
+++ b/app/static/js/tabs.js
@@ -3,6 +3,7 @@ export function initTabs() {
     const tabs = document.querySelectorAll(".tab-link");
     const contents = document.querySelectorAll(".tab-content");
     const addContainer = document.getElementById("add-setting-container");
+    const storageKey = `lastTab:${window.location.pathname}`;
     if (!tabs.length) return;
 
     tabs.forEach((tab) => {
@@ -13,6 +14,11 @@ export function initTabs() {
         contents.forEach((c) => c.classList.remove("active"));
         tab.classList.add("active");
         document.getElementById(target)?.classList.add("active");
+        try {
+          localStorage.setItem(storageKey, target);
+        } catch {
+          /* ignore */
+        }
         if (addContainer) {
           if (target === "Other-tab") {
             addContainer.classList.remove("hidden");
@@ -24,11 +30,13 @@ export function initTabs() {
     });
 
     const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab");
+    const tab = params.get("tab") || localStorage.getItem(storageKey);
     if (tab) {
       const btn = document.querySelector(`.tab-link[data-tab="${tab}"]`);
       btn?.click();
-      history.replaceState(null, "", window.location.pathname);
+      if (params.get("tab")) {
+        history.replaceState(null, "", window.location.pathname);
+      }
     }
   });
 }

--- a/tests/js/tabs.test.js
+++ b/tests/js/tabs.test.js
@@ -1,0 +1,41 @@
+import { jest } from "@jest/globals";
+
+let initTabs;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/tabs.js");
+  initTabs = mod.initTabs;
+});
+
+describe("tabs", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button class="tab-link" data-tab="one"></button>
+      <button class="tab-link" data-tab="two"></button>
+      <div id="one" class="tab-content"></div>
+      <div id="two" class="tab-content"></div>
+    `;
+    Object.defineProperty(window, "location", {
+      writable: true,
+      configurable: true,
+      value: { pathname: "/foo", search: "" },
+    });
+    localStorage.clear();
+  });
+
+  test("click stores tab", () => {
+    initTabs();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    document.querySelector('[data-tab="two"]').click();
+    expect(localStorage.getItem("lastTab:/foo")).toBe("two");
+  });
+
+  test("stored tab activates on load", () => {
+    localStorage.setItem("lastTab:/foo", "two");
+    initTabs();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    expect(document.getElementById("two").classList.contains("active")).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remember the last active tab on the settings page
- test tab persistence logic

## Testing
- `pre-commit run --all-files` *(fails: mypy missing stubs)*
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470fe00200833384cbed29b23277af