### PR TITLE
Add pytest-socket for offline testing

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,10 @@ Refer to [developer_guide.md](developer_guide.md) for setting up your environmen
 Recent tests cover screenshot capture helpers, database initialization through
 `TemplateManager`, and mocked OpenAI interactions.
 
+All tests run with `pytest-socket` active, preventing any outbound network
+requests. If a scenario truly requires network access call
+`pytest_socket.enable_socket()` within that test.
+
 ## End-to-End Tests
 
 The `tests/test_e2e_web.py` module contains browser-based scenarios powered by

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ coverage>=7.5
 pylint>=3.1
 pyinstaller>=6.6
 mkdocs>=1.6
+pytest-socket>=0.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
 import os
 
+import pytest_socket
+
 # Skip end-to-end tests unless explicitly enabled
 os.environ.setdefault("SKIP_E2E", "1")
+
+# Block network access during tests to avoid accidental HTTP requests.
+pytest_socket.disable_socket()


### PR DESCRIPTION
## Summary
- enforce offline test execution via `pytest-socket`
- block network calls in `tests/conftest.py`
- mention socket blocking in docs

## Testing
- `pre-commit run --files docs/testing.md requirements-dev.txt tests/conftest.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_684c1522c89883338d9dc3d7bbe94a13