### PR TITLE
Improve video helpers docs

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -70,7 +70,9 @@ def run_ffmpeg(command, timeout: int = 30):
     if result.stderr:
         logging.debug("ffmpeg stderr: %s", result.stderr.strip())
     if result.returncode != 0:
-        raise subprocess.CalledProcessError(result.returncode, command, output=result.stdout, stderr=result.stderr)
+        raise subprocess.CalledProcessError(
+            result.returncode, command, output=result.stdout, stderr=result.stderr
+        )
     return result
 
 
@@ -92,7 +94,9 @@ def pipe_ffmpeg_frames(command, frame_files):
     if stderr:
         logging.debug("ffmpeg stderr: %s", stderr.decode().strip())
     if process.returncode != 0:
-        raise subprocess.CalledProcessError(process.returncode, command, output=stdout, stderr=stderr)
+        raise subprocess.CalledProcessError(
+            process.returncode, command, output=stdout, stderr=stderr
+        )
     return process
 
 
@@ -142,6 +146,19 @@ def is_video_expired(video_path, max_age_days):
 
 
 def compile_to_teaser():
+    """Create short teaser videos from recent camera footage.
+
+    The function extracts the last five seconds from the most recent
+    ``in_process`` video for each configured camera and concatenates
+    these clips. One teaser aggregates all cameras while additional
+    teasers are generated per group.
+
+    Returns
+    -------
+    bool | None
+        ``False`` if ``VIDEO_DIRECTORY`` is not a directory.
+    """
+
     os.makedirs(VIDEO_DIRECTORY, exist_ok=True)
     final_videos = {}
 
@@ -156,7 +173,9 @@ def compile_to_teaser():
             os.makedirs(camera_path, exist_ok=True)
 
             # Get the most recent "in_process.mp4" video
-            video_files = sorted(glob.glob(camera_path + "/*in_process.mp4"), reverse=True)
+            video_files = sorted(
+                glob.glob(camera_path + "/*in_process.mp4"), reverse=True
+            )
             if video_files:
                 latest_video = video_files[0]
                 ldur = get_video_duration(latest_video)
@@ -175,14 +194,20 @@ def compile_to_teaser():
                     if trimmed_group_name:
                         if trimmed_group_name not in final_videos:
                             final_videos[trimmed_group_name] = []
-                        final_videos[trimmed_group_name].append(os.path.abspath(latest_video))
+                        final_videos[trimmed_group_name].append(
+                            os.path.abspath(latest_video)
+                        )
 
         # Concatenate the videos without re-encoding for all cameras
-        compile_videos(temp_file.name, os.path.join(VIDEO_DIRECTORY, "all_in_process.mp4"))
+        compile_videos(
+            temp_file.name, os.path.join(VIDEO_DIRECTORY, "all_in_process.mp4")
+        )
 
         # Concatenate the videos for each group
         for group, videos in final_videos.items():
-            with tempfile.NamedTemporaryFile(mode="w+") as group_temp_file:  # should be cleaning up automatically...
+            with tempfile.NamedTemporaryFile(
+                mode="w+"
+            ) as group_temp_file:  # should be cleaning up automatically...
                 for video in videos:
                     group_temp_file.write(f"file '{video}'\n")
                 group_temp_file.flush()
@@ -193,6 +218,20 @@ def compile_to_teaser():
 
 
 def compile_videos(input_file, output_file):
+    """Concatenate video segments into a single MP4 file.
+
+    Parameters
+    ----------
+    input_file : str
+        File containing paths to segments for the FFmpeg ``concat`` demuxer.
+    output_file : str
+        Path where the final video will be written.
+
+    Returns
+    -------
+    bool
+        ``True`` when a valid MP4 was produced; ``False`` otherwise.
+    """
 
     if not os.path.exists(input_file):
         return False
@@ -294,7 +333,9 @@ def get_video_duration(video_path):
     ]
     duration = 0
     try:
-        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         duration = float(result.stdout.strip())
     except Exception:
         pass
@@ -320,7 +361,9 @@ def get_video_resolution(video_path):
         os.path.abspath(video_path),
     ]
     try:
-        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        result = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
         if result.stdout.strip():
             w_h = result.stdout.strip().split("x")
             if len(w_h) == 2:
@@ -420,7 +463,9 @@ def concatenate_videos(in_process_video, temp_video, video_path, retries=1) -> b
         if file_updated:
             mod_time = os.path.getmtime(in_process_video)
             if abs(time.time() - mod_time) > 10:
-                logging.warning("in_process video timestamp stale: %s", in_process_video)
+                logging.warning(
+                    "in_process video timestamp stale: %s", in_process_video
+                )
                 return False
         return True
     return False
@@ -451,12 +496,32 @@ def handle_concat_error(e, temp_video, in_process_video) -> ConcatStatus:
 
 
 def compile_to_video(camera_path, video_path):
+    """Compile screenshots into an in-process video for a camera.
+
+    A file lock ensures only one encoder operates on ``video_path`` at a time.
+    All actual encoding work is handled by :func:`_compile_to_video_inner`.
+    """
+
     lock = FileLock(os.path.join(video_path, ".encode.lock"))
     with lock:  # ⬅️ holds the lock for this camera
         _compile_to_video_inner(camera_path, video_path)
 
 
 def _compile_to_video_inner(camera_path, video_path) -> bool:
+    """Internal helper that encodes screenshots into ``in_process.mp4``.
+
+    Parameters
+    ----------
+    camera_path : str
+        Directory containing screenshot images.
+    video_path : str
+        Directory where intermediate videos are stored.
+
+    Returns
+    -------
+    bool | None
+        ``False`` if either directory is invalid, otherwise ``None``.
+    """
 
     os.makedirs(video_path, exist_ok=True)
     os.makedirs(camera_path, exist_ok=True)
@@ -470,7 +535,9 @@ def _compile_to_video_inner(camera_path, video_path) -> bool:
 
     # Check size and age of the in-process video for rotation
     if os.path.isfile(in_process_video):
-        file_size_exceeded = os.path.getsize(in_process_video) > MAX_IN_PROCESS_VIDEO_SIZE
+        file_size_exceeded = (
+            os.path.getsize(in_process_video) > MAX_IN_PROCESS_VIDEO_SIZE
+        )
         file_age_exceeded = is_video_expired(in_process_video, MAX_COMPRESSED_VIDEO_AGE)
 
         # consider when the length is 2x300 frames as well so we always
@@ -489,7 +556,9 @@ def _compile_to_video_inner(camera_path, video_path) -> bool:
     if os.path.exists(in_process_video):
         video_mod_time = os.path.getmtime(in_process_video)
         ldur = get_video_duration(in_process_video)
-        if ldur < 10 and time.time() - video_mod_time > 60 * 60:  # could be a waste of 300 frames...
+        if (
+            ldur < 10 and time.time() - video_mod_time > 60 * 60
+        ):  # could be a waste of 300 frames...
             video_mod_time = 0
             # go bigger...
 
@@ -587,10 +656,14 @@ def _compile_to_video_inner(camera_path, video_path) -> bool:
                 "+faststart",
             ]
         )
-        create_command.extend(["-metadata", "creation_time=%sZ" % datetime.datetime.utcnow()])
+        create_command.extend(
+            ["-metadata", "creation_time=%sZ" % datetime.datetime.utcnow()]
+        )
         create_command.extend(["-metadata", "encoded_by=%s" % NAME])
         create_command.extend(["-metadata", "version=%s" % VERSION])
-        create_command.extend(["-y", os.path.abspath(temp_video)])  # Overwrite if exists
+        create_command.extend(
+            ["-y", os.path.abspath(temp_video)]
+        )  # Overwrite if exists
 
         lout, lerr = None, None
         try:
@@ -612,7 +685,9 @@ def _compile_to_video_inner(camera_path, video_path) -> bool:
                 ldur2 = get_video_duration(temp_video)
                 if os.path.getsize(temp_video) > 0 and ldur2 == 300 / 25:
                     os.rename(temp_video, in_process_video)
-                elif round(ldur2, 1) == round((len(new_files) / 25), 1):  # this is a perfect encode...
+                elif round(ldur2, 1) == round(
+                    (len(new_files) / 25), 1
+                ):  # this is a perfect encode...
                     concatenate_videos(in_process_video, temp_video, video_path)
                 else:
                     # this means a lot of frame drops
@@ -639,7 +714,9 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
 
     # Check size and age of the in-process video for rotation
     if os.path.isfile(in_process_video):
-        file_size_exceeded = os.path.getsize(in_process_video) > MAX_IN_PROCESS_VIDEO_SIZE
+        file_size_exceeded = (
+            os.path.getsize(in_process_video) > MAX_IN_PROCESS_VIDEO_SIZE
+        )
         file_age_exceeded = is_video_expired(in_process_video, MAX_COMPRESSED_VIDEO_AGE)
 
         # consider when the length is 2x300 frames as well so we always
@@ -659,7 +736,9 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
     if os.path.exists(in_process_video):
         video_mod_time = os.path.getmtime(in_process_video)
         ldur = get_video_duration(in_process_video)
-        if ldur < 10 and time.time() - video_mod_time > 60 * 60:  # could be a waste of 300 frames...
+        if (
+            ldur < 10 and time.time() - video_mod_time > 60 * 60
+        ):  # could be a waste of 300 frames...
             # print("  skipping ", in_process_video, ldur, time.time() - video_mod_time)
             video_mod_time = 0
             # go bigger...
@@ -710,7 +789,9 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
 
     if new_files:
         # keep the size/“_2” filter you already had
-        candidate = [f for f in new_files[-300:] if os.path.getsize(f) > 10 and "_2" in f]
+        candidate = [
+            f for f in new_files[-300:] if os.path.getsize(f) > 10 and "_2" in f
+        ]
 
         # drop corrupt or truncated PNGs
         frame_files = []
@@ -754,7 +835,9 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
                 "+faststart",
             ]
         )
-        create_command.extend(["-metadata", "creation_time=%sZ" % datetime.datetime.utcnow()])
+        create_command.extend(
+            ["-metadata", "creation_time=%sZ" % datetime.datetime.utcnow()]
+        )
         create_command.extend(["-metadata", f"encoded_by={NAME}"])
         create_command.extend(["-metadata", f"version={VERSION}"])
         create_command.extend(["-y", os.path.abspath(temp_video)])

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -59,7 +59,9 @@ class TestVideoArchiver(unittest.TestCase):
     @patch("app.utils.video_archiver.get_templates")
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("app.utils.video_archiver.compile_videos")
-    def test_compile_to_teaser(self, mock_compile_videos, mock_get_video_duration, mock_get_templates):
+    def test_compile_to_teaser(
+        self, mock_compile_videos, mock_get_video_duration, mock_get_templates
+    ):
         mock_get_templates.return_value = {
             "camera1": {"groups": "group1,group2"},
             "camera2": {"groups": "group2,group3"},
@@ -93,6 +95,21 @@ class TestVideoArchiver(unittest.TestCase):
             ):
                 result = compile_videos(temp_file.name, "output.mp4")
         self.assertTrue(result)
+
+    @patch("subprocess.run")
+    def test_compile_videos_missing_input(self, mock_subprocess_run):
+        result = compile_videos("missing.txt", "out.mp4")
+        self.assertFalse(result)
+
+    @patch("app.utils.video_archiver.compile_videos")
+    def test_compile_to_teaser_no_dir(self, mock_compile):
+        with (
+            patch("os.path.isdir", return_value=False),
+            patch("os.makedirs"),
+        ):
+            res = compile_to_teaser()
+        mock_compile.assert_not_called()
+        self.assertFalse(res)
 
     @patch("subprocess.run")
     @patch("os.path.exists")
@@ -129,7 +146,9 @@ class TestVideoArchiver(unittest.TestCase):
 
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("subprocess.run")
-    def test_concatenate_videos_retry(self, mock_subprocess_run, mock_get_video_duration):
+    def test_concatenate_videos_retry(
+        self, mock_subprocess_run, mock_get_video_duration
+    ):
         mock_get_video_duration.return_value = 10
         mock_subprocess_run.side_effect = [
             RuntimeError("Resource temporarily unavailable"),
@@ -153,7 +172,9 @@ class TestVideoArchiver(unittest.TestCase):
     @patch("app.utils.video_archiver.logging.warning")
     @patch("app.utils.video_archiver.get_video_duration")
     @patch("subprocess.run")
-    def test_concatenate_videos_stale_timestamp(self, mock_subprocess_run, mock_get_video_duration, mock_warning):
+    def test_concatenate_videos_stale_timestamp(
+        self, mock_subprocess_run, mock_get_video_duration, mock_warning
+    ):
         mock_get_video_duration.return_value = 10
         mock_subprocess_run.return_value.returncode = 0
         with (
@@ -176,7 +197,9 @@ class TestVideoArchiver(unittest.TestCase):
             patch("os.path.getsize", return_value=100),
             patch("os.rename") as mock_rename,
         ):
-            status = handle_concat_error(Exception("Invalid data found"), "temp.mp4", "in_process.mp4")
+            status = handle_concat_error(
+                Exception("Invalid data found"), "temp.mp4", "in_process.mp4"
+            )
             mock_rename.assert_called_once_with("temp.mp4", "in_process.mp4")
             self.assertEqual(status, ConcatStatus.RECOVERED)
 
@@ -196,7 +219,9 @@ class TestVideoArchiver(unittest.TestCase):
             patch("os.path.getsize", return_value=100),
             patch("os.rename") as mock_rename,
         ):
-            status = handle_concat_error(Exception("Some fatal error"), "temp.mp4", "in_process.mp4")
+            status = handle_concat_error(
+                Exception("Some fatal error"), "temp.mp4", "in_process.mp4"
+            )
             mock_rename.assert_called_once_with("temp.mp4", "in_process.mp4")
             self.assertEqual(status, ConcatStatus.FATAL)
 
@@ -237,7 +262,9 @@ class TestVideoArchiver(unittest.TestCase):
     @patch("app.utils.video_archiver.pipe_ffmpeg_frames")
     @patch("app.utils.video_archiver.Image.open")
     @patch("glob.glob")
-    def test_compile_to_video_ignores_blank_frames(self, mock_glob, mock_open, mock_pipe):
+    def test_compile_to_video_ignores_blank_frames(
+        self, mock_glob, mock_open, mock_pipe
+    ):
         mock_glob.return_value = ["shot_blank.png", "shot_2.png"]
 
         captured_lines = []


### PR DESCRIPTION
## Summary
- document compile helpers in `video_archiver`
- add edge case tests for missing input and invalid directory

## Testing
- `pre-commit run --files app/utils/video_archiver.py tests/test_video_archiver.py`
- `pytest tests/test_video_archiver.py::TestVideoArchiver::test_compile_videos_missing_input tests/test_video_archiver.py::TestVideoArchiver::test_compile_to_teaser_no_dir -q`


------
https://chatgpt.com/codex/tasks/task_e_684c12d43ef48333b3bacd43dd9db262