### PR TITLE
Add CPU per-thread metrics

### DIFF
--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -40,6 +40,13 @@ export function updatePerformanceMetrics() {
       const threadCount = document.getElementById("thread-count");
       if (threadCount) threadCount.textContent = metrics.thread_count;
 
+      const cpuList = document.getElementById("thread-cpu-list");
+      if (cpuList) {
+        cpuList.textContent = (metrics.top_threads || [])
+          .map((t) => `${t.id}:${t.cpu}%`)
+          .join(" ");
+      }
+
       const uptimeVal = document.getElementById("uptime-value");
       if (uptimeVal) uptimeVal.textContent = metrics.uptime;
 

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -62,6 +62,10 @@
     <span class="metric-label">Thread Count:</span>
     <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
+  <li title="Top threads by CPU usage">
+    <span class="metric-label">Top Threads:</span>
+    <span id="thread-cpu-list">{{ metrics.top_threads }}</span>
+  </li>
   <li title="System uptime">
     <span class="metric-label">Uptime:</span>
     <span id="uptime-value">{{ metrics.uptime }}</span>
@@ -76,118 +80,162 @@
 </ul>
 {% endcall %} {% call card('Feed Status') %}
 <div class="table-container">
-<table id="feed-status" class="feed-status">
-  <thead>
-    <tr>
-      <th class="sortable" data-type="string" title="Camera name">Feed</th>
-      <th class="sortable" data-type="date" title="Most recent caption time">Last Caption</th>
-      <th class="sortable" data-type="date" title="Most recent screenshot time">Last Image</th>
-      <th class="sortable" data-type="number" title="Total screenshots">Shots</th>
-      <th class="sortable" data-type="number" title="Total videos">Videos</th>
-      <th class="sortable" data-type="number" title="Disk usage">Storage</th>
-      <th class="sortable" data-type="number" title="LLM responses">LLM Resp</th>
-      <th class="sortable" data-type="number" title="Estimated LLM cost">LLM Cost</th>
-      <th class="sortable capture-col" data-type="string" title="Capture activity">Capturing</th>
-      <th class="sortable status-col" data-type="string" title="Current feed status">Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for feed in feeds %}
-    <tr
-      class="{{ feed.status }}{% if feed.danger_reason %} danger-{{ feed.danger_reason }}{% endif %}"
-    >
-      <td data-label="Feed" data-value="{{ feed.name }}">
-        <svg
-          width="12"
-          height="12"
-          class="camera-icon {{ feed.camera_type }}"
-          aria-label="{{ feed.camera_tooltip }}"
-          title="{{ feed.camera_tooltip }}"
+  <table id="feed-status" class="feed-status">
+    <thead>
+      <tr>
+        <th class="sortable" data-type="string" title="Camera name">Feed</th>
+        <th class="sortable" data-type="date" title="Most recent caption time">
+          Last Caption
+        </th>
+        <th
+          class="sortable"
+          data-type="date"
+          title="Most recent screenshot time"
         >
-          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#{% if feed.camera_type == 'browser' %}browser{% elif 'stealth' in feed.camera_type %}mask{% else %}camera{% endif %}" />
-        </svg>
-        {% if feed.danger %}
-        <svg
-          width="12"
-          height="12"
-          class="danger-icon-inline {{ feed.danger_reason or '' }}"
-          aria-label="Danger mode"
-          title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'Danger mode user active' if feed.danger_reason == 'user' else 'Danger mode' }}"
+          Last Image
+        </th>
+        <th class="sortable" data-type="number" title="Total screenshots">
+          Shots
+        </th>
+        <th class="sortable" data-type="number" title="Total videos">Videos</th>
+        <th class="sortable" data-type="number" title="Disk usage">Storage</th>
+        <th class="sortable" data-type="number" title="LLM responses">
+          LLM Resp
+        </th>
+        <th class="sortable" data-type="number" title="Estimated LLM cost">
+          LLM Cost
+        </th>
+        <th
+          class="sortable capture-col"
+          data-type="string"
+          title="Capture activity"
         >
-          <use href="{{ url_for('static', filename='icons/sprite.svg') }}#alert" />
-        </svg>
-        {% endif %}
-        <a href="{{ url_for('template_details', template_name=feed.name) }}" title="View template details">{{ feed.name }}</a>
-      </td>
-      <td
-        data-label="Last Caption"
-        data-value="{{ feed.last_caption_time or '' }}"
+          Capturing
+        </th>
+        <th
+          class="sortable status-col"
+          data-type="string"
+          title="Current feed status"
+        >
+          Status
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for feed in feeds %}
+      <tr
+        class="{{ feed.status }}{% if feed.danger_reason %} danger-{{ feed.danger_reason }}{% endif %}"
       >
-        {% if feed.last_caption_display %}
-        <span
-          class="humanized-time"
-          data-time="{{ feed.last_caption_time }}"
-          title="{{ feed.last_caption_time }}"
+        <td data-label="Feed" data-value="{{ feed.name }}">
+          <svg
+            width="12"
+            height="12"
+            class="camera-icon {{ feed.camera_type }}"
+            aria-label="{{ feed.camera_tooltip }}"
+            title="{{ feed.camera_tooltip }}"
+          >
+            <use
+              href="{{ url_for('static', filename='icons/sprite.svg') }}#{% if feed.camera_type == 'browser' %}browser{% elif 'stealth' in feed.camera_type %}mask{% else %}camera{% endif %}"
+            />
+          </svg>
+          {% if feed.danger %}
+          <svg
+            width="12"
+            height="12"
+            class="danger-icon-inline {{ feed.danger_reason or '' }}"
+            aria-label="Danger mode"
+            title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'Danger mode user active' if feed.danger_reason == 'user' else 'Danger mode' }}"
+          >
+            <use
+              href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+            />
+          </svg>
+          {% endif %}
+          <a
+            href="{{ url_for('template_details', template_name=feed.name) }}"
+            title="View template details"
+            >{{ feed.name }}</a
+          >
+        </td>
+        <td
+          data-label="Last Caption"
+          data-value="{{ feed.last_caption_time or '' }}"
         >
-          {{ feed.last_caption_display }}
-        </span>
-        {% else %} N/A {% endif %}
-      </td>
-      <td
-        data-label="Last Image"
-        data-value="{{ feed.last_screenshot_time or '' }}"
-      >
-        {% if feed.last_screenshot_display %}
-        <span
-          class="humanized-time"
-          data-time="{{ feed.last_screenshot_time }}"
-          title="{{ feed.last_screenshot_time }}"
+          {% if feed.last_caption_display %}
+          <span
+            class="humanized-time"
+            data-time="{{ feed.last_caption_time }}"
+            title="{{ feed.last_caption_time }}"
+          >
+            {{ feed.last_caption_display }}
+          </span>
+          {% else %} N/A {% endif %}
+        </td>
+        <td
+          data-label="Last Image"
+          data-value="{{ feed.last_screenshot_time or '' }}"
         >
-          {{ feed.last_screenshot_display }}
-        </span>
-        {% else %} N/A {% endif %}
-      </td>
-      <td data-label="Shots" data-value="{{ feed.screenshot_count }}">
-        {{ feed.screenshot_count }}
-      </td>
-      <td data-label="Videos" data-value="{{ feed.video_count }}">
-        {{ feed.video_count }}
-      </td>
-      <td data-label="Storage" data-value="{{ feed.storage_usage_bytes }}">
-        {{ feed.storage_usage }}
-      </td>
-      <td data-label="LLM Resp" data-value="{{ feed.llm_response_count }}">
-        {{ feed.llm_response_count }}
-      </td>
-      <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
-        {{ feed.llm_cost_estimate }}
-      </td>
-      <td class="capture-col" data-label="Capturing" data-value="{{ '1' if feed.capturing else '0' }}">
-        <span class="capture-dot{% if feed.capturing %} active{% endif %}"></span>
-      </td>
-      <td class="status-col" data-label="Status" data-value="{{ feed.status }}">
-        {% if feed.danger_reason %}
-        <svg
-          width="12"
-          height="12"
-          class="danger-icon {{ feed.danger_reason }}"
-          aria-label="Danger mode required"
-          title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'User active' }}"
+          {% if feed.last_screenshot_display %}
+          <span
+            class="humanized-time"
+            data-time="{{ feed.last_screenshot_time }}"
+            title="{{ feed.last_screenshot_time }}"
+          >
+            {{ feed.last_screenshot_display }}
+          </span>
+          {% else %} N/A {% endif %}
+        </td>
+        <td data-label="Shots" data-value="{{ feed.screenshot_count }}">
+          {{ feed.screenshot_count }}
+        </td>
+        <td data-label="Videos" data-value="{{ feed.video_count }}">
+          {{ feed.video_count }}
+        </td>
+        <td data-label="Storage" data-value="{{ feed.storage_usage_bytes }}">
+          {{ feed.storage_usage }}
+        </td>
+        <td data-label="LLM Resp" data-value="{{ feed.llm_response_count }}">
+          {{ feed.llm_response_count }}
+        </td>
+        <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
+          {{ feed.llm_cost_estimate }}
+        </td>
+        <td
+          class="capture-col"
+          data-label="Capturing"
+          data-value="{{ '1' if feed.capturing else '0' }}"
         >
-          <use
-            href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
-          />
-        </svg>
-        {% endif %}
-        <span
-          class="status-dot {{ feed.status }}"
-          title="{{ feed.tooltip }}"
-        ></span>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+          <span
+            class="capture-dot{% if feed.capturing %} active{% endif %}"
+          ></span>
+        </td>
+        <td
+          class="status-col"
+          data-label="Status"
+          data-value="{{ feed.status }}"
+        >
+          {% if feed.danger_reason %}
+          <svg
+            width="12"
+            height="12"
+            class="danger-icon {{ feed.danger_reason }}"
+            aria-label="Danger mode required"
+            title="{{ 'Danger mode disabled' if feed.danger_reason == 'disabled' else 'User active' }}"
+          >
+            <use
+              href="{{ url_for('static', filename='icons/sprite.svg') }}#alert"
+            />
+          </svg>
+          {% endif %}
+          <span
+            class="status-dot {{ feed.status }}"
+            title="{{ feed.tooltip }}"
+          ></span>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
 
 <p>Last summary generated: {{ last_summary or 'N/A' }}</p>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1052,12 +1052,15 @@ system_metrics = {
     "memory_usage": 0.0,
     "thread_count": 0,
     "start_time": time.time(),
+    "top_threads": [],
 }
 
 
 stop_event = threading.Event()
 metrics_thread = None
 log_caching_thread = None
+thread_cpu_times = {}
+last_thread_sample = time.time()
 
 
 def ffmpeg_version() -> str:
@@ -1094,11 +1097,27 @@ def collect_system_metrics():
     """Continuously update CPU and memory metrics."""
     # Prime psutil's CPU measurement to avoid blocking on the first call
     psutil.cpu_percent(interval=None)
+    proc = psutil.Process()
+    global thread_cpu_times, last_thread_sample
+    proc.cpu_percent(interval=None)
     while not stop_event.is_set():
+        start = time.time()
         # Non-blocking call since we primed above
         system_metrics["cpu_usage"] = psutil.cpu_percent(interval=None)
         system_metrics["memory_usage"] = psutil.virtual_memory().percent
         system_metrics["thread_count"] = threading.active_count()
+
+        interval = start - last_thread_sample or 1
+        current = {t.id: t.user_time + t.system_time for t in proc.threads()}
+        usages = []
+        for tid, ttime in current.items():
+            prev = thread_cpu_times.get(tid, ttime)
+            cpu = ((ttime - prev) / interval) * 100 / psutil.cpu_count()
+            usages.append({"id": tid, "cpu": round(cpu, 1)})
+        thread_cpu_times = current
+        last_thread_sample = start
+        usages.sort(key=lambda x: x["cpu"], reverse=True)
+        system_metrics["top_threads"] = usages[:5]
         time.sleep(5)  # Collect metrics every 5 seconds
 
 
@@ -1119,6 +1138,7 @@ def get_system_metrics():
         "disk_usage": round(disk_usage, 1),
         "open_files": open_files,
         "thread_count": system_metrics["thread_count"],
+        "top_threads": system_metrics.get("top_threads", []),
         "uptime": f"{int(uptime // 3600)}h {int((uptime % 3600) // 60)}m {int(uptime % 60)}s",
         "ffmpeg_version": ffmpeg_version(),
         "ffmpeg_path": ffmpeg_path,

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -40,6 +40,7 @@ name, last image time, last caption time, any KPI column, or status.
 - **Disk Usage** – percentage of disk space used on the main volume
 - **Open Files** – number of file descriptors opened by the process
 - **Thread Count** – active thread count for the application
+- **Top Threads** – list of threads using the most CPU time
 - **Uptime** – elapsed time since the app started
 - **FFmpeg Version** – version string and path to the ffmpeg binary
 - **Machine HW Accel** – whether GPU devices are detected

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -136,6 +136,7 @@ class TestGetSystemMetrics(unittest.TestCase):
                 "cpu_usage": 1.234,
                 "memory_usage": 2.345,
                 "thread_count": 5,
+                "top_threads": [{"id": 123, "cpu": 10.0}],
                 "start_time": time.time() - 3661,
             }
         )
@@ -156,6 +157,7 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertTrue(metrics["gpu_support"])
         self.assertTrue(metrics["ffmpeg_gpu_enabled"])
         self.assertTrue(metrics["danger_mode"])
+        self.assertEqual(metrics["top_threads"], [{"id": 123, "cpu": 10.0}])
 
 
 class TestOfflineJobQueue(unittest.TestCase):
@@ -165,7 +167,9 @@ class TestOfflineJobQueue(unittest.TestCase):
     @patch("app.utils.scheduling.multiprocessing.Process")
     @patch("app.utils.scheduling.SessionLocal")
     @patch("app.utils.scheduling.is_system_online", return_value=False)
-    def test_queue_created_when_offline(self, _online, mock_session_local, mock_process):
+    def test_queue_created_when_offline(
+        self, _online, mock_session_local, mock_process
+    ):
         class DummySession:
             def __init__(self):
                 self.added = []


### PR DESCRIPTION
## Summary
- track top CPU threads in system metrics
- display thread CPU stats on the Status tab and update script
- document the new metric
- test new `top_threads` field

## Testing
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b303640ac8333bc9569ca8aade9ab