### PR TITLE
Improve status table UI

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2168,7 +2168,19 @@ details > summary {
   text-align: center;
 }
 
+.time-col {
+  width: 5rem;
+  text-align: center;
+}
+
+.videos-col,
+.llm-col {
+  width: 3rem;
+  text-align: center;
+}
+
 .capture-dot {
+  position: relative;
   display: inline-block;
   width: 12px;
   height: 12px;
@@ -2178,6 +2190,28 @@ details > summary {
 
 .capture-dot.active {
   background-color: dodgerblue;
+}
+
+.capture-dot.active.countdown::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid dodgerblue;
+  border-top-color: transparent;
+  animation: capture-spin 1s linear infinite;
+}
+
+@keyframes capture-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .unsaved-icon {

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -98,27 +98,6 @@
     <thead>
       <tr>
         <th class="sortable" data-type="string" title="Camera name">Feed</th>
-        <th class="sortable" data-type="date" title="Most recent caption time">
-          Last Caption
-        </th>
-        <th
-          class="sortable"
-          data-type="date"
-          title="Most recent screenshot time"
-        >
-          Last Image
-        </th>
-        <th class="sortable" data-type="number" title="Total screenshots">
-          Shots
-        </th>
-        <th class="sortable" data-type="number" title="Total videos">Videos</th>
-        <th class="sortable" data-type="number" title="Disk usage">Storage</th>
-        <th class="sortable" data-type="number" title="LLM responses">
-          LLM Resp
-        </th>
-        <th class="sortable" data-type="number" title="Estimated LLM cost">
-          LLM Cost
-        </th>
         <th
           class="sortable capture-col"
           data-type="string"
@@ -132,6 +111,33 @@
           title="Current feed status"
         >
           Status
+        </th>
+        <th
+          class="sortable time-col"
+          data-type="date"
+          title="Most recent caption time"
+        >
+          Last Caption
+        </th>
+        <th
+          class="sortable time-col"
+          data-type="date"
+          title="Most recent screenshot time"
+        >
+          Last Image
+        </th>
+        <th class="sortable" data-type="number" title="Total screenshots">
+          Shots
+        </th>
+        <th class="sortable videos-col" data-type="number" title="Total videos">
+          Videos
+        </th>
+        <th class="sortable" data-type="number" title="Disk usage">Storage</th>
+        <th class="sortable llm-col" data-type="number" title="LLM responses">
+          LLM
+        </th>
+        <th class="sortable" data-type="number" title="Estimated LLM cost">
+          LLM Cost
         </th>
       </tr>
     </thead>
@@ -172,55 +178,12 @@
           >
         </td>
         <td
-          data-label="Last Caption"
-          data-value="{{ feed.last_caption_time or '' }}"
-        >
-          {% if feed.last_caption_display %}
-          <span
-            class="humanized-time"
-            data-time="{{ feed.last_caption_time }}"
-            title="{{ feed.last_caption_time }}"
-          >
-            {{ feed.last_caption_display }}
-          </span>
-          {% else %} N/A {% endif %}
-        </td>
-        <td
-          data-label="Last Image"
-          data-value="{{ feed.last_screenshot_time or '' }}"
-        >
-          {% if feed.last_screenshot_display %}
-          <span
-            class="humanized-time"
-            data-time="{{ feed.last_screenshot_time }}"
-            title="{{ feed.last_screenshot_time }}"
-          >
-            {{ feed.last_screenshot_display }}
-          </span>
-          {% else %} N/A {% endif %}
-        </td>
-        <td data-label="Shots" data-value="{{ feed.screenshot_count }}">
-          {{ feed.screenshot_count }}
-        </td>
-        <td data-label="Videos" data-value="{{ feed.video_count }}">
-          {{ feed.video_count }}
-        </td>
-        <td data-label="Storage" data-value="{{ feed.storage_usage_bytes }}">
-          {{ feed.storage_usage }}
-        </td>
-        <td data-label="LLM Resp" data-value="{{ feed.llm_response_count }}">
-          {{ feed.llm_response_count }}
-        </td>
-        <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
-          {{ feed.llm_cost_estimate }}
-        </td>
-        <td
           class="capture-col"
           data-label="Capturing"
           data-value="{{ '1' if feed.capturing else '0' }}"
         >
           <span
-            class="capture-dot{% if feed.capturing %} active{% endif %}"
+            class="capture-dot{% if feed.capturing %} active countdown{% endif %}"
           ></span>
         </td>
         <td
@@ -245,6 +208,59 @@
             class="status-dot {{ feed.status }}"
             title="{{ feed.tooltip }}"
           ></span>
+        </td>
+        <td
+          data-label="Last Caption"
+          class="time-col"
+          data-value="{{ feed.last_caption_time or '' }}"
+        >
+          {% if feed.last_caption_display %}
+          <span
+            class="humanized-time"
+            data-time="{{ feed.last_caption_time }}"
+            title="{{ feed.last_caption_time }}"
+          >
+            {{ feed.last_caption_display }}
+          </span>
+          {% else %} N/A {% endif %}
+        </td>
+        <td
+          data-label="Last Image"
+          class="time-col"
+          data-value="{{ feed.last_screenshot_time or '' }}"
+        >
+          {% if feed.last_screenshot_display %}
+          <span
+            class="humanized-time"
+            data-time="{{ feed.last_screenshot_time }}"
+            title="{{ feed.last_screenshot_time }}"
+          >
+            {{ feed.last_screenshot_display }}
+          </span>
+          {% else %} N/A {% endif %}
+        </td>
+        <td data-label="Shots" data-value="{{ feed.screenshot_count }}">
+          {{ feed.screenshot_count }}
+        </td>
+        <td
+          data-label="Videos"
+          class="videos-col"
+          data-value="{{ feed.video_count }}"
+        >
+          {{ feed.video_count }}
+        </td>
+        <td data-label="Storage" data-value="{{ feed.storage_usage_bytes }}">
+          {{ feed.storage_usage }}
+        </td>
+        <td
+          data-label="LLM"
+          class="llm-col"
+          data-value="{{ feed.llm_response_count }}"
+        >
+          {{ feed.llm_response_count }}
+        </td>
+        <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
+          {{ feed.llm_cost_estimate }}
         </td>
       </tr>
       {% endfor %}

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -10,7 +10,7 @@ This endpoint now redirects to the _Status_ tab on the Settings page. The tab sh
 
 ### Feed Dashboard
 
-Below the system metrics the page lists each configured feed with a color-coded indicator. Hovering over a red or yellow dot now shows a short tooltip describing the issue, including when the feed went offline and the most recent related log entry if available. A new **Capturing** column highlights feeds that are actively capturing.
+Below the system metrics the page lists each configured feed with a color-coded indicator. Hovering over a red or yellow dot now shows a short tooltip describing the issue, including when the feed went offline and the most recent related log entry if available. The **Capturing** and **Status** columns now appear directly after the feed name so mobile browsers show them first. The capturing icon uses a small countdown spinner whenever a job is running.
 
 - **Green** – the feed is updating on schedule.
 - **Yellow** – the last capture is behind its configured frequency.
@@ -26,7 +26,7 @@ same table appears on the _Status_ tab under Settings so you can review
 usage metrics without leaving the configuration interface.
 
 Additional KPI columns track the number of screenshots, videos, total storage
-used, LLM responses, and estimated LLM cost for each feed. Costs now display three decimal places.
+used, LLM counts, and estimated LLM cost for each feed. Costs now display three decimal places.
 
 The header row stays visible while scrolling so column names are always accessible.
 


### PR DESCRIPTION
## Summary
- show capturing status with animated countdown
- move Capturing and Status columns next to Feed
- shorten LLM Resp label and narrow columns
- document updated status table

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b73ec6e748333b31a4dc03bb0b989