### PR TITLE
Expand LLM prompt docs

### DIFF
--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -10,8 +10,12 @@ SETTINGS_TOOLTIPS = {
     "PORT": "Web server port",
     "USER_NAME": "Interface login user",
     "MAX_WORKERS": "Concurrent worker threads",
-    "LLM_CAPTION_PROMPT": "Prompt for image captioning",
-    "LLM_SUMMARY_PROMPT": "Prompt for daily summaries",
+    "LLM_CAPTION_PROMPT": (
+        "System prompt used for image captions. Supports the $datetime token and" " can span multiple lines."
+    ),
+    "LLM_SUMMARY_PROMPT": (
+        "System prompt for daily summaries. May be multi-line and also supports" " the $datetime token."
+    ),
     "MAX_RAW_DATA_SIZE": "Raw data threshold",
     "MAX_IMAGE_RETENTION_AGE": "Image retention days",
     "MAX_VIDEO_RETENTION_AGE": "Video retention days",

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -169,8 +169,10 @@ skip validation adhere to the safer defaults.
 Additional variables control AI behaviour and external tools:
 
 - `LLM_MODEL_VERSION` – language model version to use (default `gpt-4.1-mini`). Supported models: `gpt-4.1-mini`, `gpt-4.1`, `gpt-4`
-- `LLM_SUMMARY_PROMPT` – default prompt used for log summaries
-- `LLM_CAPTION_PROMPT` – default prompt used for image captions
+- `LLM_SUMMARY_PROMPT` – system prompt for log summaries. See [LLM Prompt Settings](llm_prompts.md)
+  for the default text and `$datetime` token details.
+- `LLM_CAPTION_PROMPT` – system prompt for image captions. Refer to
+  [LLM Prompt Settings](llm_prompts.md) for examples and usage.
 - `FFMPEG_PATH` – path to the `ffmpeg` binary (default `ffmpeg`)
 - `FFPROBE_PATH` – path to the `ffprobe` binary (default `ffprobe`)
 - `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (default `auto`)

--- a/docs/llm_prompts.md
+++ b/docs/llm_prompts.md
@@ -1,0 +1,45 @@
+# LLM Prompt Settings
+
+Glimpser uses long prompts to instruct the language model when generating summaries and image captions. These prompts can be overridden with environment variables or through the Settings page under **Advanced Options**.
+
+Both prompts support the special `$datetime` token. When the model request is built, `$datetime` is replaced with the current UTC timestamp in ISO 8601 format.
+
+## LLM_SUMMARY_PROMPT
+
+`LLM_SUMMARY_PROMPT` provides the system message for log summaries. The default text encourages concise, technical narration and groups related insights. A shortened example is shown below:
+
+```text
+Return one single line of plain text—no line breaks... The time is $datetime UTC.
+```
+
+To override the prompt in your `.env` file, use a multi‑line value for readability:
+
+```env
+LLM_SUMMARY_PROMPT="
+Return one single line of plain text with grouped insights.
+Mark critical items with ⚠️ and resolved items with ✔️.
+The time is \$datetime UTC."
+```
+
+## LLM_CAPTION_PROMPT
+
+`LLM_CAPTION_PROMPT` controls how image captions are generated. It requests a short headline and a brief explanation, replying with `UNREADABLE` if the frame lacks useful detail.
+
+```text
+Examine the image carefully, then reply in two paragraphs only... The time is $datetime UTC.
+```
+
+You can also supply a multi‑line value:
+
+```env
+LLM_CAPTION_PROMPT="
+Examine the image and write a short headline.
+If the frame is blank, output UNREADABLE.
+The time is \$datetime UTC."
+```
+
+Each time a request is made, `$datetime` is swapped with the current time so the model can reference when the analysis occurred.
+
+The Settings page also provides tooltips for these fields summarizing the
+multi-line syntax and `$datetime` token. Hover over **LLM_SUMMARY_PROMPT** or
+**LLM_CAPTION_PROMPT** to see a quick reminder when editing.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -51,6 +51,8 @@ Interactive forms now include additional tooltips:
 - **Help page tabs** – each tab button explains what information the section contains.
 - **Settings tabs** – hovering shows which category will open.
 - **Cost dashboards** – date selectors, the Load buttons and range slider include titles.
+- **LLM_PROMPT settings** – tooltips explain that the caption and summary prompts
+  support `$datetime` and can span multiple lines.
 
 ## Dynamic Tooltips
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Jog-Shuttle Control: jog_shuttle.md
       - Live All Playback: live_all.md
       - Live View Scrubbing: live_scrub.md
+      - LLM Prompt Settings: llm_prompts.md
       - MCP Integration: mcp_integration.md
       - In-App Onboarding: onboarding.md
       - OpenSSF Scorecard: scorecard.md


### PR DESCRIPTION
## Summary
- clarify that the LLM prompts support `$datetime` in tooltips
- document the prompt tooltips in the docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848ec071abc83339b39c130c4ac1ecf