### PR TITLE
Add memory and disk sparklines to status panel

### DIFF
--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -1,4 +1,6 @@
 let cpuData = [];
+let memoryData = [];
+let diskData = [];
 const maxDataPoints = 60;
 
 function setProgress(el, value) {
@@ -53,6 +55,8 @@ export function updatePerformanceMetrics() {
       }
 
       updateCPUSparkline(metrics.cpu_usage);
+      updateMemorySparkline(metrics.memory_usage);
+      updateDiskSparkline(metrics.disk_usage);
     });
 }
 
@@ -74,6 +78,66 @@ export function updateCPUSparkline(newValue) {
 
   const step = width / (maxDataPoints - 1);
   cpuData.forEach((value, index) => {
+    const x = index * step;
+    const y = height - (value / 100) * height;
+    if (index === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+
+  ctx.stroke();
+}
+
+export function updateMemorySparkline(newValue) {
+  memoryData.push(newValue);
+  if (memoryData.length > maxDataPoints) {
+    memoryData.shift();
+  }
+
+  const canvas = document.getElementById("memory-sparkline");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  const width = canvas.width;
+  const height = canvas.height;
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = "#28a745";
+  ctx.beginPath();
+
+  const step = width / (maxDataPoints - 1);
+  memoryData.forEach((value, index) => {
+    const x = index * step;
+    const y = height - (value / 100) * height;
+    if (index === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+
+  ctx.stroke();
+}
+
+export function updateDiskSparkline(newValue) {
+  diskData.push(newValue);
+  if (diskData.length > maxDataPoints) {
+    diskData.shift();
+  }
+
+  const canvas = document.getElementById("disk-sparkline");
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  const width = canvas.width;
+  const height = canvas.height;
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.strokeStyle = "#ffc107";
+  ctx.beginPath();
+
+  const step = width / (maxDataPoints - 1);
+  diskData.forEach((value, index) => {
     const x = index * step;
     const y = height - (value / 100) * height;
     if (index === 0) {

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -41,7 +41,12 @@
       max="100"
     ></progress>
     <span id="memory-value">{{ metrics.memory_usage }}%</span>
-    <canvas class="sparkline" width="100" height="20"></canvas>
+    <canvas
+      id="memory-sparkline"
+      class="sparkline"
+      width="100"
+      height="20"
+    ></canvas>
   </li>
   <li title="Disk space used">
     <span class="metric-label">Disk Usage:</span>
@@ -52,7 +57,12 @@
       max="100"
     ></progress>
     <span id="disk-value">{{ metrics.disk_usage }}%</span>
-    <canvas class="sparkline" width="100" height="20"></canvas>
+    <canvas
+      id="disk-sparkline"
+      class="sparkline"
+      width="100"
+      height="20"
+    ></canvas>
   </li>
   <li title="Open file handles">
     <span class="metric-label">Open Files:</span>

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -6,7 +6,7 @@ This guide explains how to check Glimpser's health metrics and view live logs.
 
 **GET /status**
 
-This endpoint now redirects to the _Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator. Metrics refresh automatically every few seconds.
+This endpoint now redirects to the _Status_ tab on the Settings page. The tab shows current system metrics and includes the live log viewer. Metrics are collected in a background thread. See `app/utils/scheduling.py` for implementation details. Raw values can also be retrieved programmatically from the `/health` endpoint. The metrics list and feed dashboard are grouped into separate cards for a cleaner layout. CPU, memory, and disk usage display small progress bars for a quick visual indicator with tiny trend lines showing recent changes. Metrics refresh automatically every few seconds.
 
 ### Feed Dashboard
 

--- a/tests/js/performance.test.js
+++ b/tests/js/performance.test.js
@@ -13,10 +13,14 @@ document.body.innerHTML = `
   <div id="thread-count"></div>
   <div id="uptime-value"></div>
   <canvas id="cpu-sparkline" width="100" height="20"></canvas>
+  <canvas id="memory-sparkline" width="100" height="20"></canvas>
+  <canvas id="disk-sparkline" width="100" height="20"></canvas>
 `;
 
 // Provide a mock canvas context
 const canvas = document.getElementById('cpu-sparkline');
+const memoryCanvas = document.getElementById('memory-sparkline');
+const diskCanvas = document.getElementById('disk-sparkline');
 const ctx = {
   clearRect: jest.fn(),
   beginPath: jest.fn(),
@@ -25,10 +29,14 @@ const ctx = {
   stroke: jest.fn(),
 };
 canvas.getContext = jest.fn(() => ctx);
+memoryCanvas.getContext = jest.fn(() => ctx);
+diskCanvas.getContext = jest.fn(() => ctx);
 
 let performanceModule;
 let updatePerformanceMetrics;
 let updateCPUSparkline;
+let updateMemorySparkline;
+let updateDiskSparkline;
 
 beforeAll(async () => {
   global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }));
@@ -36,6 +44,8 @@ beforeAll(async () => {
   performanceModule = await import('../../app/static/js/performance.js');
   updatePerformanceMetrics = performanceModule.updatePerformanceMetrics;
   updateCPUSparkline = performanceModule.updateCPUSparkline;
+  updateMemorySparkline = performanceModule.updateMemorySparkline;
+  updateDiskSparkline = performanceModule.updateDiskSparkline;
 });
 
 describe('performance.js', () => {
@@ -64,17 +74,20 @@ describe('performance.js', () => {
     expect(document.getElementById('thread-count').textContent).toBe('8');
     expect(document.getElementById('uptime-value').textContent).toBe('1h');
 
-    const ctxCalled = canvas.getContext();
-    expect(ctxCalled.clearRect).toHaveBeenCalled();
+    expect(canvas.getContext).toHaveBeenCalled();
+    expect(memoryCanvas.getContext).toHaveBeenCalled();
+    expect(diskCanvas.getContext).toHaveBeenCalled();
   });
 
-  test('updateCPUSparkline draws on the canvas', () => {
+  test('sparkline functions draw on their canvases', () => {
     updateCPUSparkline(10);
-    const ctx = canvas.getContext();
-    expect(ctx.clearRect).toHaveBeenCalled();
-    expect(ctx.beginPath).toHaveBeenCalled();
-    expect(ctx.moveTo).toHaveBeenCalled();
-    expect(ctx.lineTo).toHaveBeenCalled();
-    expect(ctx.stroke).toHaveBeenCalled();
+    updateMemorySparkline(20);
+    updateDiskSparkline(30);
+    const ctxRef = canvas.getContext();
+    expect(ctxRef.clearRect).toHaveBeenCalled();
+    expect(ctxRef.beginPath).toHaveBeenCalled();
+    expect(ctxRef.moveTo).toHaveBeenCalled();
+    expect(ctxRef.lineTo).toHaveBeenCalled();
+    expect(ctxRef.stroke).toHaveBeenCalled();
   });
 });

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -123,6 +123,11 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('<select id="groups"', components)
 
+    def test_status_tab_has_sparklines(self):
+        html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
+        self.assertIn('id="memory-sparkline"', html)
+        self.assertIn('id="disk-sparkline"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- show trend sparkline for memory and disk usage
- update performance tests for new sparkline functions
- ensure status tab template uses new canvas ids
- document CPU, memory and disk trend lines

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b334577448333a527316ff71d6add