### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import os
 import sys
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -27,9 +28,10 @@ class TestLLM(unittest.TestCase):
         }
         mock_post.return_value = mock_response
 
+        start = time.time()
         result = summarize("Test prompt")
 
-        ts = int(datetime.datetime.now().timestamp())
+        ts = int(start + 0.5)
         expected_result = json.dumps({ts: "Mock summary", ts + 5: "With multiple lines"})
         self.assertEqual(json.loads(result), json.loads(expected_result))
 
@@ -80,9 +82,10 @@ class TestLLM(unittest.TestCase):
         }
         mock_post.return_value = mock_response
 
+        start = time.time()
         result = summarize("Test prompt", history="Previous conversation")
 
-        ts = int(datetime.datetime.now().timestamp())
+        ts = int(start + 0.5)
         expected_result = json.dumps({ts: "Mock summary with history"})
         self.assertEqual(json.loads(result), json.loads(expected_result))
 

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -55,10 +55,11 @@ class TestRunWithTimeout(unittest.TestCase):
             run_with_timeout(slow, args=(d,), timeout=0.2)
             self.assertIsNone(d.get("done"))
 
+    @patch("app.utils.scheduling.psutil.cpu_percent", return_value=10)
     @patch("app.utils.scheduling.is_system_online", return_value=True)
     @patch("app.utils.scheduling.cas_error")
     @patch("app.utils.scheduling.mark_offline")
-    def test_timeout_marks_offline(self, mock_offline, mock_cas_error, _online):
+    def test_timeout_marks_offline(self, mock_offline, mock_cas_error, _online, _cpu):
         def slow(name, template):
             time.sleep(1)
 


### PR DESCRIPTION
## Summary
- stabilize timeout tests by mocking CPU usage
- use consistent timestamps in LLM tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fef78e548333adaa89238ae2cc15