### PR TITLE
Fix pre-commit stage warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
         entry: mypy --config-file=mypy.ini
         language: system
         types: [python]
-        stages: [push]
+        stages: [pre-push]
 
 # ─── JAVASCRIPT / CSS ──────────────────────────────────────────────────────────
   - repo: local
@@ -48,18 +48,18 @@ repos:
         entry: npm run lint:js
         language: system
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]
 
       - id: format-js
         name: format js write
         entry: npm run format:js:write
         language: system
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]
 
       - id: lint-css
         name: lint css
         entry: npm run lint:css
         language: system
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary
- migrate deprecated pre-commit stages to the new names

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b770ed808833398ad65d4bca97740