### PR TITLE
Fix allowed_filename test imports

### DIFF
--- a/tests/test_allowed_filename.py
+++ b/tests/test_allowed_filename.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import unittest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.routes import allowed_filename
 


### PR DESCRIPTION
## Summary
- refactor tests to import from app package without path hacks

## Testing
- `pre-commit run --files tests/test_allowed_filename.py`
- `python -m pytest -q tests/test_allowed_filename.py`

------
https://chatgpt.com/codex/tasks/task_e_684b7b380ad08333b2e1cbb4fc8e2637