### PR TITLE
Fix template name validation in routes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -31,10 +31,23 @@ from urllib.parse import urlparse
 import psutil
 import requests
 from dateutil import tz
-from flask import (Flask, Response, abort, current_app, flash, jsonify,
-                   make_response, redirect, render_template, request,
-                   send_file, send_from_directory, session,
-                   stream_with_context, url_for)
+from flask import (
+    Flask,
+    Response,
+    abort,
+    current_app,
+    flash,
+    jsonify,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    send_from_directory,
+    session,
+    stream_with_context,
+    url_for,
+)
 from PIL import Image, ImageDraw, ImageFont
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
@@ -45,25 +58,50 @@ from werkzeug.utils import secure_filename
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 import app.config as config
-from app.config import (API_KEY, BACKUP_PATH, CHYRON_SPEED, CLOCK_DIGITAL,
-                        CLOCK_NAVBAR, CLOCK_OVERLAY, DOCS_DIRECTORY,
-                        HEALTH_STATUS_ALWAYS_VISIBLE, NAV_ICON,
-                        SCREENSHOT_DIRECTORY, SENSITIVE_SETTINGS, VERSION,
-                        VIDEO_DIRECTORY, backup_config, restore_config)
+from app.config import (
+    API_KEY,
+    BACKUP_PATH,
+    CHYRON_SPEED,
+    CLOCK_DIGITAL,
+    CLOCK_NAVBAR,
+    CLOCK_OVERLAY,
+    DOCS_DIRECTORY,
+    HEALTH_STATUS_ALWAYS_VISIBLE,
+    NAV_ICON,
+    SCREENSHOT_DIRECTORY,
+    SENSITIVE_SETTINGS,
+    VERSION,
+    VIDEO_DIRECTORY,
+    backup_config,
+    restore_config,
+)
 from app.models import PushSubscription, Summary, User
-from app.utils import (camera_discovery, camera_fix, limit_rate,
-                       prompt_optimizer, scheduling, screenshots,
-                       template_manager, video_archiver)
+from app.utils import (
+    camera_discovery,
+    camera_fix,
+    limit_rate,
+    prompt_optimizer,
+    scheduling,
+    screenshots,
+    template_manager,
+    video_archiver,
+)
 from app.utils.llm import ask_question
 from app.utils.network import is_system_online
-from app.utils.screenshots import (capture_frame_from_stream,
-                                   check_user_activity,
-                                   is_chrome_debug_port_open)
-from app.utils.settings_tooltips import (EMAIL_FIELDS, LOCKED_SETTINGS,
-                                         NUMERIC_FIELDS, SETTINGS_CHOICES,
-                                         SETTINGS_GROUPS,
-                                         SETTINGS_PLACEHOLDERS,
-                                         SETTINGS_TOOLTIPS)
+from app.utils.screenshots import (
+    capture_frame_from_stream,
+    check_user_activity,
+    is_chrome_debug_port_open,
+)
+from app.utils.settings_tooltips import (
+    EMAIL_FIELDS,
+    LOCKED_SETTINGS,
+    NUMERIC_FIELDS,
+    SETTINGS_CHOICES,
+    SETTINGS_GROUPS,
+    SETTINGS_PLACEHOLDERS,
+    SETTINGS_TOOLTIPS,
+)
 
 # Names of settings that store file paths.
 FILE_LOCATION_NAMES = [
@@ -310,17 +348,27 @@ NODE_ENV = os.getenv("NODE_ENV", "development")
 from app.utils import validators
 from app.utils.email_alerts import send_email_alert
 from app.utils.profiling import get_latency_stats, profile_route
+
 # from app.models.log import Log
 from app.utils.scheduling import log_cache, log_cache_lock
-from app.utils.screenshots import (check_user_activity, get_chrome_path,
-                                   get_chrome_version,
-                                   is_chrome_debug_port_open, load_font)
+from app.utils.screenshots import (
+    check_user_activity,
+    get_chrome_path,
+    get_chrome_version,
+    is_chrome_debug_port_open,
+    load_font,
+)
 from app.utils.sms_alerts import send_sms_alert
-from app.utils.validators import (validate_setting, validate_template_name,
-                                  validate_update_data)
-from scripts.update_chrome_shortcut import (first_shortcut_path,
-                                            shortcuts_need_patch,
-                                            update_chrome_shortcuts_info)
+from app.utils.validators import (
+    validate_setting,
+    validate_template_name,
+    validate_update_data,
+)
+from scripts.update_chrome_shortcut import (
+    first_shortcut_path,
+    shortcuts_need_patch,
+    update_chrome_shortcuts_info,
+)
 
 
 def restart_server() -> None:
@@ -1891,7 +1939,7 @@ def init_routes(app: Flask) -> None:
         Endpoint to receive and process an image submitted by a remote service or camera.
         """
         raw_name = template_name
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             logging.warning("Unable to serve screenshot for %s", raw_name)
             resp = send_file(_placeholder_screenshot(), mimetype="image/png")
@@ -2746,7 +2794,7 @@ def init_routes(app: Flask) -> None:
         Serve the latest frame for a specific camera.
         """
         raw_name = template_name
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             logging.warning("Unable to serve screenshot for %s", raw_name)
             resp = send_file(_placeholder_screenshot(), mimetype="image/png")
@@ -2799,7 +2847,7 @@ def init_routes(app: Flask) -> None:
     def serve_video(template_name: TemplateName):
         """Return the latest MP4 for ``template_name`` if available."""
 
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -2832,7 +2880,7 @@ def init_routes(app: Flask) -> None:
     def serve_clip(template_name: TemplateName):
         """Return a short clip built from recent footage."""
 
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -2931,7 +2979,7 @@ def init_routes(app: Flask) -> None:
         """
 
         raw_name = template_name
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             logging.warning("Unable to serve screenshot for %s", raw_name)
             resp = send_file(_placeholder_screenshot(), mimetype="image/png")
@@ -2993,7 +3041,7 @@ def init_routes(app: Flask) -> None:
         Endpoint to upload a screenshot manually.
         """
 
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3104,7 +3152,7 @@ def init_routes(app: Flask) -> None:
         """
         Endpoint to trigger screenshot capture manually.
         """
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3132,7 +3180,7 @@ def init_routes(app: Flask) -> None:
     @login_required
     def update_video(template_name: TemplateName):
         """Endpoint to trigger screenshot capture manually."""
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3218,7 +3266,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/templates/<string:template_name>")
     @login_required
     def template_details(template_name: TemplateName):
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3242,7 +3290,7 @@ def init_routes(app: Flask) -> None:
     def list_screenshots(name: TemplateName):
         """Return a JSON list of screenshot files for ``name``."""
 
-        template_name = validate_template_name(name)
+        template_name = validate_template_name(str(name))
         if template_name is None:
             abort(404)
 
@@ -3254,7 +3302,7 @@ def init_routes(app: Flask) -> None:
     def generate_prompt_route(template_name: TemplateName):
         """Return a suggested caption prompt for ``template_name``."""
 
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3266,7 +3314,7 @@ def init_routes(app: Flask) -> None:
     def suggest_fix_route(template_name: TemplateName):
         """Return diagnostic info and replacement URL suggestions."""
 
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 
@@ -3285,7 +3333,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/screenshots/<string:name>/<string:filename>")
     @login_required
     def uploaded_file(name: TemplateName, filename: str):
-        template_name = validate_template_name(name)
+        template_name = validate_template_name(str(name))
         if template_name is None or not allowed_filename(filename):
             abort(404)
 
@@ -3322,7 +3370,7 @@ def init_routes(app: Flask) -> None:
     def list_videos(name: TemplateName):
         """Return a JSON list of video files for ``name``."""
 
-        template_name = validate_template_name(name)
+        template_name = validate_template_name(str(name))
         if template_name is None:
             abort(404)
 
@@ -3332,7 +3380,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/videos/<string:name>/<string:filename>")
     @login_required
     def view_video(name: TemplateName, filename: str):
-        template_name = validate_template_name(name)
+        template_name = validate_template_name(str(name))
         if template_name is None or not allowed_filename(filename):
             abort(404)
 
@@ -3573,7 +3621,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/update_template/<string:template_name>", methods=["POST"])
     @login_required
     def update_template(template_name: TemplateName):
-        template_name = validate_template_name(template_name)
+        template_name = validate_template_name(str(template_name))
         if template_name is None:
             abort(404)
 


### PR DESCRIPTION
## Summary
- ensure every route validates `TemplateName` objects correctly

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest -q` *(fails: tests/test_throttle_routes.py::TestHeavyRouteThrottle::test_clip_throttled)*

------
https://chatgpt.com/codex/tasks/task_e_68482219757c8333ab8480f89658b319