### PR TITLE
Add idle fadeout and autoplay

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -42,6 +42,11 @@
     transform 0.3s;
   max-width: 100vw;
 }
+.video-controls.fade-out {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(20px);
+}
 .video-container:hover .video-controls {
   opacity: 1;
   pointer-events: auto;

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -278,6 +278,31 @@ export function setupVideoControls() {
         break;
     }
   });
+
+  const container = video.closest(".video-container");
+  const controls = container?.querySelector(".video-controls");
+  let fadeTimeout;
+  let autoplayTimeout;
+
+  const showControls = () => {
+    if (controls) controls.classList.remove("fade-out");
+    clearTimeout(fadeTimeout);
+    clearTimeout(autoplayTimeout);
+    fadeTimeout = setTimeout(() => {
+      if (controls) controls.classList.add("fade-out");
+    }, 3000);
+    autoplayTimeout = setTimeout(() => {
+      video.playbackRate = 0.5;
+      if (video.paused) safePlay(video);
+    }, 60000);
+  };
+
+  if (container) {
+    ["mousemove", "touchstart", "click"].forEach((evt) =>
+      container.addEventListener(evt, showControls),
+    );
+    showControls();
+  }
 }
 
 export function setupStatusPageVideoHover() {

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -130,7 +130,7 @@ def summarize(
 
         # Convert the response text to a JSON format
         ljson = {}
-        start_time = int(time.time() + 0.5)
+        start_time = int(time.time())
         for line in re.findall(r"(.+?)(?:[\t\n]|$)", response_text, flags=re.DOTALL):
             # Remove asterisks and bullet points
             line = line.replace("**", "").strip()

--- a/docs/live_scrub.md
+++ b/docs/live_scrub.md
@@ -2,6 +2,6 @@
 
 The live viewer shows a time slider whenever **MP4** or **Loop** playback is selected. Drag the slider to seek within the current clip. The video pauses while scrubbing and resumes once released. You can also click the video to toggle play or pause.
 
-The controls fade into view when you hover over the video for a cleaner look. They are inactive when hidden so you won't accidentally scrub.
+The controls fade into view when you hover over the video for a cleaner look and fade away after a few seconds of inactivity. After one minute with no interaction the clip automatically plays at half speed until you move the mouse again.
 
 Scrubbing works only for individual cameras. When other sources such as MJPG or Live video are selected, the slider is hidden because those streams aren't seekable. If you don't see the scrub bar, switch the media source to **MP4** or **Loop** for that camera.

--- a/tests/js/player_idle.test.js
+++ b/tests/js/player_idle.test.js
@@ -1,0 +1,37 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <video id="live-video"></video>
+    <div class="video-controls"></div>
+  </div>
+  <button id="play-pause"></button>
+  <input id="seek-bar" />
+`;
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: jest.fn(() => Promise.resolve()),
+});
+
+let setup;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  setup = mod.setupVideoControls;
+});
+
+jest.useFakeTimers();
+
+test("controls fade and autoplay after idle", () => {
+  setup();
+  const container = document.querySelector(".video-container");
+  container.dispatchEvent(new Event("mousemove"));
+  jest.advanceTimersByTime(3000);
+  const controls = document.querySelector(".video-controls");
+  expect(controls.classList.contains("fade-out")).toBe(true);
+  jest.advanceTimersByTime(57000);
+  const video = document.getElementById("live-video");
+  expect(video.play).toHaveBeenCalled();
+  expect(video.playbackRate).toBe(0.5);
+});


### PR DESCRIPTION
## Summary
- fade out video controls after idle
- autoplay at half speed when idle
- document scrub bar fade behaviour
- fix time rounding in summarizer
- test idle behaviour in player

## Testing
- `npm test`
- `pytest -q`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6848fc944dbc8333996314f3a7e90567