### PR TITLE
Fix background camera loading

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -1,5 +1,5 @@
 import { initTemplates } from "./templates.js";
-import { initVideoControls } from "./video.js";
+import { initVideoControls, initVisibilityHandler } from "./video.js";
 import { initSchedulerToggle } from "./scheduler.js";
 import {
   initDiscoveryToggle,
@@ -31,6 +31,7 @@ import { initVideoZoom } from "./zoom.js";
 
 initTemplates();
 initVideoControls();
+initVisibilityHandler();
 initSchedulerToggle();
 initDiscoveryToggle();
 initSubnetInput();

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -69,6 +69,11 @@ export function enqueueClip(video) {
   if (!processing) processQueue();
 }
 
+export function clearPrefetchQueue() {
+  prefetchQueue = [];
+  processing = false;
+}
+
 function processQueue() {
   const vid = prefetchQueue.shift();
   if (!vid) {
@@ -190,6 +195,15 @@ export function updateVideoSources() {
     const timestamp = new Date().getTime();
     video.querySelector("source").src = `/clip/${name}?t=${timestamp}`;
     video.poster = `/last_screenshot/${name}?t=${timestamp}`;
+  });
+}
+
+export function initVisibilityHandler() {
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      document.querySelectorAll("video").forEach((v) => v.pause());
+      clearPrefetchQueue();
+    }
   });
 }
 
@@ -521,4 +535,5 @@ export function startCasting() {
 // expose queue functions for other modules
 window.enqueueClip = enqueueClip;
 window.setQueueDelay = setQueueDelay;
+window.clearPrefetchQueue = clearPrefetchQueue;
 export { showSpinner, hideSpinner };

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -250,6 +250,15 @@ source. That could cause extra network requests and confusing behavior.
 - The player now destroys any active HLS or looping handlers before starting the
   new stream, so switching sources cleanly stops the old one.
 
+### Problem: Cameras keep loading after leaving the dashboard
+
+Thumbnail players could keep downloading clips after you navigate away.
+
+**Solution:**
+
+- Update to the latest version.
+- Background preloading now stops when the tab loses focus.
+
 ### Problem: Loop video or the "All" camera shows `Format error`
 
 This typically happens when Glimpser cannot locate a recent MP4 clip for a

--- a/tests/js/visibility_pause.test.js
+++ b/tests/js/visibility_pause.test.js
@@ -1,0 +1,33 @@
+import { jest } from "@jest/globals";
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+  configurable: true,
+  value: jest.fn(),
+});
+
+document.body.innerHTML = `
+  <video data-hd-src="/clip/cam1"><source src="/last_video/cam1" /></video>
+  <video data-hd-src="/clip/cam2"><source src="/last_video/cam2" /></video>
+`;
+
+let enqueueClip, initVisibilityHandler;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  enqueueClip = mod.enqueueClip;
+  initVisibilityHandler = mod.initVisibilityHandler;
+});
+
+jest.useFakeTimers();
+
+test("pauses videos and clears queue on tab hide", () => {
+  const vids = document.querySelectorAll("video");
+  vids.forEach((v) => (v.load = jest.fn()));
+  initVisibilityHandler();
+  enqueueClip(vids[0]);
+  enqueueClip(vids[1]);
+  Object.defineProperty(document, "hidden", { value: true, configurable: true });
+  document.dispatchEvent(new Event("visibilitychange"));
+  vids.forEach((v) => expect(v.pause).toHaveBeenCalled());
+  jest.runOnlyPendingTimers();
+});


### PR DESCRIPTION
## Summary
- pause camera prefetch when the tab becomes hidden
- trigger visibility handler from main script
- document fix in troubleshooting guide
- test that the handler pauses all videos

## Testing
- `npm test`
- `pytest -q` *(interrupted but reported all tests passing)*

------
https://chatgpt.com/codex/tasks/task_e_684b57fd577083338b8d831e3fc777fa