### PR TITLE
Add modal video selection

### DIFF
--- a/app/static/js/recent_videos.js
+++ b/app/static/js/recent_videos.js
@@ -1,0 +1,98 @@
+export function initRecentVideosModal(list, camera) {
+  const collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+  const items = Array.from(list || []);
+  const lastIndex = items.indexOf("last_video.mp4");
+  if (lastIndex !== -1) items.splice(lastIndex, 1);
+  items.sort((a, b) => collator.compare(a, b));
+  if (lastIndex !== -1) items.push("last_video.mp4");
+
+  let index = 0;
+  const video = document.getElementById("live-video");
+  const source = video?.querySelector("source");
+  const prev = document.getElementById("prev-clip-btn");
+  const next = document.getElementById("next-clip-btn");
+
+  function updateButtons() {
+    if (prev) prev.disabled = index <= 0;
+    if (next) {
+      if (index >= items.length - 1) {
+        next.classList.add("go-live");
+        next.textContent = "Live";
+        next.disabled = false;
+      } else {
+        next.classList.remove("go-live");
+        next.textContent = "\u25B6";
+        next.disabled = false;
+      }
+    }
+  }
+
+  function loadClip(i) {
+    if (i < 0 || i >= items.length) return;
+    index = i;
+    const file = items[i];
+    if (file === "last_video.mp4") {
+      if (source) source.src = `/last_video/${camera}`;
+    } else if (source) {
+      source.src = `/videos/${camera}/${file}`;
+    }
+    video.removeAttribute("data-hd-src");
+    video.load();
+    updateButtons();
+  }
+
+  prev?.addEventListener("click", () => {
+    prev.classList.add("clicked");
+    setTimeout(() => prev.classList.remove("clicked"), 150);
+    loadClip(index - 1);
+  });
+
+  next?.addEventListener("click", () => {
+    next.classList.add("clicked");
+    setTimeout(() => next.classList.remove("clicked"), 150);
+    if (index >= items.length - 1) {
+      window.location.href = `/live?camera=${camera}`;
+    } else {
+      loadClip(index + 1);
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement
+    )
+      return;
+    if (e.key === "ArrowLeft") {
+      loadClip(index - 1);
+    } else if (e.key === "ArrowRight") {
+      if (index >= items.length - 1) {
+        window.location.href = `/live?camera=${camera}`;
+      } else {
+        loadClip(index + 1);
+      }
+    }
+  });
+
+  document.querySelectorAll("#videos-modal video").forEach((vid) => {
+    vid.addEventListener("click", () => {
+      const file = vid.dataset.file;
+      const i = items.indexOf(file);
+      if (i !== -1) loadClip(i);
+      if (typeof window.closeGenericModal === "function") {
+        window.closeGenericModal("videos-modal");
+      }
+    });
+  });
+
+  updateButtons();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  if (window.recentVideos && window.currentCamera) {
+    initRecentVideosModal(window.recentVideos, window.currentCamera);
+  }
+});

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -477,14 +477,27 @@ template_form %} {% block content %}
     <div class="videos-grid">
       {% for video in videos %}
       <div class="video">
+        {% if video == 'last_video.mp4' %}
+        <video
+          src="/last_video/{{template_name}}"
+          data-file="last_video.mp4"
+          height="200"
+          autoplay
+          loop
+          muted
+          title="Recent video capture: last"
+        ></video>
+        {% else %}
         <video
           src="/videos/{{template_name}}/{{video}}"
+          data-file="{{ video }}"
           height="200"
           autoplay
           loop
           muted
           title="Recent video capture: {{video}}"
         ></video>
+        {% endif %}
       </div>
       {% endfor %}
     </div>
@@ -535,79 +548,9 @@ template_form %} {% block content %}
 
 <script>
   window.recentVideos = {{ videos|tojson }};
-  document.addEventListener("DOMContentLoaded", () => {
-    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" });
-    const list = (window.recentVideos || []).sort((a, b) =>
-      collator.compare(a, b),
-    );
-    if (!list.length) return;
-    let index = 0;
-    const video = document.getElementById("live-video");
-    const source = video?.querySelector("source");
-    const prev = document.getElementById("prev-clip-btn");
-    const next = document.getElementById("next-clip-btn");
-
-    const updateButtons = () => {
-      if (prev) prev.disabled = index <= 0;
-      if (next) {
-        if (index >= list.length - 1) {
-          next.classList.add("go-live");
-          next.textContent = "Live";
-          next.disabled = false;
-        } else {
-          next.classList.remove("go-live");
-          next.textContent = "\u25B6";
-          next.disabled = false;
-        }
-      }
-    };
-
-    const loadClip = (i) => {
-      if (i < 0 || i >= list.length) return;
-      index = i;
-      const file = list[i];
-      if (source) source.src = `/videos/${window.currentCamera}/${file}`;
-      video.removeAttribute("data-hd-src");
-      video.load();
-      updateButtons();
-    };
-
-    const flash = (btn) => {
-      btn.classList.add("clicked");
-      setTimeout(() => btn.classList.remove("clicked"), 150);
-    };
-
-    prev?.addEventListener("click", () => {
-      flash(prev);
-      loadClip(index - 1);
-    });
-    next?.addEventListener("click", () => {
-      flash(next);
-      if (index >= list.length - 1) {
-        window.location.href = `/live?camera=${window.currentCamera}`;
-      } else {
-        loadClip(index + 1);
-      }
-    });
-
-    document.addEventListener("keydown", (e) => {
-      if (
-        e.target instanceof HTMLInputElement ||
-        e.target instanceof HTMLTextAreaElement
-      )
-        return;
-      if (e.key === "ArrowLeft") {
-        loadClip(index - 1);
-      } else if (e.key === "ArrowRight") {
-        if (index >= list.length - 1) {
-          window.location.href = `/live?camera=${window.currentCamera}`;
-        } else {
-          loadClip(index + 1);
-        }
-      }
-    });
-
-    updateButtons();
-  });
 </script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/recent_videos.js') }}"
+></script>
 {% endblock %}

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -588,6 +588,8 @@ def get_videos_for_template(name: str):
         return int(match.group(1)) if match else -1
 
     sorted_videos = sorted(videos, key=_sort_key, reverse=True)
+    if "last_video.mp4" not in sorted_videos:
+        sorted_videos.append("last_video.mp4")
     return sorted_videos[:10]
 
 

--- a/tests/js/recent_videos_modal.test.js
+++ b/tests/js/recent_videos_modal.test.js
@@ -1,0 +1,28 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="videos-modal" class="modal">
+    <video data-file="clip1.mp4"></video>
+    <video data-file="last_video.mp4"></video>
+  </div>
+  <video id="live-video"><source /></video>
+  <button id="prev-clip-btn"></button>
+  <button id="next-clip-btn"></button>
+`;
+
+let init;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/recent_videos.js");
+  init = mod.initRecentVideosModal;
+});
+
+test("clicking a modal video loads clip and closes modal", () => {
+  window.closeGenericModal = jest.fn();
+  init(["clip1.mp4", "last_video.mp4"], "cam1");
+  const clip = document.querySelector('video[data-file="clip1.mp4"]');
+  clip.dispatchEvent(new Event("click"));
+  const src = document.querySelector("#live-video source").src;
+  expect(src).toMatch(/\/videos\/cam1\/clip1.mp4$/);
+  expect(window.closeGenericModal).toHaveBeenCalledWith("videos-modal");
+});

--- a/tests/test_get_videos_for_template.py
+++ b/tests/test_get_videos_for_template.py
@@ -26,7 +26,10 @@ class TestGetVideosForTemplate(unittest.TestCase):
 
     def test_numeric_sort_descending(self):
         videos = get_videos_for_template("cam1")
-        self.assertEqual(videos, ["final_10.mp4", "final_2.mp4", "final_1.mp4"])
+        self.assertEqual(
+            videos,
+            ["final_10.mp4", "final_2.mp4", "final_1.mp4", "last_video.mp4"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include last_video placeholder at end of recent videos
- load selected clip and close modal via `recent_videos.js`
- update template to use new module
- test video list order and modal handling

## Testing
- `flake8`
- `pre-commit run --files app/utils/template_manager.py tests/test_get_videos_for_template.py app/static/js/recent_videos.js tests/js/recent_videos_modal.test.js app/templates/template_details.html`
- `pytest -q tests/test_get_videos_for_template.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b89e4059c8333a53e63e62db0e0a1