### PR TITLE
Remove serve_clip throttle

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2877,7 +2877,6 @@ def init_routes(app: Flask) -> None:
 
     @app.route("/clip/<string:template_name>")
     @login_required
-    @limit_rate(30)
     def serve_clip(template_name: TemplateName):
         """Return a short clip built from recent footage."""
 


### PR DESCRIPTION
## Summary
- remove `limit_rate` from `serve_clip` since it always triggers

## Testing
- `flake8 app/routes.py`
- `pytest tests/test_clip_route.py::test_clip_route -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68476a4891c48333912decfe7ce4edb6