### PR TITLE
Unify line length settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       # 2️⃣  Let Black format everything after isort touched the imports
       - id: black
         name: black
-        entry: black --line-length 120
+        entry: black --line-length 88
         language: system
         types: [python]
 


### PR DESCRIPTION
## Summary
- keep line length consistent across linting tools

## Testing
- `pre-commit run --files .pre-commit-config.yaml .flake8 pyproject.toml`
- `flake8`
- `pytest -q` *(fails: TestTestPattern::test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_68496a6a1be48333ab9653feb7ef3d6a