### PR TITLE
Unify player across screens

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -1,0 +1,24 @@
+export function initTilePlayer() {
+  const video = document.getElementById("live-video");
+  if (!video) return;
+  const source = video.querySelector("source");
+  const camSelect = document.getElementById("camera-selector");
+  let current =
+    camSelect?.value || Object.keys(window.templateDetails || {})[0];
+
+  function play(name) {
+    if (!name) return;
+    current = name;
+    if (source) source.src = `/last_video/${name}`;
+    video.setAttribute("data-hd-src", `/clip/${name}`);
+    video.load();
+  }
+
+  if (camSelect) {
+    camSelect.addEventListener("change", () => play(camSelect.value));
+  }
+
+  play(current);
+}
+
+document.addEventListener("DOMContentLoaded", initTilePlayer);

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -1,189 +1,47 @@
 {% extends 'base.html' %} {% block content %}
-<script>
-  // Track the last time the health endpoint failed
-  window.lastHealthFailed = false;
-</script>
-
-<link
-  rel="stylesheet"
-  href="{{ url_for('static', filename='css/player.css') }}"
-/>
-
 <div
   class="video-container full-height"
   role="region"
   aria-label="Live video feed"
 >
-  <img
-    id="live-image"
-    loading="lazy"
-    alt="Live feed frame"
-    title="Current frame from the live feed"
-  />
-  <video id="live-video" class="hidden" autoplay muted tabindex="0">
-    <source src="" type="video/mp4" />
+  <video
+    id="live-video"
+    controls
+    autoplay
+    muted
+    preload="none"
+    poster="/last_screenshot/{{ template_details.keys()|list|first }}"
+  >
+    <source
+      src="/last_video/{{ template_details.keys()|list|first }}"
+      type="video/mp4"
+    />
     Your browser does not support the video tag.
   </video>
-  <video id="preload-video" class="hidden" muted preload="auto"></video>
-  <div class="video-controls">
-    <input type="range" id="seek-bar" value="0" />
-
-    <div class="control-row">
-      <button
-        id="play-pause"
-        title="play/pause"
-        aria-label="Play or pause video"
-      >
-        <i class="fa-play-pause"></i>
-      </button>
-      <div id="speed-container">
-        <input
-          type="range"
-          id="speed-slider"
-          min="-3"
-          max="4"
-          value="0"
-          step="0.1"
-          oninput="updatePlaybackSpeed()"
-        />
-        <label for="speed-slider"
-          >Speed: <span id="speed-value">1x</span></label
-        >
-      </div>
-      <div id="jog-shuttle" title="Jog shuttle control"></div>
-
-      <!-- <button id="cast-button">Cast</button> -->
-      <button
-        id="full-screen"
-        title="fullscreen"
-        aria-label="Toggle fullscreen"
-      >
-        <i class="fas fa-expand"></i>
-      </button>
-      <button
-        id="toggle-details"
-        title="Show details"
-        aria-label="Toggle details"
-      >
-        <i class="fas fa-info-circle"></i>
-      </button>
-      <button id="rotate-video" title="Rotate 90°" aria-label="Rotate video">
-        <i class="fas fa-sync-alt"></i>
-      </button>
-
-      <select id="video-source" onchange="changeVideoSource()">
-        <option value="png" title="View a series of PNG images">
-          PNG Stream
-        </option>
-        <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
-        <option value="loop" title="Loop through available video clips">
-          Loop Videos
-        </option>
-        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
-        <option value="live" title="View the direct live stream">
-          Live Video
-        </option>
-        <option value="motion" title="View motion-detected frames">
-          Motion
-        </option>
-        <option
-          value="mjpg"
-          selected
-          title="View an MJPEG (Motion JPEG) stream"
-        >
-          MJPG
-        </option>
-      </select>
-
-      <select id="group-selector" onchange="changeGroup()">
-        <option value="all" title="View all groups">All</option>
-        {% set all_groups = [] %} {% for camera, details in
-        template_details.items() %} {% if details.groups %} {% for group in
-        details.groups.split(',') %} {% if group %} {% set _ =
-        all_groups.append(group|trim) %} {% endif %} {% endfor %} {% endif %} {%
-        endfor %} {% for group in all_groups|unique|sort %}
-        <option value="{{ group }}" title="View group {{ group }}">
-          {{ group }}
-        </option>
-        {% endfor %}
-      </select>
-
-      <select
-        id="camera-selector"
-        onchange="changeCamera()"
-        style="display: none"
-      >
-        {% for camera in template_details.keys()|sort %}
-        <option value="{{ camera }}" title="View camera {{ camera }}">
-          Camera: {{ camera }}
-        </option>
-        {% endfor %}
-      </select>
-    </div>
-  </div>
-  <div
-    id="video-overlay"
-    class="video-overlay"
-    role="region"
-    aria-live="polite"
-  >
-    <div id="loading-indicator" class="hidden" role="status">Loading...</div>
-    <div id="play-pause-indicator" class="video-icon hidden" aria-hidden="true">
-      ▶
-    </div>
-    <div
-      id="offline-indicator"
-      class="offline-indicator hidden"
-      role="alert"
-      title="Camera offline"
-    >
-      <i class="fas fa-video-slash video-icon" aria-hidden="true"></i>
-      <p id="offline-message"></p>
-    </div>
-    <div
-      id="capture-error-indicator"
-      class="error-indicator hidden"
-      role="alert"
-      title="Capture error"
-    >
-      <i class="fas fa-exclamation-triangle video-icon" aria-hidden="true"></i>
-      <p id="capture-error-message"></p>
-    </div>
-    <div
-      id="stream-error-indicator"
-      class="error-indicator hidden"
-      role="alert"
-      title="Streaming error"
-    >
-      <i class="fas fa-times-circle video-icon" aria-hidden="true"></i>
-      <p id="stream-error-message"></p>
-    </div>
-  </div>
-  {% if CLOCK_OVERLAY %}
-  <div
-    id="overlayClock"
-    class="cool-clock clock-overlay"
-    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-  >
-    <div class="clock-face">
-      <div class="clock-hands">
-        <div class="hand hour-hand"></div>
-        <div class="hand minute-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
-      <div class="digital-clock"></div>
-    </div>
-  </div>
-  {% endif %}
-  <div id="error-message" role="alert"></div>
 </div>
 
-<div id="template-details" role="region" aria-live="polite"></div>
+<select id="group-selector" onchange="changeGroup()">
+  <option value="all" title="View all groups">All</option>
+  {% set all_groups = [] %} {% for camera, details in template_details.items()
+  %} {% if details.groups %} {% for group in details.groups.split(',') %} {% if
+  group %} {% set _ = all_groups.append(group|trim) %} {% endif %} {% endfor %}
+  {% endif %} {% endfor %} {% for group in all_groups|unique|sort %}
+  <option value="{{ group }}" title="View group {{ group }}">
+    {{ group }}
+  </option>
+  {% endfor %}
+</select>
 
-<script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
+<select id="camera-selector" onchange="changeCamera()" class="hidden">
+  {% for camera in template_details.keys()|sort %}
+  <option value="{{ camera }}" title="View camera {{ camera }}">
+    Camera: {{ camera }}
+  </option>
+  {% endfor %}
+</select>
+
 <script
   type="module"
-  src="{{ url_for('static', filename='js/live.js') }}"
+  src="{{ url_for('static', filename='js/tile_player.js') }}"
 ></script>
-
 {% endblock %}

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -11,143 +11,29 @@ template_form %} {% block content %}
   {% endif %}
 </script>
 
-<link
-  rel="stylesheet"
-  href="{{ url_for('static', filename='css/player.css') }}"
-/>
-
 <div
   class="video-container full-height"
   role="region"
   aria-label="Live video feed"
 >
-  <img
-    id="live-image"
-    loading="lazy"
-    alt="Live feed frame"
-    title="Current frame from the live feed"
-  />
-  <video id="live-video" class="hidden" autoplay muted tabindex="0">
-    <source src="" type="video/mp4" />
+  <video
+    id="live-video"
+    controls
+    autoplay
+    muted
+    preload="none"
+    poster="/last_screenshot/{{ template_name }}"
+  >
+    <source src="/last_video/{{ template_name }}" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
-  <video id="preload-video" class="hidden" muted preload="auto"></video>
-  <div class="video-controls">
-    <input type="range" id="seek-bar" value="0" title="Seek position" />
-
-    <div class="control-row">
-      <button
-        id="play-pause"
-        title="play/pause"
-        aria-label="Play or pause video"
-      >
-        <i class="fa-play-pause"></i>
-      </button>
-      <div id="speed-container">
-        <input
-          type="range"
-          id="speed-slider"
-          min="-3"
-          max="4"
-          value="0"
-          step="0.1"
-          oninput="updatePlaybackSpeed()"
-          title="Adjust playback speed"
-        />
-        <label for="speed-slider"
-          >Speed: <span id="speed-value">1x</span></label
-        >
-      </div>
-      <div id="jog-shuttle" title="Jog shuttle control"></div>
-
-      <!-- <button id="cast-button">Cast</button> -->
-      <button
-        id="full-screen"
-        title="fullscreen"
-        aria-label="Toggle fullscreen"
-      >
-        <i class="fas fa-expand"></i>
-      </button>
-      <button
-        id="toggle-details"
-        title="Show details"
-        aria-label="Toggle details"
-      >
-        <i class="fas fa-info-circle"></i>
-      </button>
-      <button id="rotate-video" title="Rotate 90°" aria-label="Rotate video">
-        <i class="fas fa-sync-alt"></i>
-      </button>
-      <select id="video-source" onchange="changeVideoSource()">
-        <option value="png" title="View a series of PNG images">
-          PNG Stream
-        </option>
-        <!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
-        <option value="loop" title="Loop through available video clips">
-          Loop Videos
-        </option>
-        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
-        <option value="live" title="View the direct live stream">
-          Live Video
-        </option>
-        <option value="motion" title="View motion-detected frames">
-          Motion
-        </option>
-        <option
-          value="mjpg"
-          selected
-          title="View an MJPEG (Motion JPEG) stream"
-        >
-          MJPG
-        </option>
-      </select>
-    </div>
-  </div>
-  <div
-    id="video-overlay"
-    class="video-overlay"
-    role="region"
-    aria-live="polite"
-  >
-    <div id="loading-indicator" class="hidden">Loading...</div>
-    <div id="play-pause-indicator" class="video-icon hidden">▶</div>
-    <div id="offline-indicator" class="offline-indicator hidden">
-      <i class="fas fa-video-slash video-icon"></i>
-      <p id="offline-message"></p>
-    </div>
-    <div id="capture-error-indicator" class="error-indicator hidden">
-      <i class="fas fa-exclamation-triangle video-icon"></i>
-      <p id="capture-error-message"></p>
-    </div>
-    <div id="stream-error-indicator" class="error-indicator hidden">
-      <i class="fas fa-times-circle video-icon"></i>
-      <p id="stream-error-message"></p>
-    </div>
-  </div>
-  {% if CLOCK_OVERLAY %}
-  <div
-    id="overlayClock"
-    class="cool-clock clock-overlay"
-    data-digital="{{ 'true' if CLOCK_DIGITAL else 'false' }}"
-  >
-    <div class="clock-face">
-      <div class="clock-hands">
-        <div class="hand hour-hand"></div>
-        <div class="hand minute-hand"></div>
-        <div class="hand second-hand"></div>
-      </div>
-      <div class="digital-clock"></div>
-    </div>
-  </div>
-  {% endif %}
-  <div id="error-message"></div>
 </div>
 
 <div id="template-details"></div>
 <script src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 <script
   type="module"
-  src="{{ url_for('static', filename='js/live.js') }}"
+  src="{{ url_for('static', filename='js/tile_player.js') }}"
 ></script>
 
 <script>

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -1,0 +1,23 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <video id="live-video"><source></source></video>
+  <select id="camera-selector">
+    <option value="cam1">cam1</option>
+    <option value="cam2">cam2</option>
+  </select>
+`;
+
+window.templateDetails = { cam1: {}, cam2: {} };
+
+let init;
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/tile_player.js");
+  init = mod.initTilePlayer;
+});
+
+test("loads first camera", () => {
+  init();
+  const src = document.querySelector("#live-video source").src;
+  expect(src).toMatch(/\/last_video\/cam1$/);
+});


### PR DESCRIPTION
## Summary
- simplify live view markup
- show the same player markup on template detail
- implement tile player logic in new JS module
- test tile player behavior

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848d896dc4483338b52d9ead7f19dc3