### PR TITLE
Fix screenshot filename validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3004,7 +3004,7 @@ def init_routes(app: Flask) -> None:
             )
 
         image_file = request.files["image_file"]
-        if image_file.filename == "":
+        if not image_file.filename:
             return (
                 jsonify({"status": "error", "message": "No image file provided"}),
                 400,


### PR DESCRIPTION
## Summary
- validate screenshot upload filename before calling `.lower`

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest tests/test_throttle_routes.py::TestHeavyRouteThrottle::test_clip_throttled -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68482219c8b88333a7bc1e07f1df03a6