### PR TITLE
Add missing docs to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,3 +78,6 @@ nav:
       - UI Component Guide: style_guide.md
       - Navigation Logo: navigation_logo.md
       - Governance: governance.md
+      - Rotate Button: rotate_button.md
+      - Size Audit: size_audit.md
+      - Template Edit Preview: edit_template_preview.md


### PR DESCRIPTION
## Summary
- add rotate_button, size_audit and template edit preview docs to navigation

## Testing
- `flake8`
- `pre-commit run --files mkdocs.yml`
- `pytest` *(fails: TestTestPattern::test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_68496a76bca4833398f09cc13d463e1d