### PR TITLE
Hide volume controls

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -201,3 +201,19 @@
     display: inline-block;
   }
 }
+
+/* Hide volume controls since clips currently have no audio */
+video::-webkit-media-controls-mute-button,
+video::-webkit-media-controls-volume-slider,
+video::-webkit-media-controls-volume-control-container {
+  display: none;
+}
+
+video::-moz-volume-control {
+  display: none;
+}
+
+#volume-bar,
+#mute {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- hide mute and volume slider controls on all video players

## Testing
- `pre-commit run --all-files` *(fails: reformatted multiple files)*
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b58aea8888333b37465b24213ec93