### PR TITLE
Add date overlay to test pattern

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -375,7 +375,9 @@ def generate_test_pattern(
 
     # overlay spinner if provided
     font_small = load_font(20)
-    timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+    now = datetime.datetime.now()
+    timestamp = now.strftime("%H:%M:%S")
+    date_text = now.strftime("%Y-%m-%d")
 
     if spinner:
         sw = _braille_text_width(spinner)
@@ -442,6 +444,7 @@ def generate_test_pattern(
 
     # lighten the stacked clocks so they distract less from the pattern
     clock_color = (160, 160, 160)
+    draw.text((30, y_start), date_text, fill=clock_color, font=font_right)
     current_y = y_start
     for idx, parts in enumerate(segments):
         x = x_start

--- a/docs/test_pattern_reference.md
+++ b/docs/test_pattern_reference.md
@@ -14,5 +14,6 @@ The test pattern includes calibration checks for panel accuracy and HDR tone map
 - **Synthwave sunrise** with a small horizon line and trees for visual flair.
 - **Swatch Internet Time** (@beats) joins the stacked clocks for a fun extra.
 - **Analog second hand** in the bullseye extends to the outer dots for easy reading.
+- **Date overlay** appears on the left aligned with the standard clock.
 - **Braille spinner** in the corner updates once per second during streaming.
 - **Mini color bars** in the top-left align with a reduced checker patch and grayscale swatch.

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -61,6 +61,25 @@ class TestTestPattern(unittest.TestCase):
         end_y = min(img.height - 1, end_y)
         self.assertEqual(img.getpixel((end_x, end_y)), (255, 255, 255))
 
+    def test_date_overlay(self):
+        class FixedDatetime(datetime.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2020, 1, 1, 12, 0, 0)
+
+        with unittest.mock.patch(
+            "app.utils.test_pattern.datetime.datetime", FixedDatetime
+        ):
+            img = generate_test_pattern(width=400, height=400)
+
+        y_start = 400 // 2 - 248 // 2 + 20
+        region = [
+            img.getpixel((x, y))
+            for x in range(30, 120)
+            for y in range(y_start, y_start + 30)
+        ]
+        self.assertIn((160, 160, 160), region)
+
 
 class TestTimeFormatHelpers(unittest.TestCase):
     def test_time_format_helpers(self):


### PR DESCRIPTION
## Summary
- add date overlay aligned with standard time
- document the new overlay
- check for date overlay in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b79f989e483339fa95d21dd245e73