### PR TITLE
Add pulsing QR code overlay to test pattern

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -5,11 +5,26 @@ from __future__ import annotations
 import datetime
 import math
 import os
+import subprocess
 import time
 from typing import Optional
 
 from dateutil import tz
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageEnhance, ImageFont
+
+try:
+    import qrcode  # type: ignore
+except Exception:  # pragma: no cover
+    qrcode = None
+
+try:
+    COMMIT_HASH = (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        .decode()
+        .strip()
+    )
+except Exception:  # pragma: no cover
+    COMMIT_HASH = "unknown"
 
 from app import config
 
@@ -170,6 +185,18 @@ def load_font(size: int) -> ImageFont.FreeTypeFont:
         return ImageFont.truetype(path, size)
     except OSError:
         return font
+
+
+def _generate_qr_code(data: str, size: int) -> Image.Image:
+    """Return a QR code image for ``data`` scaled to ``size`` pixels."""
+    if qrcode is None:
+        raise RuntimeError("qrcode module not available")
+
+    qr = qrcode.QRCode(border=0, box_size=1)
+    qr.add_data(data)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="white", back_color="black").convert("RGBA")
+    return img.resize((size, size), Image.NEAREST)
 
 
 def generate_test_pattern(
@@ -609,6 +636,18 @@ def generate_test_pattern(
         draw.text(
             (10, bars_total + step_h + 10), camera_name, fill="white", font=font_small
         )
+
+    qr_size = min(width, height) // 8
+    qr_payload = f"{timestamp}-{COMMIT_HASH}"
+    try:
+        qr_img = _generate_qr_code(qr_payload, qr_size)
+        pulse = 0.8 + 0.2 * math.sin(time.time() * 2)
+        qr_img = ImageEnhance.Brightness(qr_img).enhance(pulse)
+        img.alpha_composite(
+            qr_img, (width - qr_img.width - 10, height - qr_img.height - 10)
+        )
+    except Exception:
+        pass
 
     # redraw the second hand above overlays
     h, m, s = map(int, datetime.datetime.now().strftime("%H:%M:%S").split(":"))

--- a/docs/test_pattern_reference.md
+++ b/docs/test_pattern_reference.md
@@ -17,6 +17,7 @@ The test pattern includes calibration checks for panel accuracy and HDR tone map
 - **Date overlay** appears on the left aligned with the standard clock.
 - **Braille spinner** in the corner updates once per second during streaming.
 - **Mini color bars** in the top-left align with a reduced checker patch and grayscale swatch.
+- **QR code** in the bottom-right pulses subtly and encodes the current time and build hash.
 
 The pattern now also includes:
 

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -100,6 +100,19 @@ class TestTestPattern(unittest.TestCase):
         ]
         self.assertIn((160, 160, 160), region)
 
+    def test_qr_code_overlay(self):
+        stub = Image.new("RGBA", (12, 12), (255, 255, 255, 255))
+        with (
+            unittest.mock.patch(
+                "app.utils.test_pattern._generate_qr_code", return_value=stub
+            ),
+            unittest.mock.patch("app.utils.test_pattern.time.time", return_value=0),
+        ):
+            img = generate_test_pattern(width=200, height=100)
+        x = 200 - stub.width - 10 + stub.width // 2
+        y = 100 - stub.height - 10 + stub.height // 2
+        self.assertEqual(img.getpixel((x, y)), (204, 204, 204))
+
 
 class TestTimeFormatHelpers(unittest.TestCase):
     def test_time_format_helpers(self):


### PR DESCRIPTION
## Summary
- generate QR code from build hash and timestamp
- overlay pulsing QR in lower‑right of test pattern
- test QR overlay
- document QR overlay in the test pattern reference

## Testing
- `pre-commit run --files app/utils/test_pattern.py tests/test_test_pattern.py`
- `PYTHONPATH=. pytest -q tests/test_test_pattern.py`

------
https://chatgpt.com/codex/tasks/task_e_684ba4202d788333b75cafac244492a0