### PR TITLE
Add dynamic robots.txt endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,16 +1,16 @@
 # config.py
 
-import os
+import argparse
 import json
 import logging
-import argparse
+import os
+import shutil
 import sqlite3
 import subprocess
-import shutil
-from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
-from dotenv import load_dotenv, find_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 _DOTENV_LOADED = False
 
@@ -437,6 +437,10 @@ CAP_SENDER = get_setting("CAP_SENDER", "")
 # MCP settings
 MCP_SERVER_COMMAND = get_setting("MCP_SERVER_COMMAND", "")
 MCP_SERVER_URL = get_setting("MCP_SERVER_URL", "")
+
+# When ``True`` the ``/robots.txt`` route allows search engine indexing.
+# ``False`` (the default) disallows all crawlers.
+ALLOW_BOTS = get_setting("ALLOW_BOTS", "False") == "True"
 
 # Settings that should never be displayed in the UI
 SENSITIVE_SETTINGS = [

--- a/app/routes.py
+++ b/app/routes.py
@@ -31,23 +31,10 @@ from urllib.parse import urlparse
 import psutil
 import requests
 from dateutil import tz
-from flask import (
-    Flask,
-    Response,
-    abort,
-    current_app,
-    flash,
-    jsonify,
-    make_response,
-    redirect,
-    render_template,
-    request,
-    send_file,
-    send_from_directory,
-    session,
-    stream_with_context,
-    url_for,
-)
+from flask import (Flask, Response, abort, current_app, flash, jsonify,
+                   make_response, redirect, render_template, request,
+                   send_file, send_from_directory, session,
+                   stream_with_context, url_for)
 from PIL import Image, ImageDraw, ImageFont
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
@@ -58,50 +45,25 @@ from werkzeug.utils import secure_filename
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 import app.config as config
-from app.config import (
-    API_KEY,
-    BACKUP_PATH,
-    CHYRON_SPEED,
-    CLOCK_DIGITAL,
-    CLOCK_NAVBAR,
-    CLOCK_OVERLAY,
-    DOCS_DIRECTORY,
-    HEALTH_STATUS_ALWAYS_VISIBLE,
-    NAV_ICON,
-    SCREENSHOT_DIRECTORY,
-    SENSITIVE_SETTINGS,
-    VERSION,
-    VIDEO_DIRECTORY,
-    backup_config,
-    restore_config,
-)
+from app.config import (API_KEY, BACKUP_PATH, CHYRON_SPEED, CLOCK_DIGITAL,
+                        CLOCK_NAVBAR, CLOCK_OVERLAY, DOCS_DIRECTORY,
+                        HEALTH_STATUS_ALWAYS_VISIBLE, NAV_ICON,
+                        SCREENSHOT_DIRECTORY, SENSITIVE_SETTINGS, VERSION,
+                        VIDEO_DIRECTORY, backup_config, restore_config)
 from app.models import PushSubscription, Summary, User
-from app.utils import (
-    camera_discovery,
-    camera_fix,
-    limit_rate,
-    prompt_optimizer,
-    scheduling,
-    screenshots,
-    template_manager,
-    video_archiver,
-)
+from app.utils import (camera_discovery, camera_fix, limit_rate,
+                       prompt_optimizer, scheduling, screenshots,
+                       template_manager, video_archiver)
 from app.utils.llm import ask_question
 from app.utils.network import is_system_online
-from app.utils.screenshots import (
-    capture_frame_from_stream,
-    check_user_activity,
-    is_chrome_debug_port_open,
-)
-from app.utils.settings_tooltips import (
-    EMAIL_FIELDS,
-    LOCKED_SETTINGS,
-    NUMERIC_FIELDS,
-    SETTINGS_CHOICES,
-    SETTINGS_GROUPS,
-    SETTINGS_PLACEHOLDERS,
-    SETTINGS_TOOLTIPS,
-)
+from app.utils.screenshots import (capture_frame_from_stream,
+                                   check_user_activity,
+                                   is_chrome_debug_port_open)
+from app.utils.settings_tooltips import (EMAIL_FIELDS, LOCKED_SETTINGS,
+                                         NUMERIC_FIELDS, SETTINGS_CHOICES,
+                                         SETTINGS_GROUPS,
+                                         SETTINGS_PLACEHOLDERS,
+                                         SETTINGS_TOOLTIPS)
 
 # Names of settings that store file paths.
 FILE_LOCATION_NAMES = [
@@ -348,27 +310,17 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 from app.utils import validators
 from app.utils.email_alerts import send_email_alert
 from app.utils.profiling import get_latency_stats, profile_route
-
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
-from app.utils.screenshots import (
-    check_user_activity,
-    get_chrome_path,
-    get_chrome_version,
-    is_chrome_debug_port_open,
-    load_font,
-)
+from app.utils.screenshots import (check_user_activity, get_chrome_path,
+                                   get_chrome_version,
+                                   is_chrome_debug_port_open, load_font)
 from app.utils.sms_alerts import send_sms_alert
-from app.utils.validators import (
-    validate_setting,
-    validate_template_name,
-    validate_update_data,
-)
-from scripts.update_chrome_shortcut import (
-    first_shortcut_path,
-    shortcuts_need_patch,
-    update_chrome_shortcuts_info,
-)
+from app.utils.validators import (validate_setting, validate_template_name,
+                                  validate_update_data)
+from scripts.update_chrome_shortcut import (first_shortcut_path,
+                                            shortcuts_need_patch,
+                                            update_chrome_shortcuts_info)
 
 
 def restart_server() -> None:
@@ -4004,6 +3956,18 @@ def init_routes(app: Flask) -> None:
     @app.route("/sw.js")
     def service_worker():
         response = make_response(app.send_static_file("sw.js"))
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+
+    @app.route("/robots.txt")
+    def robots_txt():
+        """Return ``robots.txt`` rules based on ``ALLOW_BOTS`` setting."""
+        rules = ["User-agent: *"]
+        if config.ALLOW_BOTS:
+            rules.append("Allow: /")
+        else:
+            rules.append("Disallow: /")
+        response = Response("\n".join(rules) + "\n", mimetype="text/plain")
         response.headers["Cache-Control"] = "no-cache"
         return response
 

--- a/docs/robots_txt.md
+++ b/docs/robots_txt.md
@@ -1,0 +1,6 @@
+# Robots.txt Endpoint
+
+The `/robots.txt` route returns indexing rules at runtime.
+Set the `ALLOW_BOTS` setting to `True` to allow indexing.
+By default crawlers are disallowed.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Testing: testing.md
       - Tooltips: tooltips.md
       - SEO Metadata: seo_metadata.md
+      - Robots.txt Endpoint: robots_txt.md
       - Troubleshooting: troubleshooting.md
       - Log Cleaner: log_cleaner.md
       - Video Archiver: video_archiver.md

--- a/tests/test_robots_txt_endpoint.py
+++ b/tests/test_robots_txt_endpoint.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestRobotsTxtEndpoint(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def test_disallow(self):
+        with patch("app.routes.config.ALLOW_BOTS", False):
+            resp = self.client.get("/robots.txt")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data.decode(), "User-agent: *\nDisallow: /\n")
+
+    def test_allow(self):
+        with patch("app.routes.config.ALLOW_BOTS", True):
+            resp = self.client.get("/robots.txt")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data.decode(), "User-agent: *\nAllow: /\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow search engine indexing to be configured via `ALLOW_BOTS`
- serve a dynamic `/robots.txt` endpoint
- document the new endpoint and link it from the docs
- add tests for the new route
- format imports after running pre-commit

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest tests/test_robots_txt_endpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_6848102ce87483339ea9bc4d382442bb