### PR TITLE
Fix discovery results UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2101,6 +2101,13 @@ details > summary {
   color: gray;
 }
 
+.info-icon {
+  vertical-align: middle;
+  margin-left: 0.25rem;
+  cursor: pointer;
+  color: var(--accent-color);
+}
+
 .status-col {
   width: 4rem;
   text-align: center;

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -31,6 +31,7 @@
       id="discover-btn"
       class="btn btn-primary"
       title="Scan the network for cameras"
+      type="button"
     >
       Discover
     </button>
@@ -71,7 +72,7 @@
           <th title="Port number">Port</th>
           <th title="MAC address">MAC</th>
           <th title="Device manufacturer">Manufacturer</th>
-          <th title="Additional information">Info</th>
+          <th title="Device details"></th>
           <th title="Add camera"></th>
         </tr>
       </thead>
@@ -84,7 +85,16 @@
           <td>{{ cam.port }}</td>
           <td>{{ cam.info.mac }}</td>
           <td>{{ cam.info.manufacturer }}</td>
-          <td>{{ show_info(cam.info) }}</td>
+          <td>
+            <svg class="camera-icon" aria-hidden="true">
+              <use
+                href="{{ url_for('static', filename='icons/sprite.svg') }}#camera"
+              ></use>
+            </svg>
+            {% if show_info(cam.info) %}
+            <span class="info-icon" title="{{ show_info(cam.info) }}">ℹ️</span>
+            {% endif %}
+          </td>
           <td>
             {% if url in existing_urls %}
             <a
@@ -123,6 +133,7 @@
 <script>
   document.addEventListener("DOMContentLoaded", () => {
     const existingMap = {{ existing_urls | tojson | safe }};
+    const iconUrl = "{{ url_for('static', filename='icons/sprite.svg') }}";
     const button = document.getElementById("discover-btn");
     const msg = document.getElementById("discover-message");
     const progress = document.getElementById("discover-progress");
@@ -189,13 +200,15 @@
                             <input type="hidden" name="name" value="${cam.ip}">
                             <button type="submit" title="Add this camera">Add</button>
                         </form>`;
+          const info = renderInfo(cam.info);
           tr.innerHTML = `
                     <td>${cam.ip}</td>
                     <td>${cam.protocol}</td>
                     <td>${cam.port}</td>
                     <td>${cam.info.mac || ""}</td>
                     <td>${cam.info.manufacturer || ""}</td>
-                    <td>${renderInfo(cam.info)}</td>
+                    <td><svg class="camera-icon" aria-hidden="true"><use href="${iconUrl}#camera"></use></svg>
+                    ${info ? `<span class="info-icon" title="${info}">ℹ️</span>` : ""}</td>
                     <td>${action}</td>`;
           body.appendChild(tr);
         };


### PR DESCRIPTION
## Summary
- prevent Add Camera form modal from triggering on Discover
- simplify discovery results by dropping the Info column
- show device and info icons for each discovered camera
- add CSS for info icon

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848eb1564008333b44a6f444a295b90