### PR TITLE
Update clip loading

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -125,7 +125,7 @@ import sqlite3
 from typing import Any, Callable, Generator, Optional, List, Dict
 
 # Clip caching constants
-CACHE_TTL_SEC = 5
+CACHE_TTL_SEC = 120
 SEGMENT_SEC = 10
 
 
@@ -2868,7 +2868,9 @@ def init_routes(app: Flask) -> None:
             and clip_path.stat().st_mtime > newest_src.stat().st_mtime
             and (time.time() - clip_path.stat().st_mtime) < CACHE_TTL_SEC
         ):
-            return send_file(clip_path, conditional=True)
+            resp = send_file(clip_path, conditional=True)
+            resp.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SEC}"
+            return resp
 
         parts: list[Path] = []
         in_process_len = 0
@@ -2906,7 +2908,9 @@ def init_routes(app: Flask) -> None:
                 and newest_src
                 and clip_path.stat().st_mtime > newest_src.stat().st_mtime
             ):
-                return send_file(clip_path, conditional=True)
+                resp = send_file(clip_path, conditional=True)
+                resp.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SEC}"
+                return resp
 
             if not parts:
                 video_archiver.create_blank_video(duration, clip_path.as_posix())
@@ -2914,7 +2918,9 @@ def init_routes(app: Flask) -> None:
                 video_archiver.create_blank_video(duration, clip_path.as_posix())
 
         if clip_path.exists():
-            return send_file(clip_path, conditional=True)
+            resp = send_file(clip_path, conditional=True)
+            resp.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SEC}"
+            return resp
 
         abort(500, "Could not create clip")
 

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -216,10 +216,27 @@ export function setupVideoControls() {
 
 export function setupStatusPageVideoHover() {
   const thumbnailVideoCells = document.querySelectorAll(".thumbnail-video");
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        const vid = entry.target;
+        if (entry.isIntersecting && vid.dataset.hdSrc && !vid.dataset.hdLoaded) {
+          const src = vid.querySelector("source");
+          if (src) {
+            src.src = vid.dataset.hdSrc;
+            vid.dataset.hdLoaded = "true";
+          }
+        }
+      });
+    },
+    { threshold: 0.5 },
+  );
+
   thumbnailVideoCells.forEach((cell) => {
     const img = cell.querySelector("img.thumbnail");
     const video = cell.querySelector("video.hover-video");
     if (img && video) {
+      observer.observe(video);
       // Update frame based on cursor position over the tile.
       const scrub = (e) => {
         const rect = cell.getBoundingClientRect();

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -90,9 +90,11 @@ template_controls %} {% block content %}
                     class="hover-video"
                     loop
                     muted
+                    preload="none"
                     poster="/last_screenshot/{{ camera }}"
+                    data-hd-src="/clip/{{ camera }}"
                   >
-                    <source src="/clip/{{ camera }}" type="video/mp4" />
+                    <source src="/last_video/{{ camera }}" type="video/mp4" />
                     Your browser does not support the video tag.
                   </video>
                 </div>

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -133,7 +133,7 @@ Several other routes provide streaming functionality:
 - **GET /last_video/<template_name>** – Download the most recent MP4 for the given template. Returns a 404 response if no video is available.
 - **GET /last_screenshot/<template_name>** – Retrieve the latest screenshot for a template.
 - **GET /last_teaser** – Returns the teaser video compiled from recent footage. Accepts an optional `group` query parameter to retrieve a group-specific teaser, e.g. `/last_teaser?group=frontdoor`.
-- **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests within a few seconds reuse the cached clip for speed.
+- **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests reuse the cached clip for speed. Responses include `Cache-Control: public, max-age=120` so browsers retain the clip for two minutes.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
 

--- a/tests/js/hover_video_hd_load.test.js
+++ b/tests/js/hover_video_hd_load.test.js
@@ -1,0 +1,38 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="thumbnail-video">
+    <img class="thumbnail" src="#" />
+    <video class="hover-video" preload="none" data-hd-src="/clip/cam1">
+      <source src="/last_video/cam1" type="video/mp4" />
+    </video>
+  </div>
+`;
+
+let setup;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  setup = mod.setupStatusPageVideoHover;
+});
+
+test("switches to clip when video becomes visible", () => {
+  let cb;
+  window.IntersectionObserver = class {
+    constructor(fn) {
+      cb = fn;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  setup();
+  const video = document.querySelector("video");
+  const source = video.querySelector("source");
+  expect(source.src).toMatch(/\/last_video\/cam1$/);
+
+  cb([{ target: video, isIntersecting: true }]);
+
+  expect(source.src).toMatch(/\/clip\/cam1$/);
+});


### PR DESCRIPTION
## Summary
- lazily load `/clip` videos by switching the source when visible
- cache clip responses for two minutes
- document clip caching headers
- add JS test for hover video intersection

## Testing
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684716cfd4088333abda46c92e5c9006