### PR TITLE
Trim clip concat from latest footage

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -31,10 +31,23 @@ from urllib.parse import urlparse
 import psutil
 import requests
 from dateutil import tz
-from flask import (Flask, Response, abort, current_app, flash, jsonify,
-                   make_response, redirect, render_template, request,
-                   send_file, send_from_directory, session,
-                   stream_with_context, url_for)
+from flask import (
+    Flask,
+    Response,
+    abort,
+    current_app,
+    flash,
+    jsonify,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    send_from_directory,
+    session,
+    stream_with_context,
+    url_for,
+)
 from PIL import Image, ImageDraw, ImageFont
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
@@ -45,25 +58,50 @@ from werkzeug.utils import secure_filename
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 import app.config as config
-from app.config import (API_KEY, BACKUP_PATH, CHYRON_SPEED, CLOCK_DIGITAL,
-                        CLOCK_NAVBAR, CLOCK_OVERLAY, DOCS_DIRECTORY,
-                        HEALTH_STATUS_ALWAYS_VISIBLE, NAV_ICON,
-                        SCREENSHOT_DIRECTORY, SENSITIVE_SETTINGS, VERSION,
-                        VIDEO_DIRECTORY, backup_config, restore_config)
+from app.config import (
+    API_KEY,
+    BACKUP_PATH,
+    CHYRON_SPEED,
+    CLOCK_DIGITAL,
+    CLOCK_NAVBAR,
+    CLOCK_OVERLAY,
+    DOCS_DIRECTORY,
+    HEALTH_STATUS_ALWAYS_VISIBLE,
+    NAV_ICON,
+    SCREENSHOT_DIRECTORY,
+    SENSITIVE_SETTINGS,
+    VERSION,
+    VIDEO_DIRECTORY,
+    backup_config,
+    restore_config,
+)
 from app.models import PushSubscription, Summary, User
-from app.utils import (camera_discovery, camera_fix, limit_rate,
-                       prompt_optimizer, scheduling, screenshots,
-                       template_manager, video_archiver)
+from app.utils import (
+    camera_discovery,
+    camera_fix,
+    limit_rate,
+    prompt_optimizer,
+    scheduling,
+    screenshots,
+    template_manager,
+    video_archiver,
+)
 from app.utils.llm import ask_question
 from app.utils.network import is_system_online
-from app.utils.screenshots import (capture_frame_from_stream,
-                                   check_user_activity,
-                                   is_chrome_debug_port_open)
-from app.utils.settings_tooltips import (EMAIL_FIELDS, LOCKED_SETTINGS,
-                                         NUMERIC_FIELDS, SETTINGS_CHOICES,
-                                         SETTINGS_GROUPS,
-                                         SETTINGS_PLACEHOLDERS,
-                                         SETTINGS_TOOLTIPS)
+from app.utils.screenshots import (
+    capture_frame_from_stream,
+    check_user_activity,
+    is_chrome_debug_port_open,
+)
+from app.utils.settings_tooltips import (
+    EMAIL_FIELDS,
+    LOCKED_SETTINGS,
+    NUMERIC_FIELDS,
+    SETTINGS_CHOICES,
+    SETTINGS_GROUPS,
+    SETTINGS_PLACEHOLDERS,
+    SETTINGS_TOOLTIPS,
+)
 
 # Names of settings that store file paths.
 FILE_LOCATION_NAMES = [
@@ -238,6 +276,9 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
         "\n".join(f"file 'file:{p.as_posix()}'" for p in concat_parts).encode() + b"\n"
     )
 
+    total_duration = sum(_duration(p) for p in concat_parts)
+    start_offset = max(0.0, total_duration - clip_len)
+
     cmd = [
         FFMPEG,
         "-loglevel",
@@ -250,6 +291,8 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
         "file,pipe",
         "-i",
         "pipe:0",
+        "-ss",
+        f"{start_offset:.3f}",  # trim from start when overlength
         "-t",
         str(clip_len),  # force exact 120 s
         "-c",
@@ -287,17 +330,27 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 from app.utils import validators
 from app.utils.email_alerts import send_email_alert
 from app.utils.profiling import get_latency_stats, profile_route
+
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
-from app.utils.screenshots import (check_user_activity, get_chrome_path,
-                                   get_chrome_version,
-                                   is_chrome_debug_port_open, load_font)
+from app.utils.screenshots import (
+    check_user_activity,
+    get_chrome_path,
+    get_chrome_version,
+    is_chrome_debug_port_open,
+    load_font,
+)
 from app.utils.sms_alerts import send_sms_alert
-from app.utils.validators import (validate_setting, validate_template_name,
-                                  validate_update_data)
-from scripts.update_chrome_shortcut import (first_shortcut_path,
-                                            shortcuts_need_patch,
-                                            update_chrome_shortcuts_info)
+from app.utils.validators import (
+    validate_setting,
+    validate_template_name,
+    validate_update_data,
+)
+from scripts.update_chrome_shortcut import (
+    first_shortcut_path,
+    shortcuts_need_patch,
+    update_chrome_shortcuts_info,
+)
 
 
 def restart_server() -> None:

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -49,6 +49,38 @@ class TestConcatCopy(unittest.TestCase):
             )
             self.assertIsNotNone(overlay_cmd)
 
+    def test_trim_uses_start_offset(self):
+        """Ensure trimming seeks forward when clips exceed the limit."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "clip.mp4"
+            p1 = Path(tmpdir) / "final_1.mp4"
+            p2 = Path(tmpdir) / "final_2.mp4"
+            p1.touch()
+            p2.touch()
+            parts = [p1, p2]
+
+            calls = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(cmd)
+                if cmd:
+                    last = cmd[-1]
+                    if isinstance(last, (str, Path)) and str(last).endswith(".mp4"):
+                        Path(str(last)).touch()
+                return None
+
+            with (
+                patch.object(routes, "_duration", return_value=2),
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                self.assertTrue(routes._concat_copy(out, parts, clip_len=3))
+
+            concat_cmd = calls[-1]
+            ss_idx = concat_cmd.index("-ss")
+            t_idx = concat_cmd.index("-t")
+            self.assertLess(ss_idx, t_idx)
+            self.assertEqual(concat_cmd[ss_idx + 1], "1.000")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- compute start offset when clip is longer than requested
- trim concatenation output from the beginning
- test seeking behaviour in `_concat_copy`

## Testing
- `pre-commit run --all-files` *(fails: isort reformatted many files, npm not found)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473eb504d0833382437ac276014e71