### PR TITLE
Fix live page group selection

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -4,11 +4,14 @@ export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
   const source = video.querySelector("source");
-  const camSelect = document.getElementById("camera-selector");
+  const camSelect =
+    document.getElementById("camera-selector") ||
+    document.getElementById("nav-camera-dropdown");
   let current =
     camSelect?.value || Object.keys(window.templateDetails || {})[0];
 
   let abortCtl;
+  let liveTimer;
 
   const container = video.parentElement;
   let spinner = container?.querySelector(".loading-spinner");
@@ -19,6 +22,11 @@ export function initTilePlayer() {
     container.appendChild(spinner);
   }
 
+  const image = document.createElement("img");
+  image.id = "live-image";
+  image.style.display = "none";
+  if (container) container.appendChild(image);
+
   function showBounce() {
     if (!spinner) return;
     spinner.textContent = "\u25CF";
@@ -28,6 +36,32 @@ export function initTilePlayer() {
   function hideBounce() {
     if (!spinner) return;
     spinner.classList.remove("bouncy", "visible");
+  }
+
+  function playMjpg(group) {
+    if (!group) return;
+    video.style.display = "none";
+    image.style.display = "block";
+    image.src = `/stream.mjpg?group=${encodeURIComponent(group)}&time=${Date.now()}`;
+  }
+
+  function scheduleLive(group) {
+    clearTimeout(liveTimer);
+    const onInteract = () => {
+      clearTimeout(liveTimer);
+      container.removeEventListener("mousemove", onInteract);
+      container.removeEventListener("mousedown", onInteract);
+      container.removeEventListener("touchstart", onInteract);
+    };
+    container.addEventListener("mousemove", onInteract);
+    container.addEventListener("mousedown", onInteract);
+    container.addEventListener("touchstart", onInteract);
+    liveTimer = setTimeout(() => {
+      container.removeEventListener("mousemove", onInteract);
+      container.removeEventListener("mousedown", onInteract);
+      container.removeEventListener("touchstart", onInteract);
+      playMjpg(group);
+    }, 2000);
   }
 
   async function loadHdClip() {
@@ -69,14 +103,18 @@ export function initTilePlayer() {
   function play(name) {
     if (!name) return;
     current = name;
+    video.style.display = "block";
+    image.style.display = "none";
 
     if (name === "All") {
       if (source) source.src = "/last_teaser?group=all";
       video.setAttribute("data-hd-src", "/stream.mp4");
     } else if (name.startsWith("group-")) {
-      const group = encodeURIComponent(name.slice(6));
+      const raw = name.slice(6);
+      const group = encodeURIComponent(raw);
       if (source) source.src = `/last_teaser?group=${group}`;
       video.setAttribute("data-hd-src", `/stream.mp4?group=${group}`);
+      scheduleLive(raw);
     } else {
       if (source) source.src = `/last_video/${name}`;
       video.setAttribute("data-hd-src", `/clip/${name}`);
@@ -97,7 +135,9 @@ export function initTilePlayer() {
 document.addEventListener("DOMContentLoaded", initTilePlayer);
 
 export function updateCameraOptions(group) {
-  const camSelect = document.getElementById("camera-selector");
+  const camSelect =
+    document.getElementById("camera-selector") ||
+    document.getElementById("nav-camera-dropdown");
   if (!camSelect) return;
   camSelect.innerHTML = "";
   if (!group || group === "all") {
@@ -141,7 +181,9 @@ export function changeGroup(group) {
   }
   if (navGroup) navGroup.value = group;
   updateCameraOptions(group);
-  const camSelect = document.getElementById("camera-selector");
+  const camSelect =
+    document.getElementById("camera-selector") ||
+    document.getElementById("nav-camera-dropdown");
   if (camSelect) camSelect.dispatchEvent(new Event("change"));
 }
 

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -57,3 +57,20 @@ test("group change updates video src", () => {
   expect(src).toMatch(/\/last_teaser\?group=kitchen$/);
   expect(hd).toMatch(/\/stream.mp4\?group=kitchen$/);
 });
+
+test("fallback to nav camera dropdown", () => {
+  document.body.innerHTML = `
+    <video id="live-video"><source></source></video>
+    <select id="nav-camera-dropdown"></select>
+  `;
+
+  window.templateDetails = {
+    cam1: { groups: "foo" },
+    cam2: { groups: "foo" },
+  };
+
+  init();
+  changeGroup("foo");
+  const src = document.querySelector("#live-video source").src;
+  expect(src).toMatch(/\/last_teaser\?group=foo$/);
+});


### PR DESCRIPTION
## Summary
- fix group selector fallback to nav camera dropdown
- autoplay last teaser then switch to MJPEG after idle
- test nav camera dropdown fallback

## Testing
- `pre-commit run --all-files` *(fails: reformats many files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8eb078e88333b73bc75d02283d3d