### PR TITLE
Purge stale clips when idle

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,39 +2,27 @@
 
 import logging
 import os
+import sys
 import threading
 import time
-import sys
-import psutil
 from datetime import timedelta
 
+import psutil
 from flask import Flask
 
-from app.utils.retention_policy import retention_cleanup
-from app.utils.scheduling import (
-    schedule_crawlers,
-    schedule_summarization,
-    schedule_discovery,
-    schedule_offline_job_processor,
-    scheduler,
-    start_log_caching,
-    start_metrics_collection,
-    stop_event,
-)
-from app.utils.video_archiver import archive_screenshots, compile_to_teaser
-from app.config import (
-    LOG_LEVEL,
-    backup_config,
-    restore_config,
-    DISCOVERY_AUTOSTART,
-    WATCHDOG_FAILURE_THRESHOLD,
-    WATCHDOG_RESTART_COOLDOWN,
-    WATCHDOG_MAX_FILE_HANDLES,
-    WATCHDOG_CPU_THRESHOLD,
-    WATCHDOG_MEMORY_THRESHOLD,
-)
+from app.config import (DISCOVERY_AUTOSTART, LOG_LEVEL, WATCHDOG_CPU_THRESHOLD,
+                        WATCHDOG_FAILURE_THRESHOLD, WATCHDOG_MAX_FILE_HANDLES,
+                        WATCHDOG_MEMORY_THRESHOLD, WATCHDOG_RESTART_COOLDOWN,
+                        backup_config, restore_config)
 from app.utils.email_alerts import email_alert
+from app.utils.retention_policy import cleanup_clips, retention_cleanup
+from app.utils.scheduling import (schedule_crawlers, schedule_discovery,
+                                  schedule_offline_job_processor,
+                                  schedule_summarization, scheduler,
+                                  start_log_caching, start_metrics_collection,
+                                  stop_event)
 from app.utils.sms_alerts import sms_alert
+from app.utils.video_archiver import archive_screenshots, compile_to_teaser
 
 # from app.utils.db import SessionLocal
 # from app.models.log import Log
@@ -100,18 +88,11 @@ def create_app(
     Flask
         The configured Flask application instance.
     """
-    from app.config import (
-        SECRET_KEY,
-        MAX_WORKERS,
-        SCREENSHOT_DIRECTORY,
-        SUMMARIES_DIRECTORY,
-        VIDEO_DIRECTORY,
-        SESSION_COOKIE_SECURE,
-        SESSION_COOKIE_HTTPONLY,
-        SESSION_TIMEOUT_MINUTES,
-        API_KEY,
-        SCHEDULER_API_ENABLED,
-    )
+    from app.config import (API_KEY, MAX_WORKERS, SCHEDULER_API_ENABLED,
+                            SCREENSHOT_DIRECTORY, SECRET_KEY,
+                            SESSION_COOKIE_HTTPONLY, SESSION_COOKIE_SECURE,
+                            SESSION_TIMEOUT_MINUTES, SUMMARIES_DIRECTORY,
+                            VIDEO_DIRECTORY)
 
     app = Flask(__name__)
     app.secret_key = SECRET_KEY
@@ -170,6 +151,12 @@ def create_app(
                 minutes=1,
             )
             scheduler.add_job(
+                id="cleanup_clips",
+                func=cleanup_clips,
+                trigger="interval",
+                minutes=5,
+            )
+            scheduler.add_job(
                 id="retention_cleanup", func=retention_cleanup, trigger="cron", day="*"
             )
             schedule_summarization()
@@ -179,6 +166,7 @@ def create_app(
 
         # Perform initial cleanup
         retention_cleanup()
+        cleanup_clips()
         logging.info("Initialization complete")
 
     # Backup the current configuration
@@ -301,6 +289,7 @@ def create_app(
                     schedule_discovery()
 
             retention_cleanup()
+            cleanup_clips()
             logging.info("Initialization complete")
 
         if enable_watchdog:

--- a/app/config.py
+++ b/app/config.py
@@ -385,6 +385,9 @@ CHYRON_SPEED = int(get_setting("CHYRON_SPEED", 0))
 # Length in seconds returned by the `/clip/<template>` endpoint.
 DEFAULT_CLIP_DURATION = int(get_setting("DEFAULT_CLIP_DURATION", 120))
 
+# Maximum age in minutes before temporary ``clip.mp4`` files are purged.
+MAX_CLIP_AGE_MINUTES = int(get_setting("MAX_CLIP_AGE_MINUTES", 5))
+
 # Whether the System Performance icon in the navigation bar should remain
 # visible even when the application reports healthy status. When set to
 # ``False`` the icon hides itself if all metrics look nominal to reduce

--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -1,15 +1,13 @@
 # utils/retention_policy.py
 
+import logging
 import os
 import time
-import logging
 
-from app.config import (
-    MAX_COMPRESSED_VIDEO_AGE,
-    MAX_RAW_DATA_SIZE,
-    SCREENSHOT_DIRECTORY,
-    VIDEO_DIRECTORY,
-)
+from app.config import (MAX_CLIP_AGE_MINUTES, MAX_COMPRESSED_VIDEO_AGE,
+                        MAX_RAW_DATA_SIZE, SCREENSHOT_DIRECTORY,
+                        VIDEO_DIRECTORY)
+from app.utils.screenshots import check_user_activity
 
 
 def get_files_sorted_by_creation_time(directory):
@@ -67,6 +65,29 @@ def delete_old_files(file_list, max_age, max_size, minimum=10):
             logging.error("Error processing %s: %s", file_path, e)
 
 
+def cleanup_clips(max_age_minutes: int = MAX_CLIP_AGE_MINUTES) -> None:
+    """Delete stale ``clip.mp4`` files when the user is idle."""
+
+    if not (max_age_minutes and max_age_minutes > 0):
+        return
+
+    if check_user_activity(timeout=1):
+        # User is active; postpone cleanup to avoid disrupting playback.
+        return
+
+    expiry = max_age_minutes * 60
+    for camera_name in os.listdir(VIDEO_DIRECTORY):
+        clip_path = os.path.join(VIDEO_DIRECTORY, camera_name, "clip.mp4")
+        if os.path.isfile(clip_path):
+            try:
+                age = time.time() - os.path.getmtime(clip_path)
+                if age > expiry:
+                    os.remove(clip_path)
+                    logging.debug("Deleted expired clip %s", clip_path)
+            except Exception as e:
+                logging.warning("Failed to delete %s: %s", clip_path, e)
+
+
 def retention_cleanup():
     # For each camera, delete old or excess videos
     for camera_name in os.listdir(VIDEO_DIRECTORY):
@@ -79,3 +100,5 @@ def retention_cleanup():
         camera_dir = os.path.join(SCREENSHOT_DIRECTORY, camera_name)
         image_files = get_files_sorted_by_creation_time(camera_dir)
         delete_old_files(image_files, MAX_COMPRESSED_VIDEO_AGE, MAX_RAW_DATA_SIZE)
+
+    cleanup_clips()

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -1,21 +1,19 @@
 # Integration tests for retention_policy cleanup logic
 
-import unittest
-import tempfile
 import os
 import sys
+import tempfile
 import time
+import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from unittest.mock import patch
 
-from app.utils.retention_policy import (
-    delete_old_files,
-    get_files_sorted_by_creation_time,
-    retention_cleanup,
-)
 import app.utils.retention_policy as retention_policy
+from app.utils.retention_policy import (cleanup_clips, delete_old_files,
+                                        get_files_sorted_by_creation_time,
+                                        retention_cleanup)
 
 
 class TestRetentionPolicy(unittest.TestCase):
@@ -61,7 +59,7 @@ class TestRetentionPolicy(unittest.TestCase):
     def test_retention_cleanup_invokes_deletion(
         self, mock_delete, mock_get_files, mock_listdir
     ):
-        mock_listdir.side_effect = [["cam1"], ["cam1"]]
+        mock_listdir.side_effect = [["cam1"], ["cam1"], ["cam1"]]
         mock_get_files.return_value = ["f1", "f2"]
 
         retention_cleanup()
@@ -104,6 +102,45 @@ class TestRetentionPolicy(unittest.TestCase):
                 len(os.listdir(os.path.join(shot_dir, "cam1"))),
                 10,
             )
+
+    def test_cleanup_clips_removes_expired(self):
+        with tempfile.TemporaryDirectory() as video_dir:
+            cam_dir = os.path.join(video_dir, "cam1")
+            os.makedirs(cam_dir)
+            clip = os.path.join(cam_dir, "clip.mp4")
+            with open(clip, "w"):
+                pass
+            old = time.time() - 600
+            os.utime(clip, (old, old))
+
+            with (
+                patch.object(retention_policy, "VIDEO_DIRECTORY", video_dir),
+                patch(
+                    "app.utils.retention_policy.check_user_activity",
+                    return_value=False,
+                ),
+            ):
+                cleanup_clips(max_age_minutes=5)
+
+            self.assertFalse(os.path.exists(clip))
+
+    def test_cleanup_clips_keeps_recent(self):
+        with tempfile.TemporaryDirectory() as video_dir:
+            cam_dir = os.path.join(video_dir, "cam1")
+            os.makedirs(cam_dir)
+            clip = os.path.join(cam_dir, "clip.mp4")
+            with open(clip, "w"):
+                pass
+            with (
+                patch.object(retention_policy, "VIDEO_DIRECTORY", video_dir),
+                patch(
+                    "app.utils.retention_policy.check_user_activity",
+                    return_value=False,
+                ),
+            ):
+                cleanup_clips(max_age_minutes=5)
+
+            self.assertTrue(os.path.exists(clip))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add MAX_CLIP_AGE_MINUTES setting
- delete expired `clip.mp4` files when the user is idle
- schedule periodic clip cleanup
- test cleanup logic

## Testing
- `flake8 app/config.py app/utils/retention_policy.py app/__init__.py tests/test_retention_policy.py`
- `pytest tests/test_retention_policy.py`
- `pre-commit run --all-files` *(fails: 207 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684859c39ee483338d652e2568ba27f7