### PR TITLE
Add braille spinner for clip loading

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2322,3 +2322,18 @@ details > summary {
   margin: 0.5rem 0;
   display: block;
 }
+
+/* Braille loading spinner */
+.loading-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: monospace;
+  font-size: 20px;
+  pointer-events: none;
+  display: none;
+}
+.loading-spinner.visible {
+  display: block;
+}

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -724,6 +724,7 @@ export async function loadTemplates() {
               <a href='/templates/${name}'>
                 <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                   <div class="camera-name">${name}</div>
+                  <div class="loading-spinner" aria-hidden="true"></div>
                   <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback data-hd-src="/clip/${name}">
                     <source src="/last_video/${name}" type="video/mp4">
                     Your browser does not support the video tag.

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -33,6 +33,29 @@ function hideScrubTooltip() {
 let prefetchQueue = [];
 let processing = false;
 let queueDelay = 1000;
+const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+function showSpinner(video) {
+  const spinner = video.parentElement?.querySelector(".loading-spinner");
+  if (!spinner || spinner.dataset.active === "true") return;
+  let i = 0;
+  spinner.textContent = spinnerFrames[i];
+  spinner.classList.add("visible");
+  spinner.dataset.active = "true";
+  const id = setInterval(() => {
+    i = (i + 1) % spinnerFrames.length;
+    spinner.textContent = spinnerFrames[i];
+  }, 100);
+  spinner.dataset.intervalId = id.toString();
+}
+
+function hideSpinner(video) {
+  const spinner = video.parentElement?.querySelector(".loading-spinner");
+  if (!spinner || spinner.dataset.active !== "true") return;
+  clearInterval(Number(spinner.dataset.intervalId));
+  spinner.dataset.active = "false";
+  spinner.classList.remove("visible");
+}
 
 export function setQueueDelay(ms) {
   queueDelay = ms;
@@ -42,6 +65,7 @@ export function enqueueClip(video) {
   if (!video.dataset.hdSrc || video.dataset.hdLoaded === "true") return;
   if (prefetchQueue.includes(video)) return;
   prefetchQueue.push(video);
+  showSpinner(video);
   if (!processing) processQueue();
 }
 
@@ -56,6 +80,8 @@ function processQueue() {
   if (src) {
     src.src = vid.dataset.hdSrc;
     vid.dataset.hdLoaded = "true";
+    vid.addEventListener("canplay", () => hideSpinner(vid), { once: true });
+    vid.addEventListener("error", () => hideSpinner(vid), { once: true });
     vid.load();
   }
   setTimeout(processQueue, queueDelay);

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -1,0 +1,6 @@
+# Braille Loading Spinner
+
+Videos initially display the quick `/last_video` clip while the full `/clip` file loads.
+A small braille spinner appears over the thumbnail until the HD video is ready.
+This keeps pages responsive and provides visual feedback that higher quality
+footage is on the way.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Release Workflow: release_workflow.md
       - Settings Page: settings_page.md
       - Clock Settings: clock_settings.md
+      - Braille Loading Spinner: braille_spinner.md
       - Configuration Management: config_management.md
       - System Monitoring: system_monitoring.md
       - Performance Tuning: performance_tuning.md

--- a/tests/js/loading_spinner.test.js
+++ b/tests/js/loading_spinner.test.js
@@ -1,0 +1,31 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <div class="loading-spinner"></div>
+    <video preload="none" data-hd-src="/clip/cam1">
+      <source src="/last_video/cam1" type="video/mp4" />
+    </video>
+  </div>
+`;
+
+let enqueueClip;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  enqueueClip = mod.enqueueClip;
+});
+
+jest.useFakeTimers();
+
+test("spinner visible while clip loads", () => {
+  const video = document.querySelector("video");
+  const spinner = document.querySelector(".loading-spinner");
+  video.load = jest.fn(() => {
+    setTimeout(() => video.dispatchEvent(new Event("canplay")), 0);
+  });
+  enqueueClip(video);
+  expect(spinner.classList.contains("visible")).toBe(true);
+  jest.runAllTimers();
+  expect(spinner.classList.contains("visible")).toBe(false);
+});


### PR DESCRIPTION
## Summary
- show braille spinner while HD clips load
- render spinner element in camera tiles
- document braille spinner behaviour
- test spinner visibility

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848fae99588833388e9db6316d3724e