### PR TITLE
Improve system metrics UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2193,6 +2193,10 @@ details > summary {
   margin-left: 0.25rem;
 }
 
+#thread-cpu-list {
+  font-family: monospace;
+}
+
 .metric-bar {
   width: 6rem;
   height: 0.6rem;

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -45,8 +45,8 @@ export function updatePerformanceMetrics() {
       const cpuList = document.getElementById("thread-cpu-list");
       if (cpuList) {
         cpuList.textContent = (metrics.top_threads || [])
-          .map((t) => `${t.id}:${t.cpu}%`)
-          .join(" ");
+          .map((t) => `${t.id} (${t.cpu}%)`)
+          .join(", ");
       }
 
       const uptimeVal = document.getElementById("uptime-value");

--- a/app/static/js/scheduler.js
+++ b/app/static/js/scheduler.js
@@ -7,8 +7,10 @@ function setStatus(el, status) {
 }
 
 function updateStatusText(el, status) {
-  el.textContent = status;
+  if (!el) return;
   const map = { running: "ok", stopped: "error", error: "error" };
+  el.title = status;
+  el.textContent = "";
   setStatus(el, map[status] || "error");
 }
 

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -13,8 +13,7 @@
       id="scheduler-status"
       class="status-dot"
       title="Green = running, red = stopped or error"
-      >Checking status...</span
-    >
+    ></span>
   </li>
   <li title="Current CPU utilization">
     <span class="metric-label">CPU Usage:</span>
@@ -82,10 +81,15 @@
   </li>
   <li title="GPU acceleration status">
     <span class="metric-label">GPU:</span>
-    <span
-      id="gpu-status"
-      class="status-dot {{ 'ok' if metrics.ffmpeg_gpu_enabled else ('slow' if metrics.gpu_support else 'error') }}"
-    ></span>
+    <a
+      href="/settings?tab=Capture-tab#FFMPEG_HWACCEL"
+      title="Configure hardware acceleration"
+    >
+      <span
+        id="gpu-status"
+        class="status-dot {{ 'ok' if metrics.ffmpeg_gpu_enabled else ('slow' if metrics.gpu_support else 'error') }}"
+      ></span>
+    </a>
   </li>
 </ul>
 {% endcall %} {% call card('Feed Status') %}


### PR DESCRIPTION
## Summary
- refine scheduler status so text only appears in tooltip
- make GPU status dot link to the Capture tab
- format top thread list as `id (cpu%)`
- display top thread IDs in monospace font for readability

## Testing
- `pre-commit run --files app/static/css/style.css app/static/js/performance.js app/static/js/scheduler.js app/templates/_status_tab.html`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b651f31508333928c4a822b6c16b5