### PR TITLE
Fix timezone handling for feed timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Live video errors now fall back to the last screenshot so the live view never
   appears blank.
+- Fixed timezone handling so feed status timestamps no longer show "in the future".
 
 [Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.7...HEAD
 [0.2.7]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.7

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -355,8 +355,10 @@ export function timeAgo(dateString) {
     dateString instanceof Date
       ? dateString.toISOString()
       : dateString.includes("T")
-        ? dateString
-        : dateString.replace(" ", "T");
+        ? /Z$|[+-]\d{2}:?\d{2}$/.test(dateString)
+          ? dateString
+          : `${dateString}Z`
+        : `${dateString.replace(" ", "T")}Z`;
   const parsed = new Date(iso);
   if (Number.isNaN(parsed.getTime())) return "just now";
   const diffInSeconds = Math.floor((now - parsed) / 1000);
@@ -383,7 +385,11 @@ export function formatExactTime(dateString) {
     dateString instanceof Date
       ? dateString
       : new Date(
-          dateString.includes("T") ? dateString : dateString.replace(" ", "T"),
+          dateString.includes("T")
+            ? /Z$|[+-]\d{2}:?\d{2}$/.test(dateString)
+              ? dateString
+              : `${dateString}Z`
+            : `${dateString.replace(" ", "T")}Z`,
         );
   return date.toString();
 }

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1313,7 +1313,7 @@ def get_feed_status():
             return None
         try:
             dt = datetime.datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
-            return dt.isoformat()
+            return dt.isoformat() + "Z"
         except Exception:
             return ts
 

--- a/tests/js/script.test.js
+++ b/tests/js/script.test.js
@@ -99,4 +99,12 @@ describe("script.js", () => {
     expect(timeAgo(null)).toBe("just now");
     expect(timeAgo(undefined)).toBe("just now");
   });
+
+  test("timeAgo treats naive timestamps as UTC", () => {
+    process.env.TZ = "America/Chicago";
+    jest.useFakeTimers().setSystemTime(new Date("2024-01-01T01:00:00Z"));
+    expect(timeAgo("2024-01-01 00:00:00")).toBe("1h ago");
+    jest.useRealTimers();
+    delete process.env.TZ;
+  });
 });


### PR DESCRIPTION
## Summary
- parse UTC timestamps correctly in JS helpers
- append `Z` for ISO feed timestamps
- test naive timestamp handling
- document fix in changelog

## Testing
- `pre-commit run --files CHANGELOG.md app/static/js/templates.js app/utils/scheduling.py tests/js/script.test.js`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b7449ffe08333a429604e0fb2fb98