### PR TITLE
Improve mobile controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -255,8 +255,9 @@ h2 {
 
 @media (max-width: 767px) {
   #sort-date {
-    width: 100%;
-    font-size: 16px;
+    width: 5rem;
+    margin-bottom: 0;
+    font-size: 14px;
   }
 }
 
@@ -334,11 +335,17 @@ h2 {
     margin-bottom: 10px;
   }
   #template-controls {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
   }
   #template-controls input[type="text"] {
-    width: 100%;
+    width: 6rem;
+  }
+  #status-legend {
+    display: none;
+  }
+  #controls-wrapper {
+    font-size: 0.75rem;
   }
   #template-list {
     grid-template-columns: 1fr; /* Single column layout on mobile */

--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -6,6 +6,7 @@ The main template view scales thumbnails with a width slider on desktop screens 
 
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 The main content now has less top padding so on‑page controls like the search bar sit closer to the navigation.
+The template control panel now compresses on phones with Search, Play All and Sort in one row while the status legend hides.
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop. The header now sticks to the top of the screen as you scroll so navigation is always accessible.
 The footer now condenses on small screens by hiding the copyright notice and build information, leaving only the essential navigation links.
 The header navigation collapses into a stacked menu on small screens. Links grow larger with extra padding so they're easier to tap. The clock, scrolling caption chyron and temporary flash messages are all hidden on phones to maximize space.


### PR DESCRIPTION
## Summary
- shrink sort dropdown on small screens
- put Search, Play All and Sort on one line in mobile view
- hide the recent/error legend on phones
- note the change in the responsive design docs

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: TestTestPattern.test_grey_patch)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684911caa6e88333937c9fd9a00a6a86