### PR TITLE
Fix retention cleanup dir removal

### DIFF
--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import time
+import shutil
 
 from app.config import (
     CLIPS_DIRECTORY,
@@ -52,6 +53,11 @@ def delete_old_files(file_list, max_age, max_size, minimum=10):
             continue
 
         try:
+            if os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+                logging.debug("Deleted directory %s", file_path)
+                continue
+
             file_age = current_time - os.path.getctime(file_path)
             file_size = os.path.getsize(file_path)
             total_size += file_size

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -39,6 +39,15 @@ class TestRetentionPolicy(unittest.TestCase):
             remaining_files = os.listdir(temp_dir)
             self.assertEqual(set(remaining_files), {"file3.txt", "file4.txt"})
 
+    def test_delete_old_files_removes_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            dir_path = os.path.join(temp_dir, "old")
+            os.makedirs(dir_path)
+
+            delete_old_files([dir_path], max_age=0, max_size=0, minimum=0)
+
+            self.assertFalse(os.path.exists(dir_path))
+
     def test_get_files_sorted_by_creation_time(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             file_paths = []


### PR DESCRIPTION
## Summary
- delete leftover screenshot directories during retention cleanup
- test directory removal path

## Testing
- `pytest -q`
- `pytest tests/test_retention_policy.py::TestRetentionPolicy::test_delete_old_files_removes_directories -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4995e9a48333b7c035ac4b3ea749