### PR TITLE
Add nav bar control to stop speech audio

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -746,6 +746,10 @@ nav a.active {
   justify-content: center;
 }
 
+#speech-stop {
+  display: none;
+}
+
 .settings-icon svg {
   width: 18px;
   height: 18px;

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -374,6 +374,22 @@ export function initNav() {
       showNav();
     };
 
+    const setupSpeechStop = () => {
+      const speechIcon = document.getElementById("speech-stop");
+      if (!speechIcon || !("speechSynthesis" in window)) return;
+      const toggle = () => {
+        speechIcon.style.display = window.speechSynthesis.speaking
+          ? "flex"
+          : "none";
+      };
+      speechIcon.addEventListener("click", () => {
+        window.speechSynthesis.cancel();
+        toggle();
+      });
+      toggle();
+      setInterval(toggle, 500);
+    };
+
     const setupCameraNavigation = () => {
       const cameraDropdown = document.getElementById("nav-camera-dropdown");
       if (!cameraDropdown) return;
@@ -449,5 +465,6 @@ export function initNav() {
     }
     initClocks();
     setupNavFade();
+    setupSpeechStop();
   });
 }

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -104,6 +104,20 @@
         </svg>
       </a>
     </div>
+    <a
+      id="speech-stop"
+      class="settings-icon"
+      role="button"
+      title="Stop audio playback"
+      aria-label="Stop audio playback"
+      href="#"
+    >
+      <svg width="20" height="20">
+        <use
+          href="{{ url_for('static', filename='icons/sprite.svg') }}#comment"
+        />
+      </svg>
+    </a>
     <a href="/live" id="live" aria-label="Open Live page">
       <div
         id="nav-clock"

--- a/tests/js/nav_speech.test.js
+++ b/tests/js/nav_speech.test.js
@@ -1,0 +1,41 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <a id="speech-stop" class="settings-icon" role="button"></a>
+  <nav></nav>
+`;
+
+let initNav;
+
+beforeAll(async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve([]),
+    }),
+  );
+  global.setInterval = jest.fn();
+  const mod = await import("../../app/static/js/nav.js");
+  initNav = mod.initNav;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.speechSynthesis = { speaking: true, cancel: jest.fn() };
+});
+
+test("speech icon shows when speaking", () => {
+  initNav();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const icon = document.getElementById("speech-stop");
+  expect(icon.style.display).toBe("flex");
+});
+
+test("clicking icon cancels speech", () => {
+  initNav();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const icon = document.getElementById("speech-stop");
+  icon.click();
+  expect(window.speechSynthesis.cancel).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- show new speech stop icon while speechSynthesis is active
- poll speech synthesis state via `setupSpeechStop`
- hide icon by default via CSS
- test nav speech icon behavior

## Testing
- `pre-commit run --all-files` *(fails: mypy found 207 errors)*
- `flake8`
- `pytest -q` *(interrupted, reported 181 passed, 2 skipped)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848520003848333baa9bdddc9f68c43