### PR TITLE
Add clip navigation controls

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -11,6 +11,32 @@
   overflow: hidden;
 }
 
+.clip-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0.25rem 0.5rem;
+  font-size: 1.5rem;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  cursor: pointer;
+  z-index: 5;
+}
+
+.clip-nav.prev {
+  left: 0.5rem;
+}
+
+.clip-nav.next {
+  right: 0.5rem;
+}
+
+.clip-nav:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .video-container.full-height {
   height: auto;
   max-height: 92vh;

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -11,16 +11,32 @@ template_form %} {% block content %}
   {% endif %}
 </script>
 
-<div
-  class="video-container full-height"
-  role="region"
-  aria-label="Live video feed"
->
-  <video
-    id="live-video"
-    controls
-    autoplay
-    muted
+  <div
+    class="video-container full-height"
+    role="region"
+    aria-label="Live video feed"
+  >
+  <button
+    id="prev-clip-btn"
+    class="clip-nav prev"
+    title="Previous clip"
+    aria-label="Previous clip"
+  >
+    &#9664;
+  </button>
+  <button
+    id="next-clip-btn"
+    class="clip-nav next"
+    title="Next clip"
+    aria-label="Next clip"
+  >
+    &#9654;
+  </button>
+    <video
+      id="live-video"
+      controls
+      autoplay
+      muted
     preload="none"
     poster="/last_screenshot/{{ template_name }}"
   >
@@ -516,4 +532,50 @@ template_form %} {% block content %}
     submit_label='Save', object_tokens=object_tokens, clip_model=clip_model ) }}
   </div>
 </div>
+
+<script>
+  window.recentVideos = {{ videos|tojson }};
+  document.addEventListener("DOMContentLoaded", () => {
+    const list = window.recentVideos || [];
+    if (!list.length) return;
+    let index = 0;
+    const video = document.getElementById("live-video");
+    const source = video?.querySelector("source");
+    const prev = document.getElementById("prev-clip-btn");
+    const next = document.getElementById("next-clip-btn");
+
+    const updateButtons = () => {
+      if (prev) prev.disabled = index <= 0;
+      if (next) next.disabled = index >= list.length - 1;
+    };
+
+    const loadClip = (i) => {
+      if (i < 0 || i >= list.length) return;
+      index = i;
+      const file = list[i];
+      if (source) source.src = `/videos/${window.currentCamera}/${file}`;
+      video.removeAttribute("data-hd-src");
+      video.load();
+      updateButtons();
+    };
+
+    prev?.addEventListener("click", () => loadClip(index - 1));
+    next?.addEventListener("click", () => loadClip(index + 1));
+
+    document.addEventListener("keydown", (e) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+      if (e.key === "ArrowLeft") {
+        loadClip(index - 1);
+      } else if (e.key === "ArrowRight") {
+        loadClip(index + 1);
+      }
+    });
+
+    updateButtons();
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add prev/next buttons to template player
- enable keyboard navigation between recent clips
- style new navigation buttons

## Testing
- `pre-commit run --files app/templates/template_details.html app/static/css/player.css`
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849dc0b1a3c83339ce706ec26ec9e2f