### PR TITLE
Avoid clip preload on dashboard

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -659,7 +659,6 @@ export async function loadTemplates() {
         entries.forEach((entry) => {
           const video = entry.target;
           if (entry.isIntersecting) {
-            enqueueClip(video);
             if (isMobile()) {
               safePlay(video);
             }
@@ -760,6 +759,7 @@ export async function loadTemplates() {
             video.addEventListener("mouseenter", (e) => {
               clearTimeout(resetTimeout);
               video.style.display = "block";
+              enqueueClip(video);
               // Load metadata on first hover so currentTime can be set
               if (video.readyState === 0) {
                 video.load();

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -3,9 +3,9 @@
 Videos initially display the quick `/last_video` clip while the full `/clip` file loads.
 A small braille spinner appears over the thumbnail until the HD video is ready.
 This keeps pages responsive and provides visual feedback that higher quality
-footage is on the way. The template details player now performs the same
-preload-and-swap so you begin watching instantly while the HD clip downloads in
-the background.
+footage is on the way. The dashboard now loads HD clips on demand when you hover
+a camera tile. The template details player performs the same preload-and-swap so
+you begin watching instantly while the HD clip downloads in the background.
 
 When system metrics exceed safe thresholds the `/clip` endpoint now falls
 back to `/last_video` immediately. The response includes an

--- a/tests/js/hd_clip_switch.test.js
+++ b/tests/js/hd_clip_switch.test.js
@@ -46,5 +46,9 @@ test("loads clip when video becomes visible", async () => {
 
   callback([{ target: video, isIntersecting: true }]);
 
+  expect(source.src).toMatch(/\/last_video\/cam1$/);
+
+  video.dispatchEvent(new Event("mouseenter"));
+
   expect(source.src).toMatch(/\/clip\/cam1$/);
 });


### PR DESCRIPTION
## Summary
- defer `/clip` loads until hovering camera tiles
- note on-demand clip behavior in docs
- adjust hover test to match new behavior

## Testing
- `pre-commit run --files app/static/js/templates.js docs/braille_spinner.md tests/js/hd_clip_switch.test.js`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b158f7a688333b0c6493fbf2686f8