### PR TITLE
Add local endpoints to camera discovery

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -989,6 +989,46 @@ def discover_cameras(progress_callback=None, subnets=None):
         }
     )
 
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "Test Pattern"},
+            "url": f"http://127.0.0.1:{PORT}/test_pattern.mjpg",
+        }
+    )
+
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "All Cameras"},
+            "url": f"http://127.0.0.1:{PORT}/stream.mjpg?group=all",
+        }
+    )
+
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "All Motion"},
+            "url": f"http://127.0.0.1:{PORT}/motion.mjpg?group=all",
+        }
+    )
+
+    cameras.append(
+        {
+            "ip": "127.0.0.1",
+            "protocol": "http",
+            "port": PORT,
+            "info": {"name": "All Captions"},
+            "url": f"http://127.0.0.1:{PORT}/caption.mjpg?group=all",
+        }
+    )
+
     # remove duplicates but keep distinct URLs
     unique = {}
     for cam in cameras:

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -191,6 +191,10 @@ It now also includes an **Internal Caption** entry streaming `/internal_caption.
 which loops recent caption text for convenient review.
 A **Test Frame** entry is also available, streaming `/test.mjpg` so you can quickly
 verify connectivity without adding a real camera.
+A `/test_pattern.mjpg` feed presents a basic pattern for overlay testing.
+You'll also see **All Cameras** endpoints like `/stream.mjpg?group=all`,
+`/motion.mjpg?group=all`, and `/caption.mjpg?group=all` that combine frames from
+every camera.
 
 ## Common cameras to try
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -10,6 +10,7 @@ from unittest.mock import mock_open, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+from app import config
 from app.utils import camera_discovery
 
 
@@ -619,6 +620,39 @@ class TestCameraDiscovery(unittest.TestCase):
         mock_get.side_effect = Exception("boom")
         vendor = camera_discovery._remote_vendor_lookup("00:11:22:33:44:55")
         self.assertIsNone(vendor)
+
+    @patch("app.utils.camera_discovery._local_subnets", return_value=[])
+    @patch("app.utils.camera_discovery._local_video_devices", return_value=[])
+    @patch("app.utils.camera_discovery._scan_hls_streams", return_value=[])
+    @patch("app.utils.camera_discovery._scan_http_endpoints", return_value=[])
+    @patch("app.utils.camera_discovery._scan_snmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_webrtc_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_sip_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtmp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._scan_rtsp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._probe_ssdp", return_value=[])
+    @patch("app.utils.camera_discovery._probe_mdns", return_value=[])
+    @patch("app.utils.camera_discovery._probe_onvif", return_value=[])
+    @patch("app.utils.camera_discovery._mac_manufacturer")
+    @patch("app.utils.camera_discovery._mac_for_ip")
+    @patch("app.utils.camera_discovery.is_port_open", return_value=False)
+    @patch("app.utils.camera_discovery._trace_upstream", return_value=None)
+    def test_local_endpoints(
+        self,
+        mock_trace,
+        mock_is_port_open,
+        mock_mac,
+        mock_vendor,
+        mock_onvif,
+        *_mocks,
+    ):
+        cams = camera_discovery.discover_cameras()
+        urls = {c["url"] for c in cams}
+        base = f"http://127.0.0.1:{config.PORT}"
+        self.assertIn(f"{base}/test_pattern.mjpg", urls)
+        self.assertIn(f"{base}/stream.mjpg?group=all", urls)
+        self.assertIn(f"{base}/motion.mjpg?group=all", urls)
+        self.assertIn(f"{base}/caption.mjpg?group=all", urls)
 
     def test_load_local_ouis(self):
         """_load_local_ouis should parse valid lines and ignore others."""


### PR DESCRIPTION
## Summary
- add Test Pattern and "all" endpoints in camera discovery results
- document the new local feeds
- cover discovery page endpoints with tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e8eec3048333bff5e30fed23af33