### PR TITLE
Add HDR metadata and ST 2110-21 alignment to test pattern

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -2374,9 +2374,7 @@ def init_routes(app: Flask) -> None:
             while True:
                 spinner = spinner_frames[index % len(spinner_frames)]
                 img = test_pattern.generate_test_pattern(spinner=spinner)
-                buf = io.BytesIO()
-                img.save(buf, format="JPEG")
-                frame = buf.getvalue()
+                frame = test_pattern.encode_jpeg_with_metadata(img)
                 yield b"--" + boundary + b"\r\n"
                 yield b"Content-Type: image/jpeg\r\n\r\n" + frame + b"\r\n"
                 index += 1

--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import datetime
+import hashlib
+import io
+import json
 import math
 import os
 import time
@@ -31,6 +34,20 @@ BRAILLE_DIGITS = {
 
 BRAILLE_RADIUS = 3
 BRAILLE_SPACING = 3
+
+
+# Static HDR metadata for SMPTE ST 2086. Embedded in JPEG headers so HDR
+# monitors can auto-switch and EDID quirks become visible.
+ST2086_METADATA = {
+    "display_primaries": [
+        [0.708, 0.292],
+        [0.170, 0.797],
+        [0.131, 0.046],
+    ],
+    "white_point": [0.3127, 0.329],
+    "luminance_min": 0.001,
+    "luminance_max": 1000,
+}
 
 
 def _to_braille(text: str) -> str:
@@ -633,3 +650,15 @@ def save_test_pattern(path: str, **kwargs) -> None:
     img = generate_test_pattern(**kwargs)
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     img.save(path, "PNG")
+
+
+def encode_jpeg_with_metadata(img: Image.Image) -> bytes:
+    """Return JPEG bytes with ST 2086 metadata and ST 2110-21 hash."""
+
+    comment_data = {
+        "smpte2086": ST2086_METADATA,
+        "st2110_21_hash": hashlib.sha256(img.tobytes()).hexdigest()[:8],
+    }
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", comment=json.dumps(comment_data).encode("utf-8"))
+    return buf.getvalue()

--- a/docs/test_pattern_reference.md
+++ b/docs/test_pattern_reference.md
@@ -24,3 +24,5 @@ The pattern now also includes:
 - **Super-white and super-black patches** on the left and right edges.
 - **Grayscale staircase** spanning the width under the bars.
 - **Concentric zone plate** behind the bullseye to expose aliasing.
+- **HDR metadata** (SMPTE ST 2086) embedded in each JPEG header for HDR auto-switching.
+- **ST 2110-21 alignment hash** marking frames for packet timing tests.

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -1,4 +1,7 @@
 import datetime
+import hashlib
+import io
+import json
 import math
 import os
 import tempfile
@@ -12,6 +15,7 @@ from app.utils.test_pattern import (
     _format_binary_time,
     _format_roman_time,
     _to_braille,
+    encode_jpeg_with_metadata,
     generate_test_pattern,
     save_test_pattern,
 )
@@ -99,6 +103,17 @@ class TestTestPattern(unittest.TestCase):
             for y in range(y_start, y_start + 30)
         ]
         self.assertIn((160, 160, 160), region)
+
+    def test_jpeg_metadata(self):
+        img = generate_test_pattern(width=50, height=50)
+        data = encode_jpeg_with_metadata(img)
+        with Image.open(io.BytesIO(data)) as im:
+            comment = im.info.get("comment")
+        self.assertIsNotNone(comment)
+        meta = json.loads(comment.decode())
+        expected_hash = hashlib.sha256(img.tobytes()).hexdigest()[:8]
+        self.assertEqual(meta["st2110_21_hash"], expected_hash)
+        self.assertIn("smpte2086", meta)
 
 
 class TestTimeFormatHelpers(unittest.TestCase):


### PR DESCRIPTION
## Summary
- embed SMPTE ST 2086 metadata in JPEG comments
- include ST 2110-21 alignment hash
- expose metadata via `/test_pattern.mjpg`
- document new HDR metadata and alignment hash
- test JPEG metadata generation

## Testing
- `pre-commit run --files app/utils/test_pattern.py app/routes.py docs/test_pattern_reference.md tests/test_test_pattern.py`
- `PYTHONPATH=. pytest -q tests/test_test_pattern.py`


------
https://chatgpt.com/codex/tasks/task_e_684ba2281c58833397f1f678fbbf7153