### PR TITLE
Limit clip fetch frequency

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -3,6 +3,9 @@ import { attemptAutoLogin } from "./login.js";
 
 const video = document.getElementById("live-video");
 
+const CLIP_THROTTLE_MS = 30000;
+let lastClipTime = 0;
+
 function safePlay(el) {
   const promise = el.play();
   if (promise && typeof promise.catch === "function") {
@@ -15,6 +18,18 @@ function safePlay(el) {
       }
     });
   }
+}
+
+function setClipSrc(cameraName) {
+  const now = Date.now();
+  if (now - lastClipTime >= CLIP_THROTTLE_MS) {
+    video.src = `/clip/${cameraName}`;
+    lastClipTime = now;
+  } else {
+    video.src = `/stream.mp4?camera=${encodeURIComponent(cameraName)}`;
+  }
+  video.load();
+  safePlay(video);
 }
 const image = document.getElementById("live-image");
 const templateDetailsContainer = document.getElementById("template-details");
@@ -674,9 +689,7 @@ function playLoop() {
         cameraIndex = 0; // Reset the index to loop through the cameras again
       }
       const cameraName = groupCameras[cameraIndex];
-      video.src = `/clip/${cameraName}`; // Update the video source with the current camera
-      video.load();
-      safePlay(video);
+      setClipSrc(cameraName);
       cameraIndex++; // Move to the next camera
     };
 
@@ -684,9 +697,7 @@ function playLoop() {
     video.addEventListener("ended", loopHandler); // Continue the loop when the video ends
   } else {
     // Handling for individual cameras
-    video.src = `/clip/${currentCamera}`;
-    video.load();
-    safePlay(video);
+    setClipSrc(currentCamera);
   }
 }
 
@@ -788,11 +799,9 @@ function handleVideoEnded() {
     const currentIndex = groupCameras.indexOf(video.dataset.currentCamera);
     const nextIndex = (currentIndex + 1) % groupCameras.length;
     const nextCamera = groupCameras[nextIndex];
-    video.src = `/clip/${nextCamera}`;
+    setClipSrc(nextCamera);
     video.dataset.currentCamera = nextCamera;
   }
-  video.load();
-  safePlay(video);
 }
 
 function playLive() {
@@ -1473,4 +1482,5 @@ export {
   getCameraNames,
   handleNetworkOffline,
   handleNetworkOnline,
+  setClipSrc,
 };

--- a/tests/js/clip_throttle.test.js
+++ b/tests/js/clip_throttle.test.js
@@ -1,0 +1,59 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container"></div>
+  <video id="live-video"></video>
+  <img id="live-image" />
+  <div id="template-details"></div>
+  <div id="speed-container"></div>
+  <input id="speed-slider" value="0" />
+  <span id="speed-value"></span>
+  <div id="video-overlay"></div>
+  <div id="loading-indicator"></div>
+  <div id="play-pause-indicator"></div>
+  <div id="offline-indicator"></div>
+  <div id="offline-message"></div>
+  <div id="capture-error-indicator"></div>
+  <div id="capture-error-message"></div>
+  <div id="stream-error-indicator"></div>
+  <div id="stream-error-message"></div>
+  <div id="error-message"></div>
+  <button id="play-pause"></button>
+  <div id="toggle-details"></div>
+  <input id="seek-bar" />
+  <div id="jog-shuttle"></div>
+  <select id="group-selector"></select>
+  <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
+`;
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: jest.fn(),
+});
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: jest.fn(() => Promise.resolve()),
+});
+
+window.templateDetails = { cam1: {}, cam2: {} };
+
+let setClipSrc;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/live.js");
+  setClipSrc = mod.setClipSrc;
+});
+
+jest.useFakeTimers();
+
+test("falls back to stream when clip throttled", () => {
+  const video = document.getElementById("live-video");
+  setClipSrc("cam1");
+  expect(video.src).toMatch(/\/clip\/cam1$/);
+  jest.advanceTimersByTime(1000);
+  setClipSrc("cam2");
+  expect(video.src).toMatch(/\/stream.mp4\?camera=cam2$/);
+  jest.advanceTimersByTime(30000);
+  setClipSrc("cam2");
+  expect(video.src).toMatch(/\/clip\/cam2$/);
+});


### PR DESCRIPTION
## Summary
- limit `/clip` requests with new `setClipSrc` in `live.js`
- export helper and add unit test to ensure fallback to `/stream.mp4`

## Testing
- `pre-commit run --all-files` *(fails: mypy errors)*
- `pytest -q`
- `npm test --silent`
- `npm run size-audit --silent`


------
https://chatgpt.com/codex/tasks/task_e_6848a37be26c833391bca5b617f8c87c