### PR TITLE
Update Chrome key import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list \
-    && apt-get update && apt-get install -y google-chrome-stable \
+RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg 
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list 
+    && apt-get update && apt-get install -y google-chrome-stable 
     && rm -rf /var/lib/apt/lists/*
 
 # Install ChromeDriver

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,8 +32,8 @@ sudo apt-get install -y curl wget gnupg2 software-properties-common apt-transpor
 Google Chrome is required for some of Glimpser's functionality. To install it:
 
 ```sh
-wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
 sudo apt-get update
 sudo apt-get install -y google-chrome-stable
 ```


### PR DESCRIPTION
## Summary
- import Chrome signing key with gpg in Dockerfile
- reference the keyring in installation docs

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c12ac0f708333822e4bfd3161083d