### PR TITLE
Unify test pattern generator

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2263,7 +2263,9 @@ def init_routes(app: Flask) -> None:
             boundary = b"frame"
             while True:
                 spinner = spinner_frames[index % len(spinner_frames)]
-                img = test_pattern.generate_indian_head_test_pattern(spinner=spinner)
+                img = test_pattern.generate_test_pattern(
+                    spinner=spinner, variant="classic"
+                )
                 buf = io.BytesIO()
                 img.save(buf, format="JPEG")
                 frame = buf.getvalue()

--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -93,8 +93,22 @@ def generate_test_pattern(
     height: int = 720,
     logo_path: Optional[str] = None,
     camera_name: str | None = None,
+    variant: str = "color",
+    spinner: str | None = None,
 ) -> Image.Image:
-    """Return a PIL image with a broadcast-style test pattern and calibration aids."""
+    """Return a PIL image with calibration aids.
+
+    ``variant`` selects the style. ``"color"`` is the default broadcast pattern
+    while ``"classic"`` reproduces the former Indian Head design. ``spinner`` is
+    ignored for the color style.
+    """
+
+    if variant == "classic":
+        return _generate_classic_test_pattern(
+            width=width, height=height, spinner=spinner
+        )
+
+    img = Image.new("RGB", (width, height))
 
     img = Image.new("RGB", (width, height))
     draw = ImageDraw.Draw(img)
@@ -269,12 +283,12 @@ def generate_test_pattern(
     return img
 
 
-def generate_indian_head_test_pattern(
+def _generate_classic_test_pattern(
     width: int = 1280,
     height: int = 720,
     spinner: str | None = None,
 ) -> Image.Image:
-    """Return a grayscale Indian Head-style test pattern with extras."""
+    """Return the classic grayscale test pattern."""
 
     img = Image.new("RGB", (width, height), "gray")
     draw = ImageDraw.Draw(img)
@@ -460,6 +474,18 @@ def generate_indian_head_test_pattern(
     return img
 
 
+def generate_indian_head_test_pattern(
+    width: int = 1280,
+    height: int = 720,
+    spinner: str | None = None,
+) -> Image.Image:
+    """Compatibility wrapper for ``variant='classic'``."""
+
+    return generate_test_pattern(
+        width=width, height=height, variant="classic", spinner=spinner
+    )
+
+
 def generate_geometric_test_pattern(
     width: int = 1280,
     height: int = 720,
@@ -468,9 +494,9 @@ def generate_geometric_test_pattern(
 ) -> Image.Image:
     """Legacy wrapper that now returns the unified test pattern."""
 
-    # `tiles` is ignored but kept for backward compatibility
-    return generate_indian_head_test_pattern(
-        width=width, height=height, spinner=spinner
+    # ``tiles`` is ignored but kept for backward compatibility
+    return generate_test_pattern(
+        width=width, height=height, variant="classic", spinner=spinner
     )
 
 

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -4,12 +4,7 @@ import unittest
 
 from PIL import Image
 
-from app.utils.test_pattern import (
-    generate_geometric_test_pattern,
-    generate_indian_head_test_pattern,
-    generate_test_pattern,
-    save_test_pattern,
-)
+from app.utils.test_pattern import generate_test_pattern, save_test_pattern
 
 
 class TestTestPattern(unittest.TestCase):
@@ -26,15 +21,10 @@ class TestTestPattern(unittest.TestCase):
             with Image.open(path) as im:
                 self.assertEqual(im.size, (100, 50))
 
-    def test_indian_head_size(self):
-        img = generate_indian_head_test_pattern(width=150, height=150)
+    def test_classic_size(self):
+        img = generate_test_pattern(width=150, height=150, variant="classic")
         self.assertIsInstance(img, Image.Image)
         self.assertEqual(img.size, (150, 150))
-
-    def test_geometric_size(self):
-        img = generate_geometric_test_pattern(width=120, height=120, tiles=5)
-        self.assertIsInstance(img, Image.Image)
-        self.assertEqual(img.size, (120, 120))
 
     def test_minibar_colors(self):
         width, height = 240, 100
@@ -69,9 +59,9 @@ class TestTestPattern(unittest.TestCase):
             px = tuple(round((l + r) / 2) for l, r in zip(px_left, px_right))
             self.assertEqual(px, expected)
 
-    def test_indian_head_minibars(self):
+    def test_classic_minibars(self):
         width, height = 240, 100
-        img = generate_indian_head_test_pattern(width=width, height=height)
+        img = generate_test_pattern(width=width, height=height, variant="classic")
         bar_h = height // 6
         mini_w = max(2, width // 100)
         mini_h = bar_h // 4


### PR DESCRIPTION
## Summary
- support `variant` parameter in `generate_test_pattern`
- keep classic pattern via helper and wrappers
- update `test_pattern_mjpg` route to use unified API
- adjust tests for new generator

## Testing
- `pre-commit run --files app/utils/test_pattern.py app/routes.py tests/test_test_pattern.py`
- `PYTHONPATH=. pytest tests/test_test_pattern.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849b877b76483338749d57227341f40