### PR TITLE
Add clock hand to test pattern

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -341,6 +341,14 @@ def generate_test_pattern(
             width=2,
         )
 
+    # add a simple second hand so the bullseye doubles as a clock face
+    h, m, s = map(int, datetime.datetime.now().strftime("%H:%M:%S").split(":"))
+    angle = math.radians((s / 60) * 360 - 90)
+    length = 60
+    end_x = center_x + length * math.cos(angle)
+    end_y = center_y + length * math.sin(angle)
+    draw.line((center_x, center_y, end_x, end_y), fill="white", width=2)
+
     # overlay spinner if provided
     font_small = load_font(20)
     timestamp = datetime.datetime.now().strftime("%H:%M:%S")
@@ -408,7 +416,8 @@ def generate_test_pattern(
     total_h = sum(line_heights) + spacing_y * (len(line_heights) - 1) + extra_gap
     y_start = height // 2 - total_h // 2 + 20
 
-    clock_color = (200, 200, 200)
+    # lighten the stacked clocks so they distract less from the pattern
+    clock_color = (160, 160, 160)
     current_y = y_start
     for idx, parts in enumerate(segments):
         x = x_start

--- a/docs/test_pattern_reference.md
+++ b/docs/test_pattern_reference.md
@@ -13,3 +13,4 @@ The test pattern includes calibration checks for panel accuracy and HDR tone map
 - **Skin‑tone chip** around CIE ab ≈ (20, 15) confirms natural faces.
 - **Synthwave sunrise** with a small horizon line and trees for visual flair.
 - **Swatch Internet Time** (@beats) joins the stacked clocks for a fun extra.
+- **Analog second hand** in the bullseye shows the live time at a glance.

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -1,6 +1,9 @@
+import datetime
+import math
 import os
 import tempfile
 import unittest
+import unittest.mock
 
 from PIL import Image
 
@@ -39,6 +42,23 @@ class TestTestPattern(unittest.TestCase):
         img = generate_test_pattern(width=120, height=60, spinner="⠋")
         region = [img.getpixel((x, y)) for x in range(80, 95) for y in range(20, 35)]
         self.assertIn((255, 255, 255), region)
+
+    def test_clock_hand_drawn(self):
+        class FixedDatetime(datetime.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2020, 1, 1, 0, 0, 15)
+
+        with unittest.mock.patch(
+            "app.utils.test_pattern.datetime.datetime", FixedDatetime
+        ):
+            img = generate_test_pattern(width=120, height=60)
+        cx, cy = 60, 30
+        end_x = int(round(cx + 60 * math.cos(math.radians((15 / 60) * 360 - 90))))
+        end_y = int(round(cy + 60 * math.sin(math.radians((15 / 60) * 360 - 90))))
+        end_x = min(img.width - 1, end_x)
+        end_y = min(img.height - 1, end_y)
+        self.assertEqual(img.getpixel((end_x, end_y)), (255, 255, 255))
 
 
 class TestTimeFormatHelpers(unittest.TestCase):


### PR DESCRIPTION
## Summary
- draw a second hand on the bullseye clock
- lighten overlay clocks to reduce distraction
- document analog second hand
- test that the hand is drawn

## Testing
- `pre-commit run --files app/utils/test_pattern.py tests/test_test_pattern.py docs/test_pattern_reference.md`
- `PYTHONPATH=. pytest -q tests/test_test_pattern.py`

------
https://chatgpt.com/codex/tasks/task_e_684b4f03ac488333b32b9f1f6448a2d5