### PR TITLE
Enhance caption sorting controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -231,6 +231,18 @@ h2 {
   padding: 5px;
 }
 
+#sort-date {
+  width: auto;
+  padding: 2px 4px;
+}
+
+@media (max-width: 767px) {
+  #sort-date {
+    width: 100%;
+    font-size: 16px;
+  }
+}
+
 #search-input {
   width: clamp(80px, 10vw, 140px);
   transition: width 0.2s;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -14,9 +14,14 @@ function safePlay(el) {
   }
 }
 
-function createMobileCard(name) {
+function createMobileCard(name, template, index) {
   const div = document.createElement("div");
   div.classList.add("templateDiv", "mobile-card");
+  div.dataset.name = name;
+  div.dataset.index = index.toString();
+  div.dataset.last = template.last_screenshot_time || "";
+  div.dataset.next = template.next_screenshot_time || "";
+  div.dataset.error = template.capture_failed ? "1" : "0";
   const link = document.createElement("a");
   link.href = `/templates/${name}`;
   link.textContent = name;
@@ -673,7 +678,7 @@ export async function loadTemplates() {
         if (isIndexPage) {
           let templateDiv;
           if (isMobile()) {
-            templateDiv = createMobileCard(name);
+            templateDiv = createMobileCard(name, template, index);
             templateList.appendChild(templateDiv);
           } else {
             templateDiv = document.createElement("div");
@@ -682,6 +687,12 @@ export async function loadTemplates() {
             templateDiv.style.transform = "translateY(20px)";
             templateDiv.style.transition =
               "opacity 0.5s ease, transform 0.5s ease";
+
+            templateDiv.dataset.name = name;
+            templateDiv.dataset.index = index.toString();
+            templateDiv.dataset.last = template.last_screenshot_time || "";
+            templateDiv.dataset.next = template.next_screenshot_time || "";
+            templateDiv.dataset.error = template.capture_failed ? "1" : "0";
 
             templateDiv.innerHTML = `
               <a href='/templates/${name}'>
@@ -866,24 +877,60 @@ export function setupSorting() {
 export function setupSortMenu() {
   const menu = document.getElementById("sort-date");
   if (!menu) return;
-  menu.addEventListener("change", () => sortCameraTable(menu.value));
+  menu.addEventListener("change", () => sortTemplates(menu.value));
 }
 
-export function sortCameraTable(option) {
+export function sortTemplates(option) {
   const table = document.getElementById("camera-table");
-  if (!table) return;
-  const tbody = table.tBodies[0];
-  const rows = Array.from(tbody.rows);
+  const list = document.getElementById("template-list");
   const [field, direction] = option.split("_");
-  if (!field) {
-    rows.sort((a, b) => parseInt(a.dataset.index) - parseInt(b.dataset.index));
-  } else {
-    rows.sort(
-      (a, b) => new Date(a.dataset[field]) - new Date(b.dataset[field]),
-    );
+
+  if (table) {
+    const tbody = table.tBodies[0];
+    const rows = Array.from(tbody.rows);
+    const getVal = (row) => {
+      if (field === "alpha") return row.textContent.trim().toLowerCase();
+      if (field === "error") return parseInt(row.dataset.error || "0");
+      return row.dataset[field] || "";
+    };
+    rows.sort((a, b) => {
+      if (!field) {
+        return parseInt(a.dataset.index) - parseInt(b.dataset.index);
+      }
+      if (field === "alpha") {
+        return getVal(a).localeCompare(getVal(b));
+      }
+      if (field === "error") {
+        return getVal(a) - getVal(b);
+      }
+      return new Date(getVal(a)) - new Date(getVal(b));
+    });
     if (direction === "desc") rows.reverse();
+    rows.forEach((row) => tbody.appendChild(row));
+    return;
   }
-  rows.forEach((row) => tbody.appendChild(row));
+
+  if (!list) return;
+  const items = Array.from(list.querySelectorAll(".templateDiv"));
+  const getVal = (item) => {
+    if (field === "alpha") return item.dataset.name?.toLowerCase() || "";
+    if (field === "error") return parseInt(item.dataset.error || "0");
+    return item.dataset[field] || "";
+  };
+  items.sort((a, b) => {
+    if (!field) {
+      return parseInt(a.dataset.index) - parseInt(b.dataset.index);
+    }
+    if (field === "alpha") {
+      return getVal(a).localeCompare(getVal(b));
+    }
+    if (field === "error") {
+      return getVal(a) - getVal(b);
+    }
+    return new Date(getVal(a)) - new Date(getVal(b));
+  });
+  if (direction === "desc") items.reverse();
+  items.forEach((item) => list.appendChild(item));
 }
 
 export function setupCaptionsFilter() {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -40,13 +40,16 @@ template_controls %} {% block content %}
 
   <div id="prompts-tab" class="tab-content active">
     {% call template_controls() %}
-    <label for="sort-date" title="Sort camera table">Sort:</label>
-    <select id="sort-date" title="Sort camera table">
-      <option value="">Default</option>
-      <option value="last_desc">Last &darr;</option>
-      <option value="last_asc">Last &uarr;</option>
-      <option value="next_asc">Next &uarr;</option>
-      <option value="next_desc">Next &darr;</option>
+    <select id="sort-date" class="sort-select" aria-label="Sort cameras">
+      <option value="">↕</option>
+      <option value="name_asc">A–Z</option>
+      <option value="name_desc">Z–A</option>
+      <option value="last_desc">Last ↓</option>
+      <option value="last_asc">Last ↑</option>
+      <option value="next_desc">Next ↓</option>
+      <option value="next_asc">Next ↑</option>
+      <option value="error_desc">Error ↓</option>
+      <option value="error_asc">Error ↑</option>
     </select>
     {% endcall %}
 
@@ -66,6 +69,7 @@ template_controls %} {% block content %}
             data-index="{{ loop.index0 }}"
             data-last="{{ template_details[camera]['last_screenshot'] }}"
             data-next="{{ template_details[camera]['next_screenshot'] }}"
+            data-error="{{ 1 if template_details[camera]['capture_failed'] else 0 }}"
             data-groups="{{ template_details[camera]['groups'] }}"
             data-screenshot_count="{{ template_details[camera]['screenshot_count'] }}"
             data-video_count="{{ template_details[camera]['video_count'] }}"

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -1,5 +1,17 @@
 {% extends 'base.html' %} {% from 'components.html' import template_controls %}
-{% block content %} {% call template_controls() %}{% endcall %}
+{% block content %} {% call template_controls() %}
+<select id="sort-date" class="sort-select" aria-label="Sort cameras">
+  <option value="">↕</option>
+  <option value="name_asc">A–Z</option>
+  <option value="name_desc">Z–A</option>
+  <option value="last_desc">Last ↓</option>
+  <option value="last_asc">Last ↑</option>
+  <option value="next_desc">Next ↓</option>
+  <option value="next_asc">Next ↑</option>
+  <option value="error_desc">Error ↓</option>
+  <option value="error_asc">Error ↑</option>
+</select>
+{% endcall %}
 <div
   id="template-list"
   title="List of all templates"

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,19 @@
 <!-- app/templates/index.html -->
 
 {% extends 'base.html' %} {% from 'components.html' import template_controls %}
-{% block content %} {% call template_controls() %}{% endcall %}
+{% block content %} {% call template_controls() %}
+<select id="sort-date" class="sort-select" aria-label="Sort cameras">
+  <option value="">↕</option>
+  <option value="name_asc">A–Z</option>
+  <option value="name_desc">Z–A</option>
+  <option value="last_desc">Last ↓</option>
+  <option value="last_asc">Last ↑</option>
+  <option value="next_desc">Next ↓</option>
+  <option value="next_asc">Next ↑</option>
+  <option value="error_desc">Error ↓</option>
+  <option value="error_asc">Error ↑</option>
+</select>
+{% endcall %}
 
 <section id="template-list-section">
   <div


### PR DESCRIPTION
## Summary
- condense caption sort menu
- support sorting on index and group pages
- implement generic sort logic for grids and tables
- style sort dropdown for compact layout

## Testing
- `pre-commit run --files app/templates/index.html app/templates/group.html app/templates/captions.html app/static/js/templates.js app/static/css/style.css`
- `flake8`
- `pytest -q` *(fails: TestHeavyRouteThrottle::test_clip_throttled)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684851737a6c8333991b7c1e38589ead