### PR TITLE
Add test image endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2144,6 +2144,46 @@ def init_routes(app: Flask) -> None:
             return send_file(last_shot)
         abort(404)
 
+    @app.route("/test_image", methods=["GET"])
+    @login_required
+    def serve_test_image():
+        """Return a test image or screenshot for debugging."""
+
+        camera = request.args.get("camera")
+        ts = request.args.get("time")
+
+        base_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
+            SCREENSHOT_DIRECTORY,
+        )
+        if camera:
+            camera = validate_template_name(camera)
+            if camera is None:
+                abort(400, "Invalid camera name")
+            base_path = os.path.join(base_path, camera)
+
+        if ts:
+            try:
+                dt = datetime.strptime(ts, "%Y%m%d%H%M%S")
+            except ValueError:
+                abort(400, "time must be YYYYMMDDHHMMSS")
+            filename = scheduling.find_closest_image(base_path, dt)
+            if filename:
+                path = os.path.join(base_path, filename)
+                if os.path.exists(path) and screenshots._is_valid_png(path):
+                    return send_file(path)
+            abort(404)
+
+        test_path = os.path.join(base_path, "test_image.png")
+        if os.path.exists(test_path):
+            return send_file(test_path)
+        img = Image.new("RGB", (64, 64), color="gray")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        return send_file(buf, mimetype="image/png")
+
     @app.route(
         "/test.rtsp",
         methods=[

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -136,6 +136,7 @@ Several other routes provide streaming functionality:
 - **GET /clip/<template_name>** – Concatenate the active `in_process.mp4` with recent finalized segments. If the in‑progress video is shorter than the requested `duration` (default `DEFAULT_CLIP_DURATION`) older finalized clips are prepended. When no footage exists the server falls back to a blank video. Subsequent requests reuse the cached clip for speed. Responses include `Cache-Control: public, max-age=120` so browsers retain the clip for two minutes.
 - **GET /test.rtsp** – Basic RTSP endpoint that serves MJPEG frames when used with `/rtsp_stream`. Send periodic `GET_PARAMETER` requests to keep the session alive.
 - **GET /test.mjpg** – MJPEG view of the test frame. Supports optional `camera` and `group` query parameters.
+- **GET /test_image** – Returns a sample image. Accepts optional `camera` or `time` parameters.
 
 ### 6. Trigger Screenshot Capture
 

--- a/tests/test_test_image_route.py
+++ b/tests/test_test_image_route.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import shutil
+import unittest
+from flask import Flask
+from PIL import Image
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+class TestTestImageRoute(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        self.sshot_dir = "test_test_image"
+        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
+        self.login_patch.start()
+        self.sc_patch.start()
+        self.app = Flask(__name__)
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+        self.sc_patch.stop()
+        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+
+    def test_global_test_image(self):
+        img_path = os.path.join(self.repo_root, self.sshot_dir, "test_image.png")
+        Image.new("RGB", (1, 1)).save(img_path)
+        resp = self.client.get("/test_image")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_camera_parameter(self):
+        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        img_path = os.path.join(img_dir, "test_image.png")
+        Image.new("RGB", (1, 1)).save(img_path)
+        resp = self.client.get("/test_image?camera=cam1")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_time_parameter(self):
+        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        ts = "20230101010101"
+        img_name = f"{ts}_motion.png"
+        img_path = os.path.join(img_dir, img_name)
+        Image.new("RGB", (1, 1)).save(img_path)
+        resp = self.client.get(f"/test_image?camera=cam1&time={ts}")
+        self.assertEqual(resp.status_code, 200)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/test_image` route to return a sample screenshot
- document new endpoint
- cover route with tests

## Testing
- `flake8`
- `pytest tests/test_test_image_route.py`
- `pre-commit run --all-files` *(fails: mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_684814b8b5b08333b55fbff7d46ea096