### PR TITLE
Fix mobile tabs layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2280,6 +2280,7 @@ details > summary {
 
 .tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- wrap settings tabs so they don't overflow on mobile

## Testing
- `pre-commit run --files app/static/css/style.css`
- `pytest -q` *(fails: TestTestPattern::test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_684911f1683083338545b172cf46af9c