### PR TITLE
Improve clip load behavior

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -755,11 +755,19 @@ export async function loadTemplates() {
             };
 
             let resetTimeout;
+            let dwellTimeout;
 
             video.addEventListener("mouseenter", (e) => {
               clearTimeout(resetTimeout);
+              clearTimeout(dwellTimeout);
               video.style.display = "block";
-              enqueueClip(video);
+              dwellTimeout = setTimeout(() => {
+                const tiles = document.querySelectorAll(".templateDiv").length;
+                const width = video.getBoundingClientRect().width;
+                if (tiles <= 8 && width >= 200) {
+                  enqueueClip(video);
+                }
+              }, 300);
               // Load metadata on first hover so currentTime can be set
               if (video.readyState === 0) {
                 video.load();
@@ -779,6 +787,7 @@ export async function loadTemplates() {
             video.addEventListener("mousemove", scrub);
 
             video.addEventListener("mouseleave", () => {
+              clearTimeout(dwellTimeout);
               resetTimeout = setTimeout(() => {
                 video.pause();
                 video.currentTime = 0;

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -7,6 +7,11 @@ footage is on the way. The dashboard now loads HD clips on demand when you hover
 a camera tile. The template details player performs the same preload-and-swap so
 you begin watching instantly while the HD clip downloads in the background.
 
+Hovering a tile for at least a third of a second now triggers the HD clip fetch.
+Rushing across many tiles no longer spawns new renders for each one. If more
+than eight tiles are visible or a tile is under 200&nbsp;px wide the dashboard
+sticks with the low‑resolution `/last_video` preview.
+
 When system metrics exceed safe thresholds the `/clip` endpoint now falls
 back to `/last_video` immediately. The response includes an
 `X-Degraded-Service: busy` header and the spinner switches to a dotted

--- a/tests/js/hd_clip_switch.test.js
+++ b/tests/js/hd_clip_switch.test.js
@@ -14,6 +14,7 @@ beforeAll(async () => {
 });
 
 test("loads clip when video becomes visible", async () => {
+  jest.useFakeTimers();
   let callback;
   window.IntersectionObserver = class {
     constructor(cb) {
@@ -41,6 +42,17 @@ test("loads clip when video becomes visible", async () => {
   await loadTemplates();
   const video = document.querySelector("video");
   const source = video.querySelector("source");
+  video.getBoundingClientRect = () => ({
+    width: 250,
+    height: 0,
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  });
   expect(source.src).toMatch(/\/last_video\/cam1$/);
   expect(video.dataset.hdSrc).toBe("/clip/cam1");
 
@@ -49,6 +61,8 @@ test("loads clip when video becomes visible", async () => {
   expect(source.src).toMatch(/\/last_video\/cam1$/);
 
   video.dispatchEvent(new Event("mouseenter"));
+
+  jest.advanceTimersByTime(300);
 
   expect(source.src).toMatch(/\/clip\/cam1$/);
 });


### PR DESCRIPTION
## Summary
- delay `/clip` requests on index/group pages
- document reduced clip loads
- adjust clip switch test for delay

## Testing
- `pre-commit run --files app/static/js/templates.js docs/braille_spinner.md tests/js/hd_clip_switch.test.js`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b4e9442388333b39110973dca47dc