### PR TITLE
Add caption/prompt toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1736,6 +1736,14 @@ body.advanced-enabled .advanced-only {
   white-space: pre-wrap;
 }
 
+.field-toggle {
+  @apply inline-flex gap-2 my-2;
+}
+
+.field-toggle label {
+  @apply flex items-center gap-1 cursor-pointer;
+}
+
 .chat-box {
   display: flex;
   flex-wrap: wrap;

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -191,6 +191,37 @@ export function initCaptions() {
       });
     });
 
+    const radios = document.querySelectorAll("input[name='caption-field']");
+    const header = document.querySelector("#camera-table th.view-header");
+    const rows = document.querySelectorAll("#camera-table tbody tr");
+
+    const applyView = (view) => {
+      if (header) header.textContent = view === "prompt" ? "Prompt" : "Caption";
+      rows.forEach((row) => {
+        const prompt = row.querySelector(".chat-prompt");
+        const response = row.querySelector(".chat-response");
+        const cell = row.cells[1];
+        if (!cell) return;
+        if (prompt) prompt.classList.toggle("hidden", view !== "prompt");
+        if (response) response.classList.toggle("hidden", view !== "caption");
+        const val =
+          view === "prompt"
+            ? prompt?.querySelector("textarea")?.value || ""
+            : response?.querySelector(".last-caption")?.textContent || "";
+        cell.dataset.value = val.toLowerCase();
+      });
+      localStorage.setItem("captionView", view);
+    };
+
+    radios.forEach((r) => {
+      r.addEventListener("change", () => applyView(r.value));
+    });
+    const stored = localStorage.getItem("captionView") || "caption";
+    radios.forEach((r) => {
+      r.checked = r.value === stored;
+    });
+    applyView(stored);
+
     const page = document.querySelector(".captions-page");
     const latest = page?.dataset.latestCaption || "";
     const chyron = document.getElementById("caption-chyron");

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -53,13 +53,22 @@ template_controls %} {% block content %}
     </select>
     {% endcall %}
 
-    <h2>Camera Notes</h2>
+    <div class="field-toggle">
+      <label>
+        <input type="radio" name="caption-field" value="caption" checked />
+        Caption
+      </label>
+      <label>
+        <input type="radio" name="caption-field" value="prompt" /> Prompt
+      </label>
+    </div>
+
     <div id="template-list">
       <table id="camera-table" class="camera-table">
         <thead>
           <tr>
             <th class="sortable" data-type="string">Camera</th>
-            <th>Caption</th>
+            <th class="sortable view-header" data-type="string">Caption</th>
           </tr>
         </thead>
         <tbody>
@@ -114,7 +123,8 @@ template_controls %} {% block content %}
                       class="notes-textarea"
                       placeholder="Edit caption prompt"
                     >
-{{ template_details[camera]['notes'] }}</textarea>
+{{ template_details[camera]['notes'] }}</textarea
+                    >
                     <button
                       class="update-button"
                       data-template="{{ camera }}"

--- a/docs/caption_prompt_toggle.md
+++ b/docs/caption_prompt_toggle.md
@@ -1,0 +1,3 @@
+# Caption or Prompt Toggle
+
+The Captions page now lets you choose whether to view each camera's last caption or its saved prompt. Use the toggle above the table to switch modes. Your selection persists in `localStorage` so it is remembered on the next visit. Sorting works on whichever field is visible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Video Archiver: video_archiver.md
       - Dashboard Border Legend: border_legend.md
       - Caption Overlay Toggle: caption_overlay_toggle.md
+      - Caption or Prompt Toggle: caption_prompt_toggle.md
       - Captions Chatbot: chatbot.md
       - Continuous Integration Checks: ci_checks.md
       - Jog-Shuttle Control: jog_shuttle.md

--- a/tests/js/caption_prompt_toggle.test.js
+++ b/tests/js/caption_prompt_toggle.test.js
@@ -1,0 +1,44 @@
+import { jest } from "@jest/globals";
+
+let initCaptions;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/captions.js");
+  initCaptions = mod.initCaptions;
+});
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <button class="tab-link" data-tab="one"></button>
+    <div id="one" class="tab-content"></div>
+    <input type="radio" name="caption-field" value="caption" checked>
+    <input type="radio" name="caption-field" value="prompt">
+    <table id="camera-table">
+      <thead>
+        <tr><th class="view-header">Caption</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>cam1</td>
+          <td>
+            <div class="chat-prompt"><textarea>hello</textarea></div>
+            <div class="chat-response"><div class="last-caption">world</div></div>
+          </td>
+        </tr>
+      </tbody>
+    </table>`;
+  localStorage.clear();
+});
+
+test("toggle switches view", () => {
+  initCaptions();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  document.querySelector("input[value='prompt']").click();
+  expect(document.querySelector(".view-header").textContent).toBe("Prompt");
+  expect(
+    document.querySelector(".chat-response").classList.contains("hidden"),
+  ).toBe(true);
+  expect(
+    document.querySelector(".chat-prompt").classList.contains("hidden"),
+  ).toBe(false);
+});


### PR DESCRIPTION
## Summary
- remove Camera Notes section
- add caption/prompt toggle with persistent choice
- hide prompt or caption column accordingly and support sorting
- document the toggle feature
- show toggle above table and test it

## Testing
- `pre-commit run --files app/static/css/style.css app/templates/captions.html tests/js/caption_prompt_toggle.test.js`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b588b4f0083339acea7992cb00f4c