### PR TITLE
Fix scheduler double start

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -129,8 +129,10 @@ def create_app(
         scheduler.init_app(app)
 
     # Set up and start the scheduler
-    if schedule is True and (
-        os.environ.get("WERKZEUG_RUN_MAIN") == "true" or not app.debug
+    if (
+        schedule is True
+        and (os.environ.get("WERKZEUG_RUN_MAIN") == "true" or not app.debug)
+        and not scheduler.running
     ):
         scheduler.start()
         logging.info("Initializing scheduler...")


### PR DESCRIPTION
## Summary
- avoid starting the scheduler when it is already running

## Testing
- `pre-commit run --all-files` *(fails to modify unrelated files, reverted)*
- `pytest tests/test_routes.py::TestRoutes::test_captions_status -q`
- `pytest tests/test_scheduler_start_once.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684c15e89008833398d9219ec8f81097