### PR TITLE
Fix banner version interpolation

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from app import create_app, scheduler
 from app.utils.cli import build_argument_parser, cli_help_text
 from app.utils.scheduling import get_system_metrics, stop_background_tasks
 
-banner = """\033[96m
+banner = f"""\033[96m
           ____  _  _
          / ___|| |(_)_ __ ___  _ __  ___  ___ _ __
         | |  _ | || | '_ ` _ `| '_ `/ __|/ _ ` '__|


### PR DESCRIPTION
## Summary
- ensure the startup banner interpolates `config.VERSION`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: test_summarize_success, test_summarize_with_history, test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_68491315ebc483339c24601b357ee549