### PR TITLE
feat: prefer GPU for ONNX clip session

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -621,12 +621,22 @@ def update_camera(name, template, image_file=None, motion=False):
 
             if use_onnx:
                 if clip_session is None:
-                    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+                    # Prefer GPU when available and fall back to CPU. This uses
+                    # the providers reported by onnxruntime so it works even
+                    # when CUDA is not installed.
+                    available = getattr(ort, "get_available_providers", lambda: [])()
+                    providers = (
+                        ["CUDAExecutionProvider"]
+                        if "CUDAExecutionProvider" in available
+                        else ["CPUExecutionProvider"]
+                    )
                     try:
                         clip_session = ort.InferenceSession(
                             CLIP_MODEL_PATH, providers=providers
                         )
-                    except Exception:
+                    except TypeError:
+                        # Some runtimes (or tests) may not accept the providers
+                        # keyword. Fall back to default initialization.
                         clip_session = ort.InferenceSession(CLIP_MODEL_PATH)
 
                 if clip_processor is None:


### PR DESCRIPTION
## Summary
- prefer CUDA when initializing the ONNX CLIP session and fallback to CPU

## Testing
- `pre-commit run --files app/utils/scheduling.py`
- `pytest -q tests/test_clip_config.py::TestClipModelSetting::test_custom_onnx_clip_model_used tests/test_clip_config.py::TestClipModelSetting::test_skips_when_onnx_missing`
- `pytest -q` *(fails: SchedulerAlreadyRunningError in test_scheduler_start_once)*

------
https://chatgpt.com/codex/tasks/task_e_684bc3c1b7c88333bac32b70fada9b65