### PR TITLE
Add live video queue backoff

### DIFF
--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -33,6 +33,7 @@ function hideScrubTooltip() {
 let prefetchQueue = [];
 let processing = false;
 let queueDelay = 1000;
+let failStreak = 0;
 const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 function showSpinner(video) {
@@ -73,6 +74,16 @@ export function setQueueDelay(ms) {
   queueDelay = ms;
 }
 
+function adjustDelay(success) {
+  failStreak = success
+    ? Math.max(0, failStreak - 1)
+    : Math.min(failStreak + 1, 5);
+  queueDelay = 1000 * (failStreak + 1);
+  if (!success && prefetchQueue.length > failStreak + 1) {
+    prefetchQueue = prefetchQueue.slice(0, failStreak + 1);
+  }
+}
+
 export function enqueueClip(video) {
   if (!video.dataset.hdSrc || video.dataset.hdLoaded === "true") return;
   if (prefetchQueue.includes(video)) return;
@@ -97,12 +108,22 @@ function processQueue() {
   if (src) {
     src.src = vid.dataset.hdSrc;
     vid.dataset.hdLoaded = "true";
-    vid.addEventListener("canplay", () => hideSpinner(vid), { once: true });
+    const start =
+      performance && performance.now ? performance.now() : Date.now();
+    vid.addEventListener(
+      "canplay",
+      () => {
+        hideSpinner(vid);
+        adjustDelay(performance.now() - start < 3000);
+      },
+      { once: true },
+    );
     vid.addEventListener(
       "error",
       () => {
         hideSpinner(vid);
         showErrorIndicator(vid);
+        adjustDelay(false);
       },
       { once: true },
     );

--- a/tests/js/queue_backoff.test.js
+++ b/tests/js/queue_backoff.test.js
@@ -1,0 +1,31 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <div class="loading-spinner"></div>
+    <video preload="none" data-hd-src="/clip/cam1">
+      <source src="/last_video/cam1" type="video/mp4" />
+    </video>
+  </div>
+`;
+
+let enqueueClip;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  enqueueClip = mod.enqueueClip;
+});
+
+jest.useFakeTimers();
+
+test("backoff queue when clip load fails", () => {
+  const video = document.querySelector("video");
+  video.load = jest.fn(() => {
+    video.dispatchEvent(new Event("error"));
+  });
+  const orig = global.setTimeout;
+  global.setTimeout = jest.fn();
+  enqueueClip(video);
+  expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 2000);
+  global.setTimeout = orig;
+});


### PR DESCRIPTION
## Summary
- adapt HD prefetch queue delay based on stream errors
- test queue backoff logic

## Testing
- `pre-commit run --files app/static/js/video.js tests/js/queue_backoff.test.js`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ba476d3548333898e9ab28f5876a6