### PR TITLE
Fix unsaved indicator for discovery toggle

### DIFF
--- a/app/static/js/unsaved.js
+++ b/app/static/js/unsaved.js
@@ -3,7 +3,9 @@ export function initUnsavedIndicator() {
     const form = document.getElementById("settings-form");
     const icon = document.getElementById("unsaved-icon");
     if (!form || !icon) return;
-    form.addEventListener("input", () => {
+    form.addEventListener("input", (e) => {
+      const target = e.target;
+      if (target && target.dataset.ignoreUnsaved !== undefined) return;
       icon.classList.remove("hidden");
     });
     form.addEventListener("submit", () => {

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -110,12 +110,13 @@ template_form %} {% block content %}
               {% if setting.name in boolean_fields %}
               <label class="switch">
                 <!-- prettier-ignore -->
-                <input
+                    <input
                     type="checkbox"
                     name="{{ setting.name }}"
                     value="True"
                     {% if setting.value == 'True' %}checked{% endif %}
                     data-boolean
+                    {% if setting.name == 'DISCOVERY_AUTOSTART' %}data-ignore-unsaved{% endif %}
                     {% if setting.name in locked_settings %}disabled data-locked{% endif %}
                     {% if setting.name == 'FFMPEG_HWACCEL' and not metrics.ffmpeg_gpu_support %}disabled data-unavailable{% endif %}
                   />


### PR DESCRIPTION
## Summary
- ignore unsaved indicator when toggling background discovery
- mark discovery autostart checkbox so the toggle doesn't count as unsaved

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c1c0b2aa08333a038675b643e0e78