### PR TITLE
Add spaced Roman time overlay

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -82,9 +82,9 @@ def _to_roman(num: int) -> str:
 
 
 def _format_roman_time(timestamp: str) -> str:
-    """Return the timestamp represented with Roman numerals without colons."""
+    """Return the timestamp represented with Roman numerals separated by colons."""
     h, m, s = map(int, timestamp.split(":"))
-    return f"{_to_roman(h)}{_to_roman(m)}{_to_roman(s)}"
+    return f"{_to_roman(h)}:{_to_roman(m)}:{_to_roman(s)}"
 
 
 def _format_binary_time(timestamp: str) -> str:
@@ -472,9 +472,9 @@ def generate_test_pattern(
     formats = [
         time_simple,
         _to_braille(time_simple),
+        _format_roman_time(time_simple),
         _format_binary_time(time_simple),
         tz_text,
-        _format_roman_time(time_simple),
         beats_time,
         hex_time,
     ]
@@ -482,8 +482,8 @@ def generate_test_pattern(
     fonts = [
         font_right,
         font_braille,
-        font_binary,
         font_right,
+        font_binary,
         font_right,
         font_right,
         font_right,
@@ -521,8 +521,8 @@ def generate_test_pattern(
     line_heights = [
         font_right.size,
         font_braille.size,
-        font_binary.size,
         font_right.size,
+        font_binary.size,
         font_right.size,
         font_right.size,
         font_right.size,
@@ -563,7 +563,8 @@ def generate_test_pattern(
         font=font_right,
     )
     current_y = y_start
-    timezone_idx = 3
+    timezone_idx = 4
+    roman_idx = 2
     for idx, parts in enumerate(segments):
         x = x_start
         y = current_y
@@ -593,6 +594,30 @@ def generate_test_pattern(
                 (x + seg3_max - _braille_text_width(parts[2]), y),
                 parts[2],
                 fill=clock_color,
+            )
+            current_y += line_heights[idx] + spacing_y
+            if idx in {1, timezone_idx}:
+                current_y += extra_gap
+        elif idx == roman_idx:
+            draw.text(
+                (x + seg1_max - draw.textlength(parts[0], font=font), y),
+                parts[0],
+                fill=clock_color,
+                font=font,
+            )
+            x += seg1_max + colon_gap
+            draw.text(
+                (x + seg2_max - draw.textlength(parts[1], font=font), y),
+                parts[1],
+                fill=clock_color,
+                font=font,
+            )
+            x += seg2_max + colon_gap
+            draw.text(
+                (x + seg3_max - draw.textlength(parts[2], font=font), y),
+                parts[2],
+                fill=clock_color,
+                font=font,
             )
             current_y += line_heights[idx] + spacing_y
             if idx in {1, timezone_idx}:

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -97,7 +97,7 @@ class TestTestPattern(unittest.TestCase):
         ):
             img = generate_test_pattern(width=400, height=400)
 
-        y_start = 400 // 2 - 248 // 2 + 20
+        y_start = 400 // 2 - 374 // 2 + 20
         region = [
             img.getpixel((x, y))
             for x in range(30, 120)
@@ -121,7 +121,7 @@ class TestTimeFormatHelpers(unittest.TestCase):
     def test_time_format_helpers(self):
         ts = "12:34:56"
         self.assertEqual(_format_binary_time(ts), "01100100010111000")
-        self.assertEqual(_format_roman_time(ts), "XIIXXXIVLVI")
+        self.assertEqual(_format_roman_time(ts), "XII:XXXIV:LVI")
         self.assertEqual(_format_hex_time(ts), "0C:22:38")
         self.assertEqual(_format_beats_time(ts), "@565")
         self.assertEqual(_to_braille(ts), "⠁⠃⠒⠉⠙⠒⠑⠋")


### PR DESCRIPTION
## Summary
- display Roman numeral time separated into segments
- position Roman time directly under Braille overlay
- adjust date overlay test expectations

## Testing
- `pre-commit run --all-files` *(fails: isort and black modify unrelated files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba5ff8fc08333998e8e0b98e72d67