### PR TITLE
Handle malformed network log entries

### DIFF
--- a/app/utils/network_testing.py
+++ b/app/utils/network_testing.py
@@ -27,7 +27,11 @@ def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=Fals
         logs = driver.get_log("performance")
         events = [log for log in logs if "Network.response" in log["message"] or "Network.request" in log["message"]]
         for gevent in events:
-            levent = json.loads(gevent.get("message"))
+            try:
+                levent = json.loads(gevent.get("message"))
+            except json.JSONDecodeError:
+                # Skip malformed log entries instead of raising an exception
+                continue
             lurl = levent.get("message", {}).get("params", {}).get("response", {}).get("url")
             if lurl == gurl:
                 lstatus = levent.get("message", {}).get("params", {}).get("response", {}).get("status")

--- a/tests/test_network_testing_utils.py
+++ b/tests/test_network_testing_utils.py
@@ -110,6 +110,15 @@ class TestNetworkTestingUtils(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(status, 800)
 
+    def test_network_idle_condition_skips_bad_logs(self):
+        bad = {"message": "Network.response not-json"}
+        driver = DummyDriver(performance_logs=[[bad]])
+        gen = self._time_gen(step=0.2)
+        with patch("time.time", side_effect=gen), patch("time.sleep"):
+            result, status = network_idle_condition(driver, "http://ex", timeout=0.5, idle_time=0)
+        self.assertTrue(result)
+        self.assertEqual(status, 800)
+
     def test_check_network_errors_no_error(self):
         driver = DummyDriver(browser_logs=[[{"level": "INFO", "message": "ok"}]])
         gen = self._time_gen()


### PR DESCRIPTION
## Summary
- skip invalid JSON entries in `network_idle_condition`
- test that malformed network log entries are ignored

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: tests/test_test_pattern.py::TestTestPattern::test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_68491315bec08333bbd5b8d1f802d63b