### PR TITLE
Disable FFMPEG hw accel toggle when unavailable

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3660,11 +3660,15 @@ def init_routes(app: Flask) -> None:
         templates = template_manager.get_templates()
         existing_urls = {t.get("url"): n for n, t in templates.items() if t.get("url")}
 
+        tooltips = dict(SETTINGS_TOOLTIPS)
+        if not metrics.get("ffmpeg_gpu_support"):
+            tooltips["FFMPEG_HWACCEL"] = "Hardware acceleration not available"
+
         return render_template(
             "settings.html",
             grouped_settings=grouped_settings,
             collapsed_groups=collapsed_groups,
-            tooltips=SETTINGS_TOOLTIPS,
+            tooltips=tooltips,
             metrics=metrics,
             feeds=feeds,
             last_summary=last_summary,

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1198,6 +1198,11 @@ input:checked + .slider:before {
   cursor: not-allowed;
 }
 
+.settings-table input[data-unavailable] + .slider {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .settings-table input[data-locked]:not([type="checkbox"]) {
   opacity: 0.5;
   cursor: not-allowed;

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -117,6 +117,7 @@ template_form %} {% block content %}
                     {% if setting.value == 'True' %}checked{% endif %}
                     data-boolean
                     {% if setting.name in locked_settings %}disabled data-locked{% endif %}
+                    {% if setting.name == 'FFMPEG_HWACCEL' and not metrics.ffmpeg_gpu_support %}disabled data-unavailable{% endif %}
                   />
                 <span class="slider round"></span>
               </label>

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -24,6 +24,7 @@ SETTINGS_TOOLTIPS = {
     "MAX_IN_PROCESS_VIDEO_SIZE": "Temporary video size cap",
     "LOG_LEVEL": "Python logging level",
     "FFMPEG_PATH": "Location of the FFmpeg binary",
+    "FFMPEG_HWACCEL": "Enable ffmpeg hardware acceleration when supported",
     "FFMPEG_THREADS": "Threads for video processing",
     "LIVE_FALLBACK_FPS": "Frame rate for still image streams",
     "LIVE_MAX_FAILURES": "Max retries for live streams",


### PR DESCRIPTION
## Summary
- disable FFMPEG_HWACCEL toggle when ffmpeg lacks hw accel support
- explain unavailability in tooltip
- style unavailable toggles

## Testing
- `pre-commit run --files app/utils/settings_tooltips.py app/routes.py app/static/css/style.css app/templates/settings.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b67b404fc8333a062442bfb82f73b