### PR TITLE
Add tests for URL validation and snapshot detection

### DIFF
--- a/tests/test_is_snapshot_url.py
+++ b/tests/test_is_snapshot_url.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.template_manager import is_snapshot_url
+
+
+class TestIsSnapshotUrl(unittest.TestCase):
+    def test_detects_snapshot_endpoints(self):
+        self.assertTrue(is_snapshot_url("http://cam/snapshot.jpg"))
+        self.assertTrue(is_snapshot_url("http://cam/picture"))
+        self.assertTrue(is_snapshot_url("http://cam/foo.SNAPSHOT"))
+
+    def test_non_snapshot_urls(self):
+        self.assertFalse(is_snapshot_url("http://cam/stream.m3u8"))
+        self.assertFalse(is_snapshot_url(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_url.py
+++ b/tests/test_validate_url.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.validators import validate_url
+
+
+class TestValidateUrl(unittest.TestCase):
+    def test_valid_http(self):
+        self.assertEqual(validate_url("http://example.com"), "http://example.com")
+
+    def test_valid_https(self):
+        self.assertEqual(validate_url("https://example.com"), "https://example.com")
+
+    def test_invalid_scheme(self):
+        self.assertIsNone(validate_url("ftp://example.com"))
+
+    def test_disallows_newline_and_dash(self):
+        self.assertIsNone(validate_url("http://example.com\n"))
+        self.assertIsNone(validate_url("-http://bad"))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(validate_url(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for `validate_url`
- add tests for `is_snapshot_url`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', 'psutil', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848079191708333a588f2618b93e435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests to verify snapshot URL detection.
  - Added tests to validate URL formats and ensure proper handling of invalid or unsupported URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->