### PR TITLE
Improve captions layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1740,6 +1740,9 @@ body.advanced-enabled .advanced-only {
   display: flex;
   flex-direction: column;
 }
+.chat-prompt {
+  position: relative;
+}
 
 .chat-response .last-caption {
   background-color: var(--form-bg-color);
@@ -1749,6 +1752,16 @@ body.advanced-enabled .advanced-only {
 
 .chat-box label {
   font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .chat-box {
+    flex-direction: column;
+  }
+  .chat-prompt,
+  .chat-response {
+    flex: 1 1 100%;
+  }
 }
 
 .filter-controls {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -114,8 +114,19 @@ template_controls %} {% block content %}
                       class="notes-textarea"
                       placeholder="Edit caption prompt"
                     >
-{{ template_details[camera]['notes'] }}</textarea
+{{ template_details[camera]['notes'] }}</textarea>
+                    <button
+                      class="update-button"
+                      data-template="{{ camera }}"
+                      title="Send updated prompt"
+                      aria-label="Send updated prompt"
                     >
+                      <svg width="16" height="16" aria-hidden="true">
+                        <use
+                          href="{{ url_for('static', filename='icons/sprite.svg') }}#login"
+                        />
+                      </svg>
+                    </button>
                   </div>
                   <div class="chat-response">
                     <label id="last-caption-label-{{ camera }}"
@@ -130,18 +141,6 @@ template_controls %} {% block content %}
                     </div>
                   </div>
                 </div>
-                <button
-                  class="update-button"
-                  data-template="{{ camera }}"
-                  title="Send updated prompt"
-                  aria-label="Send updated prompt"
-                >
-                  <svg width="16" height="16" aria-hidden="true">
-                    <use
-                      href="{{ url_for('static', filename='icons/sprite.svg') }}#login"
-                    />
-                  </svg>
-                </button>
               </form>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- stack prompt and last caption vertically for smaller screens
- keep update button next to prompt field

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848d9bce0008333b03261ccc118cab4