### PR TITLE
Improve capture reliability with ffmpeg check

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 import shutil
+from typing import Optional
 import socket
 import subprocess
 import time
@@ -75,6 +76,8 @@ from app.config import (
 import app.config as config
 from app.utils.validators import validate_proxy, validate_url
 
+FFMPEG_AVAILABLE: Optional[bool] = None
+
 last_camera_test = {}
 last_camera_test_time = {}
 last_camera_header = {}
@@ -128,6 +131,17 @@ def _persist_status_cache() -> None:
 
 
 _load_status_cache()
+
+
+def _check_ffmpeg() -> bool:
+    """Return ``True`` if ``ffmpeg`` executable is available."""
+
+    global FFMPEG_AVAILABLE
+    if FFMPEG_AVAILABLE is None:
+        FFMPEG_AVAILABLE = shutil.which(FFMPEG_PATH) is not None
+        if not FFMPEG_AVAILABLE:
+            logging.error("ffmpeg not found at %s", FFMPEG_PATH)
+    return FFMPEG_AVAILABLE
 
 
 FONT_CANDIDATES = [
@@ -1527,6 +1541,8 @@ def capture_frame_with_ytdlp(url, output_path, name="unknown", invert=False):
     if shutil.which("yt-dlp") is None:
         logging.error("yt-dlp is not installed or not in the system path.")
         return False
+    if not _check_ffmpeg():
+        return False
 
     if (
         lurl_cache.get(url, "none") != "good"
@@ -1643,6 +1659,8 @@ def capture_frame_from_stream(
     stealth=False,
 ):
     """Use ffmpeg to capture multiple frames from a video stream and save the last one."""
+    if not _check_ffmpeg():
+        return False
 
     if timeout < 5:
         timeout = 5

--- a/tests/test_ffmpeg_missing.py
+++ b/tests/test_ffmpeg_missing.py
@@ -1,0 +1,35 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import app.utils.screenshots as ss
+
+
+class TestFFmpegMissing(unittest.TestCase):
+    def setUp(self):
+        ss.FFMPEG_AVAILABLE = None
+
+    def test_ytdlp_returns_false_without_ffmpeg(self):
+        with patch("app.utils.screenshots.shutil.which", return_value=None):
+            with patch("app.utils.screenshots.subprocess.run") as mock_run:
+                res = ss.capture_frame_with_ytdlp("http://example.com", "out.png")
+        self.assertFalse(res)
+        mock_run.assert_not_called()
+
+    def test_stream_returns_false_without_ffmpeg(self):
+        with patch("app.utils.screenshots.shutil.which", return_value=None):
+            with patch("app.utils.screenshots.subprocess.run") as mock_run:
+                with (
+                    patch("app.utils.screenshots.os.makedirs"),
+                    patch("app.utils.screenshots.os.path.exists", return_value=False),
+                ):
+                    res = ss.capture_frame_from_stream("http://example.com", "out.png")
+        self.assertFalse(res)
+        mock_run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- verify ffmpeg availability before capturing
- return early when ffmpeg is missing
- add tests for ffmpeg absence

## Testing
- `flake8 app/utils/screenshots.py tests/test_ffmpeg_missing.py`
- `pytest -q tests/test_ffmpeg_missing.py`

------
https://chatgpt.com/codex/tasks/task_e_68471018da088333874e645b8cf8e79e