### PR TITLE
Add capture status indicator

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2113,6 +2113,23 @@ details > summary {
   text-align: center;
 }
 
+.capture-col {
+  width: 3rem;
+  text-align: center;
+}
+
+.capture-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: gray;
+}
+
+.capture-dot.active {
+  background-color: dodgerblue;
+}
+
 .unsaved-icon {
   vertical-align: middle;
   margin-left: 0.25rem;

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -87,6 +87,7 @@
       <th class="sortable" data-type="number" title="Disk usage">Storage</th>
       <th class="sortable" data-type="number" title="LLM responses">LLM Resp</th>
       <th class="sortable" data-type="number" title="Estimated LLM cost">LLM Cost</th>
+      <th class="sortable capture-col" data-type="string" title="Capture activity">Capturing</th>
       <th class="sortable status-col" data-type="string" title="Current feed status">Status</th>
     </tr>
   </thead>
@@ -160,6 +161,9 @@
       </td>
       <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
         {{ feed.llm_cost_estimate }}
+      </td>
+      <td class="capture-col" data-label="Capturing" data-value="{{ '1' if feed.capturing else '0' }}">
+        <span class="capture-dot{% if feed.capturing %} active{% endif %}"></span>
       </td>
       <td class="status-col" data-label="Status" data-value="{{ feed.status }}">
         {% if feed.danger_reason %}

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1252,6 +1252,10 @@ def get_feed_status():
             elif not user_idle:
                 danger_reason = "user"
 
+        with active_jobs_lock:
+            job = active_jobs.get(name)
+            capturing = bool(job and job.is_alive())
+
         feeds.append(
             {
                 "name": name,
@@ -1271,6 +1275,7 @@ def get_feed_status():
                 "llm_cost_estimate": llm_cost,
                 "danger": danger,
                 "danger_reason": danger_reason,
+                "capturing": capturing,
             }
         )
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -10,11 +10,12 @@ This endpoint now redirects to the _System Status_ tab on the Settings page. The
 
 ### Feed Dashboard
 
-Below the system metrics the page lists each configured feed with a color-coded indicator. Hovering over a red or yellow dot now shows a short tooltip describing the issue, including when the feed went offline and the most recent related log entry if available.
+Below the system metrics the page lists each configured feed with a color-coded indicator. Hovering over a red or yellow dot now shows a short tooltip describing the issue, including when the feed went offline and the most recent related log entry if available. A new **Capturing** column highlights feeds that are actively capturing.
 
 - **Green** – the feed is updating on schedule.
 - **Yellow** – the last capture is behind its configured frequency.
 - **Red** – capturing failed or the feed is offline.
+- **Blue** – a capture job is currently running.
 - Cameras marked as **Danger** show a hazard icon when the feature is required.
   The icon is orange if Danger mode is available but suppressed due to recent
   user activity and red when Danger mode is disabled or Chrome's debugging port

--- a/tests/test_feed_status_tooltip.py
+++ b/tests/test_feed_status_tooltip.py
@@ -62,6 +62,22 @@ class TestFeedStatusTooltip(unittest.TestCase):
             feeds = scheduling.get_feed_status()
         self.assertEqual(feeds[0]["danger_reason"], "user")
 
+    def test_capturing_flag_set(self):
+        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        templates = {"cam1": {"last_screenshot_time": now}}
+
+        class DummyProcess:
+            def is_alive(self):
+                return True
+
+        with (
+            patch("app.utils.scheduling.get_templates", return_value=templates),
+            patch("app.utils.scheduling.active_jobs", {"cam1": DummyProcess()}),
+            patch("app.utils.scheduling.active_jobs_lock", DummyLock()),
+        ):
+            feeds = scheduling.get_feed_status()
+        self.assertTrue(feeds[0]["capturing"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add capturing flag in scheduler feed status
- display capture activity in feed dashboard
- style capture indicator dot
- document capturing column
- test capturing flag

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849064b41e88333bf33f27e71756728