### PR TITLE
Remove obsolete thumbnail input

### DIFF
--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -133,24 +133,6 @@ preview_src=None, preview_id=None, include_name=True, submit_label='Submit') -%}
       <span id="url-status" class="url-status" title="URL test result"></span>
     </div>
     <div class="form-row">
-      <label for="thumbnail" title="Thumbnail image URL">Thumbnail URL:</label>
-      <input
-        type="url"
-        id="thumbnail"
-        name="thumbnail"
-        value="{{ template.thumbnail if template else '' }}"
-        placeholder="https://example.com/thumb.jpg"
-        title="Optional thumbnail image URL"
-      />
-      <div class="thumbnail-preview">
-        <img
-          id="thumbnail-img"
-          src="{{ template.thumbnail or url_for('static', filename='img/glimpser_small.png') }}"
-          alt="Thumbnail preview"
-        />
-      </div>
-    </div>
-    <div class="form-row">
       <label for="frequency" title="How often to check the URL"
         >Frequency (minutes):</label
       >

--- a/docs/navigation_logo.md
+++ b/docs/navigation_logo.md
@@ -1,0 +1,3 @@
+# Navigation Logo
+
+Use the **Navigation Logo** card on the Settings page to replace the default icon with your own branding. Upload a PNG or pick one of the built-in images. The selected path is stored in the `NAV_ICON` setting and persists across restarts.

--- a/docs/thumbnail_field.md
+++ b/docs/thumbnail_field.md
@@ -1,3 +1,0 @@
-# Thumbnail Field
-
-Camera templates now accept an optional **Thumbnail URL**. When provided, this image appears beside the live preview while adding or editing a camera. If left blank, a small Glimpser logo is used instead so the layout stays balanced.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,5 +72,5 @@ nav:
       - OpenSSF Scorecard: scorecard.md
       - Startup Tips and Gotchas: startup_tips.md
       - UI Component Guide: style_guide.md
-      - Thumbnail Field: thumbnail_field.md
+      - Navigation Logo: navigation_logo.md
       - Governance: governance.md

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -113,10 +113,6 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('min="0.1"', components)
 
-    def test_template_form_has_thumbnail_field(self):
-        components = Path("app/templates/components.html").read_text(encoding="utf-8")
-        self.assertIn('name="thumbnail"', components)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- drop camera thumbnail field
- document navigation logo
- update docs navigation entry
- adjust HTML template tests

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest -q` *(fails: test_clip_throttled)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68485236b74c8333b359f0b6be17c497