### PR TITLE
Fix manage_templates data guard

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3168,6 +3168,8 @@ def init_routes(app: Flask) -> None:
     def manage_templates():
         if request.method == "POST":
             data = request.json
+            if data is None or "name" not in data:
+                abort(400)
             template_name = validate_template_name(data["name"])
             if template_name is None:
                 abort(404)
@@ -3204,6 +3206,8 @@ def init_routes(app: Flask) -> None:
 
         elif request.method == "DELETE":
             data = request.json
+            if data is None or "name" not in data:
+                abort(400)
             template_name = validate_template_name(data["name"])
             if template_name is None:
                 abort(404)


### PR DESCRIPTION
## Summary
- add safety checks when accessing template name in template management

## Testing
- `pre-commit run --files app/routes.py` *(fails: mypy errors)*
- `pytest tests/test_throttle_routes.py::TestHeavyRouteThrottle::test_clip_throttled -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6848221abe988333819e0ac0cce9b474