### PR TITLE
Update docs on optional heavy deps

### DIFF
--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -53,7 +53,7 @@ Glimpser uses different methods to capture various types of content:
 For web pages, Glimpser uses two main approaches:
 
 1. **Lightweight Browser Capture**: Uses `wkhtmltoimage` for simple web pages without complex JavaScript or popup handling requirements. The URL and output path are passed directly to `wkhtmltoimage` without shell quoting.
-2. **Full Browser Capture**: Uses Selenium with Chrome/Chromium for more complex web pages, supporting JavaScript execution, popup handling, and custom selectors.
+2. **Full Browser Capture**: Uses Selenium with Chrome/Chromium for more complex web pages, supporting JavaScript execution, popup handling, and custom selectors. These packages live in the optional `browser` extras and are not required for the default installation.
 
 The choice between these methods depends on factors such as:
 - Presence of popups that need to be handled

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,7 +188,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. `onnxruntime-gpu` is the default dependency; if only `onnxruntime` is installed, filtering falls back to the CPU.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. `onnxruntime` is now the default dependency. Install `onnxruntime-gpu` to enable CUDA acceleration.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -16,8 +16,9 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    pip install -r requirements.txt
    pip install -r requirements-dev.txt
    ```
-   Screenshots now rely solely on Selenium; the optional `nodriver` dependency
-   has been removed from `requirements.txt`.
+   Browser automation packages used for screenshots are grouped under the
+   optional `browser` extras in `setup.py`. A minimal install only requires
+   `wkhtmltoimage` for lightweight captures.
 3. Set up tooling:
    ```sh
    make setup  # installs pre-commit hooks and JS packages

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -329,7 +329,9 @@ If shutdown is interrupted it can leave background threads running.
 
 ### Problem: "pynput not available" or "failed to acquire X connection"
 
-This happens when Glimpser cannot open an X display. The logs may show
+This happens when Glimpser cannot open an X display. The optional
+`pynput` package enables activity detection; when missing, the
+application simply logs the failure and continues. The logs may show
 `Maximum number of clients reached` or `Can't connect to display`.
 
 **Solution:**


### PR DESCRIPTION
## Summary
- clarify that `onnxruntime` is default CPU option
- explain optional Selenium extras for screenshots
- note browser extras in capture workflow
- document that `pynput` is optional

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c1134670883338c9480a8527a73bc