### PR TITLE
Implement HD clip preload

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -6,12 +6,42 @@ export function initTilePlayer() {
   let current =
     camSelect?.value || Object.keys(window.templateDetails || {})[0];
 
+  let abortCtl;
+
+  async function loadHdClip() {
+    const url = video.dataset.hdSrc;
+    if (!url) return;
+    if (abortCtl) abortCtl.abort();
+    abortCtl = new AbortController();
+    const timer = setTimeout(() => abortCtl.abort(), 10000);
+    try {
+      const res = await fetch(url, { signal: abortCtl.signal });
+      clearTimeout(timer);
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const objUrl = URL.createObjectURL(blob);
+      const pos = video.currentTime;
+      const paused = video.paused;
+      const onLoad = () => {
+        video.currentTime = Math.min(pos, video.duration || pos);
+        if (!paused) video.play().catch(() => {});
+        URL.revokeObjectURL(objUrl);
+      };
+      video.addEventListener("loadedmetadata", onLoad, { once: true });
+      if (source) source.src = objUrl;
+      video.load();
+    } catch (_) {
+      /* ignore */
+    }
+  }
+
   function play(name) {
     if (!name) return;
     current = name;
     if (source) source.src = `/last_video/${name}`;
     video.setAttribute("data-hd-src", `/clip/${name}`);
     video.load();
+    loadHdClip();
   }
 
   if (camSelect) {

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -3,4 +3,6 @@
 Videos initially display the quick `/last_video` clip while the full `/clip` file loads.
 A small braille spinner appears over the thumbnail until the HD video is ready.
 This keeps pages responsive and provides visual feedback that higher quality
-footage is on the way.
+footage is on the way. The template details player now performs the same
+preload-and-swap so you begin watching instantly while the HD clip downloads in
+the background.

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -21,3 +21,22 @@ test("loads first camera", () => {
   const src = document.querySelector("#live-video source").src;
   expect(src).toMatch(/\/last_video\/cam1$/);
 });
+
+test("swaps to clip after preload", async () => {
+  const video = document.getElementById("live-video");
+  video.load = jest.fn(() => {
+    video.dispatchEvent(new Event("loadedmetadata"));
+  });
+
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(["hi"], { type: "video/mp4" })),
+    }),
+  );
+
+  init();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledWith("/clip/cam1", expect.any(Object));
+});


### PR DESCRIPTION
## Summary
- enhance template player to preload `/clip` in the background
- update braille spinner docs with new player behaviour
- test tile player preload logic

## Testing
- `pre-commit run --all-files`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848f8a2d0b083339e4afe7fe1a4fd63