### PR TITLE
Improve login page style

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -594,7 +594,7 @@ body.dark-mode {
 header {
   background-color: #000; /* Dark background for better contrast */
   color: #fff; /* White text */
-  padding: 0 4px; /* More compact padding */
+  padding: 2px 4px; /* Add slight spacing from top */
   display: flex; /* Flexbox for layout */
   align-items: center; /* Vertically align items */
   justify-content: flex-start; /* Align items to the left */
@@ -1088,6 +1088,16 @@ a {
   gap: 0.5rem;
 }
 
+#remember {
+  width: 0.9rem;
+  height: 0.9rem;
+  accent-color: var(--primary-color);
+}
+
+.checkbox-row label {
+  font-size: 0.9rem;
+}
+
 /* Toggle switch styling for boolean settings */
 .switch {
   position: relative;
@@ -1335,7 +1345,7 @@ footer {
   max-width: 100vw;
   background-color: #000;
   color: #fff;
-  padding: 10px 10px 0 10px;
+  padding: 10px 10px 2px 10px;
   border-top: 2px solid #444;
   box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
   position: fixed;
@@ -1453,7 +1463,7 @@ footer.fade-out {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: calc(100vh - 150px);
+  min-height: calc(100dvh - 120px); /* Reduce excess vertical scroll */
   padding: 20px 0;
 }
 .login-container {

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -1,8 +1,8 @@
 import os
 import sys
-from pathlib import Path
-from html.parser import HTMLParser
 import unittest
+from html.parser import HTMLParser
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -63,6 +63,12 @@ class TestHtmlTemplates(unittest.TestCase):
         placeholders = {i.get("placeholder") for i in parser.forms[0]["inputs"]}
         self.assertIn("Username", placeholders)
         self.assertIn("Password", placeholders)
+
+    def test_login_has_remember_checkbox(self):
+        parser = parse_template(Path("app/templates/login.html"))
+        inputs = [i for i in parser.forms[0]["inputs"] if i.get("name") == "remember"]
+        self.assertTrue(inputs, "remember checkbox missing")
+        self.assertEqual(inputs[0].get("type"), "checkbox")
 
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- refine spacing around header logo
- reduce login page scroll height
- style the "remember me" checkbox
- avoid footer scrollbar with extra padding
- test for checkbox presence in login template

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest tests/test_html_templates.py::TestHtmlTemplates::test_login_has_remember_checkbox -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68480d7634a08333976c775d8a60b342