### PR TITLE
Add GPU warning when ffmpeg lacks hwaccel

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1132,6 +1132,7 @@ def get_system_metrics():
     disk_usage = psutil.disk_usage("/").percent
     open_files = len(psutil.Process().open_files())
     ffmpeg_path = shutil.which(FFMPEG_PATH) or FFMPEG_PATH
+    ffmpeg_gpu_support = ffmpeg_supports_hwaccel()
     return {
         "cpu_usage": round(system_metrics["cpu_usage"], 1),
         "memory_usage": round(system_metrics["memory_usage"], 1),
@@ -1143,7 +1144,8 @@ def get_system_metrics():
         "ffmpeg_version": ffmpeg_version(),
         "ffmpeg_path": ffmpeg_path,
         "machine_hwaccel": machine_supports_hwaccel(),
-        "ffmpeg_hwaccel": ffmpeg_supports_hwaccel(),
+        "ffmpeg_hwaccel": ffmpeg_gpu_support,
+        "ffmpeg_gpu_support": ffmpeg_gpu_support,
         "hwaccel_enabled": bool(FFMPEG_HWACCEL and FFMPEG_HWACCEL.lower() != "false"),
         "gpu_support": machine_supports_hwaccel(),
         "ffmpeg_gpu_enabled": bool(

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -45,6 +45,7 @@ name, last image time, last caption time, any KPI column, or status.
 - **FFmpeg Version** – version string and path to the ffmpeg binary
 - **Machine HW Accel** – whether GPU devices are detected
 - **FFmpeg HW Accel** – whether ffmpeg supports hardware acceleration
+- **FFmpeg GPU Support** – whether ffmpeg lists available hwaccel methods
 - **HW Accel Enabled** – if hardware acceleration is configured
 - **FFmpeg GPU Enabled** – whether ffmpeg is currently using GPU acceleration
 - **Danger Mode Enabled** – whether the DANGER_MODE setting is on
@@ -52,6 +53,10 @@ name, last image time, last caption time, any KPI column, or status.
 Boolean metrics now display a green dot when enabled and a red dot when
 disabled to make the status easier to scan. GPU acceleration uses a yellow dot
 when hardware is available but not currently active.
+
+If the system detects GPU hardware but `ffmpeg` lacks hardware acceleration
+support, a warning is printed during startup. Ensure your `ffmpeg` binary is
+built with the necessary drivers when this appears.
 
 ## Streaming Logs
 

--- a/main.py
+++ b/main.py
@@ -55,7 +55,9 @@ def setup_config(args=None):
     config.DATABASE_PATH = args.db_path
     config.HOST = args.host
     if config.ENFORCE_DOMAIN_IN_HOST and "." not in config.HOST:
-        raise ValueError("HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled")
+        raise ValueError(
+            "HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled"
+        )
     config.PORT = args.port
     config.LOGGING_PATH = args.log_path
     config.DEBUG_MODE = args.debug
@@ -143,7 +145,9 @@ def create_application(args=None):
         setup_logging()
 
     if config.ENFORCE_DOMAIN_IN_HOST and "." not in config.HOST:
-        raise ValueError("HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled")
+        raise ValueError(
+            "HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled"
+        )
 
     ensure_directories()
     generate_credentials_if_needed()
@@ -214,7 +218,9 @@ class CleanupManager:
                 try:
                     thread.join(timeout=0.01)
                     if thread.is_alive():
-                        logging.warning("Thread %s is still alive after join", thread.name)
+                        logging.warning(
+                            "Thread %s is still alive after join", thread.name
+                        )
                 except Exception as e:
                     logging.error("Error terminating thread %s: %s", thread.name, e)
 
@@ -272,11 +278,15 @@ def display_startup_tips():
             config.HOST,
         )
     if config.SESSION_COOKIE_SECURE:
-        logging.warning("SESSION_COOKIE_SECURE is enabled; browsers only send the login cookie over HTTPS.")
+        logging.warning(
+            "SESSION_COOKIE_SECURE is enabled; browsers only send the login cookie over HTTPS."
+        )
 
 
 def _format_table(rows, headers):
-    col_widths = [max(len(str(item)) for item in column) for column in zip(headers, *rows)]
+    col_widths = [
+        max(len(str(item)) for item in column) for column in zip(headers, *rows)
+    ]
     header = " | ".join(h.ljust(w) for h, w in zip(headers, col_widths))
     separator = "-+-".join("-" * w for w in col_widths)
     lines = [header, separator]
@@ -340,6 +350,10 @@ def display_startup_info(args=None):
     ]
     logging.info("\n" + _format_table(metrics_table, ["Metric", "Value"]))
     logging.info(border)
+    if metrics["machine_hwaccel"] and not metrics["ffmpeg_gpu_support"]:
+        logging.warning(
+            "GPU hardware detected but ffmpeg lacks hardware acceleration support."
+        )
 
 
 def is_port_in_use(port):
@@ -403,7 +417,9 @@ def main(argv=None):
             config.HOST,
             config.PORT,
         )
-        app.run(host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True)
+        app.run(
+            host=config.HOST, port=config.PORT, debug=config.DEBUG_MODE, threaded=True
+        )
     except KeyboardInterrupt:
         logging.info("KeyboardInterrupt received. Cleaning up...")
         cleanup_resources()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,9 +62,13 @@ class TestMain(unittest.TestCase):
         self.assertEqual(config.PORT, 8080)
         self.assertEqual(config.LOGGING_PATH, os.path.join(self.temp_dir, "log.txt"))
         self.assertTrue(config.DEBUG_MODE)
-        self.assertEqual(config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots"))
+        self.assertEqual(
+            config.SCREENSHOT_DIRECTORY, os.path.join(self.temp_dir, "screenshots")
+        )
         self.assertEqual(config.VIDEO_DIRECTORY, os.path.join(self.temp_dir, "videos"))
-        self.assertEqual(config.SUMMARIES_DIRECTORY, os.path.join(self.temp_dir, "summaries"))
+        self.assertEqual(
+            config.SUMMARIES_DIRECTORY, os.path.join(self.temp_dir, "summaries")
+        )
 
     @patch.object(logging, "getLogger")
     def test_setup_logging(self, mock_get_logger):
@@ -78,7 +82,9 @@ class TestMain(unittest.TestCase):
         main.setup_logging(args)
 
         mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
-        mock_logger.addHandler.assert_any_call(mock.ANY)  # Check that any handler was added
+        mock_logger.addHandler.assert_any_call(
+            mock.ANY
+        )  # Check that any handler was added
 
     """
     @patch("logging.FileHandler")
@@ -190,9 +196,10 @@ class TestMain(unittest.TestCase):
             "127.0.0.1",
         )
 
+    @patch("logging.warning")
     @patch("main.get_system_metrics")
     @patch("logging.info")
-    def test_display_startup_info(self, mock_info, mock_metrics):
+    def test_display_startup_info(self, mock_info, mock_metrics, mock_warn):
         mock_metrics.return_value = {
             "cpu_usage": 0,
             "memory_usage": 0,
@@ -203,6 +210,7 @@ class TestMain(unittest.TestCase):
             "ffmpeg_version": "test",
             "machine_hwaccel": False,
             "ffmpeg_hwaccel": False,
+            "ffmpeg_gpu_support": False,
             "hwaccel_enabled": False,
             "gpu_support": False,
             "ffmpeg_gpu_enabled": False,
@@ -214,6 +222,36 @@ class TestMain(unittest.TestCase):
         main.display_startup_info(args)
         mock_info.assert_any_call("Startup Configuration")
         mock_info.assert_any_call("System Metrics")
+        mock_warn.assert_not_called()
+
+    @patch("logging.warning")
+    @patch("main.get_system_metrics")
+    def test_display_startup_warns_on_missing_ffmpeg_support(
+        self, mock_metrics, mock_warn
+    ):
+        mock_metrics.return_value = {
+            "cpu_usage": 0,
+            "memory_usage": 0,
+            "disk_usage": 0,
+            "open_files": 0,
+            "thread_count": 1,
+            "uptime": "0h 0m 0s",
+            "ffmpeg_version": "test",
+            "machine_hwaccel": True,
+            "ffmpeg_hwaccel": False,
+            "ffmpeg_gpu_support": False,
+            "hwaccel_enabled": False,
+            "gpu_support": True,
+            "ffmpeg_gpu_enabled": False,
+            "danger_mode": False,
+        }
+        args = MagicMock()
+        args.no_scheduler = False
+        args.no_watchdog = False
+        main.display_startup_info(args)
+        mock_warn.assert_any_call(
+            "GPU hardware detected but ffmpeg lacks hardware acceleration support."
+        )
 
     def test_enforce_domain_host_setup_config(self):
         args = MagicMock()
@@ -239,7 +277,9 @@ class TestMain(unittest.TestCase):
     @patch("main.create_app")
     @patch("main.ensure_directories")
     @patch("main.generate_credentials_if_needed")
-    def test_enforce_domain_host_create_application(self, mock_generate, mock_ensure, mock_create_app):
+    def test_enforce_domain_host_create_application(
+        self, mock_generate, mock_ensure, mock_create_app
+    ):
         args = MagicMock()
         args.db_path = os.path.join(self.temp_dir, "db.sqlite")
         args.host = "localhost"

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -153,6 +153,7 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertEqual(metrics["ffmpeg_path"], "/usr/bin/ffmpeg")
         self.assertTrue(metrics["machine_hwaccel"])
         self.assertTrue(metrics["ffmpeg_hwaccel"])
+        self.assertTrue(metrics["ffmpeg_gpu_support"])
         self.assertTrue(metrics["hwaccel_enabled"])
         self.assertTrue(metrics["gpu_support"])
         self.assertTrue(metrics["ffmpeg_gpu_enabled"])


### PR DESCRIPTION
## Summary
- compute `ffmpeg_gpu_support` metric
- warn at startup if hardware is present but ffmpeg lacks acceleration
- document new metric and warning
- update unit tests

## Testing
- `pre-commit run --files app/utils/scheduling.py main.py docs/system_monitoring.md tests/test_scheduling_more.py tests/test_main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b383e2c98833396d9a6f364737b76