### PR TITLE
Improve network utils coverage

### DIFF
--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.utils.network import is_system_online
+from app.utils.network import is_system_online, _get_test_hosts
 
 
 class TestIsSystemOnline(unittest.TestCase):
@@ -21,6 +21,25 @@ class TestIsSystemOnline(unittest.TestCase):
         with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1,2.2.2.2"}):
             self.assertFalse(is_system_online())
             self.assertEqual(mock_conn.call_count, 2)
+
+    def test_get_test_hosts_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_get_test_hosts(), ["8.8.8.8", "1.1.1.1"])
+
+    @patch("app.utils.network.socket.create_connection")
+    @patch("app.utils.network._get_test_hosts", return_value=[" ", "2.2.2.2"])
+    def test_is_system_online_skips_blank(self, mock_hosts, mock_conn):
+        mock_conn.return_value = None
+        self.assertTrue(is_system_online(timeout=2))
+        mock_conn.assert_called_once_with(("2.2.2.2", 53), timeout=2)
+
+    @patch("app.utils.network.logging.warning")
+    @patch("app.utils.network.socket.create_connection", side_effect=OSError("fail"))
+    def test_logs_when_all_fail(self, mock_conn, mock_warn):
+        with patch("app.utils.network._get_test_hosts", return_value=["1.1.1.1"]):
+            self.assertFalse(is_system_online(timeout=1))
+        mock_conn.assert_called_once_with(("1.1.1.1", 53), timeout=1)
+        mock_warn.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand tests for network utils

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest tests/test_network_online.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684809f7ea708333b2cfb9cb8e9284b1