### PR TITLE
Make discovery table sortable and shrink icons

### DIFF
--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -1,4 +1,5 @@
 import { fetchJson } from "./fetch_utils.js";
+import { setupTableSorting } from "./templates.js";
 
 export function initDiscoveryToggle() {
   document.addEventListener("DOMContentLoaded", () => {
@@ -116,5 +117,13 @@ export function initSubnetInput() {
         input.setCustomValidity("");
       }
     });
+  });
+}
+
+export function initDiscoveryTable() {
+  document.addEventListener("DOMContentLoaded", () => {
+    if (document.getElementById("discover-table")) {
+      setupTableSorting("discover-table");
+    }
   });
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,7 +1,11 @@
 import { initTemplates } from "./templates.js";
 import { initVideoControls } from "./video.js";
 import { initSchedulerToggle } from "./scheduler.js";
-import { initDiscoveryToggle, initSubnetInput } from "./discovery.js";
+import {
+  initDiscoveryToggle,
+  initSubnetInput,
+  initDiscoveryTable,
+} from "./discovery.js";
 import { initNav } from "./nav.js";
 import { initFormValidation, initAddSettingValidation } from "./form.js";
 import { initFooterFade } from "./footer.js";
@@ -28,6 +32,7 @@ initVideoControls();
 initSchedulerToggle();
 initDiscoveryToggle();
 initSubnetInput();
+initDiscoveryTable();
 initNav();
 initFormValidation();
 initAddSettingValidation();

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -64,14 +64,14 @@
         Export CSV
       </button>
     </div>
-    <table class="camera-table">
+    <table id="discover-table" class="camera-table">
       <thead>
         <tr>
-          <th title="Camera IP address">IP</th>
-          <th title="Protocol type">Protocol</th>
-          <th title="Port number">Port</th>
-          <th title="MAC address">MAC</th>
-          <th title="Device manufacturer">Manufacturer</th>
+          <th class="sortable" title="Camera IP address">IP</th>
+          <th class="sortable" title="Protocol type">Protocol</th>
+          <th class="sortable" data-type="number" title="Port number">Port</th>
+          <th class="sortable" title="MAC address">MAC</th>
+          <th class="sortable" title="Device manufacturer">Manufacturer</th>
           <th title="Device details"></th>
           <th title="Add camera"></th>
         </tr>
@@ -86,7 +86,7 @@
           <td>{{ cam.info.mac }}</td>
           <td>{{ cam.info.manufacturer }}</td>
           <td>
-            <svg class="camera-icon" aria-hidden="true">
+            <svg class="camera-icon" width="12" height="12" aria-hidden="true">
               <use
                 href="{{ url_for('static', filename='icons/sprite.svg') }}#camera"
               ></use>
@@ -207,7 +207,7 @@
                     <td>${cam.port}</td>
                     <td>${cam.info.mac || ""}</td>
                     <td>${cam.info.manufacturer || ""}</td>
-                    <td><svg class="camera-icon" aria-hidden="true"><use href="${iconUrl}#camera"></use></svg>
+                    <td><svg class="camera-icon" width="12" height="12" aria-hidden="true"><use href="${iconUrl}#camera"></use></svg>
                     ${info ? `<span class="info-icon" title="${info}">ℹ️</span>` : ""}</td>
                     <td>${action}</td>`;
           body.appendChild(tr);

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -79,6 +79,11 @@ class TestHtmlTemplates(unittest.TestCase):
             html = f.read()
         self.assertIn("existingMap", html)
 
+    def test_discover_table_sortable(self):
+        html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
+        self.assertIn('<table id="discover-table"', html)
+        self.assertIn('th class="sortable"', html)
+
     def test_header_preloads_sprite(self):
         parser = parse_template(Path("app/templates/header.html"))
         expected_href = "{{ url_for('static', filename='icons/sprite.svg') }}"


### PR DESCRIPTION
## Summary
- make the discovery results table sortable
- shrink camera icons on the discovery page
- hook table sorting via new `initDiscoveryTable`
- test that discovery table markup includes sortable headers

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6848f668e0108333a1cef92c59b27763