### PR TITLE
Improve clip navigation

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -22,6 +22,18 @@
   border: none;
   cursor: pointer;
   z-index: 5;
+  transition:
+    background 0.2s,
+    transform 0.2s;
+}
+
+.clip-nav.clicked {
+  transform: translateY(-50%) scale(0.9);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.clip-nav.go-live {
+  background: rgba(0, 128, 0, 0.6);
 }
 
 .clip-nav.prev {

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -11,11 +11,11 @@ template_form %} {% block content %}
   {% endif %}
 </script>
 
-  <div
-    class="video-container full-height"
-    role="region"
-    aria-label="Live video feed"
-  >
+<div
+  class="video-container full-height"
+  role="region"
+  aria-label="Live video feed"
+>
   <button
     id="prev-clip-btn"
     class="clip-nav prev"
@@ -32,11 +32,11 @@ template_form %} {% block content %}
   >
     &#9654;
   </button>
-    <video
-      id="live-video"
-      controls
-      autoplay
-      muted
+  <video
+    id="live-video"
+    controls
+    autoplay
+    muted
     preload="none"
     poster="/last_screenshot/{{ template_name }}"
   >
@@ -536,7 +536,8 @@ template_form %} {% block content %}
 <script>
   window.recentVideos = {{ videos|tojson }};
   document.addEventListener("DOMContentLoaded", () => {
-    const list = window.recentVideos || [];
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
+    const list = (window.recentVideos || []).sort((a, b) => collator.compare(b, a));
     if (!list.length) return;
     let index = 0;
     const video = document.getElementById("live-video");
@@ -546,7 +547,17 @@ template_form %} {% block content %}
 
     const updateButtons = () => {
       if (prev) prev.disabled = index <= 0;
-      if (next) next.disabled = index >= list.length - 1;
+      if (next) {
+        if (index >= list.length - 1) {
+          next.classList.add("go-live");
+          next.textContent = "Live";
+          next.disabled = false;
+        } else {
+          next.classList.remove("go-live");
+          next.textContent = "\u25B6";
+          next.disabled = false;
+        }
+      }
     };
 
     const loadClip = (i) => {
@@ -559,8 +570,23 @@ template_form %} {% block content %}
       updateButtons();
     };
 
-    prev?.addEventListener("click", () => loadClip(index - 1));
-    next?.addEventListener("click", () => loadClip(index + 1));
+    const flash = (btn) => {
+      btn.classList.add("clicked");
+      setTimeout(() => btn.classList.remove("clicked"), 150);
+    };
+
+    prev?.addEventListener("click", () => {
+      flash(prev);
+      loadClip(index - 1);
+    });
+    next?.addEventListener("click", () => {
+      flash(next);
+      if (index >= list.length - 1) {
+        window.location.href = `/live?camera=${window.currentCamera}`;
+      } else {
+        loadClip(index + 1);
+      }
+    });
 
     document.addEventListener("keydown", (e) => {
       if (
@@ -571,7 +597,11 @@ template_form %} {% block content %}
       if (e.key === "ArrowLeft") {
         loadClip(index - 1);
       } else if (e.key === "ArrowRight") {
-        loadClip(index + 1);
+        if (index >= list.length - 1) {
+          window.location.href = `/live?camera=${window.currentCamera}`;
+        } else {
+          loadClip(index + 1);
+        }
       }
     });
 

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 from datetime import datetime
 
@@ -32,7 +33,9 @@ def is_snapshot_url(url: str) -> bool:
     if not url:
         return False
     url = url.lower()
-    return url.endswith((".jpg", ".jpeg", ".png")) or "snapshot" in url or "picture" in url
+    return (
+        url.endswith((".jpg", ".jpeg", ".png")) or "snapshot" in url or "picture" in url
+    )
 
 
 class Template(db.Base):
@@ -161,7 +164,11 @@ class TemplateManager:
 
         session = self.get_session()
         try:
-            templates = session.query(Template).order_by(Template.last_caption_time.desc()).all()
+            templates = (
+                session.query(Template)
+                .order_by(Template.last_caption_time.desc())
+                .all()
+            )
             result = []
             for template in templates:
                 if template.name is None or template.name == "":
@@ -233,17 +240,29 @@ class TemplateManager:
                             value = int(value)
                         elif key in ["frequency", "timeout"]:
                             if value == "":
-                                value = default_frequency if key == "frequency" else default_timeout
+                                value = (
+                                    default_frequency
+                                    if key == "frequency"
+                                    else default_timeout
+                                )
 
                             value = int(value)
                             if key == "frequency" and value > 525600:
                                 value = 525600
-                            if key == "frequency" and value < 0.01:  # that's less than 1 fps...
+                            if (
+                                key == "frequency" and value < 0.01
+                            ):  # that's less than 1 fps...
                                 value = 0.01
 
-                            if key == "timeout" and value >= float(details.get("frequency", template.frequency)) * 60:
+                            if (
+                                key == "timeout"
+                                and value
+                                >= float(details.get("frequency", template.frequency))
+                                * 60
+                            ):
                                 value = (
-                                    int(details.get("frequency", template.frequency)) * 60
+                                    int(details.get("frequency", template.frequency))
+                                    * 60
                                 )  # adjust the timeout down
                             if key == "timeout" and value < 1:
                                 value = 1
@@ -252,8 +271,12 @@ class TemplateManager:
                             if value == "":
                                 value = 0.5
                             value = float(value)
-                            if details.get("object_filter", template.object_filter) and (value < 0 or value > 1):
-                                raise ValueError("Object confidence must be between 0 and 1")
+                            if details.get(
+                                "object_filter", template.object_filter
+                            ) and (value < 0 or value > 1):
+                                raise ValueError(
+                                    "Object confidence must be between 0 and 1"
+                                )
                         elif key in ["popup_xpath", "dedicated_xpath"]:
                             if value and not value.startswith("//"):
                                 raise ValueError(f"{key} must start with '//'")
@@ -514,13 +537,18 @@ def get_screenshots_for_template(name: str) -> list:
     screenshots = [
         f
         for f in os.listdir(os.path.join(SCREENSHOT_DIRECTORY, name))
-        if f.startswith(name) and f.endswith(".png") and ".tmp" not in f and ".partial" not in f
+        if f.startswith(name)
+        and f.endswith(".png")
+        and ".tmp" not in f
+        and ".partial" not in f
     ]
 
     try:
         sorted_screenshots = sorted(
             screenshots,
-            key=lambda x: datetime.strptime(x[len(name) + 1 : -4].replace("_blank", ""), "%Y%m%d%H%M%S"),
+            key=lambda x: datetime.strptime(
+                x[len(name) + 1 : -4].replace("_blank", ""), "%Y%m%d%H%M%S"
+            ),
             reverse=True,
         )
     except Exception as e:
@@ -554,10 +582,12 @@ def get_videos_for_template(name: str):
         for f in os.listdir(os.path.join(VIDEO_DIRECTORY, name))
         if (f.startswith(name) or f.startswith("final_")) and f.endswith(".mp4")
     ]
-    sorted_videos = sorted(
-        videos,
-        reverse=True,
-    )
+
+    def _sort_key(filename: str) -> int:
+        match = re.search(r"(\d+)(?=\.mp4$)", filename)
+        return int(match.group(1)) if match else -1
+
+    sorted_videos = sorted(videos, key=_sort_key, reverse=True)
     return sorted_videos[:10]
 
 
@@ -669,7 +699,9 @@ def record_llm_usage(name: str, tokens: int) -> None:
     elif not isinstance(entry, dict):
         entry = {"total": 0, "entries": []}
 
-    entry["entries"].append({"time": datetime.utcnow().strftime("%Y-%m-%d"), "tokens": int(tokens)})
+    entry["entries"].append(
+        {"time": datetime.utcnow().strftime("%Y-%m-%d"), "tokens": int(tokens)}
+    )
     entry["total"] += int(tokens)
     data[name] = entry
 
@@ -712,7 +744,9 @@ def get_llm_response_count(name: str) -> int:
     return 0
 
 
-def get_llm_cost_estimate(name: str, start_date: str | None = None, end_date: str | None = None) -> str:
+def get_llm_cost_estimate(
+    name: str, start_date: str | None = None, end_date: str | None = None
+) -> str:
     """Estimate LLM cost for ``name`` within an optional date range."""
 
     name = validate_template_name(name)
@@ -811,7 +845,9 @@ def update_last_screenshot_time(name: str) -> None:
     try:
         template = session.query(Template).filter_by(name=name).first()
         if template:
-            template.last_screenshot_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+            template.last_screenshot_time = datetime.utcnow().strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
             template.offline_since = ""
             template.capture_failed = False
             session.commit()

--- a/docs/clip_navigation.md
+++ b/docs/clip_navigation.md
@@ -1,0 +1,3 @@
+# Clip Navigation
+
+The player on the template details page now orders clips chronologically. The next button shows **Live** on the last clip and links to `/live?camera=<name>`. Buttons briefly change color when clicked so it's clear the action registered.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - Jog-Shuttle Control: jog_shuttle.md
       - Live All Playback: live_all.md
       - Live View Scrubbing: live_scrub.md
+      - Clip Navigation: clip_navigation.md
       - LLM Prompt Settings: llm_prompts.md
       - MCP Integration: mcp_integration.md
       - In-App Onboarding: onboarding.md

--- a/tests/test_get_videos_for_template.py
+++ b/tests/test_get_videos_for_template.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.template_manager import get_videos_for_template
+
+
+class TestGetVideosForTemplate(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = "test_sort_videos"
+        self.base = os.path.join(self.test_dir, "cam1")
+        os.makedirs(self.base, exist_ok=True)
+        self.patch = patch("app.utils.template_manager.VIDEO_DIRECTORY", self.test_dir)
+        self.patch.start()
+        open(os.path.join(self.base, "final_1.mp4"), "wb").close()
+        open(os.path.join(self.base, "final_10.mp4"), "wb").close()
+        open(os.path.join(self.base, "final_2.mp4"), "wb").close()
+
+    def tearDown(self):
+        self.patch.stop()
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_numeric_sort_descending(self):
+        videos = get_videos_for_template("cam1")
+        self.assertEqual(videos, ["final_10.mp4", "final_2.mp4", "final_1.mp4"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sort video filenames numerically
- show flash on clip nav buttons
- add a live navigation state at the end
- document clip navigation
- test numeric sort for videos

## Testing
- `pre-commit run --files app/utils/template_manager.py tests/test_get_videos_for_template.py app/templates/template_details.html app/static/css/player.css docs/clip_navigation.md mkdocs.yml`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f2ed106c8333971ecd3eaadea4dc