### PR TITLE
Add onnxruntime‑gpu support

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,7 +188,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. If `onnxruntime` is not installed, object filtering is skipped.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. Install `onnxruntime-gpu` for GPU support. If `onnxruntime` is not installed, object filtering is skipped.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pyvirtualdisplay==3.0
 selenium==4.33.0
 SQLAlchemy==2.0.41
 pywebpush==2.0.3
-onnxruntime==1.18.0
+onnxruntime-gpu==1.18.0
 transformers>=4.40.0
 tokenizers>=0.15.0
 undetected-chromedriver==3.5.5


### PR DESCRIPTION
## Summary
- switch CPU `onnxruntime` dependency to `onnxruntime-gpu`
- document GPU usage in the configuration guide

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684bc1bd5ffc833392a8f7b6965c03c9