### PR TITLE
Add typing to grouped settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3488,7 +3488,9 @@ def init_routes(app: Flask) -> None:
             return redirect(url_for("settings"))
 
         settings = get_all_settings()
-        grouped_settings = {group: [] for group in SETTINGS_GROUPS}
+        grouped_settings: Dict[str, List[Dict[str, Any]]] = {
+            group: [] for group in SETTINGS_GROUPS
+        }
         grouped_settings["Other"] = []
         for setting in settings:
             placed = False


### PR DESCRIPTION
## Summary
- annotate the `grouped_settings` variable in `settings` route

## Testing
- `flake8 app/routes.py`
- `pytest` *(fails: KeyboardInterrupt after tests completed)*
- `pre-commit run --all-files` *(fails: KeyboardInterrupt while running mypy)*

------
https://chatgpt.com/codex/tasks/task_e_6848221a92348333afab8faef2f2b885