### PR TITLE
Refactor sleeps in network utilities

### DIFF
--- a/app/utils/network_testing.py
+++ b/app/utils/network_testing.py
@@ -1,10 +1,18 @@
 import json
+import threading
 import time
 
 from selenium.webdriver.common.by import By
 
 
-def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=False):
+def network_idle_condition(
+    driver,
+    url,
+    timeout=30,
+    idle_time=0.25,
+    stealth=False,
+    stop_event: threading.Event | None = None,
+):
     """
     Returns a function that can be used as a condition for WebDriverWait.
     It checks if the network has been idle for a specified amount of time.
@@ -21,20 +29,37 @@ def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=Fals
     end_time = time.time() + timeout
     not_moving = 0
     while time.time() < end_time:
+        if stop_event and stop_event.is_set():
+            return False, lstatus
         if not_moving > 5:
             break
 
         logs = driver.get_log("performance")
-        events = [log for log in logs if "Network.response" in log["message"] or "Network.request" in log["message"]]
+        events = [
+            log
+            for log in logs
+            if "Network.response" in log["message"]
+            or "Network.request" in log["message"]
+        ]
         for gevent in events:
             try:
                 levent = json.loads(gevent.get("message"))
             except json.JSONDecodeError:
                 # Skip malformed log entries instead of raising an exception
                 continue
-            lurl = levent.get("message", {}).get("params", {}).get("response", {}).get("url")
+            lurl = (
+                levent.get("message", {})
+                .get("params", {})
+                .get("response", {})
+                .get("url")
+            )
             if lurl == gurl:
-                lstatus = levent.get("message", {}).get("params", {}).get("response", {}).get("status")
+                lstatus = (
+                    levent.get("message", {})
+                    .get("params", {})
+                    .get("response", {})
+                    .get("status")
+                )
 
                 # Treat any 4xx or 5xx response as a failure so the caller can
                 # bail out early on server errors.
@@ -44,14 +69,19 @@ def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=Fals
             not_moving += 1
         else:
             not_moving = 0
-        time.sleep(idle_time)
+        if stop_event:
+            stop_event.wait(idle_time)
+        else:
+            time.sleep(idle_time)
 
     if stealth:
         return False, lstatus
     return True, lstatus
 
 
-def check_network_errors(driver, url, timeout=30):
+def check_network_errors(
+    driver, url, timeout=30, stop_event: threading.Event | None = None
+):
     """
     Check for network errors during page load.
 
@@ -67,18 +97,26 @@ def check_network_errors(driver, url, timeout=30):
         logs = driver.get_log("browser")
         for log in logs:
             if log["level"] == "SEVERE":
-                if "Failed to load resource" in log["message"] or "NetworkError" in log["message"]:
+                if (
+                    "Failed to load resource" in log["message"]
+                    or "NetworkError" in log["message"]
+                ):
                     errors.append(log["message"])
 
         if errors:
             return True, errors
 
-        time.sleep(0.5)
+        if stop_event:
+            stop_event.wait(0.5)
+        else:
+            time.sleep(0.5)
 
     return False, errors
 
 
-def wait_for_element(driver, selector, timeout=10):
+def wait_for_element(
+    driver, selector, timeout=10, stop_event: threading.Event | None = None
+):
     """
     Wait for an element to be present on the page.
 
@@ -92,6 +130,9 @@ def wait_for_element(driver, selector, timeout=10):
         try:
             element = driver.find_element(By.CSS_SELECTOR, selector)
             return element
-        except:
-            time.sleep(0.5)
+        except Exception:
+            if stop_event:
+                stop_event.wait(0.5)
+            else:
+                time.sleep(0.5)
     return None

--- a/tests/test_network_testing_utils.py
+++ b/tests/test_network_testing_utils.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import json
+import threading
 import unittest
 from unittest.mock import patch
 
@@ -62,7 +63,9 @@ class TestNetworkTestingUtils(unittest.TestCase):
         driver = DummyDriver(performance_logs=[[log]])
         gen = self._time_gen()
         with patch("time.time", side_effect=gen), patch("time.sleep"):
-            result, status = network_idle_condition(driver, "http://ex", timeout=0.1, idle_time=0)
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=0.1, idle_time=0
+            )
         self.assertTrue(result)
         self.assertEqual(status, 200)
 
@@ -80,7 +83,9 @@ class TestNetworkTestingUtils(unittest.TestCase):
         driver = DummyDriver(performance_logs=[[log]])
         gen = self._time_gen()
         with patch("time.time", side_effect=gen), patch("time.sleep"):
-            result, status = network_idle_condition(driver, "http://ex", timeout=0.1, idle_time=0)
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=0.1, idle_time=0
+            )
         self.assertFalse(result)
         self.assertEqual(status, 404)
 
@@ -98,7 +103,9 @@ class TestNetworkTestingUtils(unittest.TestCase):
         driver = DummyDriver(performance_logs=[[log]])
         gen = self._time_gen()
         with patch("time.time", side_effect=gen), patch("time.sleep"):
-            result, status = network_idle_condition(driver, "http://ex", timeout=0.1, idle_time=0)
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=0.1, idle_time=0
+            )
         self.assertFalse(result)
         self.assertEqual(status, 500)
 
@@ -106,7 +113,9 @@ class TestNetworkTestingUtils(unittest.TestCase):
         driver = DummyDriver()
         gen = self._time_gen(step=0.2)
         with patch("time.time", side_effect=gen), patch("time.sleep"):
-            result, status = network_idle_condition(driver, "http://ex", timeout=1, idle_time=0, stealth=True)
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=1, idle_time=0, stealth=True
+            )
         self.assertFalse(result)
         self.assertEqual(status, 800)
 
@@ -115,9 +124,22 @@ class TestNetworkTestingUtils(unittest.TestCase):
         driver = DummyDriver(performance_logs=[[bad]])
         gen = self._time_gen(step=0.2)
         with patch("time.time", side_effect=gen), patch("time.sleep"):
-            result, status = network_idle_condition(driver, "http://ex", timeout=0.5, idle_time=0)
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=0.5, idle_time=0
+            )
         self.assertTrue(result)
         self.assertEqual(status, 800)
+
+    def test_network_idle_condition_stop_event(self):
+        driver = DummyDriver()
+        ev = threading.Event()
+        ev.set()
+        gen = self._time_gen()
+        with patch("time.time", side_effect=gen), patch("time.sleep"):
+            result, status = network_idle_condition(
+                driver, "http://ex", timeout=1, idle_time=0.1, stop_event=ev
+            )
+        self.assertFalse(result)
 
     def test_check_network_errors_no_error(self):
         driver = DummyDriver(browser_logs=[[{"level": "INFO", "message": "ok"}]])
@@ -128,7 +150,9 @@ class TestNetworkTestingUtils(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_check_network_errors_detects_error(self):
-        driver = DummyDriver(browser_logs=[[{"level": "SEVERE", "message": "Failed to load resource"}]])
+        driver = DummyDriver(
+            browser_logs=[[{"level": "SEVERE", "message": "Failed to load resource"}]]
+        )
         gen = self._time_gen()
         with patch("time.time", side_effect=gen), patch("time.sleep"):
             result, errors = check_network_errors(driver, "http://ex", timeout=0.1)


### PR DESCRIPTION
## Summary
- allow `network_idle_condition`, `check_network_errors`, and `wait_for_element` to be interrupted via an optional `Event`
- add test covering the stop-event path in `network_idle_condition`

## Testing
- `pre-commit run --files app/utils/network_testing.py tests/test_network_testing_utils.py`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c12b9e5dc833381257d15a7e108c0