### PR TITLE
Improve clip navigation and live link

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -19,6 +19,17 @@ export function initNav() {
     const cameraDropdown = document.getElementById("nav-camera-dropdown");
     const currentGroup = window.currentGroup || null;
     const currentCamera = window.currentCamera || null;
+    const liveLink = document.getElementById("live");
+
+    if (liveLink) {
+      if (currentCamera) {
+        liveLink.href = `/live?camera=${encodeURIComponent(currentCamera)}`;
+      } else if (currentGroup && currentGroup !== "all") {
+        liveLink.href = `/live?group=${encodeURIComponent(currentGroup)}`;
+      } else {
+        liveLink.href = "/live";
+      }
+    }
     const menuToggle = document.getElementById("menu-toggle");
 
     if (nav && menuToggle) {

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -537,7 +537,9 @@ template_form %} {% block content %}
   window.recentVideos = {{ videos|tojson }};
   document.addEventListener("DOMContentLoaded", () => {
     const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-    const list = (window.recentVideos || []).sort((a, b) => collator.compare(b, a));
+    const list = (window.recentVideos || []).sort((a, b) =>
+      collator.compare(a, b),
+    );
     if (!list.length) return;
     let index = 0;
     const video = document.getElementById("live-video");

--- a/docs/clip_navigation.md
+++ b/docs/clip_navigation.md
@@ -1,3 +1,3 @@
 # Clip Navigation
 
-The player on the template details page now orders clips chronologically. The next button shows **Live** on the last clip and links to `/live?camera=<name>`. Buttons briefly change color when clicked so it's clear the action registered.
+The player on the template details page now orders clips chronologically from oldest to newest. The next button shows **Live** on the last clip and links to `/live?camera=<name>`. Buttons briefly change color when clicked so it's clear the action registered.

--- a/tests/js/nav_live_link.test.js
+++ b/tests/js/nav_live_link.test.js
@@ -1,0 +1,54 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <a id="live"></a>
+  <nav></nav>
+`;
+
+let initNav;
+
+beforeAll(async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve([]),
+    }),
+  );
+  global.setInterval = jest.fn();
+  const mod = await import("../../app/static/js/nav.js");
+  initNav = mod.initNav;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.getElementById("live").href = "";
+});
+
+test("live link uses camera when set", () => {
+  window.currentCamera = "cam1";
+  window.currentGroup = "front";
+  initNav();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  expect(document.getElementById("live").getAttribute("href")).toBe(
+    "/live?camera=cam1",
+  );
+});
+
+test("live link falls back to group", () => {
+  delete window.currentCamera;
+  window.currentGroup = "front";
+  initNav();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  expect(document.getElementById("live").getAttribute("href")).toBe(
+    "/live?group=front",
+  );
+});
+
+test("live link defaults to /live", () => {
+  delete window.currentCamera;
+  window.currentGroup = "all";
+  initNav();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  expect(document.getElementById("live").getAttribute("href")).toBe("/live");
+});


### PR DESCRIPTION
## Summary
- link nav clock icon to current camera or group on /live
- sort video clips oldest to newest on camera details page
- document clip order
- test new live link logic

## Testing
- `pre-commit run --files app/static/js/nav.js app/templates/template_details.html docs/clip_navigation.md tests/js/nav_live_link.test.js`
- `flake8`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b662678c88333b1a980922dc403da