### PR TITLE
Add JS test for API discovery

### DIFF
--- a/tests/js/api_discover.test.js
+++ b/tests/js/api_discover.test.js
@@ -1,0 +1,23 @@
+import { execFileSync } from "child_process";
+
+describe("API discover", () => {
+  function fetchApiInfo() {
+    const script = [
+      "import json, os",
+      'os.environ["LOG_LEVEL"] = "CRITICAL"',
+      "from app import create_app",
+      "app = create_app(enable_watchdog=False, schedule=False, crawlers=False, log_cache=False)",
+      "client = app.test_client()",
+      'print(json.dumps(client.get("/api/discover").get_json()))',
+    ].join("; ");
+    return execFileSync("python3", ["-c", script], { encoding: "utf8" });
+  }
+
+  test("returns list of endpoints", () => {
+    const output = fetchApiInfo().trim().split("\n").pop();
+    const data = JSON.parse(output);
+    expect(Array.isArray(data.endpoints)).toBe(true);
+    expect(data.endpoints.length).toBeGreaterThan(0);
+    expect(data.version).toBeDefined();
+  });
+});

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -105,7 +105,6 @@ class TestTestPattern(unittest.TestCase):
         ]
         self.assertIn((160, 160, 160), region)
 
-
     def test_qr_code_overlay(self):
         stub = Image.new("RGBA", (12, 12), (255, 255, 255, 255))
         with (


### PR DESCRIPTION
## Summary
- add `api_discover.test.js` to verify /api/discover offline
- fix blank line style in `test_test_pattern.py`

## Testing
- `pre-commit run --files tests/test_test_pattern.py tests/js/api_discover.test.js`
- `pytest tests/test_authentication.py::TestAuthentication::test_login_success -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ba7a2c2508333bd01955303d2a39e