### PR TITLE
Add MJPG Indian head pattern stream

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -84,6 +84,7 @@ from app.utils import (
     scheduling,
     screenshots,
     template_manager,
+    test_pattern,
     video_archiver,
 )
 from app.utils.llm import ask_question
@@ -2335,6 +2336,25 @@ def init_routes(app: Flask) -> None:
         logging.debug("last motion caption")
         return Response(
             generate(group=group, camera=camera, filename="last_motion_caption.png"),
+            mimetype="multipart/x-mixed-replace; boundary=frame",
+        )
+
+    @app.route("/test_pattern.mjpg", methods=["GET"])
+    @login_required
+    def test_pattern_mjpg():
+        def generate_pattern():
+            boundary = b"frame"
+            while True:
+                img = test_pattern.generate_indian_head_test_pattern()
+                buf = io.BytesIO()
+                img.save(buf, format="JPEG")
+                frame = buf.getvalue()
+                yield b"--" + boundary + b"\r\n"
+                yield b"Content-Type: image/jpeg\r\n\r\n" + frame + b"\r\n"
+                time.sleep(1)
+
+        return Response(
+            generate_pattern(),
             mimetype="multipart/x-mixed-replace; boundary=frame",
         )
 

--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -104,6 +104,38 @@ def generate_test_pattern(
     return img
 
 
+def generate_indian_head_test_pattern(
+    width: int = 1280, height: int = 720
+) -> Image.Image:
+    """Return a grayscale Indian Head-style test pattern."""
+
+    img = Image.new("RGB", (width, height), "gray")
+    draw = ImageDraw.Draw(img)
+
+    draw.line((width // 2, 0, width // 2, height), fill="black", width=3)
+    draw.line((0, height // 2, width, height // 2), fill="black", width=3)
+
+    for scale in (0.4, 0.6, 0.8):
+        radius = int(min(width, height) * scale / 2)
+        bbox = (
+            width // 2 - radius,
+            height // 2 - radius,
+            width // 2 + radius,
+            height // 2 + radius,
+        )
+        draw.ellipse(bbox, outline="black", width=3)
+
+    font = load_font(int(height * 0.05))
+    text = "PLEASE STAND BY"
+    tb = draw.textbbox((0, 0), text, font=font)
+    tw, th = tb[2] - tb[0], tb[3] - tb[1]
+    draw.text(
+        (width // 2 - tw // 2, height // 2 - th // 2), text, fill="black", font=font
+    )
+
+    return img
+
+
 def save_test_pattern(path: str, **kwargs) -> None:
     """Generate a test pattern image and save it as PNG."""
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -136,6 +136,7 @@ Several other routes provide streaming functionality:
 - **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests reuse the cached clip for speed. Responses include `Cache-Control: public, max-age=120` so browsers retain the clip for two minutes.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
+- **GET /test_pattern.mjpg** – Streams a generated Indian Head test pattern for debugging purposes.
 
 ### 6. Trigger Screenshot Capture
 

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -4,7 +4,11 @@ import tempfile
 
 from PIL import Image
 
-from app.utils.test_pattern import generate_test_pattern, save_test_pattern
+from app.utils.test_pattern import (
+    generate_indian_head_test_pattern,
+    generate_test_pattern,
+    save_test_pattern,
+)
 
 
 class TestTestPattern(unittest.TestCase):
@@ -20,6 +24,11 @@ class TestTestPattern(unittest.TestCase):
             self.assertTrue(os.path.exists(path))
             with Image.open(path) as im:
                 self.assertEqual(im.size, (100, 50))
+
+    def test_indian_head_size(self):
+        img = generate_indian_head_test_pattern(width=150, height=150)
+        self.assertIsInstance(img, Image.Image)
+        self.assertEqual(img.size, (150, 150))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `generate_indian_head_test_pattern` utility
- expose `/test_pattern.mjpg` route for the pattern
- document the new endpoint
- test new pattern generator

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest -q` *(fails: TestHeavyRouteThrottle::test_clip_throttled)*

------
https://chatgpt.com/codex/tasks/task_e_68481ec319788333aaf06c41c45ead5c