### PR TITLE
Add missing clip feedback

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2459,3 +2459,20 @@ details > summary {
 .loading-spinner.bouncy {
   animation: bounce-ball 0.6s ease-in-out infinite;
 }
+
+@keyframes shake-no {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
+}
+
+.loading-spinner.shake {
+  animation: shake-no 0.4s ease-in-out infinite;
+}

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -1,4 +1,4 @@
-import { showSpinner, hideSpinner } from "./video.js";
+import { showSpinner, hideSpinner, showErrorIndicator } from "./video.js";
 
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
@@ -75,7 +75,10 @@ export function initTilePlayer() {
       const res = await fetch(url, { signal: abortCtl.signal });
       clearTimeout(timer);
       hideSpinner(video);
-      if (!res.ok) return;
+      if (!res.ok) {
+        showErrorIndicator(video);
+        return;
+      }
       const blob = await res.blob();
       const objUrl = URL.createObjectURL(blob);
       const pos = video.currentTime;
@@ -97,6 +100,7 @@ export function initTilePlayer() {
     } catch (_) {
       hideSpinner(video);
       hideBounce();
+      showErrorIndicator(video);
     }
   }
 

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -57,6 +57,18 @@ function hideSpinner(video) {
   spinner.classList.remove("visible");
 }
 
+function showErrorIndicator(video) {
+  const spinner = video.parentElement?.querySelector(".loading-spinner");
+  if (!spinner) return;
+  spinner.textContent = "⠿";
+  spinner.classList.add("shake", "visible");
+  clearTimeout(spinner.errorTimeoutId);
+  spinner.errorTimeoutId = setTimeout(() => {
+    spinner.classList.remove("shake", "visible");
+    spinner.textContent = "";
+  }, 2000);
+}
+
 export function setQueueDelay(ms) {
   queueDelay = ms;
 }
@@ -86,7 +98,14 @@ function processQueue() {
     src.src = vid.dataset.hdSrc;
     vid.dataset.hdLoaded = "true";
     vid.addEventListener("canplay", () => hideSpinner(vid), { once: true });
-    vid.addEventListener("error", () => hideSpinner(vid), { once: true });
+    vid.addEventListener(
+      "error",
+      () => {
+        hideSpinner(vid);
+        showErrorIndicator(vid);
+      },
+      { once: true },
+    );
     vid.load();
   }
   setTimeout(processQueue, queueDelay);
@@ -536,4 +555,4 @@ export function startCasting() {
 window.enqueueClip = enqueueClip;
 window.setQueueDelay = setQueueDelay;
 window.clearPrefetchQueue = clearPrefetchQueue;
-export { showSpinner, hideSpinner };
+export { showSpinner, hideSpinner, showErrorIndicator };

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -20,3 +20,6 @@ pattern to indicate reduced quality.
 If `/clip` hasn't finished rendering yet the server adds an
 `X-Clip-Status: waiting` header. The braille glyph becomes a bouncing dot in the
 corner so you know the HD version is still processing.
+
+When a clip is missing the spinner briefly shakes left and right with a solid
+braille block `⠿` to signal that no footage is available.

--- a/tests/js/error_indicator.test.js
+++ b/tests/js/error_indicator.test.js
@@ -1,0 +1,31 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <div class="loading-spinner"></div>
+    <video preload="none" data-hd-src="/clip/cam1">
+      <source src="/last_video/cam1" type="video/mp4" />
+    </video>
+  </div>
+`;
+
+let enqueueClip;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  enqueueClip = mod.enqueueClip;
+});
+
+jest.useFakeTimers();
+
+test("shows shake indicator when clip missing", () => {
+  const video = document.querySelector("video");
+  const spinner = document.querySelector(".loading-spinner");
+  video.load = jest.fn(() => {
+    video.dispatchEvent(new Event("error"));
+  });
+  enqueueClip(video);
+  expect(spinner.classList.contains("shake")).toBe(true);
+  jest.runAllTimers();
+  expect(spinner.classList.contains("shake")).toBe(false);
+});


### PR DESCRIPTION
## Summary
- animate spinner with a shake when a clip can't be loaded
- surface clip errors during hover preload
- document the new spinner behavior
- test missing clip indicator

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b99a9860883339ff186ca871bfd0a