### PR TITLE
Add terminal dashboard

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -4,5 +4,6 @@ This package collects modules for network checks, camera interaction,
 scheduling tasks, alerting, and other supporting functionality.
 """
 
+from . import console_dashboard
 from .throttle import clear as clear_throttle
 from .throttle import limit_rate

--- a/app/utils/console_dashboard.py
+++ b/app/utils/console_dashboard.py
@@ -1,0 +1,60 @@
+"""Terminal dashboard for feed status."""
+
+from __future__ import annotations
+
+import curses
+import time
+from typing import Any
+
+from .scheduling import get_feed_status
+
+REFRESH_INTERVAL = 5
+
+
+def _render(screen: curses.window) -> None:
+    """Render the feed dashboard until ``q`` is pressed."""
+    curses.curs_set(0)
+    curses.start_color()
+    curses.use_default_colors()
+    curses.init_pair(1, curses.COLOR_GREEN, -1)
+    curses.init_pair(2, curses.COLOR_YELLOW, -1)
+    curses.init_pair(3, curses.COLOR_RED, -1)
+
+    while True:
+        feeds = get_feed_status()
+        height, width = screen.getmaxyx()
+        screen.erase()
+        screen.addstr(0, 0, "Glimpser Feed Dashboard (press q to quit)"[: width - 1])
+        header = f"{'Name':20} {'Status':8} {'Last Image':14} {'Last Caption':14}"
+        screen.addstr(1, 0, header[: width - 1])
+
+        for idx, feed in enumerate(feeds, start=2):
+            if idx >= height:
+                break
+            row = (
+                f"{feed['name']:<20} {feed['status']:<8} "
+                f"{(feed['last_screenshot_display'] or '-'):14} "
+                f"{(feed['last_caption_display'] or '-'):14}"
+            )
+            color = curses.color_pair(1)
+            if feed["status"] == "slow":
+                color = curses.color_pair(2)
+            elif feed["status"] == "error":
+                color = curses.color_pair(3)
+            screen.addstr(idx, 0, row[: width - 1], color)
+
+        screen.refresh()
+        for _ in range(REFRESH_INTERVAL * 10):
+            time.sleep(0.1)
+            ch = screen.getch()
+            if ch in (ord("q"), ord("Q")):
+                return
+
+
+def main() -> None:
+    """Entry point for ``glimpser-dashboard``."""
+    curses.wrapper(_render)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -6,45 +6,45 @@ This guide describes the available command line arguments for the main `glimpser
 
 The primary application script accepts the following options:
 
-| Argument | Description |
-| --- | --- |
-| `--db-path` | Path to the SQLite database file. |
-| `--host` | Host for the web server. |
-| `--port` | Port for the web server. |
-| `--log-path` | Path to the log file. |
-| `--log-level` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
-| `--console-log` | Enable logging to the console. |
-| `--debug` | Enable debug mode. |
-| `--no-scheduler` | Disable the background scheduler. |
-| `--no-watchdog` | Disable the watchdog thread. |
-| `--no-crawlers` | Skip scheduling crawler jobs. |
-| `--no-log-cache` | Disable the log caching thread. |
-| `--screenshot-dir` | Directory for storing screenshots. |
-| `--video-dir` | Directory for storing video files. |
-| `--summaries-dir` | **Deprecated:** summaries are now stored in the database. |
+| Argument           | Description                                                      |
+| ------------------ | ---------------------------------------------------------------- |
+| `--db-path`        | Path to the SQLite database file.                                |
+| `--host`           | Host for the web server.                                         |
+| `--port`           | Port for the web server.                                         |
+| `--log-path`       | Path to the log file.                                            |
+| `--log-level`      | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |
+| `--console-log`    | Enable logging to the console.                                   |
+| `--debug`          | Enable debug mode.                                               |
+| `--no-scheduler`   | Disable the background scheduler.                                |
+| `--no-watchdog`    | Disable the watchdog thread.                                     |
+| `--no-crawlers`    | Skip scheduling crawler jobs.                                    |
+| `--no-log-cache`   | Disable the log caching thread.                                  |
+| `--screenshot-dir` | Directory for storing screenshots.                               |
+| `--video-dir`      | Directory for storing video files.                               |
+| `--summaries-dir`  | **Deprecated:** summaries are now stored in the database.        |
 
 ## generate_credentials.py
 
 This helper script creates or updates the credentials stored in the database.
 
-| Argument | Description |
-| --- | --- |
-| `--db-path` | Path to the SQLite database file. |
-| `--username` | Username for login. |
-| `--password` | Password for login. |
+| Argument            | Description                                                |
+| ------------------- | ---------------------------------------------------------- |
+| `--db-path`         | Path to the SQLite database file.                          |
+| `--username`        | Username for login.                                        |
+| `--password`        | Password for login.                                        |
 | `--update-password` | Update only the password without modifying other settings. |
-| `--secret-key` | Custom secret key; a new one is generated if not provided. |
-| `--update-key` | Replace the stored secret key. |
+| `--secret-key`      | Custom secret key; a new one is generated if not provided. |
+| `--update-key`      | Replace the stored secret key.                             |
 
 ## config.py
 
 When invoked directly, `app/config.py` accepts a few path options to override the
 defaults loaded from environment variables:
 
-| Argument | Description |
-| --- | --- |
-| `--db-path` | Override the SQLite database location. |
-| `--log-path` | Override the main log file path. |
+| Argument        | Description                             |
+| --------------- | --------------------------------------- |
+| `--db-path`     | Override the SQLite database location.  |
+| `--log-path`    | Override the main log file path.        |
 | `--backup-path` | Override the configuration backup file. |
 
 Use `--help` with any script to see these options from the command line.
@@ -53,3 +53,7 @@ Use `--help` with any script to see these options from the command line.
 
 This helper clears the console screen. It uses the same logic as the main
 application's startup routine and works on Windows, macOS and Linux.
+
+## glimpser-dashboard
+
+`glimpser-dashboard` opens a lightweight terminal dashboard that lists each feed with its current status. The display refreshes every few seconds. Press `q` to exit.

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "console_scripts": [
             "glimpser=main:main",
             "glimpser-clear=main:clear_console_cli",
+            "glimpser-dashboard=app.utils.console_dashboard:main",
         ],
     },
 )

--- a/tests/test_console_dashboard.py
+++ b/tests/test_console_dashboard.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.utils import console_dashboard
+
+
+class TestConsoleDashboard(unittest.TestCase):
+    @patch("app.utils.console_dashboard.curses.wrapper")
+    def test_main_wraps_render(self, mock_wrapper):
+        console_dashboard.main()
+        mock_wrapper.assert_called_once_with(console_dashboard._render)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `glimpser-dashboard` console command
- document the new command
- test the console dashboard entrypoint

## Testing
- `pre-commit run --files app/utils/console_dashboard.py app/utils/__init__.py setup.py docs/command_line.md tests/test_console_dashboard.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6402f6148333b9bd393ea7b9bfc2