### PR TITLE
Fix gray reference patch test

### DIFF
--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -87,7 +87,8 @@ class TestTestPattern(unittest.TestCase):
         width, height = 220, 110
         img = generate_test_pattern(width=width, height=height)
         self.assertEqual(img.size, (220, 110))
-        self.assertEqual(img.getpixel((116, 58)), (255, 255, 255))
+        # the patch is drawn as a mid-gray reference point
+        self.assertEqual(img.getpixel((116, 58)), (118, 118, 118))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update expected color for the stability patch

## Testing
- `pre-commit run --all-files` *(fails: hook id `black` reformatted files)*
- `PYTHONPATH=$PWD pytest tests/test_test_pattern.py::TestTestPattern::test_grey_patch -q`

------
https://chatgpt.com/codex/tasks/task_e_68496c27800c83338a6f7973304ddf42