### PR TITLE
Add process titles for worker processes

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -17,6 +17,11 @@ import time
 from collections import deque
 
 import psutil
+
+try:
+    from setproctitle import setproctitle
+except Exception:  # pragma: no cover - optional dependency
+    setproctitle = None
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -127,6 +132,16 @@ class GracefulAPScheduler(APScheduler):
 scheduler = GracefulAPScheduler()
 
 
+def _run_target(func, args):
+    """Wrapper to set process title before executing ``func``."""
+    if setproctitle:
+        title = getattr(func, "__name__", "job")
+        if args and isinstance(args[0], str):
+            title += f":{args[0]}"
+        setproctitle(f"glimpser {title}")
+    func(*args)
+
+
 def run_with_timeout(func, args=(), timeout=300):
     """Run *func* in a separate process with a timeout.
 
@@ -187,7 +202,7 @@ def run_with_timeout(func, args=(), timeout=300):
             if existing and existing.is_alive():
                 logging.info("job already running")
                 return
-            process = multiprocessing.Process(target=func, args=args)
+            process = multiprocessing.Process(target=_run_target, args=(func, args))
             active_jobs[key] = process
         process.start()
     except OSError as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ yt-dlp==2025.5.22
 pynput==1.8.1
 python-dateutil
 python-dotenv
+setproctitle==1.3.3


### PR DESCRIPTION
## Summary
- set worker process titles using `setproctitle`
- include `setproctitle` in requirements

## Testing
- `pre-commit run --files app/utils/scheduling.py requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b36736ed08333a1c5cb9b780457fe