### PR TITLE
Improve add camera template usability

### DIFF
--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -122,6 +122,11 @@
     </table>
   </div>
   {% endcall %} {% call card('Add Camera') %}
+  <p class="form-help">
+    Enter the camera or dashboard URL and tab out of the field to verify it
+    works. The live preview updates automatically. Expand
+    <em>Advanced Options</em> to configure XPaths, callbacks and credentials.
+  </p>
   <div class="wizard-step" title="Form to add a new camera">
     {{ template_form( 'add-template-form', '/templates',
     preview_src='/test_pattern.mjpg?pattern=geometric',

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -198,221 +198,224 @@ object_tokens=None, clip_model=None) -%}
 {{ template.notes if template else '' }}</textarea
       >
     </div>
-    <div class="form-row">
-      <label
-        for="object_filter"
-        title="Filter for specific objects using {{ clip_model }}"
-        >Object Filter:</label
-      >
-      <input
-        type="text"
-        id="object_filter"
-        name="object_filter"
-        value="{{ template.object_filter if template else '' }}"
-        placeholder="person,car"
-        list="object-filter-options"
-        title="Enter object types to filter (e.g., 'person,car')"
-      />
-      <datalist id="object-filter-options">
-        {% for token in object_tokens or [] %}
-        <option value="{{ token }}"></option>
-        {% endfor %}
-      </datalist>
-    </div>
-    <div class="form-row">
-      <label
-        for="object_confidence"
-        title="Minimum confidence for object detection"
-        >Object Confidence:</label
-      >
-      <input
-        type="number"
-        id="object_confidence"
-        name="object_confidence"
-        class="short-input"
-        value="{{ template.object_confidence if template else '' }}"
-        min="0"
-        max="1"
-        step="0.01"
-        placeholder="0.5"
-        title="Enter the minimum confidence level for object detection (0-1)"
-      />
-    </div>
-    <div class="form-row">
-      <label for="popup_xpath">Popup XPath:</label>
-      <div class="xpath-input-container">
+    <details class="advanced-settings">
+      <summary title="Show additional fields">Advanced Options</summary>
+      <div class="form-row">
+        <label
+          for="object_filter"
+          title="Filter for specific objects using {{ clip_model }}"
+          >Object Filter:</label
+        >
         <input
           type="text"
-          id="popup_xpath"
-          name="popup_xpath"
-          value="{{ template.popup_xpath if template else '' }}"
+          id="object_filter"
+          name="object_filter"
+          value="{{ template.object_filter if template else '' }}"
+          placeholder="person,car"
+          list="object-filter-options"
+          title="Enter object types to filter (e.g., 'person,car')"
         />
-        <button
-          type="button"
-          onclick="showStructuredInput('popup_xpath')"
-          title="Open structured XPath editor"
-        >
-          Structured
-        </button>
+        <datalist id="object-filter-options">
+          {% for token in object_tokens or [] %}
+          <option value="{{ token }}"></option>
+          {% endfor %}
+        </datalist>
       </div>
-    </div>
-    <div class="form-row">
-      <label for="dedicated_xpath">Dedicated XPath:</label>
-      <div class="xpath-input-container">
+      <div class="form-row">
+        <label
+          for="object_confidence"
+          title="Minimum confidence for object detection"
+          >Object Confidence:</label
+        >
+        <input
+          type="number"
+          id="object_confidence"
+          name="object_confidence"
+          class="short-input"
+          value="{{ template.object_confidence if template else '' }}"
+          min="0"
+          max="1"
+          step="0.01"
+          placeholder="0.5"
+          title="Enter the minimum confidence level for object detection (0-1)"
+        />
+      </div>
+      <div class="form-row">
+        <label for="popup_xpath">Popup XPath:</label>
+        <div class="xpath-input-container">
+          <input
+            type="text"
+            id="popup_xpath"
+            name="popup_xpath"
+            value="{{ template.popup_xpath if template else '' }}"
+          />
+          <button
+            type="button"
+            onclick="showStructuredInput('popup_xpath')"
+            title="Open structured XPath editor"
+          >
+            Structured
+          </button>
+        </div>
+      </div>
+      <div class="form-row">
+        <label for="dedicated_xpath">Dedicated XPath:</label>
+        <div class="xpath-input-container">
+          <input
+            type="text"
+            id="dedicated_xpath"
+            name="dedicated_xpath"
+            value="{{ template.dedicated_xpath if template else '' }}"
+          />
+          <button
+            type="button"
+            onclick="showStructuredInput('dedicated_xpath')"
+            title="Open structured XPath editor"
+          >
+            Structured
+          </button>
+        </div>
+      </div>
+      <div class="form-row">
+        <label for="callback_url" title="URL for notifications"
+          >Callback URL:</label
+        >
+        <input
+          type="url"
+          id="callback_url"
+          name="callback_url"
+          value="{{ template.callback_url if template else '' }}"
+          placeholder="https://example.com/callback"
+          title="Enter URL to receive notifications"
+        />
+      </div>
+      <div class="form-row">
+        <label for="proxy" title="Proxy server address">Proxy:</label>
         <input
           type="text"
-          id="dedicated_xpath"
-          name="dedicated_xpath"
-          value="{{ template.dedicated_xpath if template else '' }}"
+          id="proxy"
+          name="proxy"
+          value="{{ template.proxy if template else '' }}"
+          placeholder="proxy.example.com:8080"
+          title="Enter proxy server address (optional)"
         />
-        <button
-          type="button"
-          onclick="showStructuredInput('dedicated_xpath')"
-          title="Open structured XPath editor"
-        >
-          Structured
-        </button>
       </div>
-    </div>
-    <div class="form-row">
-      <label for="callback_url" title="URL for notifications"
-        >Callback URL:</label
-      >
-      <input
-        type="url"
-        id="callback_url"
-        name="callback_url"
-        value="{{ template.callback_url if template else '' }}"
-        placeholder="https://example.com/callback"
-        title="Enter URL to receive notifications"
-      />
-    </div>
-    <div class="form-row">
-      <label for="proxy" title="Proxy server address">Proxy:</label>
-      <input
-        type="text"
-        id="proxy"
-        name="proxy"
-        value="{{ template.proxy if template else '' }}"
-        placeholder="proxy.example.com:8080"
-        title="Enter proxy server address (optional)"
-      />
-    </div>
-    <div class="form-row">
-      <label for="auth_username" title="Username for camera authentication"
-        >Username:</label
-      >
-      <input
-        type="text"
-        id="auth_username"
-        name="auth_username"
-        value="{{ template.auth_username if template else '' }}"
-        placeholder="user"
-        title="Camera username"
-      />
-    </div>
-    <div class="form-row">
-      <label for="auth_password" title="Password for camera authentication"
-        >Password:</label
-      >
-      <input
-        type="password"
-        id="auth_password"
-        name="auth_password"
-        value="{{ template.auth_password if template else '' }}"
-        placeholder="pass"
-        title="Camera password"
-      />
-    </div>
-    <div class="form-row">
-      <label for="groups" title="Select an existing group">Group:</label>
-      <select id="groups" name="groups" title="Choose a group"></select>
-    </div>
-    <div class="form-row hidden">
-      <label for="rollback_frames" title="Number of frames to rollback"
-        >Rollback Frames:</label
-      >
-      <input
-        type="number"
-        id="rollback_frames"
-        name="rollback_frames"
-        value="{{ template.rollback_frames if template else 0 }}"
-        min="0"
-        title="Enter number of frames to rollback"
-      />
-    </div>
-    <div class="checkbox-row">
-      <label for="invert" title="Invert image colors">
+      <div class="form-row">
+        <label for="auth_username" title="Username for camera authentication"
+          >Username:</label
+        >
         <input
-          type="checkbox"
-          id="invert"
-          name="invert"
-          {%
-          if
-          template
-          and
-          template.invert
-          %}checked{%
-          endif
-          %}
-          title="Invert colors of the captured image"
+          type="text"
+          id="auth_username"
+          name="auth_username"
+          value="{{ template.auth_username if template else '' }}"
+          placeholder="user"
+          title="Camera username"
         />
-        Invert
-      </label>
-      <label for="dark" title="Use dark mode">
+      </div>
+      <div class="form-row">
+        <label for="auth_password" title="Password for camera authentication"
+          >Password:</label
+        >
         <input
-          type="checkbox"
-          id="dark"
-          name="dark"
-          {%
-          if
-          not
-          template
-          or
-          template.dark
-          %}checked{%
-          endif
-          %}
-          title="Enable dark mode for the captured page"
+          type="password"
+          id="auth_password"
+          name="auth_password"
+          value="{{ template.auth_password if template else '' }}"
+          placeholder="pass"
+          title="Camera password"
         />
-        Dark Mode
-      </label>
-      <label for="headless" title="Run in headless mode">
+      </div>
+      <div class="form-row">
+        <label for="groups" title="Select an existing group">Group:</label>
+        <select id="groups" name="groups" title="Choose a group"></select>
+      </div>
+      <div class="form-row hidden">
+        <label for="rollback_frames" title="Number of frames to rollback"
+          >Rollback Frames:</label
+        >
         <input
-          type="checkbox"
-          id="headless"
-          name="headless"
-          {%
-          if
-          not
-          template
-          or
-          template.headless
-          %}checked{%
-          endif
-          %}
-          title="Run browser in headless mode"
+          type="number"
+          id="rollback_frames"
+          name="rollback_frames"
+          value="{{ template.rollback_frames if template else 0 }}"
+          min="0"
+          title="Enter number of frames to rollback"
         />
-        Headless
-      </label>
-      <label for="stealth" title="Use stealth mode">
-        <input
-          type="checkbox"
-          id="stealth"
-          name="stealth"
-          {%
-          if
-          template
-          and
-          template.stealth
-          %}checked{%
-          endif
-          %}
-          title="Use stealth mode to avoid detection"
-        />
-        Stealth
-      </label>
-    </div>
+      </div>
+      <div class="checkbox-row">
+        <label for="invert" title="Invert image colors">
+          <input
+            type="checkbox"
+            id="invert"
+            name="invert"
+            {%
+            if
+            template
+            and
+            template.invert
+            %}checked{%
+            endif
+            %}
+            title="Invert colors of the captured image"
+          />
+          Invert
+        </label>
+        <label for="dark" title="Use dark mode">
+          <input
+            type="checkbox"
+            id="dark"
+            name="dark"
+            {%
+            if
+            not
+            template
+            or
+            template.dark
+            %}checked{%
+            endif
+            %}
+            title="Enable dark mode for the captured page"
+          />
+          Dark Mode
+        </label>
+        <label for="headless" title="Run in headless mode">
+          <input
+            type="checkbox"
+            id="headless"
+            name="headless"
+            {%
+            if
+            not
+            template
+            or
+            template.headless
+            %}checked{%
+            endif
+            %}
+            title="Run browser in headless mode"
+          />
+          Headless
+        </label>
+        <label for="stealth" title="Use stealth mode">
+          <input
+            type="checkbox"
+            id="stealth"
+            name="stealth"
+            {%
+            if
+            template
+            and
+            template.stealth
+            %}checked{%
+            endif
+            %}
+            title="Use stealth mode to avoid detection"
+          />
+          Stealth
+        </label>
+      </div>
+    </details>
     <div class="form-actions">
       <input
         type="submit"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,9 +47,10 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 3. Choose a data source type (e.g., camera, dashboard, or video stream).
 
-4. Configure the source settings (URL, refresh rate, etc.). A small status icon
-   next to the URL turns green once the address is reachable, helping catch typos
-   before saving.
+4. Configure the source settings (URL, refresh rate, etc.). As you leave the URL
+   field, Glimpser checks the address and shows a green check mark when it
+   responds. Expand **Advanced Options** to enter XPaths, callbacks or login
+   credentials if needed.
 
 5. Save the source configuration.
 

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -36,7 +36,7 @@ These tooltips aim to make the interface self‑explanatory and easier to naviga
 
 Interactive forms now include additional tooltips:
 
-- **Add Camera** – explains each field on the Discover tab and the "Structured" XPath buttons.
+- **Add Camera** – describes each field on the Discover tab and the "Structured" XPath buttons. A short helper paragraph guides you to test the URL and open the Advanced Options section.
 - **URL tester** – a tooltip shows "checking" then "valid" or "invalid" next to the URL field.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
 - **Template toolbar** – quick actions appear at the bottom-left of the details page and fade out when idle.


### PR DESCRIPTION
## Summary
- streamline Add Camera form by placing less common fields in a collapsible **Advanced Options** section
- provide short instructions above the form
- document the workflow in `getting_started.md`
- update tooltip docs for the Add Camera section

## Testing
- `pre-commit run --files app/templates/components.html app/templates/_discover_tab.html docs/getting_started.md docs/tooltips.md`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a5817ae14833397de4bde4d77298b