### PR TITLE
Add docs exclude list check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,3 +63,11 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+  - repo: local
+    hooks:
+      - id: check-exclude-docs
+        name: docs exclude list in sync
+        entry: python scripts/check_exclude_docs.py
+        language: system
+        pass_filenames: false

--- a/docs/exclude_docs
+++ b/docs/exclude_docs
@@ -1,0 +1,1 @@
+README.md

--- a/scripts/check_exclude_docs.py
+++ b/scripts/check_exclude_docs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Validate mkdocs.yml exclude_docs matches docs/exclude_docs list."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+MKDOCS_FILE = Path("mkdocs.yml")
+DOCS_LIST_FILE = Path("docs/exclude_docs")
+
+
+def parse_mkdocs_excludes(file: Path = MKDOCS_FILE) -> list[str]:
+    """Return list of excluded docs from mkdocs.yml."""
+    if not file.exists():
+        raise FileNotFoundError(file)
+    data = yaml.safe_load(file.read_text())
+    value = data.get("exclude_docs", "")
+    return [line.strip() for line in value.splitlines() if line.strip()]
+
+
+def parse_docs_list(file: Path = DOCS_LIST_FILE) -> list[str]:
+    """Return expected list of excluded docs."""
+    if not file.exists():
+        raise FileNotFoundError(file)
+    return [line.strip() for line in file.read_text().splitlines() if line.strip()]
+
+
+def main() -> int:
+    mkdocs_list = parse_mkdocs_excludes()
+    expected_list = parse_docs_list()
+    if mkdocs_list != expected_list:
+        print("exclude_docs mismatch", file=sys.stderr)
+        print(f"mkdocs.yml: {mkdocs_list}", file=sys.stderr)
+        print(f"docs/exclude_docs: {expected_list}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_exclude_docs.py
+++ b/tests/test_exclude_docs.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts import check_exclude_docs  # noqa: E402
+
+
+class TestExcludeDocs(unittest.TestCase):
+    def test_main_matches(self):
+        self.assertEqual(check_exclude_docs.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track a maintained `docs/exclude_docs` list
- script to verify `mkdocs.yml` exclusion list
- test the new script
- enforce the check via pre-commit

## Testing
- `pre-commit run --files scripts/check_exclude_docs.py tests/test_exclude_docs.py .pre-commit-config.yaml docs/exclude_docs`
- `pytest -q tests/test_exclude_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_684c12ce10888333a33a71a45decf98d