### PR TITLE
Remove scikit-image dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced camera list UI and video player controls
 - Updated package requirements and cleaned up imports
 - Added CPU builds of JAX 0.6.1 and Flax 0.2.0
-- Bumped scikit-image to 0.25.0
+- Removed the `scikit-image` dependency in favor of a lightweight image
+  comparison implementation
 - Bumped numpy to 1.26.0
 - Removed nodriver and its screenshot helper
 - Updated default VERSION to 0.2.7 for footer display

--- a/app/utils/detect.py
+++ b/app/utils/detect.py
@@ -4,12 +4,14 @@ import logging
 
 import numpy as np
 from PIL import Image
-from skimage.metrics import structural_similarity as ssim
 
 
 def calculate_difference_fast(image_path_a, image_path_b, downsample_size=(100, 100)):
-    """
-    Calculate the difference between two images using the Structural Similarity Index (SSIM).
+    """Compute a quick dissimilarity score between two images.
+
+    The function downsamples the images and calculates the mean squared
+    difference. The result is normalized to ``0`` for identical images and
+    ``1`` for completely different 8-bit grayscale images.
 
     Args:
         image_path_a (str): The file path to the first image.
@@ -17,21 +19,22 @@ def calculate_difference_fast(image_path_a, image_path_b, downsample_size=(100, 
         downsample_size (tuple): The new size for downsampling the images before comparison.
 
     Returns:
-        float: Dissimilarity score between the downsampled images where ``0``
-        means the images are identical.
+        float: Dissimilarity score between the downsampled images. ``0`` means
+        the images are identical.
     """
     try:
         # Open and resize the images
         image_a = Image.open(image_path_a).resize(downsample_size).convert("L")
         image_b = Image.open(image_path_b).resize(downsample_size).convert("L")
 
-        # Convert images to arrays
-        array_a = np.array(image_a)
-        array_b = np.array(image_b)
+        # Convert images to float arrays for calculation
+        array_a = np.array(image_a, dtype=np.float32)
+        array_b = np.array(image_b, dtype=np.float32)
 
-        # Calculate SSIM
-        ssim_index, _ = ssim(array_a, array_b, full=True)
-        return 1 - ssim_index  # Convert to a dissimilarity measure
+        # Compute mean squared error and normalize to the range [0, 1]
+        mse = np.mean((array_a - array_b) ** 2)
+        normalized = mse / (255.0**2)
+        return float(min(1.0, normalized))
     except Exception as e:
         # Handle exceptions (e.g., file not found, invalid image format)
         logging.error("Error calculating difference: %s", e)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,8 +55,7 @@ pip install -r requirements.txt
 ```
 
 The `requirements.txt` file now includes the CPU builds of **JAX 0.6.1** and
-**Flax 0.8.5**, along with updated `scikit-image` (0.25.0) and
-`numpy` (1.25.0).
+**Flax 0.8.5**, along with updated `numpy` (1.25.0).
 
 ### 6. (Optional) Configure Environment Variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ pdf2image==1.17.0
 Pillow==11.2.1
 psutil~=7.0.0
 pyvirtualdisplay==3.0
-scikit-image==0.25.0
 selenium==4.33.0
 SQLAlchemy==2.0.41
 pywebpush==2.0.3


### PR DESCRIPTION
## Summary
- swap scikit-image SSIM call with a simple MSE-based method
- drop scikit-image requirement
- update docs and changelog

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684909b247b0833388c009f4e942139e