### PR TITLE
Fix stacked clock overlay

### DIFF
--- a/app/utils/test_pattern.py
+++ b/app/utils/test_pattern.py
@@ -545,7 +545,6 @@ def generate_test_pattern(
         _format_roman_time(time_simple),
         _to_braille(time_simple),
         _format_binary_time(time_simple),
-        beats_time,
         tz_text,
     ]
 
@@ -554,7 +553,6 @@ def generate_test_pattern(
         font_right,
         font_braille,
         font_binary,
-        font_right,
         font_right,
     ]
     segments = [t.replace("\u2812", ":").split(":") for t in formats]
@@ -580,10 +578,10 @@ def generate_test_pattern(
     )
     seg3_max = seg2_max
 
-    beats_w = draw.textlength(beats_time, font=font_right)
+    tz_w = draw.textlength(tz_text, font=font_right)
     total_w = max(
         seg1_max + colon_gap + seg2_max + colon_gap + seg3_max,
-        beats_w,
+        tz_w,
     )
     x_start = width - total_w - 30
 
@@ -592,7 +590,6 @@ def generate_test_pattern(
         font_right.size,
         font_braille.size,
         font_binary.size,
-        font_right.size,
         font_right.size,
     ]
     spacing_y = 22
@@ -636,7 +633,7 @@ def generate_test_pattern(
     x_date += space_w
     draw.text((x_date, y_start), beats_time, fill=clock_color, font=font_right)
     current_y = y_start
-    timezone_idx = 5
+    timezone_idx = 4
     roman_idx = 1
     for idx, parts in enumerate(segments):
         x = x_start
@@ -669,7 +666,7 @@ def generate_test_pattern(
                 fill=clock_color,
             )
             current_y += line_heights[idx] + spacing_y
-            if idx in {1, timezone_idx}:
+            if idx == timezone_idx:
                 current_y += extra_gap
         elif idx == roman_idx:
             draw.text(
@@ -693,7 +690,7 @@ def generate_test_pattern(
                 font=font,
             )
             current_y += line_heights[idx] + spacing_y
-            if idx in {1, timezone_idx}:
+            if idx == timezone_idx:
                 current_y += extra_gap
         elif len(parts) == 1:
             draw.text(
@@ -703,7 +700,7 @@ def generate_test_pattern(
                 font=font,
             )
             current_y += line_heights[idx] + spacing_y
-            if idx in {1, timezone_idx}:
+            if idx == timezone_idx:
                 current_y += extra_gap
         else:
             draw.text(
@@ -731,7 +728,7 @@ def generate_test_pattern(
                 font=font,
             )
             current_y += line_heights[idx] + spacing_y
-            if idx in {1, timezone_idx}:
+            if idx == timezone_idx:
                 current_y += extra_gap
     if camera_name:
         draw.text(

--- a/docs/test_pattern_reference.md
+++ b/docs/test_pattern_reference.md
@@ -13,7 +13,7 @@ The test pattern includes calibration checks for panel accuracy and HDR tone map
 - **Skin‑tone chip** around CIE ab ≈ (20, 15) confirms natural faces.
 - **Synthwave sunrise** with a small horizon line and trees for visual flair.
 - **Moon phase display** rises opposite the sun in a smaller arc.
-- **Swatch Internet Time** (@beats) joins the stacked clocks for a fun extra.
+- **Timezone label** replaces Swatch Internet Time in the stacked clocks.
 - **Analog second hand** in the bullseye extends to the outer dots for easy reading.
 - **Date overlay** appears on the left aligned with the standard clock.
 - **Braille spinner** in the corner updates once per second during streaming.

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -97,7 +97,9 @@ class TestTestPattern(unittest.TestCase):
         ):
             img = generate_test_pattern(width=400, height=400)
 
-        y_start = 400 // 2 - 374 // 2 + 20
+        line_heights = [26, 26, 30, 22, 26]
+        total_h = sum(line_heights) + 22 * (len(line_heights) - 1) + 30 * 2
+        y_start = 400 // 2 - total_h // 2 + 20
         region = [
             img.getpixel((x, y))
             for x in range(30, 120)


### PR DESCRIPTION
## Summary
- display timezone instead of Swatch beats
- tighten spacing after Roman clock so braille clock shifts up
- adjust tests for new layout
- update docs about stacked clock

## Testing
- `pre-commit run --all-files` *(fails: files modified)*
- `pytest` *(fails: 2 failed, 519 passed, 3 skipped)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684bbc4c465c8333be426104bdb1fb95