### PR TITLE
Add lazy loading for dashboard posters

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -665,6 +665,9 @@ export async function loadTemplates() {
         entries.forEach((entry) => {
           const video = entry.target;
           if (entry.isIntersecting) {
+            if (!video.poster && video.dataset.poster) {
+              video.poster = video.dataset.poster;
+            }
             if (isMobile()) {
               safePlay(video);
             }
@@ -730,7 +733,7 @@ export async function loadTemplates() {
                 <div class="${videoContainerClass} ${errorClass}" data-timestamp="${lastScreenshotTime}" style="border-color: ${borderColor}">
                   <div class="camera-name">${name}</div>
                   <div class="loading-spinner" aria-hidden="true"></div>
-                  <video data-name="${name}" poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback data-hd-src="/clip/${name}">
+                  <video data-name="${name}" data-poster="/last_screenshot/${name}" alt="${name}" style="width:100%" muted title="${template.last_caption} (${humanizedTimestamp})" preload="none" disableRemotePlayback data-hd-src="/clip/${name}" loading="lazy">
                     <source src="/last_video/${name}" type="video/mp4">
                     Your browser does not support the video tag.
                   </video>

--- a/docs/performance_tuning.md
+++ b/docs/performance_tuning.md
@@ -14,3 +14,6 @@ Crawler startups are spread automatically using a mathematical scheduler that
 minimizes simultaneous runs. At launch, each crawler is assigned an offset based
 on its frequency so heavy jobs are distributed evenly over the window defined by
 `CRAWLER_STARTUP_SPREAD`.
+
+Dashboard thumbnails now lazy load. Each video tile sets its poster image only
+when it enters the viewport, reducing initial network requests for large setups.

--- a/tests/js/lazy_poster.test.js
+++ b/tests/js/lazy_poster.test.js
@@ -1,0 +1,48 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="template-list"></div>
+  <select id="group-dropdown"></select>
+  <input id="grid-width-slider" type="range">
+`;
+
+let loadTemplates;
+let cb;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/templates.js");
+  loadTemplates = mod.loadTemplates;
+});
+
+beforeEach(() => {
+  window.IntersectionObserver = class {
+    constructor(fn) {
+      cb = fn;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => "application/json" },
+    json: () =>
+      Promise.resolve({
+        cam1: {
+          url: "#",
+          capture_failed: false,
+          last_caption: "",
+          last_screenshot_time: 0,
+        },
+      }),
+  });
+});
+
+test("poster loads when video becomes visible", async () => {
+  await loadTemplates();
+  const video = document.querySelector("video");
+  expect(video.dataset.poster).toBe("/last_screenshot/cam1");
+  expect(video.poster).toBe("");
+  cb([{ target: video, isIntersecting: true }]);
+  expect(video.poster.endsWith("/last_screenshot/cam1")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- lazy load poster images on the dashboard
- document dashboard poster lazy loading
- cover new behavior with a Jest test

## Testing
- `pre-commit run --files app/static/js/templates.js tests/js/lazy_poster.test.js docs/performance_tuning.md`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b9f746364833380efc2a1c11d550e