### PR TITLE
Fix group selection on live view

### DIFF
--- a/app/static/js/nav.js
+++ b/app/static/js/nav.js
@@ -145,6 +145,8 @@ export function initNav() {
 
     if (cameraDropdown) {
       cameraDropdown.addEventListener("change", () => {
+        // Avoid navigation when adjusting the live view
+        if (window.location.pathname.startsWith("/live")) return;
         if (cameraDropdown.value) {
           window.location.href = `/templates/${encodeURIComponent(
             cameraDropdown.value,
@@ -407,7 +409,11 @@ export function initNav() {
         const next = (idx + delta + opts.length) % opts.length;
         const cam = opts[next].value;
         cameraDropdown.value = cam;
-        window.location.href = `/templates/${encodeURIComponent(cam)}`;
+        if (window.location.pathname.startsWith("/live")) {
+          cameraDropdown.dispatchEvent(new Event("change"));
+        } else {
+          window.location.href = `/templates/${encodeURIComponent(cam)}`;
+        }
       };
 
       document.addEventListener("keydown", (e) => {


### PR DESCRIPTION
## Summary
- prevent the nav camera dropdown from redirecting when viewing `/live`
- handle keyboard/swipe camera navigation without leaving the live page

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: isort/black reformatted but reverted)*
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b948fa28c8333b8ed532f378d9148