### PR TITLE
Document caption prefix issue

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -5,12 +5,26 @@ import datetime
 import io
 import logging
 import os
+import re
 
 import requests
 from PIL import Image
 
 from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, LLM_MODEL_VERSION
 from app.utils import llm_cache
+
+HEADER_PREFIX_RE = re.compile(r"^(caption|title|summary):\s*", re.IGNORECASE)
+
+
+def clean_caption(text: str) -> str:
+    """Return caption text without header prefixes or Markdown markers."""
+
+    if not text:
+        return ""
+    cleaned = text.replace("**", "").strip()
+    cleaned = HEADER_PREFIX_RE.sub("", cleaned)
+    return cleaned.strip()
+
 
 last_429_error_time = None
 
@@ -23,14 +37,18 @@ class ChatGPTImageComparison:
         self.headers = {"Authorization": f"Bearer {self.api_key}"}
         self.url = "https://api.openai.com/v1/chat/completions"
 
-    def compare_images(self, prompt, image_paths, max_size=512, low_res=False, tokens=48):
+    def compare_images(
+        self, prompt, image_paths, max_size=512, low_res=False, tokens=48
+    ):
 
         global last_429_error_time
 
         if not self.api_key:
             return None, 0
         # Check if a 429 error occurred in the last 30 minutes
-        if last_429_error_time and (datetime.datetime.now() - last_429_error_time) < datetime.timedelta(minutes=15):
+        if last_429_error_time and (
+            datetime.datetime.now() - last_429_error_time
+        ) < datetime.timedelta(minutes=15):
             return None, 0
 
         detail = "high"
@@ -90,7 +108,9 @@ class ChatGPTImageComparison:
             response = requests.post(self.url, headers=self.headers, json=payload)
             if response.status_code == 429:
                 last_429_error_time = datetime.datetime.now()
-                logging.warning("429 error encountered. Blocking requests for 30 minutes.")
+                logging.warning(
+                    "429 error encountered. Blocking requests for 30 minutes."
+                )
                 return None, 0
             result = response.json()
         except Exception as e:
@@ -99,7 +119,10 @@ class ChatGPTImageComparison:
         # Process the response
         # For demonstration, we'll just return the text response
         try:
-            response_text = result["choices"][0]["message"]["content"].replace("\n\n", "\t").strip()
+            raw_text = (
+                result["choices"][0]["message"]["content"].replace("\n\n", "\t").strip()
+            )
+            response_text = clean_caption(raw_text)
             ltokens = result["usage"]["total_tokens"]
             logging.info(
                 " total tokens $%0.5f images: %d %s",
@@ -125,13 +148,14 @@ def chatgpt_compare(prompt, image_paths, template_name=None):
 
     cached = llm_cache.get(prompt, image_paths)
     if cached is not None:
-        result = cached.get("response")
+        result = clean_caption(cached.get("response"))
         tokens = cached.get("tokens", 0)
     else:
         chatgpt_comparison = ChatGPTImageComparison()
         result, tokens = chatgpt_comparison.compare_images(prompt, image_paths)
         if result:
             llm_cache.store(prompt, result, tokens, image_paths)
+            result = clean_caption(result)
 
     if template_name and tokens:
         try:

--- a/docs/caption_prefix.md
+++ b/docs/caption_prefix.md
@@ -1,0 +1,9 @@
+# Avoiding Caption Prefix Responses
+
+Older versions of Glimpser sometimes displayed captions that began with
+`Caption:` or `Title:`. The application now removes these prefixes and any
+simple Markdown like `**bold**` before showing the text.
+
+If you still encounter unwanted prefixes, verify you are running the latest
+version. You can also add a line to `LLM_CAPTION_PROMPT` instructing the model
+to reply with plain text only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Dashboard Border Legend: border_legend.md
       - Caption Overlay Toggle: caption_overlay_toggle.md
       - Caption or Prompt Toggle: caption_prompt_toggle.md
+      - Caption Prefix Issue: caption_prefix.md
       - Captions Chatbot: chatbot.md
       - Continuous Integration Checks: ci_checks.md
       - Jog-Shuttle Control: jog_shuttle.md

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -79,7 +79,9 @@ class TestImageProcessing(unittest.TestCase):
         image_size = (100, 100)
 
         # Apply adjust_bbox_to_aspect_ratio function
-        adjusted_bbox = adjust_bbox_to_aspect_ratio(bbox, image_size, aspect_ratio=(16, 9))
+        adjusted_bbox = adjust_bbox_to_aspect_ratio(
+            bbox, image_size, aspect_ratio=(16, 9)
+        )
 
         # Check if the adjusted bounding box has the correct aspect ratio
         width = adjusted_bbox[2] - adjusted_bbox[0]
@@ -132,7 +134,9 @@ class TestChatGPTImageComparison(unittest.TestCase):
             mock_post.return_value = mock_response
 
             # Test the compare_images method
-            result, tokens = comparison.compare_images("Test prompt", [image1_path, image2_path])
+            result, tokens = comparison.compare_images(
+                "Test prompt", [image1_path, image2_path]
+            )
 
             # Assertions
             self.assertIsNotNone(result)
@@ -142,23 +146,35 @@ class TestChatGPTImageComparison(unittest.TestCase):
             # Check if the API was called with correct parameters
             mock_post.assert_called_once()
             call_args = mock_post.call_args[1]
-            self.assertEqual(call_args["headers"]["Authorization"], f"Bearer {comparison.api_key}")
-            self.assertEqual(call_args["json"]["model"], "gpt-4.1-mini")  # Assuming this is the default model
+            self.assertEqual(
+                call_args["headers"]["Authorization"], f"Bearer {comparison.api_key}"
+            )
+            self.assertEqual(
+                call_args["json"]["model"], "gpt-4.1-mini"
+            )  # Assuming this is the default model
             self.assertIn("Test prompt", str(call_args["json"]["messages"]))
 
             # Test with low_res=True
-            comparison.compare_images("Test prompt", [image1_path, image2_path], low_res=True)
-            self.assertIn("'detail': 'low'", str(mock_post.call_args[1]["json"]["messages"]))
+            comparison.compare_images(
+                "Test prompt", [image1_path, image2_path], low_res=True
+            )
+            self.assertIn(
+                "'detail': 'low'", str(mock_post.call_args[1]["json"]["messages"])
+            )
 
             # Test error handling
             mock_post.side_effect = Exception("API Error")
-            result, tokens = comparison.compare_images("Test prompt", [image1_path, image2_path])
+            result, tokens = comparison.compare_images(
+                "Test prompt", [image1_path, image2_path]
+            )
             self.assertIsNone(result)
             self.assertEqual(tokens, 0)
 
             # Test rate limiting
             comparison.last_429_error_time = datetime.datetime.now()
-            result, tokens = comparison.compare_images("Test prompt", [image1_path, image2_path])
+            result, tokens = comparison.compare_images(
+                "Test prompt", [image1_path, image2_path]
+            )
             self.assertIsNone(result)
             self.assertEqual(tokens, 0)
 
@@ -175,7 +191,9 @@ class TestChatGPTCompareIntegration(unittest.TestCase):
     @patch("app.utils.llm_cache.store")
     @patch("app.utils.llm_cache.get")
     @patch.object(ChatGPTImageComparison, "compare_images")
-    def test_chatgpt_compare_uses_cache(self, mock_compare, mock_get, mock_store, mock_record, mock_exists):
+    def test_chatgpt_compare_uses_cache(
+        self, mock_compare, mock_get, mock_store, mock_record, mock_exists
+    ):
         mock_get.return_value = {"response": "cached", "tokens": 3}
         result = chatgpt_compare("Prompt", ["img.png"], template_name="cam1")
         self.assertEqual(result, "cached")
@@ -189,13 +207,30 @@ class TestChatGPTCompareIntegration(unittest.TestCase):
     @patch("app.utils.llm_cache.store")
     @patch("app.utils.llm_cache.get", return_value=None)
     @patch.object(ChatGPTImageComparison, "compare_images")
-    def test_chatgpt_compare_calls_api(self, mock_compare, mock_get, mock_store, mock_record, mock_exists):
+    def test_chatgpt_compare_calls_api(
+        self, mock_compare, mock_get, mock_store, mock_record, mock_exists
+    ):
         mock_compare.return_value = ("result", 5)
         result = chatgpt_compare("Prompt", ["img.png"], template_name="cam1")
         self.assertEqual(result, "result")
         mock_compare.assert_called_once()
         mock_store.assert_called_once_with("Prompt", "result", 5, ["img.png"])
         mock_record.assert_called_once_with("cam1", 5)
+
+
+class TestCleanCaption(unittest.TestCase):
+    def test_clean_caption_removes_headers_and_formatting(self):
+        from app.utils.image_processing import clean_caption
+
+        self.assertEqual(
+            clean_caption("Caption: **A bird**"),
+            "A bird",
+        )
+
+    def test_clean_caption_handles_title(self):
+        from app.utils.image_processing import clean_caption
+
+        self.assertEqual(clean_caption("Title: **Scene**"), "Scene")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- document how to avoid the **Caption:** prefix
- add new page to nav
- handle header prefixes in code

## Testing
- `pre-commit run --all-files` *(failed: made formatting changes, reverted)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b8a33f1e88333a6860585fe94b593