### PR TITLE
Refine exception handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -131,6 +131,7 @@ def get_setting(name, default=None):
             logging.warning("initialization error %s", e)
     except SQLAlchemyError as e:
         logging.warning("database error %s", e)
+    # Catch any unforeseen errors so they are logged before being re-raised.
     except Exception as e:  # pragma: no cover - unexpected errors
         logging.exception("unexpected error while fetching setting")
         raise
@@ -152,6 +153,7 @@ def backup_config() -> bool:
     except (OperationalError, SQLAlchemyError, sqlite3.OperationalError, OSError) as e:
         logging.warning("backup failed: %s", e)
         success = False
+    # Log unexpected errors before re-raising so callers see the original issue.
     except Exception as e:  # pragma: no cover - unexpected errors
         logging.exception("unexpected error during backup")
         raise
@@ -206,6 +208,7 @@ def sync_version(pkg_version: str) -> None:
             logging.warning("initialization error %s", e)
     except SQLAlchemyError as e:
         logging.warning("database error %s", e)
+    # Catch-all ensures any other DB errors are logged before raising them.
     except Exception as e:  # pragma: no cover - unexpected errors
         logging.exception("unexpected error during version sync")
         raise
@@ -326,7 +329,7 @@ def _ffmpeg_supports_hwaccel() -> bool:
         ).decode()
         lines = [l.strip() for l in output.splitlines() if l.strip()]
         return len(lines) > 1
-    except Exception:
+    except (subprocess.SubprocessError, FileNotFoundError, UnicodeDecodeError):
         return False
 
 

--- a/app/utils/auto_update.py
+++ b/app/utils/auto_update.py
@@ -22,7 +22,7 @@ def _ci_green(commit: str) -> bool:
         resp = requests.get(GITHUB_STATUS_URL.format(sha=commit), timeout=5)
         if resp.status_code == 200:
             return resp.json().get("state") == "success"
-    except Exception as exc:  # pragma: no cover - log and ignore failures
+    except requests.RequestException as exc:  # pragma: no cover - network error
         logging.debug("CI status check failed: %s", exc)
     return False
 
@@ -66,5 +66,8 @@ def check_for_update() -> None:
         if _download_and_install(latest):
             logging.warning("Auto-updating to %s", latest)
             os.execv(sys.executable, [sys.executable] + sys.argv)
-    except Exception as exc:  # pragma: no cover - log and ignore failures
+    except (
+        requests.RequestException,
+        OSError,
+    ) as exc:  # pragma: no cover - network or OS error
         logging.debug("Auto-update check failed: %s", exc)

--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -21,13 +21,19 @@ def get_latest_file(directory, ext="png"):
     if os.path.exists(lpath):
         return lpath
 
-    files = [f for f in os.listdir(directory) if f.endswith("." + ext) and os.path.isfile(os.path.join(directory, f))]
+    files = [
+        f
+        for f in os.listdir(directory)
+        if f.endswith("." + ext) and os.path.isfile(os.path.join(directory, f))
+    ]
     if not files:
         return None
     try:
-        latest_file = max(files, key=lambda x: os.path.getmtime(os.path.join(directory, x)))
-    except Exception as e:
-        logging.warning("file error %s", e)
+        latest_file = max(
+            files, key=lambda x: os.path.getmtime(os.path.join(directory, x))
+        )
+    except OSError as exc:
+        logging.warning("file error %s", exc)
         return None
     return latest_file
 
@@ -55,8 +61,8 @@ def get_latest_date(directory, ext="png"):
         latest_file_path = os.path.join(directory, latest_file)
         # Get the creation time of the latest file
         latest_file_mtime = os.path.getmtime(latest_file_path)
-    except Exception as e:
-        logging.warning("file error %s", e)
+    except OSError as exc:
+        logging.warning("file error %s", exc)
         return None
 
     # Convert the timestamp to UTC datetime string


### PR DESCRIPTION
## Summary
- replace catch-all exception handling in auto update, video details, and ffmpeg hardware checks
- document why broad exception handling remains in `config.py`

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: files were modified by hook)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7b397dc483339608242506d204f6