### PR TITLE
Fix summary timestamp rounding

### DIFF
--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -130,7 +130,7 @@ def summarize(
 
         # Convert the response text to a JSON format
         ljson = {}
-        start_time = int(time.time() + 0.5)
+        start_time = int(time.time())
         for line in re.findall(r"(.+?)(?:[\t\n]|$)", response_text, flags=re.DOTALL):
             # Remove asterisks and bullet points
             line = line.replace("**", "").strip()


### PR DESCRIPTION
## Summary
- remove fractional rounding from LLM summary timestamps

## Testing
- `pre-commit run --files app/utils/llm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848fde3fe488333bbaa484a2c3595a2