### PR TITLE
Fix pie chart sizing

### DIFF
--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -57,7 +57,10 @@ export function initCosts() {
         chart = new Chart(ctx, {
           type: "pie",
           data: chartData,
-          options: { plugins: { legend: { display: false } } },
+          options: {
+            responsive: false,
+            plugins: { legend: { display: false } },
+          },
         });
       }
     };
@@ -149,7 +152,10 @@ export function initCostSummary(startTime) {
         chart = new Chart(ctx, {
           type: "pie",
           data: chartData,
-          options: { plugins: { legend: { display: false } } },
+          options: {
+            responsive: false,
+            plugins: { legend: { display: false } },
+          },
         });
       }
     };

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -21,7 +21,7 @@
   />
   <span id="cost-top-label">Top 10</span>
 </div>
-<canvas id="costChart" width="160" height="160"></canvas>
+<canvas id="costChart" width="500" height="500"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>

--- a/app/templates/cost_summary.html
+++ b/app/templates/cost_summary.html
@@ -13,7 +13,7 @@ content %}
   <button type="button" id="load-cost" title="Load cost data">Load</button>
 </form>
 {% endcall %}
-<canvas id="costChart" width="300" height="225"></canvas>
+<canvas id="costChart" width="500" height="500"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- reduce pie chart canvas responsiveness so 500×500 sizing applies

## Testing
- `pre-commit run --all-files` *(fails: isort/black modified unrelated files)*
- `pytest -q` *(fails: 3 failed, 518 passed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bb94f831c83338c908b612e3e5368