### PR TITLE
Add hex time to test pattern

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -65,15 +65,21 @@ def _to_roman(num: int) -> str:
 
 
 def _format_roman_time(timestamp: str) -> str:
-    """Return the timestamp represented with Roman numerals."""
+    """Return the timestamp represented with Roman numerals without colons."""
     h, m, s = map(int, timestamp.split(":"))
-    return f"{_to_roman(h)}:{_to_roman(m)}:{_to_roman(s)}"
+    return f"{_to_roman(h)}{_to_roman(m)}{_to_roman(s)}"
 
 
 def _format_binary_time(timestamp: str) -> str:
-    """Return the timestamp in binary notation."""
+    """Return the timestamp in binary notation without colons."""
     h, m, s = map(int, timestamp.split(":"))
-    return f"{h:05b}:{m:06b}:{s:06b}"
+    return f"{h:05b}{m:06b}{s:06b}"
+
+
+def _format_hex_time(timestamp: str) -> str:
+    """Return the timestamp in hexadecimal notation."""
+    h, m, s = map(int, timestamp.split(":"))
+    return f"{h:02X}:{m:02X}:{s:02X}"
 
 
 def _format_beats_time(timestamp: str) -> str:
@@ -445,26 +451,29 @@ def generate_test_pattern(
     font_braille = load_font(30)
     time_simple = timestamp
     beats_time = _format_beats_time(time_simple)
+    hex_time = _format_hex_time(time_simple)
     formats = [
         time_simple,
-        _format_binary_time(time_simple),
-        _format_roman_time(time_simple),
         _to_braille(time_simple),
+        _format_binary_time(time_simple),
         tz_text,
+        _format_roman_time(time_simple),
         beats_time,
+        hex_time,
     ]
 
     fonts = [
         font_right,
+        font_braille,
         font_binary,
         font_right,
-        font_braille,
+        font_right,
         font_right,
         font_right,
     ]
     segments = [t.replace("\u2812", ":").split(":") for t in formats]
 
-    braille_idx = 3
+    braille_idx = 1
 
     roman_w1, roman_w2, roman_w3, colon_w_std = _roman_segment_widths(font_right)
     colon_w = max(
@@ -486,14 +495,18 @@ def generate_test_pattern(
     seg3_max = seg2_max
 
     beats_w = draw.textlength(beats_time, font=font_right)
-    total_w = max(seg1_max + colon_gap + seg2_max + colon_gap + seg3_max, beats_w)
+    hex_w = draw.textlength(hex_time, font=font_right)
+    total_w = max(
+        seg1_max + colon_gap + seg2_max + colon_gap + seg3_max, beats_w, hex_w
+    )
     x_start = width - total_w - 30
 
     line_heights = [
         font_right.size,
+        font_braille.size,
         font_binary.size,
         font_right.size,
-        font_braille.size,
+        font_right.size,
         font_right.size,
         font_right.size,
     ]
@@ -533,7 +546,7 @@ def generate_test_pattern(
         font=font_right,
     )
     current_y = y_start
-    timezone_idx = 4
+    timezone_idx = 3
     for idx, parts in enumerate(segments):
         x = x_start
         y = current_y

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -10,6 +10,7 @@ from PIL import Image
 from app.utils.test_pattern import (
     _format_beats_time,
     _format_binary_time,
+    _format_hex_time,
     _format_roman_time,
     _to_braille,
     generate_test_pattern,
@@ -104,8 +105,9 @@ class TestTestPattern(unittest.TestCase):
 class TestTimeFormatHelpers(unittest.TestCase):
     def test_time_format_helpers(self):
         ts = "12:34:56"
-        self.assertEqual(_format_binary_time(ts), "01100:100010:111000")
-        self.assertEqual(_format_roman_time(ts), "XII:XXXIV:LVI")
+        self.assertEqual(_format_binary_time(ts), "01100100010111000")
+        self.assertEqual(_format_roman_time(ts), "XIIXXXIVLVI")
+        self.assertEqual(_format_hex_time(ts), "0C:22:38")
         self.assertEqual(_format_beats_time(ts), "@565")
         self.assertEqual(_to_braille(ts), "⠁⠃⠒⠉⠙⠒⠑⠋")
 


### PR DESCRIPTION
## Summary
- support hex time in test pattern
- reorder stacked time displays
- drop colons from binary and roman clocks
- update tests for new time formats

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ba12c7db0833391eb3159ad0d9ca6