### PR TITLE
Simplify add camera template

### DIFF
--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -121,12 +121,12 @@
       </tbody>
     </table>
   </div>
-  {% endcall %} {% call card('Add Camera') %}
-  <p class="form-help">
-    Enter the camera or dashboard URL and tab out of the field to verify it
-    works. The live preview updates automatically. Expand
-    <em>Advanced Options</em> to configure XPaths, callbacks and credentials.
-  </p>
+  {% endcall %} {% call card('Add Camera
+  <span
+    class="info-icon"
+    title="Enter the camera or dashboard URL and tab out to verify it works. The live preview updates automatically. Use Advanced Options for XPaths, callbacks and credentials."
+    >ℹ️</span
+  >' | safe) %}
   <div class="wizard-step" title="Form to add a new camera">
     {{ template_form( 'add-template-form', '/templates',
     preview_src='/test_pattern.mjpg?pattern=geometric',

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -135,8 +135,8 @@ object_tokens=None, clip_model=None) -%}
       <span id="url-status" class="url-status" title="URL test result"></span>
     </div>
     <div class="form-row double-row">
-      <label for="frequency" title="How often to check the URL"
-        >Frequency (minutes):</label
+      <label for="frequency" class="sr-only" title="How often to check the URL"
+        >Frequency</label
       >
       <input
         type="number"
@@ -149,8 +149,8 @@ object_tokens=None, clip_model=None) -%}
         list="frequency-options"
         class="short-input"
         required
-        placeholder="30"
-        title="Enter how often to check the URL (in minutes)"
+        placeholder="Minutes"
+        title="How often to check the URL (minutes)"
       />
       <!-- suggestions only; users may enter any value -->
       <datalist id="frequency-options">
@@ -161,8 +161,11 @@ object_tokens=None, clip_model=None) -%}
         <option value="360"></option>
         <option value="1440"></option>
       </datalist>
-      <label for="timeout" title="Maximum time to wait for a response"
-        >Timeout (seconds):</label
+      <label
+        for="timeout"
+        class="sr-only"
+        title="Maximum time to wait for a response"
+        >Timeout</label
       >
       <input
         type="number"
@@ -175,8 +178,8 @@ object_tokens=None, clip_model=None) -%}
         list="timeout-options"
         class="short-input"
         required
-        placeholder="10"
-        title="Enter the maximum time to wait for a response (in seconds)"
+        placeholder="Seconds"
+        title="Maximum wait time (seconds)"
       />
       <datalist id="timeout-options">
         <option value="5"></option>
@@ -192,6 +195,11 @@ object_tokens=None, clip_model=None) -%}
       name="notes"
       value="{{ template.notes if template else '' }}"
     />
+    <div class="form-row">
+      <label for="groups" title="Select an existing group">Group:</label>
+      <!-- prettier-ignore -->
+      <select id="groups" name="groups" class="sm-select" title="Choose a group"></select>
+    </div>
     <details class="advanced-settings">
       <summary title="Show additional fields">Advanced Options</summary>
       <div class="form-row double-row">
@@ -290,7 +298,7 @@ object_tokens=None, clip_model=None) -%}
           title="Enter proxy server address (optional)"
         />
       </div>
-      <div class="form-row">
+      <div class="form-row hidden">
         <label for="auth_username" title="Username for camera authentication"
           >Username:</label
         >
@@ -301,9 +309,10 @@ object_tokens=None, clip_model=None) -%}
           value="{{ template.auth_username if template else '' }}"
           placeholder="user"
           title="Camera username"
+          disabled
         />
       </div>
-      <div class="form-row">
+      <div class="form-row hidden">
         <label for="auth_password" title="Password for camera authentication"
           >Password:</label
         >
@@ -314,12 +323,8 @@ object_tokens=None, clip_model=None) -%}
           value="{{ template.auth_password if template else '' }}"
           placeholder="pass"
           title="Camera password"
+          disabled
         />
-      </div>
-      <div class="form-row">
-        <label for="groups" title="Select an existing group">Group:</label>
-        <!-- prettier-ignore -->
-        <select id="groups" name="groups" class="sm-select" title="Choose a group"></select>
       </div>
       <div class="form-row hidden">
         <label for="rollback_frames" title="Number of frames to rollback"


### PR DESCRIPTION
## Summary
- tuck add-camera help text into tooltip
- shorten frequency/timeout labels
- move group select out of advanced settings
- hide username/password fields

## Testing
- `pre-commit run --files app/templates/_discover_tab.html app/templates/components.html`
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b7872a5508333be3318d1e66a0561