### PR TITLE
Fix live view group dropdown

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -52,3 +52,54 @@ export function initTilePlayer() {
 }
 
 document.addEventListener("DOMContentLoaded", initTilePlayer);
+
+export function updateCameraOptions(group) {
+  const camSelect = document.getElementById("camera-selector");
+  if (!camSelect) return;
+  camSelect.innerHTML = "";
+  if (!group || group === "all") {
+    camSelect.style.display = "none";
+    const opt = document.createElement("option");
+    opt.value = "All";
+    opt.textContent = "All";
+    camSelect.appendChild(opt);
+    camSelect.value = "All";
+    return;
+  }
+  camSelect.style.display = "";
+  const groupOpt = document.createElement("option");
+  groupOpt.value = `group-${group}`;
+  groupOpt.textContent = `Group: ${group}`;
+  camSelect.appendChild(groupOpt);
+  Object.entries(window.templateDetails || {})
+    .filter(
+      ([, det]) =>
+        det.groups &&
+        det.groups
+          .split(",")
+          .map((s) => s.trim())
+          .includes(group),
+    )
+    .map(([cam]) => cam)
+    .sort()
+    .forEach((cam) => {
+      const opt = document.createElement("option");
+      opt.value = cam;
+      opt.textContent = cam;
+      camSelect.appendChild(opt);
+    });
+  camSelect.value = `group-${group}`;
+}
+
+export function changeGroup() {
+  const groupSelector = document.getElementById("group-selector");
+  const group = groupSelector ? groupSelector.value : "all";
+  const navGroup = document.getElementById("nav-group-dropdown");
+  if (navGroup) navGroup.value = group;
+  updateCameraOptions(group);
+  const camSelect = document.getElementById("camera-selector");
+  if (camSelect) camSelect.dispatchEvent(new Event("change"));
+}
+
+window.changeGroup = changeGroup;
+window.updateCameraOptions = updateCameraOptions;

--- a/tests/js/nav_group.test.js
+++ b/tests/js/nav_group.test.js
@@ -3,6 +3,7 @@ import { jest } from "@jest/globals";
 document.body.innerHTML = `
   <select id="nav-group-dropdown"></select>
   <select id="nav-camera-dropdown"></select>
+  <select id="group-selector"></select>
   <nav></nav>
 `;
 
@@ -49,5 +50,15 @@ describe("nav group dropdown", () => {
     dd.value = "all";
     dd.dispatchEvent(new Event("change"));
     expect(window.location.href).toBe("/live");
+  });
+
+  test("live page uses changeGroup", () => {
+    window.changeGroup = jest.fn();
+    const dd = setup();
+    window.location.pathname = "/live";
+    dd.value = "kitchen";
+    dd.dispatchEvent(new Event("change"));
+    expect(window.changeGroup).toHaveBeenCalled();
+    expect(window.location.href).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- enable group switching on live view
- test nav group dropdown behavior on live page

## Testing
- `pre-commit run --files app/static/js/tile_player.js tests/js/nav_group.test.js`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849df5f2cdc8333865a07b8d22ff65f