### PR TITLE
Fix mobile toolbar layout

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -75,6 +75,13 @@
   width: 100%;
 }
 
+@media (max-width: 768px) {
+  .control-row {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+}
+
 #jog-shuttle {
   width: 60px;
   height: 60px;


### PR DESCRIPTION
## Summary
- keep video toolbar controls on one line using media query

## Testing
- `pre-commit run --files app/static/css/player.css`
- `flake8`
- `pytest -q` *(fails: TestHeavyRouteThrottle::test_clip_throttled)*

------
https://chatgpt.com/codex/tasks/task_e_684797bbf2008333a3ee321a36cbb1e5