### PR TITLE
Add docstrings for video helpers and pytest tests

### DIFF
--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -4,14 +4,60 @@ from datetime import datetime
 
 
 def get_latest_video_date(directory):
+    """Return the timestamp of the newest ``.mp4`` in ``directory``.
+
+    Parameters
+    ----------
+    directory: str
+        Folder to search for video files.
+
+    Returns
+    -------
+    str | None
+        Timestamp formatted as ``"%Y-%m-%d %H:%M:%S"`` or ``None`` if no file is
+        found.
+    """
+
     return get_latest_date(directory, ext="mp4")
 
 
 def get_latest_screenshot_date(directory):
+    """Return the timestamp of the newest ``.png`` in ``directory``.
+
+    This helper mirrors :func:`get_latest_video_date` but searches for
+    screenshot files instead of videos.
+
+    Parameters
+    ----------
+    directory: str
+        Folder to search for screenshot files.
+
+    Returns
+    -------
+    str | None
+        Timestamp formatted as ``"%Y-%m-%d %H:%M:%S"`` or ``None`` if no file is
+        found.
+    """
+
     return get_latest_date(directory, ext="png")
 
 
 def get_latest_file(directory, ext="png"):
+    """Return the most recent file name within ``directory``.
+
+    Parameters
+    ----------
+    directory: str
+        Folder to search.
+    ext: str, optional
+        File extension to filter for. Defaults to ``"png"``.
+
+    Returns
+    -------
+    str | None
+        Path to ``latest_camera.<ext>`` when present, otherwise the name of the
+        newest matching file or ``None`` if no file exists.
+    """
 
     if not os.path.exists(directory):
         return None
@@ -21,11 +67,17 @@ def get_latest_file(directory, ext="png"):
     if os.path.exists(lpath):
         return lpath
 
-    files = [f for f in os.listdir(directory) if f.endswith("." + ext) and os.path.isfile(os.path.join(directory, f))]
+    files = [
+        f
+        for f in os.listdir(directory)
+        if f.endswith("." + ext) and os.path.isfile(os.path.join(directory, f))
+    ]
     if not files:
         return None
     try:
-        latest_file = max(files, key=lambda x: os.path.getmtime(os.path.join(directory, x)))
+        latest_file = max(
+            files, key=lambda x: os.path.getmtime(os.path.join(directory, x))
+        )
     except Exception as e:
         logging.warning("file error %s", e)
         return None
@@ -33,6 +85,22 @@ def get_latest_file(directory, ext="png"):
 
 
 def get_latest_date(directory, ext="png"):
+    """Return a formatted timestamp for the newest file in ``directory``.
+
+    Parameters
+    ----------
+    directory: str
+        Directory to inspect.
+    ext: str, optional
+        File extension to filter for. Defaults to ``"png"``.
+
+    Returns
+    -------
+    str | None
+        Timestamp of the latest file in ``"%Y-%m-%d %H:%M:%S"`` format or
+        ``None`` if nothing is found.
+    """
+
     if not os.path.exists(directory):
         return None
 

--- a/tests/test_video_details.py
+++ b/tests/test_video_details.py
@@ -1,99 +1,61 @@
 import importlib.util
 import os
-import tempfile
-import unittest
 from datetime import datetime, timedelta
+from pathlib import Path
 
-# Dynamically load the video_details module without importing the full
-# ``app`` package and its heavy dependencies.
-module_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "app", "utils", "video_details.py"))
-spec = importlib.util.spec_from_file_location("video_details", module_path)
+import pytest
+
+# Dynamically load the module to avoid importing heavy app dependencies
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "utils" / "video_details.py"
+spec = importlib.util.spec_from_file_location("video_details", MODULE_PATH)
 video_details = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(video_details)
 
-get_latest_video_date = video_details.get_latest_video_date
-get_latest_screenshot_date = video_details.get_latest_screenshot_date
-get_latest_file = video_details.get_latest_file
-get_latest_date = video_details.get_latest_date
+
+def _make_file(tmp_path, name: str, days_ago: int = 0):
+    path = tmp_path / name
+    path.write_text("data")
+    ts = datetime.now() - timedelta(days=days_ago)
+    os.utime(path, (ts.timestamp(), ts.timestamp()))
+    return path
 
 
-class TestVideoDetails(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        for file in os.listdir(self.temp_dir):
-            os.remove(os.path.join(self.temp_dir, file))
-        os.rmdir(self.temp_dir)
-
-    def create_dummy_file(self, filename, days_ago=0):
-        file_path = os.path.join(self.temp_dir, filename)
-        with open(file_path, "w") as f:
-            f.write("dummy content")
-        file_time = datetime.now() - timedelta(days=days_ago)
-        os.utime(file_path, (file_time.timestamp(), file_time.timestamp()))
-
-    def test_get_latest_video_date(self):
-        self.create_dummy_file("video1.mp4", days_ago=2)
-        self.create_dummy_file("video2.mp4", days_ago=1)
-        self.create_dummy_file("video3.mp4", days_ago=3)
-
-        latest_date = get_latest_video_date(self.temp_dir)
-        expected_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
-        self.assertEqual(latest_date[:10], expected_date[:10])  # Compare only the date part
-
-    def test_get_latest_screenshot_date(self):
-        self.create_dummy_file("screenshot1.png", days_ago=2)
-        self.create_dummy_file("screenshot2.png", days_ago=1)
-        self.create_dummy_file("screenshot3.png", days_ago=3)
-
-        latest_date = get_latest_screenshot_date(self.temp_dir)
-        expected_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
-        self.assertEqual(latest_date[:10], expected_date[:10])  # Compare only the date part
-
-    def test_get_latest_file(self):
-        self.create_dummy_file("file1.txt", days_ago=2)
-        self.create_dummy_file("file2.txt", days_ago=1)
-        self.create_dummy_file("file3.txt", days_ago=3)
-        latest_file = get_latest_file(self.temp_dir, ext="mp4")
-        self.assertEqual(latest_file, None)
-
-        latest_file = get_latest_file(self.temp_dir, ext="txt")
-        self.assertEqual(latest_file, "file2.txt")
-
-        self.create_dummy_file("latest_camera.png", days_ago=5)
-        latest_file = get_latest_file(self.temp_dir, ext="txt")
-        self.assertEqual(latest_file, "file2.txt")
-
-        latest_file = get_latest_file(self.temp_dir, ext="png")
-        expected_path = os.path.join(self.temp_dir, "latest_camera.png")
-        self.assertEqual(latest_file, expected_path)
-
-    def test_get_latest_date(self):
-        self.create_dummy_file("file1.txt", days_ago=2)
-        self.create_dummy_file("file2.txt", days_ago=1)
-        self.create_dummy_file("file3.txt", days_ago=3)
-
-        latest_date = get_latest_date(self.temp_dir, ext="txt")
-        expected_date = (datetime.now() - timedelta(days=1)).date()
-
-        # Convert latest_date to a date object for comparison
-        latest_date_obj = datetime.strptime(latest_date, "%Y-%m-%d %H:%M:%S").date()
-
-        self.assertEqual(
-            latest_date_obj,
-            expected_date,
-            "The latest date does not match the expected date",
-        )
-
-    def test_get_latest_file_empty_directory(self):
-        latest_file = get_latest_file(self.temp_dir, ext="txt")
-        self.assertIsNone(latest_file)
-
-    def test_get_latest_date_empty_directory(self):
-        latest_date = get_latest_date(self.temp_dir, ext="txt")
-        self.assertIsNone(latest_date)
+def test_get_latest_video_date(tmp_path):
+    _make_file(tmp_path, "old.mp4", days_ago=2)
+    latest = _make_file(tmp_path, "new.mp4", days_ago=0)
+    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    assert video_details.get_latest_video_date(str(tmp_path)) == expected
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_get_latest_screenshot_date(tmp_path):
+    _make_file(tmp_path, "shot1.png", days_ago=1)
+    latest = _make_file(tmp_path, "shot2.png", days_ago=0)
+    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    assert video_details.get_latest_screenshot_date(str(tmp_path)) == expected
+
+
+def test_get_latest_file(tmp_path):
+    _make_file(tmp_path, "file1.txt", days_ago=1)
+    latest = _make_file(tmp_path, "file2.txt", days_ago=0)
+    assert video_details.get_latest_file(str(tmp_path), ext="txt") == latest.name
+
+    link = tmp_path / "latest_camera.txt"
+    link.symlink_to(latest.name)
+    assert video_details.get_latest_file(str(tmp_path), ext="txt") == str(link)
+
+
+def test_get_latest_date(tmp_path):
+    _make_file(tmp_path, "a.txt", days_ago=2)
+    latest = _make_file(tmp_path, "b.txt", days_ago=0)
+    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    assert video_details.get_latest_date(str(tmp_path), ext="txt") == expected
+
+
+def test_get_latest_date_empty(tmp_path):
+    assert video_details.get_latest_date(str(tmp_path), ext="txt") is None


### PR DESCRIPTION
## Summary
- document video helper utilities
- add pytest coverage for video detail helpers

## Testing
- `pre-commit run --files app/utils/video_details.py tests/test_video_details.py`
- `pytest tests/test_video_details.py`


------
https://chatgpt.com/codex/tasks/task_e_684b7b3546e88333b9798209ff20195a