### PR TITLE
Remove in-page group selector

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -101,7 +101,6 @@ let jogSpeed = 1;
 let jogDirection = 1;
 let jogging = false;
 let isSeeking = false;
-const groupSelector = document.getElementById("group-selector");
 // Track whether template details are shown. Expose on window so inline
 // scripts and other modules can share this state.
 window.detailsVisible = false;
@@ -148,12 +147,14 @@ function updateCameraOptions(group) {
   camSelect.value = `group-${group}`;
 }
 
-function changeGroup() {
-  const group = groupSelector ? groupSelector.value : "all";
+function changeGroup(group) {
   const navGroup = document.getElementById("nav-group-dropdown");
+  if (!group) {
+    group = navGroup ? navGroup.value : "all";
+  }
   if (navGroup) navGroup.value = group;
   updateCameraOptions(group);
-  changeCamera();
+  changeCamera(group === "all" ? "All" : `group-${group}`);
 }
 
 // Restore previously selected camera, source and speed from localStorage so
@@ -171,13 +172,6 @@ function loadSavedPreferences() {
     ) {
       currentCamera = savedCam;
       camSelect.value = savedCam;
-      if (groupSelector) {
-        if (savedCam === "All") {
-          groupSelector.value = "all";
-        } else if (savedCam.startsWith("group-")) {
-          groupSelector.value = savedCam.split("group-")[1];
-        }
-      }
     }
     if (navGroup) {
       if (currentCamera === "All") {
@@ -185,8 +179,8 @@ function loadSavedPreferences() {
       } else if (currentCamera.startsWith("group-")) {
         navGroup.value = currentCamera.split("group-")[1];
       }
+      updateCameraOptions(navGroup.value);
     }
-    if (groupSelector) updateCameraOptions(groupSelector.value);
   }
 
   const sourceSelect = document.getElementById("video-source");
@@ -389,10 +383,21 @@ image.addEventListener("error", () => {
   }, 2000);
 });
 
-function changeCamera() {
+function changeCamera(selectedValue) {
   showLoadingIndicator();
-  const cameraSelector = document.getElementById("camera-selector");
-  const selectedValue = cameraSelector.value;
+  if (!selectedValue) {
+    const cameraSelector = document.getElementById("camera-selector");
+    if (cameraSelector) {
+      selectedValue = cameraSelector.value;
+    } else {
+      const navGroup = document.getElementById("nav-group-dropdown");
+      if (navGroup && navGroup.value !== "all") {
+        selectedValue = `group-${navGroup.value}`;
+      } else {
+        selectedValue = "All";
+      }
+    }
+  }
   // Check if the camera is connected
   let isConnected = checkCameraConnection(currentCamera);
 
@@ -441,13 +446,6 @@ function changeCamera() {
       navGroup.value = selectedValue.split("group-")[1];
     } else {
       navGroup.value = "";
-    }
-  }
-  if (groupSelector) {
-    if (selectedValue === "All") {
-      groupSelector.value = "all";
-    } else if (selectedValue.startsWith("group-")) {
-      groupSelector.value = selectedValue.split("group-")[1];
     }
   }
 
@@ -1380,6 +1378,8 @@ window.selectPreviousCamera = selectPreviousCamera;
 window.selectNextSource = selectNextSource;
 window.selectPreviousSource = selectPreviousSource;
 window.togglePlayback = togglePlayback;
+window.changeGroup = changeGroup;
+window.updateCameraOptions = updateCameraOptions;
 
 if (playButton) {
   playButton.addEventListener("click", togglePlayback);

--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -62,12 +62,8 @@ export function initNav() {
           if (cameraDropdown && currentCamera) {
             cameraDropdown.value = currentCamera;
           }
-          const grpSelector = document.getElementById("group-selector");
-          if (grpSelector) {
-            grpSelector.value = currentGroup;
-            if (typeof window.updateCameraOptions === "function") {
-              window.updateCameraOptions(currentGroup);
-            }
+          if (typeof window.updateCameraOptions === "function") {
+            window.updateCameraOptions(currentGroup);
           }
         }
       } catch (error) {
@@ -122,13 +118,9 @@ export function initNav() {
           window.location.pathname.startsWith("/live") &&
           typeof window.changeGroup === "function"
         ) {
-          const grpSelector = document.getElementById("group-selector");
-          if (grpSelector) {
-            grpSelector.value = selected;
-            window.changeGroup();
-            loadNavCameras(selected);
-            return;
-          }
+          window.changeGroup(selected);
+          loadNavCameras(selected);
+          return;
         }
         if (selected === "all") {
           window.location.href = "/live";

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -123,10 +123,11 @@ export function updateCameraOptions(group) {
   camSelect.value = `group-${group}`;
 }
 
-export function changeGroup() {
-  const groupSelector = document.getElementById("group-selector");
-  const group = groupSelector ? groupSelector.value : "all";
+export function changeGroup(group) {
   const navGroup = document.getElementById("nav-group-dropdown");
+  if (!group) {
+    group = navGroup ? navGroup.value : "all";
+  }
   if (navGroup) navGroup.value = group;
   updateCameraOptions(group);
   const camSelect = document.getElementById("camera-selector");

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -20,26 +20,6 @@
   </video>
 </div>
 
-<select id="group-selector" onchange="changeGroup()">
-  <option value="all" title="View all groups">All</option>
-  {% set all_groups = [] %} {% for camera, details in template_details.items()
-  %} {% if details.groups %} {% for group in details.groups.split(',') %} {% if
-  group %} {% set _ = all_groups.append(group|trim) %} {% endif %} {% endfor %}
-  {% endif %} {% endfor %} {% for group in all_groups|unique|sort %}
-  <option value="{{ group }}" title="View group {{ group }}">
-    {{ group }}
-  </option>
-  {% endfor %}
-</select>
-
-<select id="camera-selector" onchange="changeCamera()" class="hidden">
-  {% for camera in template_details.keys()|sort %}
-  <option value="{{ camera }}" title="View camera {{ camera }}">
-    Camera: {{ camera }}
-  </option>
-  {% endfor %}
-</select>
-
 <script
   type="module"
   src="{{ url_for('static', filename='js/tile_player.js') }}"

--- a/tests/js/clip_throttle.test.js
+++ b/tests/js/clip_throttle.test.js
@@ -22,7 +22,6 @@ document.body.innerHTML = `
   <div id="toggle-details"></div>
   <input id="seek-bar" />
   <div id="jog-shuttle"></div>
-  <select id="group-selector"></select>
   <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
 `;
 

--- a/tests/js/get_camera_names.test.js
+++ b/tests/js/get_camera_names.test.js
@@ -22,8 +22,6 @@ document.body.innerHTML = `
   <input id="seek-bar" />
   <div id="jog-shuttle"></div>
   <select id="video-source"><option value="mjpg">MJPG</option></select>
-  <select id="camera-selector"></select>
-  <select id="group-selector"></select>
 `;
 
 window.templateDetails = {
@@ -33,26 +31,16 @@ window.templateDetails = {
 
 describe("getCameraNames", () => {
   let getCameraNames;
-  let changeCamera;
+  let changeGroup;
   beforeAll(async () => {
     const mod = await import("../../app/static/js/live.js");
     getCameraNames = mod.getCameraNames;
-    changeCamera = window.changeCamera;
+    changeGroup = window.changeGroup;
   });
 
   test("filters out group entries", () => {
-    const selector = document.getElementById("camera-selector");
-    selector.innerHTML = `
-      <option value="All">All</option>
-      <option value="group-test">group-test</option>
-      <option value="cam1">cam1</option>
-      <option value="cam2">cam2</option>
-    `;
-    selector.value = "group-test";
-    changeCamera();
-
-    selector.value = "All";
-    changeCamera();
+    changeGroup("test");
+    changeGroup("all");
 
     expect(getCameraNames()).toEqual(["cam1", "cam2"]);
     expect(window.templateDetails["All"].groupCameras).toEqual([

--- a/tests/js/live_tooltip.test.js
+++ b/tests/js/live_tooltip.test.js
@@ -22,7 +22,6 @@ document.body.innerHTML = `
   <div id="toggle-details"></div>
   <input id="seek-bar">
   <div id="jog-shuttle"></div>
-  <select id="group-selector"></select>
   <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
 `;
 Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {

--- a/tests/js/nav_group.test.js
+++ b/tests/js/nav_group.test.js
@@ -3,7 +3,6 @@ import { jest } from "@jest/globals";
 document.body.innerHTML = `
   <select id="nav-group-dropdown"></select>
   <select id="nav-camera-dropdown"></select>
-  <select id="group-selector"></select>
   <nav></nav>
 `;
 

--- a/tests/js/network_reconnect.test.js
+++ b/tests/js/network_reconnect.test.js
@@ -22,7 +22,6 @@ document.body.innerHTML = `
   <div id="toggle-details"></div>
   <input id="seek-bar" />
   <div id="jog-shuttle"></div>
-  <select id="group-selector"></select>
   <select id="video-source"><option value="mjpg" selected>MJPG</option></select>
 `;
 

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -2,10 +2,6 @@ import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
   <video id="live-video"><source></source></video>
-  <select id="camera-selector">
-    <option value="cam1">cam1</option>
-    <option value="cam2">cam2</option>
-  </select>
 `;
 
 window.templateDetails = { cam1: {}, cam2: {} };

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -173,8 +173,6 @@ def test_login_and_redirect(live_server_with_user, browser):
     browser.find_element(By.ID, "search-input")
     browser.get(f"{live_server_with_user}/live")
     video = browser.find_element(By.ID, "live-video")
-    selector = browser.find_element(By.ID, "camera-selector")
     slider = browser.find_element(By.ID, "speed-slider")
     assert video is not None
-    assert selector is not None
     assert slider is not None


### PR DESCRIPTION
## Summary
- drop group dropdown from live view
- update JS modules to read group from the nav menu
- simplify tests now that the select element is gone

## Testing
- `pre-commit run --files app/static/js/live.js app/static/js/nav.js app/static/js/tile_player.js app/templates/live.html tests/js/clip_throttle.test.js tests/js/get_camera_names.test.js tests/js/live_tooltip.test.js tests/js/nav_group.test.js tests/js/network_reconnect.test.js`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684a4bf9dd088333bf3941d9496b6851