### PR TITLE
Limit cost tab to top templates

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3640,6 +3640,7 @@ def init_routes(app: Flask) -> None:
         last_summary = scheduling.get_last_summary_time()
         danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
         cost_summary, total_tokens, total_cost = template_manager.get_llm_cost_summary()
+        cost_summary = template_manager.group_cost_summary(cost_summary, top=10)
 
         chrome_path = get_chrome_path()
         danger_info = {

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -1,7 +1,9 @@
 import { setupTableSorting } from "./templates.js";
 
 export function groupSmallValues(rows, limit = 15) {
-  if (rows.length <= limit) return rows;
+  if (limit <= 0 || rows.length <= limit) {
+    return [...rows].sort((a, b) => b.cost - a.cost);
+  }
   const sorted = [...rows].sort((a, b) => a.cost - b.cost);
   const bottom = sorted.slice(0, limit);
   const other = bottom.reduce(
@@ -27,14 +29,16 @@ export function initCosts() {
     let chart;
 
     const render = (rows) => {
+      const limit = rows.length > 10 ? rows.length - 9 : 0;
+      const grouped =
+        limit > 0 ? groupSmallValues(rows, limit) : groupSmallValues(rows, 0);
       tbody.innerHTML = "";
-      for (const row of rows) {
+      for (const row of grouped) {
         const tr = document.createElement("tr");
         tr.innerHTML = `<td>${row.name}</td><td data-value="${row.tokens}">${row.tokens}</td><td data-value="${row.cost}">$${row.cost.toFixed(2)}</td>`;
         tbody.appendChild(tr);
       }
       if (!ctx) return;
-      const grouped = groupSmallValues(rows);
       const labels = grouped.map((r) => r.name);
       const values = grouped.map((r) => r.cost);
       const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -834,6 +834,28 @@ def get_llm_cost_summary(
     return summary, total_tokens, f"${total_cost:.3f}"
 
 
+def group_cost_summary(
+    summary: list[dict[str, object]], top: int = 10
+) -> list[dict[str, object]]:
+    """Return ``summary`` sorted by cost with smaller entries grouped."""
+
+    def _cost_val(entry: dict[str, object]) -> float:
+        try:
+            return float(str(entry.get("cost", "$0")).replace("$", ""))
+        except Exception:
+            return 0.0
+
+    rows = sorted(summary, key=_cost_val, reverse=True)
+    if len(rows) <= top:
+        return rows
+
+    keep = rows[: top - 1]
+    other_tokens = sum(r.get("tokens", 0) for r in rows[top - 1 :])
+    other_cost = sum(_cost_val(r) for r in rows[top - 1 :])
+    keep.append({"name": "Other", "tokens": other_tokens, "cost": f"${other_cost:.3f}"})
+    return keep
+
+
 def update_last_screenshot_time(name: str) -> None:
     """Set ``last_screenshot_time`` to now and clear ``offline_since``."""
     name = validate_template_name(name)

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -8,6 +8,10 @@ An overall cost summary now appears under **Settings → Costs**. This tab now
 includes a small pie chart and sortable columns. Adjust the date range with the
 slider to view recent spending.
 
+The Settings cost tab shows only the nine most expensive templates when more
+than ten cameras are present. All remaining templates are combined into a
+single **Other** row to keep the table manageable.
+
 An additional **LLM Cost Summary** page now provides a date range picker to
 review costs for a specific period. Use the **Since Last Restart** shortcut to
 fill the start date with the server start time. A pie chart shows how costs are

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -52,3 +52,14 @@ test("groups bottom rows", () => {
   expect(other.name).toBe("Other");
   expect(other.cost).toBeGreaterThan(0);
 });
+
+test("limits to top 10 rows", () => {
+  const rows = Array.from({ length: 12 }, (_, i) => ({
+    name: `cam${i}`,
+    tokens: 1,
+    cost: i + 1,
+  }));
+  const grouped = groupSmallValues(rows, rows.length - 9);
+  expect(grouped.length).toBe(10);
+  expect(grouped[grouped.length - 1].name).toBe("Other");
+});

--- a/tests/test_llm_cost_summary.py
+++ b/tests/test_llm_cost_summary.py
@@ -6,6 +6,7 @@ from app.utils.template_manager import (
     LLM_COST_PER_TOKEN,
     LLM_USAGE_PATH,
     get_llm_cost_summary,
+    group_cost_summary,
 )
 
 
@@ -26,6 +27,14 @@ class TestLLMCostSummary(unittest.TestCase):
         expected_cost = round(2000 * LLM_COST_PER_TOKEN, 3)
         self.assertEqual(cost, f"${expected_cost:.3f}")
         self.assertEqual(len(summary), 2)
+
+    def test_group_cost_summary(self):
+        summary = [
+            {"name": f"cam{i}", "tokens": i, "cost": f"${i:.3f}"} for i in range(1, 12)
+        ]
+        grouped = group_cost_summary(summary, top=10)
+        self.assertEqual(len(grouped), 10)
+        self.assertEqual(grouped[-1]["name"], "Other")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- group cost data so the settings page shows only the top 9 entries plus **Other**
- update settings route and JavaScript to use grouped data
- document the new limit in `cost_tracking.md`
- add unit tests for the grouping helpers

## Testing
- `pre-commit run --all-files` *(fails: files were reformatted)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a4e53fb4c8333a6affd929e87e08a