### PR TITLE
Add collection waterfall diagram

### DIFF
--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -39,7 +39,10 @@ The general flow of the capture process is as follows:
 9. **Post-Processing**: Apply any necessary post-processing steps, such as adding timestamps or applying dark mode.
 10. **Result Handling**: Return the success status of the capture process.
 
-![Collection Waterfall](images/collection_waterfall.svg)
+The waterfall diagram below shows how captured data moves from the initial
+source through processing and finally to visualization.
+
+![Collection Waterfall Diagram](images/collection_waterfall.svg)
 
 ## Content-Specific Capture Methods
 

--- a/docs/images/collection_waterfall.svg
+++ b/docs/images/collection_waterfall.svg
@@ -1,21 +1,29 @@
-<svg width="200" height="240" viewBox="0 0 200 240" xmlns="http://www.w3.org/2000/svg">
+<svg width="220" height="300" viewBox="0 0 220 300" xmlns="http://www.w3.org/2000/svg">
   <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
     <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L10,5 L0,10 z" fill="#333" />
     </marker>
   </defs>
-  <rect x="40" y="10" width="120" height="30" fill="#e0e0e0" stroke="#333" />
-  <text x="100" y="30" font-size="12" text-anchor="middle" fill="#333">Data Source</text>
-  <line x1="100" y1="40" x2="100" y2="60" stroke="#333" marker-end="url(#arrow)" />
-  <rect x="40" y="60" width="120" height="30" fill="#e0e0e0" stroke="#333" />
-  <text x="100" y="80" font-size="12" text-anchor="middle" fill="#333">Extraction</text>
-  <line x1="100" y1="90" x2="100" y2="110" stroke="#333" marker-end="url(#arrow)" />
-  <rect x="40" y="110" width="120" height="30" fill="#e0e0e0" stroke="#333" />
-  <text x="100" y="130" font-size="12" text-anchor="middle" fill="#333">Transformation</text>
-  <line x1="100" y1="140" x2="100" y2="160" stroke="#333" marker-end="url(#arrow)" />
-  <rect x="40" y="160" width="120" height="30" fill="#e0e0e0" stroke="#333" />
-  <text x="100" y="180" font-size="12" text-anchor="middle" fill="#333">Storage</text>
-  <line x1="100" y1="190" x2="100" y2="210" stroke="#333" marker-end="url(#arrow)" />
-  <rect x="40" y="210" width="120" height="30" fill="#e0e0e0" stroke="#333" />
-  <text x="100" y="230" font-size="12" text-anchor="middle" fill="#333">Analysis</text>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Data Source</text>
+  <line x1="110" y1="40" x2="110" y2="70" stroke="#333" marker-end="url(#arrow)" />
+
+  <rect x="50" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="90" font-size="12" text-anchor="middle" fill="#333">Extraction</text>
+  <line x1="110" y1="100" x2="110" y2="130" stroke="#333" marker-end="url(#arrow)" />
+
+  <rect x="50" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="150" font-size="12" text-anchor="middle" fill="#333">Normalization</text>
+  <line x1="110" y1="160" x2="110" y2="190" stroke="#333" marker-end="url(#arrow)" />
+
+  <rect x="50" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="210" font-size="12" text-anchor="middle" fill="#333">Storage</text>
+  <line x1="110" y1="220" x2="110" y2="250" stroke="#333" marker-end="url(#arrow)" />
+
+  <rect x="50" y="250" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="270" font-size="12" text-anchor="middle" fill="#333">Visualization</text>
 </svg>


### PR DESCRIPTION
## Summary
- add collection waterfall SVG diagram
- include the diagram in capture process docs

## Testing
- `pre-commit run --all-files` *(fails: isort/black modified files)*
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c1d539070833384ec072d0c30d17d