### PR TITLE
Lower and darken clouds in test pattern

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -250,15 +250,15 @@ def generate_test_pattern(
     cloud_layer = Image.new("RGBA", (width, height))
     cloud_draw = ImageDraw.Draw(cloud_layer)
     offset = int(time.time() * 10) % (width + sun_r) - sun_r // 2
-    base_y = horizon_y - sun_r - 20
+    base_y = horizon_y - sun_r // 2
     c_rx = sun_r // 2
-    c_ry = sun_r // 3
+    c_ry = sun_r // 4
     for i in range(5):
         cx = (offset + i * c_rx * 2) % (width + sun_r) - c_rx
         cy = base_y - (i % 3) * (sun_r // 6)
         cloud_draw.ellipse(
             [cx, cy, cx + c_rx * 2, cy + c_ry],
-            fill=(255, 255, 255, 40),
+            fill=(0, 0, 0, 40),
         )
     img = Image.alpha_composite(img, cloud_layer)
     draw = ImageDraw.Draw(img)


### PR DESCRIPTION
## Summary
- adjust cloud position and size
- draw clouds with a dark translucent fill so they only darken the sun

## Testing
- `pre-commit run --files app/utils/test_pattern.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b689cd75c83338ae6413618c677c4