### PR TITLE
feat: add geometric pattern option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Footer warns when a newer release is available
 - Stream error overlay distinguishes network and unsupported format errors
 - Sortable KPI table on captions page with filtering
+- Escher-inspired geometric test pattern generator
+- `/test_pattern.mjpg` accepts `pattern=geometric` to view the new style
 
 ### Changed
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -2428,10 +2428,15 @@ def init_routes(app: Flask) -> None:
     @app.route("/test_pattern.mjpg", methods=["GET"])
     @login_required
     def test_pattern_mjpg():
+        style = request.args.get("pattern", "indian")
+
         def generate_pattern():
             boundary = b"frame"
             while True:
-                img = test_pattern.generate_indian_head_test_pattern()
+                if style == "geometric":
+                    img = test_pattern.generate_geometric_test_pattern()
+                else:
+                    img = test_pattern.generate_indian_head_test_pattern()
                 buf = io.BytesIO()
                 img.save(buf, format="JPEG")
                 frame = buf.getvalue()

--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from PIL import Image, ImageDraw, ImageFont
 
-
 FONT_CANDIDATES = [
     "DejaVuSans-Bold.ttf",
     "DejaVuSans.ttf",
@@ -132,6 +131,41 @@ def generate_indian_head_test_pattern(
     draw.text(
         (width // 2 - tw // 2, height // 2 - th // 2), text, fill="black", font=font
     )
+
+    return img
+
+
+def generate_geometric_test_pattern(
+    width: int = 1280,
+    height: int = 720,
+    tiles: int = 10,
+) -> Image.Image:
+    """Return a geometric test pattern inspired by Escher."""
+
+    img = Image.new("RGB", (width, height), "black")
+    draw = ImageDraw.Draw(img)
+
+    tri_w = width // tiles
+    tri_h = height // tiles
+    colors = [(30, 30, 30), (80, 80, 80)]
+
+    for row in range(tiles):
+        for col in range(tiles * 2):
+            x = col * tri_w // 2
+            y = row * tri_h
+            color = colors[(row + col) % 2]
+            points = [(x, y), (x + tri_w // 2, y + tri_h), (x + tri_w, y)]
+            draw.polygon(points, fill=color)
+
+    center = (width // 2, height // 2)
+    for r in range(min(width, height) // 8, min(width, height) // 2, tri_w):
+        bbox = (
+            center[0] - r,
+            center[1] - r,
+            center[0] + r,
+            center[1] + r,
+        )
+        draw.ellipse(bbox, outline="white")
 
     return img
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -136,7 +136,9 @@ Several other routes provide streaming functionality:
 - **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests reuse the cached clip for speed. Responses include `Cache-Control: public, max-age=120` so browsers retain the clip for two minutes.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
-- **GET /test_pattern.mjpg** – Streams a generated Indian Head test pattern for debugging purposes.
+- **GET /test_pattern.mjpg** – Streams a generated test pattern. Pass
+  `?pattern=geometric` to view the Escher-style geometric design instead of the
+  default Indian Head pattern.
 
 ### 6. Trigger Screenshot Capture
 

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -1,14 +1,12 @@
-import unittest
 import os
 import tempfile
+import unittest
 
 from PIL import Image
 
-from app.utils.test_pattern import (
-    generate_indian_head_test_pattern,
-    generate_test_pattern,
-    save_test_pattern,
-)
+from app.utils.test_pattern import (generate_geometric_test_pattern,
+                                    generate_indian_head_test_pattern,
+                                    generate_test_pattern, save_test_pattern)
 
 
 class TestTestPattern(unittest.TestCase):
@@ -29,6 +27,11 @@ class TestTestPattern(unittest.TestCase):
         img = generate_indian_head_test_pattern(width=150, height=150)
         self.assertIsInstance(img, Image.Image)
         self.assertEqual(img.size, (150, 150))
+
+    def test_geometric_size(self):
+        img = generate_geometric_test_pattern(width=120, height=120, tiles=5)
+        self.assertIsInstance(img, Image.Image)
+        self.assertEqual(img.size, (120, 120))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `/test_pattern.mjpg` with a `pattern` query parameter
- document geometric pattern option in API docs
- update changelog

## Testing
- `pre-commit run --files app/routes.py CHANGELOG.md docs/api_documentation.md` *(fails: isort and mypy issues)*
- `pytest -k test_test_pattern -q`

------
https://chatgpt.com/codex/tasks/task_e_684856543ddc833392a42d722f27d666