### PR TITLE
Fix caption prompt layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1765,13 +1765,12 @@ body.advanced-enabled .advanced-only {
 
 .chat-box {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 0.5rem;
 }
 
 .chat-prompt,
 .chat-response {
-  flex: 1 1 300px;
   display: flex;
   flex-direction: column;
 }
@@ -1787,16 +1786,6 @@ body.advanced-enabled .advanced-only {
 
 .chat-box label {
   font-weight: 600;
-}
-
-@media (max-width: 600px) {
-  .chat-box {
-    flex-direction: column;
-  }
-  .chat-prompt,
-  .chat-response {
-    flex: 1 1 100%;
-  }
 }
 
 .filter-controls {

--- a/docs/caption_prompt_toggle.md
+++ b/docs/caption_prompt_toggle.md
@@ -1,3 +1,3 @@
 # Caption or Prompt Toggle
 
-The Captions page now lets you choose whether to view each camera's last caption or its saved prompt. Use the toggle above the table to switch modes. Your selection persists in `localStorage` so it is remembered on the next visit. Sorting works on whichever field is visible.
+The Captions page now lets you choose whether to view each camera's last caption or its saved prompt. Use the toggle above the table to switch modes. Both fields are stacked in a single column, and switching modes simply hides one to keep the layout compact. Your selection persists in `localStorage` so it is remembered on the next visit. Sorting works on whichever field is visible.


### PR DESCRIPTION
## Summary
- ensure caption prompts stack vertically
- document layout

## Testing
- `pre-commit run --files app/static/css/style.css docs/caption_prompt_toggle.md`
- `pytest` *(fails: AssertionError in tests/test_routes.py::TestRoutes::test_captions_status)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bb0e546fc8333b3c35b3a553cdff5