### PR TITLE
Update status UI layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2141,7 +2141,7 @@ details > summary {
 }
 
 .metric-bar {
-  width: 8rem;
+  width: 6rem;
   height: 0.6rem;
   vertical-align: middle;
   margin: 0 0.25rem;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -337,17 +337,17 @@ export function timeAgo(dateString) {
   if (diffInSeconds < 0) return "in the future";
 
   const intervals = [
-    { label: "year", seconds: 31536000 },
-    { label: "month", seconds: 2592000 },
-    { label: "day", seconds: 86400 },
-    { label: "hour", seconds: 3600 },
-    { label: "minute", seconds: 60 },
-    { label: "second", seconds: 1 },
+    { label: "year", short: "y", seconds: 31536000 },
+    { label: "month", short: "mo", seconds: 2592000 },
+    { label: "day", short: "d", seconds: 86400 },
+    { label: "hour", short: "h", seconds: 3600 },
+    { label: "minute", short: "m", seconds: 60 },
+    { label: "second", short: "s", seconds: 1 },
   ];
 
-  for (const { label, seconds } of intervals) {
+  for (const { label, short, seconds } of intervals) {
     const count = Math.floor(diffInSeconds / seconds);
-    if (count >= 1) return `${count} ${label}${count > 1 ? "s" : ""} ago`;
+    if (count >= 1) return `${count}${short} ago`;
   }
   return "just now";
 }

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -80,8 +80,8 @@
   <thead>
     <tr>
       <th class="sortable" data-type="string" title="Camera name">Feed</th>
-      <th class="sortable" data-type="date" title="Most recent screenshot time">Last Image</th>
       <th class="sortable" data-type="date" title="Most recent caption time">Last Caption</th>
+      <th class="sortable" data-type="date" title="Most recent screenshot time">Last Image</th>
       <th class="sortable" data-type="number" title="Total screenshots">Shots</th>
       <th class="sortable" data-type="number" title="Total videos">Videos</th>
       <th class="sortable" data-type="number" title="Disk usage">Storage</th>
@@ -119,20 +119,6 @@
         <a href="{{ url_for('template_details', template_name=feed.name) }}" title="View template details">{{ feed.name }}</a>
       </td>
       <td
-        data-label="Last Image"
-        data-value="{{ feed.last_screenshot_time or '' }}"
-      >
-        {% if feed.last_screenshot_display %}
-        <span
-          class="humanized-time"
-          data-time="{{ feed.last_screenshot_time }}"
-          title="{{ feed.last_screenshot_time }}"
-        >
-          {{ feed.last_screenshot_display }}
-        </span>
-        {% else %} N/A {% endif %}
-      </td>
-      <td
         data-label="Last Caption"
         data-value="{{ feed.last_caption_time or '' }}"
       >
@@ -143,6 +129,20 @@
           title="{{ feed.last_caption_time }}"
         >
           {{ feed.last_caption_display }}
+        </span>
+        {% else %} N/A {% endif %}
+      </td>
+      <td
+        data-label="Last Image"
+        data-value="{{ feed.last_screenshot_time or '' }}"
+      >
+        {% if feed.last_screenshot_display %}
+        <span
+          class="humanized-time"
+          data-time="{{ feed.last_screenshot_time }}"
+          title="{{ feed.last_screenshot_time }}"
+        >
+          {{ feed.last_screenshot_display }}
         </span>
         {% else %} N/A {% endif %}
       </td>

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -130,7 +130,7 @@ def summarize(
 
         # Convert the response text to a JSON format
         ljson = {}
-        start_time = int(time.time())
+        start_time = int(time.time() + 0.5)
         for line in re.findall(r"(.+?)(?:[\t\n]|$)", response_text, flags=re.DOTALL):
             # Remove asterisks and bullet points
             line = line.replace("**", "").strip()

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,8 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 
 The main dashboard now displays the current time in the lower right corner. Hover over the time to view the full ISO 8601 timestamp.
 
-Thumbnails also now show the last capture time in a human readable
-"X ago" format, matching the tables on the Captions page.
+Thumbnails also now show the last capture time in a compact
+"5m ago" style, matching the tables on the Captions page.
 The Live View page displays the time of the latest frame in the
 lower-right corner using the same format. Timestamp parsing was improved so
 times display correctly across time zones instead of always showing

--- a/tests/js/script.test.js
+++ b/tests/js/script.test.js
@@ -90,9 +90,9 @@ describe("script.js", () => {
     const oneDayAgo = new Date(now.getTime() - 86400000);
 
     expect(timeAgo(now)).toBe("just now");
-    expect(timeAgo(oneMinuteAgo)).toBe("1 minute ago");
-    expect(timeAgo(oneHourAgo)).toBe("1 hour ago");
-    expect(timeAgo(oneDayAgo)).toBe("1 day ago");
+    expect(timeAgo(oneMinuteAgo)).toBe("1m ago");
+    expect(timeAgo(oneHourAgo)).toBe("1h ago");
+    expect(timeAgo(oneDayAgo)).toBe("1d ago");
   });
 
   test("timeAgo handles null and undefined", () => {


### PR DESCRIPTION
## Summary
- put Last Caption column next to the feed name
- show compact "5m ago"-style timestamps
- shrink metric bars to keep them inside the card
- adjust timestamp rounding logic
- update docs and tests

## Testing
- `pre-commit run --files app/static/js/templates.js tests/js/script.test.js app/utils/llm.py app/templates/_status_tab.html app/static/css/style.css docs/index.md`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848f528edb88333833b460ee27875a4