### PR TITLE
Add top slider to cost window

### DIFF
--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -24,12 +24,16 @@ export function initCosts() {
     if (!dataEl) return;
     const range = document.getElementById("cost-range");
     const label = document.getElementById("cost-range-label");
+    const topSlider = document.getElementById("cost-top");
+    const topLabel = document.getElementById("cost-top-label");
     const tbody = document.querySelector("#cost-table tbody");
     const ctx = document.getElementById("costChart");
     let chart;
+    let rowsData = [];
 
-    const render = (rows) => {
-      const limit = rows.length > 10 ? rows.length - 9 : 0;
+    const render = (rows = rowsData) => {
+      const top = topSlider ? parseInt(topSlider.value, 10) : 10;
+      const limit = rows.length > top ? rows.length - (top - 1) : 0;
       const grouped =
         limit > 0 ? groupSmallValues(rows, limit) : groupSmallValues(rows, 0);
       tbody.innerHTML = "";
@@ -50,13 +54,18 @@ export function initCosts() {
         chart.data = chartData;
         chart.update();
       } else {
-        chart = new Chart(ctx, { type: "pie", data: chartData });
+        chart = new Chart(ctx, {
+          type: "pie",
+          data: chartData,
+          options: { plugins: { legend: { display: false } } },
+        });
       }
     };
 
     const fetchData = async () => {
       if (!range) {
-        render(JSON.parse(dataEl.textContent));
+        rowsData = JSON.parse(dataEl.textContent);
+        render();
         return;
       }
       const days = parseInt(range.value, 10);
@@ -73,13 +82,19 @@ export function initCosts() {
         tokens: info.tokens,
         cost: parseFloat(info.cost.replace("$", "")),
       }));
-      render(rows);
+      rowsData = rows;
+      render();
     };
 
     range?.addEventListener("input", () => {
       if (label) label.textContent = `Last ${range.value} days`;
     });
     range?.addEventListener("change", fetchData);
+
+    topSlider?.addEventListener("input", () => {
+      if (topLabel) topLabel.textContent = `Top ${topSlider.value}`;
+      render();
+    });
 
     setupTableSorting("cost-table");
     fetchData();
@@ -131,7 +146,11 @@ export function initCostSummary(startTime) {
         chart.data = chartData;
         chart.update();
       } else {
-        chart = new Chart(ctx, { type: "pie", data: chartData });
+        chart = new Chart(ctx, {
+          type: "pie",
+          data: chartData,
+          options: { plugins: { legend: { display: false } } },
+        });
       }
     };
 

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -10,8 +10,18 @@
     title="Select cost range"
   />
   <span id="cost-range-label">Last 7 days</span>
+  <label for="cost-top" class="ml-4">Top:</label>
+  <input
+    type="range"
+    id="cost-top"
+    min="5"
+    max="20"
+    value="10"
+    title="Number of top templates"
+  />
+  <span id="cost-top-label">Top 10</span>
 </div>
-<canvas id="costChart" width="200" height="200"></canvas>
+<canvas id="costChart" width="160" height="160"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>

--- a/app/templates/cost_summary.html
+++ b/app/templates/cost_summary.html
@@ -13,7 +13,7 @@ content %}
   <button type="button" id="load-cost" title="Load cost data">Load</button>
 </form>
 {% endcall %}
-<canvas id="costChart" width="400" height="300"></canvas>
+<canvas id="costChart" width="300" height="225"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -8,9 +8,9 @@ An overall cost summary now appears under **Settings → Costs**. This tab now
 includes a small pie chart and sortable columns. Adjust the date range with the
 slider to view recent spending.
 
-The Settings cost tab shows only the nine most expensive templates when more
-than ten cameras are present. All remaining templates are combined into a
-single **Other** row to keep the table manageable.
+The Settings cost tab shows the most expensive templates and groups the rest
+into a single **Other** row. Use the **Top** slider to adjust how many
+individual templates appear before grouping occurs.
 
 An additional **LLM Cost Summary** page now provides a date range picker to
 review costs for a specific period. Use the **Since Last Restart** shortcut to

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -3,6 +3,8 @@ import { jest } from "@jest/globals";
 document.body.innerHTML = `
   <input id="cost-range" type="range" value="7">
   <span id="cost-range-label"></span>
+  <input id="cost-top" type="range" value="10">
+  <span id="cost-top-label"></span>
   <table id="cost-table"><tbody></tbody></table>
   <canvas id="costChart"></canvas>
   <script id="cost-data" type="application/json">[]</script>
@@ -38,6 +40,18 @@ test("slider triggers fetch", async () => {
   slider.dispatchEvent(new Event("change"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+test("top slider does not fetch", async () => {
+  initCosts();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  await Promise.resolve();
+  fetch.mockClear();
+  const top = document.getElementById("cost-top");
+  top.value = "15";
+  top.dispatchEvent(new Event("input"));
+  await Promise.resolve();
+  expect(fetch).toHaveBeenCalledTimes(0);
 });
 
 test("groups bottom rows", () => {


### PR DESCRIPTION
## Summary
- resize cost charts and hide legends
- allow choosing number of top templates to show
- document new Top slider in cost tracking
- test slider behaviour in cost tab

## Testing
- `pre-commit run --files app/static/js/costs.js app/templates/_costs_tab.html app/templates/cost_summary.html docs/cost_tracking.md tests/js/cost_tab.test.js`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b678299088333a1c0935be25a2cfb