### PR TITLE
Update settings tab titles

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3616,12 +3616,10 @@ def init_routes(app: Flask) -> None:
             if not placed:
                 grouped_settings["Other"].append(setting)
 
-        if "Integrations & Other" in grouped_settings:
-            grouped_settings["Integrations & Other"].extend(
-                grouped_settings.get("Other", [])
-            )
+        if "Advanced" in grouped_settings:
+            grouped_settings["Advanced"].extend(grouped_settings.get("Other", []))
         else:
-            grouped_settings["Integrations & Other"] = grouped_settings.get("Other", [])
+            grouped_settings["Advanced"] = grouped_settings.get("Other", [])
         grouped_settings.pop("Other", None)
 
         # Remove empty groups to avoid blank headings in the UI
@@ -3629,8 +3627,8 @@ def init_routes(app: Flask) -> None:
 
         collapsed_groups = {
             "Capture",
-            "Credentials & Management",
-            "Integrations & Other",
+            "Admin",
+            "Advanced",
         }
         file_location_items = [s for s in settings if s["name"] in FILE_LOCATION_NAMES]
         file_info = file_location_metrics(file_location_items)
@@ -3967,7 +3965,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/status")
     @login_required
     def status():
-        """Redirect to the System Status tab under Settings for consistency."""
+        """Redirect to the Status tab under Settings for consistency."""
         return redirect(url_for("settings", tab="status-tab"))
 
     @app.route("/logs")

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -157,7 +157,7 @@ export function initNav() {
         if (!data) return;
         if (data.status === "healthy") {
           healthStatus.style.color = "green";
-          healthStatus.title = "System Status: Healthy\n\n";
+          healthStatus.title = "Status: Healthy\n\n";
           if (!healthAlwaysVisible) {
             healthStatus.style.display = "none";
           } else {
@@ -166,7 +166,7 @@ export function initNav() {
         } else {
           healthStatus.style.display = "flex";
           healthStatus.style.color = "red";
-          healthStatus.title = "System Status: Degraded\n\n";
+          healthStatus.title = "Status: Degraded\n\n";
         }
         healthStatus.title +=
           `CPU: ${data.metrics.cpu_usage}%\n` +

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -14,7 +14,7 @@ template_form %} {% block content %}
     <button
       type="button"
       class="tab-link{% if loop.first %} active{% endif %}"
-      data-tab="{{ 'management-tab' if group == 'Credentials & Management' else group|replace(' ', '-') ~ '-tab' }}"
+      data-tab="{{ 'management-tab' if group == 'Admin' else group|replace(' ', '-') ~ '-tab' }}"
       title="Open {{ group }} tab"
     >
       {{ group }}
@@ -32,9 +32,9 @@ template_form %} {% block content %}
       type="button"
       class="tab-link"
       data-tab="status-tab"
-      title="Open System Status tab"
+      title="Open Status tab"
     >
-      System Status
+      Status
     </button>
     <button
       type="button"
@@ -88,7 +88,7 @@ template_form %} {% block content %}
     </datalist>
     {% endfor %} {% for group, items in grouped_settings.items() %}
     <div
-      id="{{ 'management-tab' if group == 'Credentials & Management' else group|replace(' ', '-') ~ '-tab' }}"
+      id="{{ 'management-tab' if group == 'Admin' else group|replace(' ', '-') ~ '-tab' }}"
       class="tab-content{% if loop.first %} active{% endif %}"
     >
       {% call card(group) %}
@@ -120,15 +120,23 @@ template_form %} {% block content %}
                   />
                 <span class="slider round"></span>
               </label>
-              {% elif 'KEY' in setting.name %}
-              {% set sprite = url_for('static', filename='icons/sprite.svg') %}
+              {% elif 'KEY' in setting.name %} {% set sprite = url_for('static',
+              filename='icons/sprite.svg') %}
               <input
                 id="{{ setting.name }}"
                 type="password"
                 name="{{ setting.name }}"
                 value="{{ setting.value }}"
                 title="Edit value for {{ setting.name }}"
-                {% if setting.name in locked_settings %}disabled data-locked{% endif %}
+                {%
+                if
+                setting.name
+                in
+                locked_settings
+                %}disabled
+                data-locked{%
+                endif
+                %}
               />
               <button
                 type="button"
@@ -194,8 +202,8 @@ template_form %} {% block content %}
           {% endfor %}
         </tbody>
       </table>
-      {% endcall %} {% if group == 'Credentials & Management' %} {% call
-      card('Configuration Management') %}
+      {% endcall %} {% if group == 'Admin' %} {% call card('Configuration
+      Management') %}
       <div class="checkbox-row">
         <span>Advanced Options</span>
         <label class="switch" title="Toggle advanced options">

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -107,7 +107,7 @@ SETTINGS_GROUPS = {
         "CLOCK_DIGITAL",
         "CLOCK_NAVBAR",
     ],
-    "Credentials & Management": [
+    "Admin": [
         "USER_NAME",
         "USER_PASSWORD_HASH",
         "SECRET_KEY",
@@ -148,7 +148,7 @@ SETTINGS_GROUPS = {
         "FFMPEG_HWACCEL",
         "FFMPEG_THREADS",
     ],
-    "Integrations & Other": [
+    "Advanced": [
         "EMAIL_ENABLED",
         "SMS_ENABLED",
         "CAP_ENABLED",

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -154,17 +154,17 @@ Example response:
 { "status": "success", "message": "Screenshot for camera1 taken" }
 ```
 
-### 7. View System Status
+### 7. View Status
 
 **GET /status**
 
-Redirects to the _System Status_ tab on the Settings page which displays metrics such as CPU, memory, and disk usage along with open file count, thread count, and uptime. These metrics are gathered in a background thread (see `app/utils/scheduling.py`).
+Redirects to the _Status_ tab on the Settings page which displays metrics such as CPU, memory, and disk usage along with open file count, thread count, and uptime. These metrics are gathered in a background thread (see `app/utils/scheduling.py`).
 
 ### 8. Stream Logs
 
 **GET /stream_logs**
 
-Streams log records via Server-Sent Events. Optional query parameters `level`, `source`, `start_date`, `end_date`, and `search` allow filtering. The `/logs` page and _System Status_ tab use this endpoint for the live log viewer.
+Streams log records via Server-Sent Events. Optional query parameters `level`, `source`, `start_date`, `end_date`, and `search` allow filtering. The `/logs` page and _Status_ tab use this endpoint for the live log viewer.
 
 To reduce load during rapid typing, identical `level`/`search` combinations are ignored if a stream for the same user is already active.
 

--- a/docs/clock_settings.md
+++ b/docs/clock_settings.md
@@ -1,6 +1,6 @@
 # Clock Settings
 
-The application includes a configurable clock that can appear in multiple places. Open the **Settings** page and switch to the **Integrations & Other** tab to adjust its behaviour.
+The application includes a configurable clock that can appear in multiple places. Open the **Settings** page and switch to the **Advanced** tab to adjust its behaviour.
 
 - **CLOCK_OVERLAY** – display the clock on video overlays.
 - **CLOCK_DIGITAL** – show the clock as digital text rather than an analogue face.

--- a/docs/config_management.md
+++ b/docs/config_management.md
@@ -5,7 +5,7 @@ Glimpser allows you to export and restore configuration data from the web interf
 ## Downloading the Configuration
 
 1. Open the **Settings** page from the navigation bar.
-2. Switch to the **Credentials & Management** tab.
+2. Switch to the **Admin** tab.
 3. Click **Download Configuration** to save the current settings as a JSON backup.
    A new backup is created automatically before the file is served.
 
@@ -13,7 +13,7 @@ The downloaded file contains every setting and camera template defined in the da
 
 ## Uploading the Configuration
 
-1. From the same **Credentials & Management** tab, choose a previously saved JSON file.
+1. From the same **Admin** tab, choose a previously saved JSON file.
 2. Click **Upload Configuration** and confirm the restore action.
 
 All existing settings and templates will be replaced by the contents of the file.

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -37,7 +37,7 @@ Be cautious with this feature, as it can interact with your browser while you ar
 
 Visit `/danger` to toggle the feature on or off. When disabled, captures marked as "Danger" are skipped even if Chrome's debugging port is open.
 
-The **Credentials & Management** tab on the Settings page summarizes Danger mode. It shows the detected browser path, indicates if your Chrome shortcuts already include the debugging flag, and reports whether the debugging port is open. Green or red dots highlight the patched and running state.
+The **Admin** tab on the Settings page summarizes Danger mode. It shows the detected browser path, indicates if your Chrome shortcuts already include the debugging flag, and reports whether the debugging port is open. Green or red dots highlight the patched and running state.
 
 ## Danger Page Overview
 

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -15,7 +15,7 @@ Key topics covered include:
 - Tracking AI usage and cost for captions and summaries.
 - Configuration file locations and environment overrides.
 - Dark mode toggle and mobile-friendly responsive layout.
-- System Status metrics, feed dashboard, and live log viewer.
+- Status metrics, feed dashboard, and live log viewer.
 - Offline preview of recent snapshots and locally hosted fonts.
 - "Remember me" option on the login page for automatic sign in.
 - Logging out now clears any saved credentials so shared devices stay secure.

--- a/docs/offline_preview.md
+++ b/docs/offline_preview.md
@@ -1,6 +1,6 @@
 # Offline Preview
 
-A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the dashboard (`/`), the System Status tab (`/settings?tab=status-tab`), the main Settings page, and the Templates page (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
+A simple Service Worker allows Glimpser to keep showing recent images when the network is spotty. The browser automatically registers `/sw.js`, which caches the dashboard (`/`), the Status tab (`/settings?tab=status-tab`), the main Settings page, and the Templates page (including the Discover tab). Key stylesheets and scripts are stored as well, along with the most recent 20 snapshot images. If fetching a new image fails or returns a 504 error, the cached copy is displayed instead so the player does not show a blank pane.
 
 Requests now time out after five seconds so the UI quickly falls back to the cached pages when the server is slow or restarting.
 

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -7,7 +7,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Add New Setting** – quickly create additional key/value pairs.
 - **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
-- **Credentials & Management** – buttons are organized into cards for a cleaner layout.
+- **Admin** – buttons are organized into cards for a cleaner layout.
 - **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
@@ -15,9 +15,9 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Tab headers removed** – the active tab is highlighted, freeing space.
 - **Unsaved Changes Indicator** – a small alert icon appears next to the Save
   Changes button when edits haven't been saved.
-- **System Status** – view CPU, memory, disk usage, and live logs.
-- **Certain tabs start collapsed** – Capture, Credentials & Management, and
-  Integrations & Other appear collapsed until expanded.
+- **Status** – view CPU, memory, disk usage, and live logs.
+- **Certain tabs start collapsed** – Capture, Admin, and
+  Advanced appear collapsed until expanded.
 
 All form elements now use unique IDs across tabs to avoid browser warnings.
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-This endpoint now redirects to the _System Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator. Metrics refresh automatically every few seconds.
+This endpoint now redirects to the _Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator. Metrics refresh automatically every few seconds.
 
 ### Feed Dashboard
 
@@ -22,7 +22,7 @@ Below the system metrics the page lists each configured feed with a color-coded 
   is closed. Rows for disabled feeds are slightly greyed out.
 
 The dashboard also shows when the most recent system summary was generated. The
-same table appears on the _System Status_ tab under Settings so you can review
+same table appears on the _Status_ tab under Settings so you can review
 usage metrics without leaving the configuration interface.
 
 Additional KPI columns track the number of screenshots, videos, total storage
@@ -56,7 +56,7 @@ when hardware is available but not currently active.
 
 **GET /stream_logs**
 
-This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the _System Status_ tab consume this endpoint to display updates in real time.
+This endpoint delivers log entries using Server‑Sent Events. Optional query parameters allow filtering by level, source, date range, and text search. The `/logs` page and the _Status_ tab consume this endpoint to display updates in real time.
 
 To filter logs by level and message text, you could request:
 
@@ -66,7 +66,7 @@ To filter logs by level and message text, you could request:
 
 ## Using the Live Log Viewer
 
-1. Open the _System Status_ tab under Settings or navigate to `/logs` after logging in.
+1. Open the _Status_ tab under Settings or navigate to `/logs` after logging in.
 2. Use the search box and dropdowns to filter log output.
 3. Hover over each field for a tooltip explaining the filter.
 4. Results update automatically via `/stream_logs`.
@@ -75,7 +75,7 @@ To filter logs by level and message text, you could request:
 
 The log viewer reads log lines from memory, ensuring minimal disk overhead.
 
-The _System Status_ tab also appears as a **System Status** camera under Discover.
+The _Status_ tab also appears as a **System Status** camera under Discover.
 Adding it lets Glimpser capture periodic screenshots of its own health metrics.
 An accompanying **Internal Caption** camera shows `/internal_caption.mjpg` so you
 can monitor recent caption text without leaving the dashboard.
@@ -101,7 +101,7 @@ Opening the Captions page now also restarts the scrolling banner when
 ## System Performance Icon
 
 The System Performance icon in the navigation bar provides quick access to the
-_System Status_ tab. When all metrics look healthy the icon now hides to reduce
+_Status_ tab. When all metrics look healthy the icon now hides to reduce
 clutter. Set the `HEALTH_STATUS_ALWAYS_VISIBLE` option to `True` if you prefer
 to keep it shown at all times.
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -45,7 +45,7 @@ Interactive forms now include additional tooltips:
 - **Live video player** – tooltip now refreshes with the full caption as it updates.
 - **Group selector** – choose a group on the live page. Selecting one reveals a second dropdown for cameras and syncs with the navigation bar.
 - **Info icon** – toggles camera metadata on the live page.
-- **Feed status indicators** – on the System Status page, red or yellow dots display a tooltip with offline time and the latest log message.
+- **Feed status indicators** – on the Status page, red or yellow dots display a tooltip with offline time and the latest log message.
 - **Camera type icons** – small symbols next to each feed name show whether the capture runs in a full browser, headless mode, or uses stealth.
 - **Chat modal controls** – the close icon and submit button now describe their actions.
 - **Help page tabs** – each tab button explains what information the section contains.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,7 +50,7 @@ This guide addresses common issues that users might encounter while using Glimps
 - Increase the refresh interval for less critical sources
 - Check the `MAX_WORKERS` setting and adjust if necessary
 - Increase `CRAWLER_STARTUP_SPREAD` to stagger camera startup more gently
-- Open the _System Status_ tab under Settings to watch CPU and memory usage in real time
+- Open the _Status_ tab under Settings to watch CPU and memory usage in real time
 
 ### Problem: Out of memory errors
 
@@ -187,7 +187,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 
 ## 9. Logging and Debugging Tips
 
-Glimpser writes logs to the console and exposes them via the _System Status_ tab. If something goes wrong:
+Glimpser writes logs to the console and exposes them via the _Status_ tab. If something goes wrong:
 
 - Use the **System Monitoring and Logs** guide to access live logs.
 - Increase the `LOG_LEVEL` or `FLASK_LOG_LEVEL` environment variable to `DEBUG` for more details.


### PR DESCRIPTION
## Summary
- rename System Status tab to Status
- rename Credentials & Management tab to Admin
- rename Integrations & Other tab to Advanced
- update docs and tooltips for new names

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6849d9b386f083338717efb33e267420