### PR TITLE
Fix group preview on live page

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -69,8 +69,19 @@ export function initTilePlayer() {
   function play(name) {
     if (!name) return;
     current = name;
-    if (source) source.src = `/last_video/${name}`;
-    video.setAttribute("data-hd-src", `/clip/${name}`);
+
+    if (name === "All") {
+      if (source) source.src = "/last_teaser?group=all";
+      video.setAttribute("data-hd-src", "/stream.mp4");
+    } else if (name.startsWith("group-")) {
+      const group = encodeURIComponent(name.slice(6));
+      if (source) source.src = `/last_teaser?group=${group}`;
+      video.setAttribute("data-hd-src", `/stream.mp4?group=${group}`);
+    } else {
+      if (source) source.src = `/last_video/${name}`;
+      video.setAttribute("data-hd-src", `/clip/${name}`);
+    }
+
     video.load();
     hideBounce();
     loadHdClip();

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -7,9 +7,11 @@ document.body.innerHTML = `
 window.templateDetails = { cam1: {}, cam2: {} };
 
 let init;
+let changeGroup;
 beforeAll(async () => {
   const mod = await import("../../app/static/js/tile_player.js");
   init = mod.initTilePlayer;
+  changeGroup = mod.changeGroup;
 });
 
 test("loads first camera", () => {
@@ -35,4 +37,23 @@ test("swaps to clip after preload", async () => {
   await Promise.resolve();
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledWith("/clip/cam1", expect.any(Object));
+});
+
+test("group change updates video src", () => {
+  document.body.innerHTML = `
+    <video id="live-video"><source></source></video>
+    <select id="camera-selector"></select>
+  `;
+
+  window.templateDetails = {
+    cam1: { groups: "kitchen" },
+    cam2: { groups: "kitchen" },
+  };
+
+  init();
+  changeGroup("kitchen");
+  const src = document.querySelector("#live-video source").src;
+  const hd = document.querySelector("#live-video").dataset.hdSrc;
+  expect(src).toMatch(/\/last_teaser\?group=kitchen$/);
+  expect(hd).toMatch(/\/stream.mp4\?group=kitchen$/);
 });


### PR DESCRIPTION
## Summary
- update tile player to use `/last_teaser` when a group is selected
- test that changing groups updates the video source

## Testing
- `pre-commit run --files app/static/js/tile_player.js tests/js/tile_player.test.js`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b591f60ac8333a9fa002c0373f693