### PR TITLE
Fix runtime error by pinning numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved screenshot reliability
 - Enhanced camera list UI and video player controls
 - Updated package requirements and cleaned up imports
-- Added CPU builds of JAX 0.6.1 and Flax 0.2.0
+- Removed the JAX and Flax dependencies
 - Removed the `scikit-image` dependency in favor of a lightweight image
   comparison implementation
-- Bumped numpy to 1.26.0
+- Pinned numpy below version 2.0 due to compatibility issues
 - Removed nodriver and its screenshot helper
 - Updated default VERSION to 0.2.7 for footer display
 - The footer name now links to https://glimpser.net

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -54,8 +54,8 @@ Install the required Python packages:
 pip install -r requirements.txt
 ```
 
-The `requirements.txt` file now includes the CPU builds of **JAX 0.6.1** and
-**Flax 0.8.5**, along with updated `numpy` (1.25.0).
+The `requirements.txt` file lists the dependencies, including `numpy` pinned
+below version 2 (>=1.26,<2.0).
 
 ### 6. (Optional) Configure Environment Variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask==3.1.1
 Flask-APScheduler==1.13.1
 Flask-Login==0.6.3
 Jinja2==3.1.6
-numpy==2.2.6
+numpy>=1.26,<2.0
 pdf2image==1.17.0
 Pillow==11.2.1
 psutil~=7.0.0


### PR DESCRIPTION
## Summary
- pin numpy below version 2 for compatibility with onnxruntime
- update installation docs
- document the change in the changelog
- drop references to deprecated JAX and Flax dependencies

## Testing
- `pre-commit run --all-files` *(reformatted a large set of files; reverted unrelated changes)*
- `flake8`
- `pytest -q` *(fails: 3 failed, 518 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684bba818ed483339af09a24adb4c840