### PR TITLE
Suppress scrub tooltip on captions page

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -397,12 +397,10 @@ export function setupCaptionsPageVideoHover() {
       const clamped = Math.max(0, Math.min(1, ratio));
       if (!Number.isNaN(video.duration)) {
         targetTime = video.duration * clamped;
-        updateScrubTooltip(targetTime, e);
       }
     };
 
     container.addEventListener("mouseenter", (e) => {
-      createScrubTooltip();
       if (video.readyState === 0) {
         video.load();
         const onLoad = () => {

--- a/tests/js/captions_player.test.js
+++ b/tests/js/captions_player.test.js
@@ -17,7 +17,7 @@ beforeAll(async () => {
   setup = mod.setupCaptionsPageVideoHover;
 });
 
-test("scrub tooltip appears on captions page hover", () => {
+test("scrub tooltip is suppressed on captions page hover", () => {
   Object.defineProperty(HTMLMediaElement.prototype, "duration", {
     configurable: true,
     get() {
@@ -33,6 +33,5 @@ test("scrub tooltip appears on captions page hover", () => {
     new MouseEvent("mousemove", { clientX: 5, clientY: 5 }),
   );
   const tooltip = document.querySelector(".scrub-tooltip");
-  expect(tooltip).not.toBeNull();
-  expect(tooltip.classList.contains("visible")).toBe(true);
+  expect(tooltip).toBeNull();
 });


### PR DESCRIPTION
## Summary
- stop showing scrub tooltip when hovering video previews on captions page
- update JS test expectations

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f7f78300833382eeb664bfdb5ede