### PR TITLE
Add bouncing icon when clip pending

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2912,7 +2912,9 @@ def init_routes(app: Flask) -> None:
             return send_file(path, conditional=True)
         except FileNotFoundError:
             logging.warning("Missing clip %s; using last_video", template)
-            return serve_video(template)
+            resp = serve_video(template)
+            resp.headers["X-Clip-Status"] = "waiting"
+            return resp
 
     def _system_is_busy() -> bool:
         """Return ``True`` when system metrics exceed safe thresholds."""

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2380,3 +2380,17 @@ details > summary {
 .loading-spinner.visible {
   display: block;
 }
+
+@keyframes bounce-ball {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.loading-spinner.bouncy {
+  animation: bounce-ball 0.6s ease-in-out infinite;
+}

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -1,3 +1,5 @@
+import { showSpinner, hideSpinner } from "./video.js";
+
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
@@ -8,6 +10,26 @@ export function initTilePlayer() {
 
   let abortCtl;
 
+  const container = video.parentElement;
+  let spinner = container?.querySelector(".loading-spinner");
+  if (!spinner && container) {
+    spinner = document.createElement("div");
+    spinner.className = "loading-spinner";
+    spinner.setAttribute("aria-hidden", "true");
+    container.appendChild(spinner);
+  }
+
+  function showBounce() {
+    if (!spinner) return;
+    spinner.textContent = "\u25CF";
+    spinner.classList.add("bouncy", "visible");
+  }
+
+  function hideBounce() {
+    if (!spinner) return;
+    spinner.classList.remove("bouncy", "visible");
+  }
+
   async function loadHdClip() {
     const url = video.dataset.hdSrc;
     if (!url) return;
@@ -15,13 +37,21 @@ export function initTilePlayer() {
     abortCtl = new AbortController();
     const timer = setTimeout(() => abortCtl.abort(), 10000);
     try {
+      showSpinner(video);
       const res = await fetch(url, { signal: abortCtl.signal });
       clearTimeout(timer);
+      hideSpinner(video);
       if (!res.ok) return;
       const blob = await res.blob();
       const objUrl = URL.createObjectURL(blob);
       const pos = video.currentTime;
       const paused = video.paused;
+      if (res.headers.get("X-Clip-Status") === "waiting") {
+        showBounce();
+        const onHide = () => hideBounce();
+        video.addEventListener("canplay", onHide, { once: true });
+        video.addEventListener("error", onHide, { once: true });
+      }
       const onLoad = () => {
         video.currentTime = Math.min(pos, video.duration || pos);
         if (!paused) video.play().catch(() => {});
@@ -31,7 +61,8 @@ export function initTilePlayer() {
       if (source) source.src = objUrl;
       video.load();
     } catch (_) {
-      /* ignore */
+      hideSpinner(video);
+      hideBounce();
     }
   }
 
@@ -41,6 +72,7 @@ export function initTilePlayer() {
     if (source) source.src = `/last_video/${name}`;
     video.setAttribute("data-hd-src", `/clip/${name}`);
     video.load();
+    hideBounce();
     loadHdClip();
   }
 

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -521,3 +521,4 @@ export function startCasting() {
 // expose queue functions for other modules
 window.enqueueClip = enqueueClip;
 window.setQueueDelay = setQueueDelay;
+export { showSpinner, hideSpinner };

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -11,3 +11,7 @@ When system metrics exceed safe thresholds the `/clip` endpoint now falls
 back to `/last_video` immediately. The response includes an
 `X-Degraded-Service: busy` header and the spinner switches to a dotted
 pattern to indicate reduced quality.
+
+If `/clip` hasn't finished rendering yet the server adds an
+`X-Clip-Status: waiting` header. The braille glyph becomes a bouncing dot in the
+corner so you know the HD version is still processing.


### PR DESCRIPTION
## Summary
- show `X-Clip-Status: waiting` header when clip fallback occurs
- animate a bouncing dot for pending clips
- expose spinner helpers
- document new pending indicator

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849e55aa73c83339750791bd0631f05