### PR TITLE
Use ONNXRuntime for CLIP filtering

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -344,6 +344,12 @@ CLIP_MODEL_NAME = get_setting(
     "openai/clip-vit-base-patch32",
 )
 
+# Path to ONNX model used for object filtering
+CLIP_MODEL_PATH = get_setting(
+    "CLIP_MODEL_PATH",
+    "models/clip-vit-b-32.onnx",
+)
+
 
 # New settings for capture_frame_from_stream function
 NUM_FRAMES = int(get_setting("NUM_FRAMES", 3))

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -25,14 +25,25 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     setproctitle = None
 import numpy as np
-import onnxruntime as ort
+
+try:  # prefer ONNX for lightweight deployments
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+
+try:  # fall back to PyTorch when ONNXRuntime isn't installed
+    from transformers import CLIPModel, CLIPProcessor
+except Exception:  # pragma: no cover - optional dependency
+    from transformers import CLIPProcessor
+
+    CLIPModel = None
+    # PyTorch is heavy, so we only import the model when available
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dateutil import parser
 from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw
-from transformers import CLIPProcessor
 
 from app.config import (
     AUTO_UPDATE_BRANCH,
@@ -93,7 +104,7 @@ from .validators import validate_template_name
 
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
-clip_processor, clip_session = None, None
+clip_processor, clip_session, clip_model = None, None, None
 
 # Track currently running jobs to avoid launching duplicates.
 active_jobs: dict[str, multiprocessing.Process] = {}
@@ -609,10 +620,16 @@ def update_camera(name, template, image_file=None, motion=False):
         # run the object detect AFTER the motion detetor
         if allow is True and object_filter and object_confidence is not None:
 
-            global clip_session, clip_processor
+            global clip_session, clip_processor, clip_model
 
-            if clip_session is None:
+            # Prefer the lightweight ONNX backend when available
+            use_onnx = ort is not None
+
+            if use_onnx and clip_session is None:
                 clip_session = ort.InferenceSession(CLIP_MODEL_PATH)
+
+            if not use_onnx and clip_model is None and CLIPModel is not None:
+                clip_model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
 
             if clip_processor is None:
                 clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
@@ -621,23 +638,30 @@ def update_camera(name, template, image_file=None, motion=False):
             latest_image_path = os.path.join(directory, png_files[-1])
             image = Image.open(latest_image_path)
 
-            # Process the image and text
             inputs = clip_processor(
-                text=[object_filter], images=image, return_tensors="np", padding=True
+                text=[object_filter],
+                images=image,
+                return_tensors="np" if use_onnx else "pt",
+                padding=True,
             )
 
-            # Run the ONNX model
-            outputs = clip_session.run(
-                None,
-                {
-                    "input_ids": inputs["input_ids"],
-                    "attention_mask": inputs["attention_mask"],
-                    "pixel_values": inputs["pixel_values"],
-                },
-            )
-            logits = outputs[0]
-            exp = np.exp(logits)
-            probs = exp / exp.sum(axis=1, keepdims=True)
+            if use_onnx:
+                outputs = clip_session.run(
+                    None,
+                    {
+                        "input_ids": inputs["input_ids"],
+                        "attention_mask": inputs["attention_mask"],
+                        "pixel_values": inputs["pixel_values"],
+                    },
+                )
+                logits = outputs[0]
+                exp = np.exp(logits)
+                probs = exp / exp.sum(axis=1, keepdims=True)
+            elif clip_model is not None:
+                outputs = clip_model(**inputs)
+                probs = outputs.logits_per_image.softmax(dim=1).detach().cpu().numpy()
+            else:
+                probs = np.array([[0.0]])
 
             # Check if the object is detected with confidence higher than the threshold
             if probs[0, 0] >= object_confidence:

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -24,17 +24,20 @@ try:
     from setproctitle import setproctitle
 except Exception:  # pragma: no cover - optional dependency
     setproctitle = None
+import numpy as np
+import onnxruntime as ort
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dateutil import parser
 from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw
-from transformers import CLIPModel, CLIPProcessor
+from transformers import CLIPProcessor
 
 from app.config import (
     AUTO_UPDATE_BRANCH,
     CLIP_MODEL_NAME,
+    CLIP_MODEL_PATH,
     CLIP_REFRESH_MAX_CAMERAS,
     CRAWLER_STARTUP_SPREAD,
     DEBUG,
@@ -90,7 +93,7 @@ from .validators import validate_template_name
 
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
-clip_processor, clip_model = None, None
+clip_processor, clip_session = None, None
 
 # Track currently running jobs to avoid launching duplicates.
 active_jobs: dict[str, multiprocessing.Process] = {}
@@ -606,10 +609,10 @@ def update_camera(name, template, image_file=None, motion=False):
         # run the object detect AFTER the motion detetor
         if allow is True and object_filter and object_confidence is not None:
 
-            global clip_model, clip_processor
+            global clip_session, clip_processor
 
-            if clip_model is None:
-                clip_model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
+            if clip_session is None:
+                clip_session = ort.InferenceSession(CLIP_MODEL_PATH)
 
             if clip_processor is None:
                 clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
@@ -620,17 +623,21 @@ def update_camera(name, template, image_file=None, motion=False):
 
             # Process the image and text
             inputs = clip_processor(
-                text=[object_filter], images=image, return_tensors="pt", padding=True
+                text=[object_filter], images=image, return_tensors="np", padding=True
             )
 
-            # Get the logits from the model
-            outputs = clip_model(**inputs)
-            logits_per_image = (
-                outputs.logits_per_image
-            )  # this is the image-text similarity score
-            probs = logits_per_image.softmax(
-                dim=1
-            )  # we can take the softmax to get probabilities
+            # Run the ONNX model
+            outputs = clip_session.run(
+                None,
+                {
+                    "input_ids": inputs["input_ids"],
+                    "attention_mask": inputs["attention_mask"],
+                    "pixel_values": inputs["pixel_values"],
+                },
+            )
+            logits = outputs[0]
+            exp = np.exp(logits)
+            probs = exp / exp.sum(axis=1, keepdims=True)
 
             # Check if the object is detected with confidence higher than the threshold
             if probs[0, 0] >= object_confidence:

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -31,19 +31,13 @@ try:  # prefer ONNX for lightweight deployments
 except Exception:  # pragma: no cover - optional dependency
     ort = None
 
-try:  # fall back to PyTorch when ONNXRuntime isn't installed
-    from transformers import CLIPModel, CLIPProcessor
-except Exception:  # pragma: no cover - optional dependency
-    from transformers import CLIPProcessor
-
-    CLIPModel = None
-    # PyTorch is heavy, so we only import the model when available
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from dateutil import parser
 from flask_apscheduler import APScheduler
 from PIL import Image, ImageDraw
+from transformers import CLIPProcessor
 
 from app.config import (
     AUTO_UPDATE_BRANCH,
@@ -104,7 +98,7 @@ from .validators import validate_template_name
 
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
-clip_processor, clip_session, clip_model = None, None, None
+clip_processor, clip_session = None, None
 
 # Track currently running jobs to avoid launching duplicates.
 active_jobs: dict[str, multiprocessing.Process] = {}
@@ -620,32 +614,35 @@ def update_camera(name, template, image_file=None, motion=False):
         # run the object detect AFTER the motion detetor
         if allow is True and object_filter and object_confidence is not None:
 
-            global clip_session, clip_processor, clip_model
+            global clip_session, clip_processor
 
             # Prefer the lightweight ONNX backend when available
             use_onnx = ort is not None
 
-            if use_onnx and clip_session is None:
-                clip_session = ort.InferenceSession(CLIP_MODEL_PATH)
-
-            if not use_onnx and clip_model is None and CLIPModel is not None:
-                clip_model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
-
-            if clip_processor is None:
-                clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
-
-            # Load the latest image
-            latest_image_path = os.path.join(directory, png_files[-1])
-            image = Image.open(latest_image_path)
-
-            inputs = clip_processor(
-                text=[object_filter],
-                images=image,
-                return_tensors="np" if use_onnx else "pt",
-                padding=True,
-            )
-
             if use_onnx:
+                if clip_session is None:
+                    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+                    try:
+                        clip_session = ort.InferenceSession(
+                            CLIP_MODEL_PATH, providers=providers
+                        )
+                    except Exception:
+                        clip_session = ort.InferenceSession(CLIP_MODEL_PATH)
+
+                if clip_processor is None:
+                    clip_processor = CLIPProcessor.from_pretrained(CLIP_MODEL_NAME)
+
+                # Load the latest image
+                latest_image_path = os.path.join(directory, png_files[-1])
+                image = Image.open(latest_image_path)
+
+                inputs = clip_processor(
+                    text=[object_filter],
+                    images=image,
+                    return_tensors="np",
+                    padding=True,
+                )
+
                 outputs = clip_session.run(
                     None,
                     {
@@ -657,10 +654,8 @@ def update_camera(name, template, image_file=None, motion=False):
                 logits = outputs[0]
                 exp = np.exp(logits)
                 probs = exp / exp.sum(axis=1, keepdims=True)
-            elif clip_model is not None:
-                outputs = clip_model(**inputs)
-                probs = outputs.logits_per_image.softmax(dim=1).detach().cpu().numpy()
             else:
+                # Skip detection when onnxruntime is unavailable
                 probs = np.array([[0.0]])
 
             # Check if the object is detected with confidence higher than the threshold

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,6 +188,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`)
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,7 +188,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`) If `onnxruntime` is missing the PyTorch model from `CLIP_MODEL_NAME` is used instead.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. If `onnxruntime` is not installed, object filtering is skipped.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,7 +188,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`)
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`) If `onnxruntime` is missing the PyTorch model from `CLIP_MODEL_NAME` is used instead.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ selenium==4.33.0
 SQLAlchemy==2.0.41
 pywebpush==2.0.3
 #torch==2.4.0
-transformers==4.52.4
+onnxruntime==1.18.0
+transformers>=4.40.0
+tokenizers>=0.15.0
 undetected-chromedriver==3.5.5
 webdriver-manager==4.0.2
 Werkzeug==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ pyvirtualdisplay==3.0
 selenium==4.33.0
 SQLAlchemy==2.0.41
 pywebpush==2.0.3
-#torch==2.4.0
 onnxruntime==1.18.0
 transformers>=4.40.0
 tokenizers>=0.15.0

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import types
 import unittest
 from unittest.mock import patch
 
@@ -13,7 +14,7 @@ import app.utils.scheduling as scheduling
 
 
 class TestClipModelSetting(unittest.TestCase):
-    def test_custom_clip_model_used(self):
+    def test_custom_onnx_clip_model_used(self):
         with tempfile.TemporaryDirectory() as tmp:
             cam_dir = os.path.join(tmp, "cam1")
             os.makedirs(cam_dir)
@@ -51,7 +52,11 @@ class TestClipModelSetting(unittest.TestCase):
                     return cls()
 
                 def __call__(self, text, images, return_tensors=None, padding=None):
-                    return {}
+                    return {
+                        "input_ids": np.array([[0]]),
+                        "attention_mask": np.array([[1]]),
+                        "pixel_values": np.zeros((1, 3, 32, 32)),
+                    }
 
             with (
                 patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
@@ -70,8 +75,9 @@ class TestClipModelSetting(unittest.TestCase):
                 patch("os.rename"),
                 patch("os.unlink"),
                 patch(
-                    "app.utils.scheduling.ort.InferenceSession", DummySession
-                ) as mock_sess_class,
+                    "app.utils.scheduling.ort",
+                    types.SimpleNamespace(InferenceSession=DummySession),
+                ),
                 patch(
                     "app.utils.scheduling.CLIPProcessor", DummyProcessor
                 ) as mock_processor_class,
@@ -80,6 +86,100 @@ class TestClipModelSetting(unittest.TestCase):
                 scheduling.clip_processor = None
                 scheduling.update_camera("cam1", template)
                 self.assertEqual(DummySession.calls, ["custom-model"])
+                self.assertEqual(DummyProcessor.calls, ["custom-model"])
+
+    def test_custom_pytorch_clip_model_used(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cam_dir = os.path.join(tmp, "cam1")
+            os.makedirs(cam_dir)
+            Image.new("RGB", (10, 10)).save(
+                os.path.join(cam_dir, "cam1_20240101000000.png")
+            )
+
+            template = {
+                "name": "cam1",
+                "object_filter": "dog",
+                "object_confidence": 0,
+                "last_caption": "",
+                "last_motion_caption": "",
+                "notes": "",
+                "frequency": 30,
+                "motion": 0,
+                "livecaption": "false",
+            }
+
+            class DummyModel:
+                calls = []
+
+                @classmethod
+                def from_pretrained(cls, name):
+                    cls.calls.append(name)
+                    return cls()
+
+                def __call__(self, **inputs):
+                    class Out:
+                        def __init__(self):
+                            self.logits_per_image = DummyTensor()
+
+                    return Out()
+
+            class DummyTensor:
+                def softmax(self, dim):
+                    class Prob:
+                        def detach(self):
+                            class C:
+                                def cpu(self):
+                                    class N:
+                                        def numpy(self):
+                                            return np.array([[1.0]])
+
+                                    return N()
+
+                            return C()
+
+                    return Prob()
+
+            class DummyProcessor:
+                calls = []
+
+                @classmethod
+                def from_pretrained(cls, name):
+                    cls.calls.append(name)
+                    return cls()
+
+                def __call__(self, text, images, return_tensors=None, padding=None):
+                    return {
+                        "input_ids": np.array([[0]]),
+                        "attention_mask": np.array([[1]]),
+                        "pixel_values": np.zeros((1, 3, 32, 32)),
+                    }
+
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("app.utils.scheduling.CLIP_MODEL_NAME", "custom-model"),
+                patch("app.utils.scheduling.capture_or_download", return_value=True),
+                patch("app.utils.scheduling.add_timestamp"),
+                patch("app.utils.scheduling.remove_background"),
+                patch("app.utils.scheduling.add_motion_and_caption"),
+                patch("app.utils.scheduling.save_template"),
+                patch("app.utils.scheduling.send_http_callback"),
+                patch("app.utils.scheduling.chatgpt_compare", return_value="caption"),
+                patch("app.utils.scheduling.is_mostly_blank", return_value=False),
+                patch("app.utils.scheduling.get_template", return_value=template),
+                patch("os.symlink"),
+                patch("os.rename"),
+                patch("os.unlink"),
+                patch("app.utils.scheduling.ort", None),
+                patch("app.utils.scheduling.CLIPModel", DummyModel) as mock_model_class,
+                patch(
+                    "app.utils.scheduling.CLIPProcessor", DummyProcessor
+                ) as mock_processor_class,
+            ):
+                scheduling.clip_session = None
+                scheduling.clip_model = None
+                scheduling.clip_processor = None
+                scheduling.update_camera("cam1", template)
+                self.assertEqual(DummyModel.calls, ["custom-model"])
                 self.assertEqual(DummyProcessor.calls, ["custom-model"])
 
 

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 from PIL import Image
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -16,7 +17,9 @@ class TestClipModelSetting(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             cam_dir = os.path.join(tmp, "cam1")
             os.makedirs(cam_dir)
-            Image.new("RGB", (10, 10)).save(os.path.join(cam_dir, "cam1_20240101000000.png"))
+            Image.new("RGB", (10, 10)).save(
+                os.path.join(cam_dir, "cam1_20240101000000.png")
+            )
 
             template = {
                 "name": "cam1",
@@ -30,28 +33,14 @@ class TestClipModelSetting(unittest.TestCase):
                 "livecaption": "false",
             }
 
-            class DummyLogits:
-                def softmax(self, dim):
-                    class Prob:
-                        def __getitem__(self, idx):
-                            return 1.0
-
-                    return Prob()
-
-            class DummyOutput:
-                def __init__(self):
-                    self.logits_per_image = DummyLogits()
-
-            class DummyModel:
+            class DummySession:
                 calls = []
 
-                @classmethod
-                def from_pretrained(cls, name):
-                    cls.calls.append(name)
-                    return cls()
+                def __init__(self, path):
+                    DummySession.calls.append(path)
 
-                def __call__(self, **inputs):
-                    return DummyOutput()
+                def run(self, *_args, **_kwargs):
+                    return [np.array([[1.0]])]
 
             class DummyProcessor:
                 calls = []
@@ -67,6 +56,7 @@ class TestClipModelSetting(unittest.TestCase):
             with (
                 patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
                 patch("app.utils.scheduling.CLIP_MODEL_NAME", "custom-model"),
+                patch("app.utils.scheduling.CLIP_MODEL_PATH", "custom-model"),
                 patch("app.utils.scheduling.capture_or_download", return_value=True),
                 patch("app.utils.scheduling.add_timestamp"),
                 patch("app.utils.scheduling.remove_background"),
@@ -79,13 +69,17 @@ class TestClipModelSetting(unittest.TestCase):
                 patch("os.symlink"),
                 patch("os.rename"),
                 patch("os.unlink"),
-                patch("app.utils.scheduling.CLIPModel", DummyModel) as mock_model_class,
-                patch("app.utils.scheduling.CLIPProcessor", DummyProcessor) as mock_processor_class,
+                patch(
+                    "app.utils.scheduling.ort.InferenceSession", DummySession
+                ) as mock_sess_class,
+                patch(
+                    "app.utils.scheduling.CLIPProcessor", DummyProcessor
+                ) as mock_processor_class,
             ):
-                scheduling.clip_model = None
+                scheduling.clip_session = None
                 scheduling.clip_processor = None
                 scheduling.update_camera("cam1", template)
-                self.assertEqual(DummyModel.calls, ["custom-model"])
+                self.assertEqual(DummySession.calls, ["custom-model"])
                 self.assertEqual(DummyProcessor.calls, ["custom-model"])
 
 

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -88,7 +88,7 @@ class TestClipModelSetting(unittest.TestCase):
                 self.assertEqual(DummySession.calls, ["custom-model"])
                 self.assertEqual(DummyProcessor.calls, ["custom-model"])
 
-    def test_custom_pytorch_clip_model_used(self):
+    def test_skips_when_onnx_missing(self):
         with tempfile.TemporaryDirectory() as tmp:
             cam_dir = os.path.join(tmp, "cam1")
             os.makedirs(cam_dir)
@@ -108,51 +108,13 @@ class TestClipModelSetting(unittest.TestCase):
                 "livecaption": "false",
             }
 
-            class DummyModel:
-                calls = []
-
-                @classmethod
-                def from_pretrained(cls, name):
-                    cls.calls.append(name)
-                    return cls()
-
-                def __call__(self, **inputs):
-                    class Out:
-                        def __init__(self):
-                            self.logits_per_image = DummyTensor()
-
-                    return Out()
-
-            class DummyTensor:
-                def softmax(self, dim):
-                    class Prob:
-                        def detach(self):
-                            class C:
-                                def cpu(self):
-                                    class N:
-                                        def numpy(self):
-                                            return np.array([[1.0]])
-
-                                    return N()
-
-                            return C()
-
-                    return Prob()
-
             class DummyProcessor:
-                calls = []
+                called = False
 
                 @classmethod
                 def from_pretrained(cls, name):
-                    cls.calls.append(name)
+                    cls.called = True
                     return cls()
-
-                def __call__(self, text, images, return_tensors=None, padding=None):
-                    return {
-                        "input_ids": np.array([[0]]),
-                        "attention_mask": np.array([[1]]),
-                        "pixel_values": np.zeros((1, 3, 32, 32)),
-                    }
 
             with (
                 patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
@@ -170,17 +132,12 @@ class TestClipModelSetting(unittest.TestCase):
                 patch("os.rename"),
                 patch("os.unlink"),
                 patch("app.utils.scheduling.ort", None),
-                patch("app.utils.scheduling.CLIPModel", DummyModel) as mock_model_class,
-                patch(
-                    "app.utils.scheduling.CLIPProcessor", DummyProcessor
-                ) as mock_processor_class,
+                patch("app.utils.scheduling.CLIPProcessor", DummyProcessor),
             ):
                 scheduling.clip_session = None
-                scheduling.clip_model = None
                 scheduling.clip_processor = None
                 scheduling.update_camera("cam1", template)
-                self.assertEqual(DummyModel.calls, ["custom-model"])
-                self.assertEqual(DummyProcessor.calls, ["custom-model"])
+                self.assertFalse(DummyProcessor.called)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- swap Torch CLIP usage with ONNXRuntime session
- add `CLIP_MODEL_PATH` setting
- document new setting in configuration guide
- update requirements for ONNXRuntime
- adjust unit test for ONNXRuntime session

## Testing
- `pre-commit run --files app/utils/scheduling.py app/config.py tests/test_clip_config.py docs/configuration_guide.md requirements.txt`
- `pytest -q tests/test_clip_config.py` *(fails: ModuleNotFoundError: No module named 'onnxruntime')*

------
https://chatgpt.com/codex/tasks/task_e_684b88255910833388048c2516b5b94a