### PR TITLE
Fix tooltip overflow

### DIFF
--- a/app/static/js/tooltips.js
+++ b/app/static/js/tooltips.js
@@ -7,12 +7,27 @@ export function initTooltips() {
     const moveTooltip = (e) => {
       const offset = 10;
       const tooltipWidth = tooltip.offsetWidth;
-      let left = e.pageX + offset;
+      const tooltipHeight = tooltip.offsetHeight;
+
+      const x = e.pageX ?? e.clientX;
+      const y = e.pageY ?? e.clientY;
+
+      let left = x + offset;
       if (left + tooltipWidth > window.innerWidth) {
-        left = e.pageX - tooltipWidth - offset;
+        left = x - tooltipWidth - offset;
       }
+
+      let top = y + offset;
+      const viewportBottom = window.scrollY + window.innerHeight;
+      if (top + tooltipHeight > viewportBottom) {
+        top = y - tooltipHeight - offset;
+      }
+      if (top < window.scrollY) {
+        top = window.scrollY;
+      }
+
       tooltip.style.left = `${left}px`;
-      tooltip.style.top = `${e.pageY + offset}px`;
+      tooltip.style.top = `${top}px`;
     };
 
     const showTooltip = (e) => {

--- a/tests/js/tooltip_position.test.js
+++ b/tests/js/tooltip_position.test.js
@@ -1,0 +1,35 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `<span id="item" title="Hello"></span>`;
+
+let initTooltips;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/tooltips.js");
+  initTooltips = mod.initTooltips;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.querySelector("#item").setAttribute("title", "Hello");
+});
+
+test("repositions tooltip above when near bottom", () => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: 300 });
+  Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: 500 });
+  Object.defineProperty(window, "scrollY", { configurable: true, writable: true, value: 0 });
+
+  initTooltips();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+
+  const tooltip = document.querySelector(".dynamic-tooltip");
+  Object.defineProperty(tooltip, "offsetWidth", { configurable: true, value: 50 });
+  Object.defineProperty(tooltip, "offsetHeight", { configurable: true, value: 40 });
+
+  const el = document.getElementById("item");
+  el.dispatchEvent(
+    new MouseEvent("mouseover", { clientX: 260, clientY: 490, bubbles: true })
+  );
+
+  expect(tooltip.style.top).toBe("440px");
+});


### PR DESCRIPTION
## Summary
- constrain tooltips within viewport
- test tooltip position logic

## Testing
- `pre-commit run --files app/static/js/tooltips.js tests/js/tooltip_position.test.js`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848aa72d1608333a8686a8e22aae188