### PR TITLE
Add missing-clip shake animation

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2459,3 +2459,20 @@ details > summary {
 .loading-spinner.bouncy {
   animation: bounce-ball 0.6s ease-in-out infinite;
 }
+
+@keyframes shake-ball {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
+}
+
+.loading-spinner.shake {
+  animation: shake-ball 0.4s ease-in-out infinite;
+}

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -30,6 +30,20 @@ export function initTilePlayer() {
     spinner.classList.remove("bouncy", "visible");
   }
 
+  let shakeTimer;
+  function showShake() {
+    if (!spinner) return;
+    spinner.textContent = "\u25CF";
+    spinner.classList.add("shake", "visible");
+    clearTimeout(shakeTimer);
+    shakeTimer = setTimeout(hideShake, 1200);
+  }
+
+  function hideShake() {
+    if (!spinner) return;
+    spinner.classList.remove("shake", "visible");
+  }
+
   async function loadHdClip() {
     const url = video.dataset.hdSrc;
     if (!url) return;
@@ -41,7 +55,10 @@ export function initTilePlayer() {
       const res = await fetch(url, { signal: abortCtl.signal });
       clearTimeout(timer);
       hideSpinner(video);
-      if (!res.ok) return;
+      if (!res.ok) {
+        if (res.status === 404) showShake();
+        return;
+      }
       const blob = await res.blob();
       const objUrl = URL.createObjectURL(blob);
       const pos = video.currentTime;
@@ -63,6 +80,7 @@ export function initTilePlayer() {
     } catch (_) {
       hideSpinner(video);
       hideBounce();
+      hideShake();
     }
   }
 

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -20,3 +20,8 @@ pattern to indicate reduced quality.
 If `/clip` hasn't finished rendering yet the server adds an
 `X-Clip-Status: waiting` header. The braille glyph becomes a bouncing dot in the
 corner so you know the HD version is still processing.
+
+When a clip is missing altogether the request returns **404**.
+The spinner briefly shakes side to side to signal that no footage
+is available. The effect lasts about a second so it doesn't clutter
+the interface.

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -57,3 +57,21 @@ test("group change updates video src", () => {
   expect(src).toMatch(/\/last_teaser\?group=kitchen$/);
   expect(hd).toMatch(/\/stream.mp4\?group=kitchen$/);
 });
+
+test("shake spinner on missing clip", async () => {
+  document.body.innerHTML = `<video id="live-video"><source></source></video>`;
+  window.templateDetails = { cam1: {} };
+  jest.useFakeTimers();
+
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: false, status: 404 }),
+  );
+
+  init();
+  await Promise.resolve();
+  await Promise.resolve();
+  const spinner = document.querySelector(".loading-spinner");
+  expect(spinner.classList.contains("shake")).toBe(true);
+  jest.runAllTimers();
+  expect(spinner.classList.contains("shake")).toBe(false);
+});


### PR DESCRIPTION
## Summary
- shake the braille spinner when HD clip is missing
- document new 404 feedback
- test shake animation logic

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `npm test --silent`
- `npm run size-audit --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b914c1e5c8333a263d44c889d5b9a