### PR TITLE
Add thumbnail field to camera templates

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1893,6 +1893,21 @@ details > summary {
   border-radius: 4px;
   border: 1px solid var(--accent-color);
 }
+
+.thumbnail-preview {
+  float: right;
+  width: 120px;
+  height: 90px;
+  margin-left: 1rem;
+}
+
+.thumbnail-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 4px;
+  border: 1px solid var(--accent-color);
+}
 #chat-modal .modal-content {
   width: 90%;
   max-width: 600px;

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -131,6 +131,23 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
       />
       <span id="url-status" class="url-status" title="URL test result"></span>
 
+      <label for="thumbnail" title="Thumbnail image URL">Thumbnail URL:</label>
+      <input
+        type="url"
+        id="thumbnail"
+        name="thumbnail"
+        value="{{ template.thumbnail if template else '' }}"
+        placeholder="https://example.com/thumb.jpg"
+        title="Optional thumbnail image URL"
+      />
+      <div class="thumbnail-preview">
+        <img
+          id="thumbnail-img"
+          src="{{ template.thumbnail or url_for('static', filename='img/glimpser_small.png') }}"
+          alt="Thumbnail preview"
+        />
+      </div>
+
       <label for="frequency" title="How often to check the URL"
         >Frequency (minutes):</label
       >

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -65,6 +65,7 @@ class Template(db.Base):
     auth_username = Column(String, default="")
     auth_password = Column(String, default="")
     url = Column(String, default="")
+    thumbnail = Column(String, default="")
     groups = Column(String, default="")
     invert = Column(Boolean, default=False)
     dark = Column(Boolean, default=False)
@@ -123,6 +124,7 @@ class TemplateManager:
         ensure_column("templates", "capture_failed", "BOOLEAN", "0")
         ensure_column("templates", "auth_username", "VARCHAR(255)", "''")
         ensure_column("templates", "auth_password", "VARCHAR(255)", "''")
+        ensure_column("templates", "thumbnail", "VARCHAR(255)", "''")
 
     def get_session(self):
         """Return a new SQLAlchemy session bound to the app database."""

--- a/docs/thumbnail_field.md
+++ b/docs/thumbnail_field.md
@@ -1,0 +1,3 @@
+# Thumbnail Field
+
+Camera templates now accept an optional **Thumbnail URL**. When provided, this image appears beside the live preview while adding or editing a camera. If left blank, a small Glimpser logo is used instead so the layout stays balanced.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,4 +71,5 @@ nav:
       - OpenSSF Scorecard: scorecard.md
       - Startup Tips and Gotchas: startup_tips.md
       - UI Component Guide: style_guide.md
+      - Thumbnail Field: thumbnail_field.md
       - Governance: governance.md

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -107,6 +107,10 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('min="0.1"', components)
 
+    def test_template_form_has_thumbnail_field(self):
+        components = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn('name="thumbnail"', components)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add optional `thumbnail` column for camera templates
- support `thumbnail` in the template form and style
- document new field
- test that template form includes the new input

## Testing
- `flake8`
- `pytest -q`
- `npm test`
- `pre-commit run --all-files` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847403f4a44833383e437ffea606b0d