### PR TITLE
Fix live view initial playback

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -40,6 +40,8 @@ export function initTilePlayer() {
 
   function playMjpg(group) {
     if (!group) return;
+    showSpinner(video);
+    image.onload = () => hideSpinner(video);
     video.style.display = "none";
     image.style.display = "block";
     image.src = `/stream.mjpg?group=${encodeURIComponent(group)}&time=${Date.now()}`;
@@ -107,14 +109,36 @@ export function initTilePlayer() {
     image.style.display = "none";
 
     if (name === "All") {
-      if (source) source.src = "/last_teaser?group=all";
+      const first = Object.keys(window.templateDetails || {})[0];
+      if (first && source) source.src = `/last_video/${first}`;
       video.setAttribute("data-hd-src", "/stream.mp4");
+      video.addEventListener(
+        "ended",
+        () => {
+          showSpinner(video);
+          image.addEventListener("load", () => hideSpinner(video), {
+            once: true,
+          });
+          playMjpg("all");
+        },
+        { once: true },
+      );
     } else if (name.startsWith("group-")) {
       const raw = name.slice(6);
       const group = encodeURIComponent(raw);
       if (source) source.src = `/last_teaser?group=${group}`;
       video.setAttribute("data-hd-src", `/stream.mp4?group=${group}`);
-      scheduleLive(raw);
+      video.addEventListener(
+        "ended",
+        () => {
+          showSpinner(video);
+          image.addEventListener("load", () => hideSpinner(video), {
+            once: true,
+          });
+          playMjpg(raw);
+        },
+        { once: true },
+      );
     } else {
       if (source) source.src = `/last_video/${name}`;
       video.setAttribute("data-hd-src", `/clip/${name}`);

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -19,6 +19,9 @@
     Your browser does not support the video tag.
   </video>
 </div>
+<script>
+  window.templateDetails = {{ template_details|tojson }};
+</script>
 
 <script
   type="module"

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -74,3 +74,17 @@ test("fallback to nav camera dropdown", () => {
   const src = document.querySelector("#live-video source").src;
   expect(src).toMatch(/\/last_teaser\?group=foo$/);
 });
+
+test("all group uses last_video clip", () => {
+  document.body.innerHTML = `
+    <video id="live-video"><source></source></video>
+    <select id="camera-selector"><option>All</option></select>
+  `;
+
+  window.templateDetails = { cam1: {}, cam2: {} };
+
+  init();
+  changeGroup("all");
+  const src = document.querySelector("#live-video source").src;
+  expect(src).toMatch(/\/last_video\/cam1$/);
+});


### PR DESCRIPTION
## Summary
- embed templateDetails in `live.html`
- start streaming MJPEG after last video ends
- add test covering "All" group playback

## Testing
- `pre-commit run --files app/static/js/tile_player.js tests/js/tile_player.test.js app/templates/live.html`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b9cb885108333bba2cef0b1bdc206