### PR TITLE
Enhance test pattern clocks

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2355,7 +2355,7 @@ details > summary {
   right: 0.5rem;
   left: auto;
   transform: none;
-  font-family: monospace;
+  font-family: SimBraille, "Apple Braille", "DejaVu Sans Mono", monospace;
   font-size: 20px;
   pointer-events: none;
   color: #fff;

--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -239,13 +239,6 @@ def generate_test_pattern(
         (width // 2 - tw // 2, bar_h + 6), timestamp, fill="white", font=font_large
     )
 
-    mystic = "Seek the unseen"
-    mb = draw.textbbox((0, 0), mystic, font=font_small)
-    mw, mh = mb[2] - mb[0], mb[3] - mb[1]
-    draw.text(
-        (width // 2 - mw // 2, bar_h + th + 14), mystic, fill="white", font=font_small
-    )
-
     if spinner:
         sb = draw.textbbox((0, 0), spinner, font=font_small)
         sw, sh = sb[2] - sb[0], sb[3] - sb[1]
@@ -256,17 +249,55 @@ def generate_test_pattern(
     patch_y = height // 2 + 3
     draw.point((patch_x, patch_y), fill=(118, 118, 118))
 
-    # timestamp repeated near the vertical center on the right side
-    font_right = load_font(24)
-    rb = draw.textbbox((0, 0), timestamp, font=font_right)
-    rw, rh = rb[2] - rb[0], rb[3] - rb[1]
-    x_pos = max(width - rw - 10, width // 2 + 10)
-    draw.text(
-        (x_pos, height // 2 - rh // 2),
-        timestamp,
-        fill="white",
-        font=font_right,
+    # multiple time codes stacked on the right side
+    font_right = load_font(26)
+    time_simple = timestamp.split(" ")[1]
+    formats = [
+        time_simple,
+        _format_binary_time(time_simple),
+        _format_roman_time(time_simple),
+        _to_braille(time_simple),
+    ]
+
+    segments = [t.replace("\u2812", ":").split(":") for t in formats]
+    seg1_max = max(draw.textlength(s[0], font=font_right) for s in segments)
+    seg2_max = max(draw.textlength(s[1], font=font_right) for s in segments)
+    seg3_max = max(draw.textlength(s[2], font=font_right) for s in segments)
+    colon_w = draw.textlength(":", font=font_right)
+
+    total_w = seg1_max + colon_w + seg2_max + colon_w + seg3_max
+    x_start = width - total_w - 10
+    y_start = height // 2 - (
+        (len(formats) * font_right.size + (len(formats) - 1) * 4) // 2
     )
+
+    for idx, parts in enumerate(segments):
+        x = x_start
+        y = y_start + idx * (font_right.size + 4)
+        draw.text(
+            (x + seg1_max - draw.textlength(parts[0], font=font_right), y),
+            parts[0],
+            fill="white",
+            font=font_right,
+        )
+        x += seg1_max
+        draw.text((x, y), ":", fill="white", font=font_right)
+        x += colon_w
+        draw.text(
+            (x + seg2_max - draw.textlength(parts[1], font=font_right), y),
+            parts[1],
+            fill="white",
+            font=font_right,
+        )
+        x += seg2_max
+        draw.text((x, y), ":", fill="white", font=font_right)
+        x += colon_w
+        draw.text(
+            (x + seg3_max - draw.textlength(parts[2], font=font_right), y),
+            parts[2],
+            fill="white",
+            font=font_right,
+        )
 
     if camera_name:
         draw.text((10, bar_h + 10), camera_name, fill="white", font=font_small)

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -4,7 +4,13 @@ import unittest
 
 from PIL import Image
 
-from app.utils.test_pattern import generate_test_pattern, save_test_pattern
+from app.utils.test_pattern import (
+    _format_binary_time,
+    _format_roman_time,
+    _to_braille,
+    generate_test_pattern,
+    save_test_pattern,
+)
 
 
 class TestTestPattern(unittest.TestCase):
@@ -27,6 +33,14 @@ class TestTestPattern(unittest.TestCase):
         self.assertEqual(img.size, (220, 110))
         # the patch is drawn as a mid-gray reference point
         self.assertEqual(img.getpixel((116, 58)), (118, 118, 118))
+
+
+class TestTimeFormatHelpers(unittest.TestCase):
+    def test_time_format_helpers(self):
+        ts = "12:34:56"
+        self.assertEqual(_format_binary_time(ts), "01100:100010:111000")
+        self.assertEqual(_format_roman_time(ts), "XII:XXXIV:LVI")
+        self.assertEqual(_to_braille(ts), "⠁⠃⠒⠉⠙⠒⠑⠋")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove mystic text from test pattern
- stack binary, Roman numeral, and Braille clocks
- align clock segments on the right side
- ensure Braille loader uses proper fonts
- test helper functions for time conversions

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849d1ada4848333bb4444c362929e18