### PR TITLE
Add zoom on scroll for video player

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -27,6 +27,7 @@ import { initKeyVisibility } from "./key_visibility.js";
 import { initCliHelp } from "./cli_help.js";
 import { initNetworkBanner } from "./network_banner.js";
 import { initUnsavedIndicator } from "./unsaved.js";
+import { initVideoZoom } from "./zoom.js";
 
 initTemplates();
 initVideoControls();
@@ -56,3 +57,4 @@ initAdvanced();
 initKeyVisibility();
 initUnsavedIndicator();
 initCliHelp();
+initVideoZoom();

--- a/app/static/js/zoom.js
+++ b/app/static/js/zoom.js
@@ -1,0 +1,41 @@
+export function initVideoZoom() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const video = document.getElementById("live-video");
+    if (!video) return;
+
+    let scale = 1;
+    let resetId;
+
+    const applyScale = (x, y) => {
+      video.style.transformOrigin = `${x}% ${y}%`;
+      video.style.transform = `scale(${scale})`;
+    };
+
+    video.addEventListener(
+      "wheel",
+      (e) => {
+        e.preventDefault();
+        if (resetId) {
+          clearTimeout(resetId);
+          resetId = null;
+        }
+        const rect = video.getBoundingClientRect();
+        const originX = ((e.clientX - rect.left) / rect.width) * 100;
+        const originY = ((e.clientY - rect.top) / rect.height) * 100;
+        scale += e.deltaY < 0 ? 0.1 : -0.1;
+        scale = Math.min(3, Math.max(1, scale));
+        applyScale(originX, originY);
+      },
+      { passive: false },
+    );
+
+    video.addEventListener("mouseleave", () => {
+      if (resetId) clearTimeout(resetId);
+      resetId = setTimeout(() => {
+        scale = 1;
+        video.style.transform = "";
+        video.style.transformOrigin = "";
+      }, 1000);
+    });
+  });
+}

--- a/tests/js/video_zoom.test.js
+++ b/tests/js/video_zoom.test.js
@@ -1,0 +1,28 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <video id="live-video"></video>
+  </div>
+`;
+
+let init;
+
+beforeAll(async () => {
+  ({ initVideoZoom: init } = await import("../../app/static/js/zoom.js"));
+});
+
+jest.useFakeTimers();
+
+test("zooms on wheel and resets on mouse leave", () => {
+  const video = document.getElementById("live-video");
+  video.getBoundingClientRect = () => ({ left: 0, top: 0, width: 100, height: 100 });
+  init();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const wheel = new WheelEvent("wheel", { deltaY: -100, clientX: 50, clientY: 50 });
+  video.dispatchEvent(wheel);
+  expect(video.style.transform).toMatch(/scale/);
+  video.dispatchEvent(new Event("mouseleave"));
+  jest.advanceTimersByTime(1000);
+  expect(video.style.transform).toBe("");
+});


### PR DESCRIPTION
## Summary
- enable zooming on `#live-video` via scroll wheel
- initialize zoom handler in the main script
- test zoom behavior in JS unit tests

## Testing
- `npm run lint:js`
- `npm run lint:css`
- `npm test`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6849cd49653c8333b124fcb9cf68d908