### PR TITLE
Limit clip prerendering

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -394,6 +394,10 @@ CRAWLER_STARTUP_SPREAD = int(get_setting("CRAWLER_STARTUP_SPREAD", 10))
 
 MAX_CLIP_AGE_MINUTES = int(get_setting("MAX_CLIP_AGE_MINUTES", 5))
 
+# Skip clip pre-rendering when the number of cameras exceeds this limit.
+# Set to 0 to always refresh clips regardless of count.
+CLIP_REFRESH_MAX_CAMERAS = int(get_setting("CLIP_REFRESH_MAX_CAMERAS", 10))
+
 # Whether the System Performance icon in the navigation bar should remain
 # visible even when the application reports healthy status. When set to
 # ``False`` the icon hides itself if all metrics look nominal to reduce

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -28,6 +28,7 @@ from transformers import CLIPModel, CLIPProcessor
 from app.config import (
     AUTO_UPDATE_BRANCH,
     CLIP_MODEL_NAME,
+    CLIP_REFRESH_MAX_CAMERAS,
     CRAWLER_STARTUP_SPREAD,
     DEBUG,
     FFMPEG_HWACCEL,
@@ -1526,11 +1527,20 @@ def schedule_auto_update() -> None:
 
 def refresh_clips() -> None:
     """Pre-generate short clips for each camera."""
+    cameras = [
+        name for name in os.listdir(VIDEO_DIRECTORY) if validate_template_name(name)
+    ]
+
+    if CLIP_REFRESH_MAX_CAMERAS and len(cameras) > CLIP_REFRESH_MAX_CAMERAS:
+        logging.info(
+            "Skipping clip refresh for %d cameras (limit %d)",
+            len(cameras),
+            CLIP_REFRESH_MAX_CAMERAS,
+        )
+        return
 
     base_url = f"http://127.0.0.1:{PORT}"
-    for camera_name in os.listdir(VIDEO_DIRECTORY):
-        if not validate_template_name(camera_name):
-            continue
+    for camera_name in cameras:
         try:
             requests.get(f"{base_url}/clip/{camera_name}", timeout=5)
         except Exception:

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -75,6 +75,8 @@ user table in sync.
 - `SCREENSHOT_DIRECTORY` – directory for raw screenshots (default `data/screenshots/`)
 - `VIDEO_DIRECTORY` – directory for recorded videos (default `data/video/`)
 - `CLIPS_DIRECTORY` – directory used to cache short clips (default `data/clips/`)
+- `CLIP_REFRESH_MAX_CAMERAS` – skip clip pre-rendering when more than this many
+  cameras exist (default `10`, use `0` to disable the check)
 - `SUMMARIES_DIRECTORY` – **deprecated**; summaries are now stored in the database.
 
   Older deployments may still reference this path but it is no longer used.


### PR DESCRIPTION
## Summary
- add `CLIP_REFRESH_MAX_CAMERAS` setting
- skip clip refresh when camera count exceeds the limit
- document the new configuration option

## Testing
- `pre-commit run --files app/config.py app/utils/scheduling.py docs/configuration_guide.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849db10aa0c83338c84b7354612888c