### PR TITLE
Add shortcut picker in danger page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1646,10 +1646,26 @@ def init_routes(app: Flask) -> None:
         danger_cameras = sorted(
             [name for name, t in templates.items() if t.get("danger")]
         )
+
+        chrome_path = get_chrome_path()
+        shortcut_opts = [
+            str(p) for p in LINUX_PATHS if p.exists() and os.access(p, os.W_OK)
+        ]
+        danger_info = {
+            "browser": os.path.basename(chrome_path) if chrome_path else "N/A",
+            "path": chrome_path or "N/A",
+            "version": (get_chrome_version(chrome_path) if chrome_path else "N/A"),
+            "shortcut": str(first_shortcut_path() or "N/A"),
+            "patched": not shortcuts_need_patch(),
+            "running": is_chrome_debug_port_open("127.0.0.1", 9222),
+        }
+
         return render_template(
             "danger.html",
             enabled=current,
             danger_cameras=danger_cameras,
+            danger_info=danger_info,
+            shortcut_options=shortcut_opts,
             page_title="Danger Mode",
         )
 

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -1,21 +1,20 @@
-{% extends 'base.html' %}
-{% block content %}
+{% extends 'base.html' %} {% block content %}
 <main class="container danger-page">
   <h2>Danger Mode</h2>
   <p class="page-tip">
     For a full walkthrough see the
-    <a href="../docs/danger_mode.md" target="_blank">Danger Mode documentation</a>.
-    Use the button below if Chrome was not launched with the debugging flag.
+    <a href="../docs/danger_mode.md" target="_blank"
+      >Danger Mode documentation</a
+    >. Use the button below if Chrome was not launched with the debugging flag.
   </p>
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-    <div class="flash-messages">
-      {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
-      {% endfor %}
-    </div>
-    {% endif %}
-  {% endwith %}
+  {% with messages = get_flashed_messages(with_categories=true) %} {% if
+  messages %}
+  <div class="flash-messages">
+    {% for category, message in messages %}
+    <div class="alert alert-{{ category }}">{{ message }}</div>
+    {% endfor %}
+  </div>
+  {% endif %} {% endwith %}
 
   <section>
     <h3>What is it?</h3>
@@ -50,7 +49,11 @@
     <ul>
       {% for camera in danger_cameras %}
       <li>
-        <a href="{{ url_for('template_details', template_name=camera) }}" title="Open {{ camera }} details">{{ camera }}</a>
+        <a
+          href="{{ url_for('template_details', template_name=camera) }}"
+          title="Open {{ camera }} details"
+          >{{ camera }}</a
+        >
       </li>
       {% endfor %}
     </ul>
@@ -64,7 +67,12 @@
         id="danger-checkbox"
         type="checkbox"
         name="enabled"
-        {% if enabled %}checked{% endif %}
+        {%
+        if
+        enabled
+        %}checked{%
+        endif
+        %}
         title="Enable or disable danger mode"
       />
       <span class="slider round"></span>
@@ -80,6 +88,20 @@
       Danger Mode to use.
     </p>
     <form method="post">
+      <label for="shortcut-path" class="sr-only">Chrome shortcut</label>
+      <input
+        id="shortcut-path"
+        name="shortcut_path"
+        type="text"
+        list="shortcut-options"
+        value="{{ danger_info.shortcut if danger_info.shortcut != 'N/A' else (shortcut_options[0] if shortcut_options else '') }}"
+        placeholder="/usr/share/applications/google-chrome.desktop"
+      />
+      <datalist id="shortcut-options">
+        {% for opt in shortcut_options %}
+        <option value="{{ opt }}"></option>
+        {% endfor %}
+      </datalist>
       <input type="hidden" name="action" value="update_shortcut" />
       <button type="submit" title="Patch shortcuts for Danger mode">
         Patch Chrome Shortcuts
@@ -87,7 +109,5 @@
     </form>
   </section>
 </main>
-  {% from 'components.html' import confirm_modal %}
-  {{ confirm_modal('danger') }}
+{% from 'components.html' import confirm_modal %} {{ confirm_modal('danger') }}
 {% endblock %}
-

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -303,7 +303,8 @@ template_form %} {% block content %}
         form="nav-logo-form"
         title="Upload your own PNG image. Select the default option to restore the original logo."
       >
-        <option value="img/glimpser_small.png">Default</option>
+        <option value="img/glimpser_small.png">Default Small</option>
+        <option value="img/glimpser.png">Default Large</option>
       </select>
       <input
         type="file"

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -18,6 +18,7 @@ After Chrome updates, shortcuts may revert to their original command line. Two a
 
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
 - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the _Update Chrome Shortcut_ button on the Settings page or the _Patch Chrome Shortcuts_ button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
+- **Dropdown selector**: The Danger page lets you choose a detected shortcut from a dropdown or enter a custom path before patching.
 - **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
 - **Default shortcut locations**: `%USERPROFILE%\Desktop`, `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs`. On Linux, try `/usr/share/applications/google-chrome.desktop` or `~/.local/share/applications/google-chrome.desktop`. The Settings page lists any writable shortcuts it discovers.
 


### PR DESCRIPTION
## Summary
- add dropdown picker for danger mode shortcuts
- allow choosing either built-in logo on settings page
- expose shortcut info in the danger route
- document the new dropdown in the danger mode guide

## Testing
- `pre-commit run --files app/routes.py app/templates/danger.html app/templates/settings.html docs/danger_mode.md`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b7937750c8333bde35972c08d3b56