### PR TITLE
Add bounce feedback when clip fails

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2380,3 +2380,17 @@ details > summary {
 .loading-spinner.visible {
   display: block;
 }
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+.loading-spinner.bounce {
+  animation: bounce 0.6s infinite;
+}

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -1,3 +1,5 @@
+import { showBounce } from "./video.js";
+
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
@@ -17,7 +19,10 @@ export function initTilePlayer() {
     try {
       const res = await fetch(url, { signal: abortCtl.signal });
       clearTimeout(timer);
-      if (!res.ok) return;
+      if (!res.ok) {
+        showBounce(video);
+        return;
+      }
       const blob = await res.blob();
       const objUrl = URL.createObjectURL(blob);
       const pos = video.currentTime;
@@ -31,7 +36,7 @@ export function initTilePlayer() {
       if (source) source.src = objUrl;
       video.load();
     } catch (_) {
-      /* ignore */
+      showBounce(video);
     }
   }
 

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -38,6 +38,7 @@ const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "
 function showSpinner(video) {
   const spinner = video.parentElement?.querySelector(".loading-spinner");
   if (!spinner || spinner.dataset.active === "true") return;
+  spinner.classList.remove("bounce");
   let i = 0;
   spinner.textContent = spinnerFrames[i];
   spinner.classList.add("visible");
@@ -51,10 +52,19 @@ function showSpinner(video) {
 
 function hideSpinner(video) {
   const spinner = video.parentElement?.querySelector(".loading-spinner");
-  if (!spinner || spinner.dataset.active !== "true") return;
+  if (!spinner) return;
   clearInterval(Number(spinner.dataset.intervalId));
   spinner.dataset.active = "false";
   spinner.classList.remove("visible");
+  spinner.classList.remove("bounce");
+}
+
+export function showBounce(video) {
+  const spinner = video.parentElement?.querySelector(".loading-spinner");
+  if (!spinner) return;
+  clearInterval(Number(spinner.dataset.intervalId));
+  spinner.dataset.active = "false";
+  spinner.classList.add("visible", "bounce");
 }
 
 export function setQueueDelay(ms) {
@@ -81,7 +91,7 @@ function processQueue() {
     src.src = vid.dataset.hdSrc;
     vid.dataset.hdLoaded = "true";
     vid.addEventListener("canplay", () => hideSpinner(vid), { once: true });
-    vid.addEventListener("error", () => hideSpinner(vid), { once: true });
+    vid.addEventListener("error", () => showBounce(vid), { once: true });
     vid.load();
   }
   setTimeout(processQueue, queueDelay);

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -16,6 +16,7 @@ template_form %} {% block content %}
   role="region"
   aria-label="Live video feed"
 >
+  <div class="loading-spinner" aria-hidden="true"></div>
   <video
     id="live-video"
     controls

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -11,3 +11,5 @@ When system metrics exceed safe thresholds the `/clip` endpoint now falls
 back to `/last_video` immediately. The response includes an
 `X-Degraded-Service: busy` header and the spinner switches to a dotted
 pattern to indicate reduced quality.
+If the clip fails to load, the braille icon now bounces in place so you know the
+player is waiting for the higher quality video.

--- a/tests/js/loading_spinner.test.js
+++ b/tests/js/loading_spinner.test.js
@@ -10,10 +10,12 @@ document.body.innerHTML = `
 `;
 
 let enqueueClip;
+let showBounce;
 
 beforeAll(async () => {
   const mod = await import("../../app/static/js/video.js");
   enqueueClip = mod.enqueueClip;
+  showBounce = mod.showBounce;
 });
 
 jest.useFakeTimers();
@@ -28,4 +30,11 @@ test("spinner visible while clip loads", () => {
   expect(spinner.classList.contains("visible")).toBe(true);
   jest.runAllTimers();
   expect(spinner.classList.contains("visible")).toBe(false);
+});
+
+test("spinner bounces when clip fails", () => {
+  const video = document.querySelector("video");
+  const spinner = document.querySelector(".loading-spinner");
+  showBounce(video);
+  expect(spinner.classList.contains("bounce")).toBe(true);
 });

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -123,6 +123,10 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('<select id="groups"', components)
 
+    def test_template_details_has_spinner(self):
+        html = Path("app/templates/template_details.html").read_text(encoding="utf-8")
+        self.assertIn('class="loading-spinner"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- animate braille spinner with a bounce effect
- show bounce when HD clip fetch fails
- add spinner container to template details view
- document bounce behavior
- test updated spinner behavior

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6849db676c0c8333b2ab2f2f9b3d9e14