### PR TITLE
Add offset support test

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -167,6 +167,7 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
 
     fixed.sort(key=os.path.getmtime)  # oldest → newest
     total = sum(_duration(p) for p in fixed)
+    offset = max(total - clip_len, 0)
 
     # 2) create FRONT-pad if needed
     if total < clip_len:
@@ -238,10 +239,11 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
         "\n".join(f"file 'file:{p.as_posix()}'" for p in concat_parts).encode() + b"\n"
     )
 
-    cmd = [
-        FFMPEG,
-        "-loglevel",
-        "warning",
+    cmd = [FFMPEG, "-loglevel", "warning"]
+    if offset:
+        cmd += ["-ss", f"{offset:.3f}"]
+
+    cmd += [
         "-f",
         "concat",
         "-safe",

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -1,9 +1,9 @@
+import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-import os
-import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -48,6 +48,44 @@ class TestConcatCopy(unittest.TestCase):
                 None,
             )
             self.assertIsNotNone(overlay_cmd)
+
+    def test_concat_copy_uses_offset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "clip.mp4"
+            part1 = Path(tmpdir) / "final_0.mp4"
+            part2 = Path(tmpdir) / "final_1.mp4"
+            part1.touch()
+            part2.touch()
+            parts = [part1, part2]
+
+            calls = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(cmd)
+                if cmd:
+                    last = cmd[-1]
+                    if isinstance(last, (str, Path)) and str(last).endswith(".mp4"):
+                        Path(str(last)).touch()
+                return None
+
+            with (
+                patch.object(routes, "_duration", return_value=3),
+                patch.object(
+                    routes,
+                    "_probe",
+                    side_effect=lambda p, k: {
+                        "width": "640",
+                        "height": "360",
+                        "r_frame_rate": "30/1",
+                    }[k],
+                ),
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                self.assertTrue(routes._concat_copy(out, parts, clip_len=2))
+
+            concat_cmd = next((c for c in calls if "concat" in c), [])
+            self.assertIn("-ss", concat_cmd)
+            self.assertIn("4.000", concat_cmd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- test FFmpeg concat uses `-ss` when trimming
- calculate offset before building concat command

## Testing
- `pre-commit run --files app/routes.py tests/test_concat_copy.py`
- `pytest tests/test_concat_copy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68473ebbe5a48333a3be467584ca6be7