### PR TITLE
Update captions page tab label

### DIFF
--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -34,7 +34,7 @@ template_controls %} {% block content %}
 
   <div class="tabs">
     <button class="tab-link active" data-tab="prompts-tab">Prompts</button>
-    <button class="tab-link" data-tab="history-tab">History</button>
+    <button class="tab-link" data-tab="history-tab">Summaries</button>
     <button class="tab-link" data-tab="bulk-tab">Bulk Tools</button>
   </div>
 
@@ -53,12 +53,7 @@ template_controls %} {% block content %}
     </select>
     <div class="field-toggle">
       <label>
-        <input
-          type="radio"
-          name="caption-field"
-          value="caption"
-          checked
-        />
+        <input type="radio" name="caption-field" value="caption" checked />
         Caption
       </label>
       <label>
@@ -127,7 +122,8 @@ template_controls %} {% block content %}
                       class="notes-textarea"
                       placeholder="Edit caption prompt"
                     >
-{{ template_details[camera]['notes'] }}</textarea>
+{{ template_details[camera]['notes'] }}</textarea
+                    >
                     <button
                       class="update-button"
                       data-template="{{ camera }}"

--- a/docs/captions_live_update.md
+++ b/docs/captions_live_update.md
@@ -3,4 +3,4 @@
 The captions page can refresh without reloading the entire application. When automatic updates are enabled, new caption text appears as soon as it is generated.
 
 Use the **Update Automatically** toggle to switch live updates on or off. Disabling it pauses the feed so you can copy text without the view jumping around.
-When the **History** table on the Captions page is sorted by Timestamp in descending order, new summaries are automatically inserted at the top. The page checks `/captions_status` every 10&nbsp;seconds and only adds a row when a newer caption exists. Click the Timestamp header again to disable live updates.
+When the **Summaries** table on the Captions page is sorted by Timestamp in descending order, new summaries are automatically inserted at the top. The page checks `/captions_status` every 10&nbsp;seconds and only adds a row when a newer caption exists. Click the Timestamp header again to disable live updates.

--- a/docs/chatbot.md
+++ b/docs/chatbot.md
@@ -1,7 +1,7 @@
 # Captions Chatbot
 
 The Captions page now includes a small chat interface. Click **Chat** in the
-Captions history tab to open a modal window where you can ask questions about
+Captions Summaries tab to open a modal window where you can ask questions about
 recent captions. The query sends up to the last 100 captions (or the selected
 date range) to the language model configured by `CHATGPT_KEY`.
 If more than 100 entries match your filters, the request is truncated and the

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,7 +61,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **History** (recent captions table), and **Bulk Tools** for TSV updates. The History tab is always expanded and provides search and date range filters. Use the search box or metric dropdown in the Prompts tab to instantly filter cameras as you type. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
+10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **Summaries** (recent captions table), and **Bulk Tools** for TSV updates. The Summaries tab is always expanded and provides search and date range filters. Use the search box or metric dropdown in the Prompts tab to instantly filter cameras as you type. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
 
 
 ## Next Steps

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -100,7 +100,7 @@ after a caption, changes to
 yellow for the next five minutes and turns red once thirty minutes have passed
 without an update.
 You can toggle the chyron from the **Captions** page using the button in the
-History tab.
+Summaries tab.
 Opening the Captions page now also restarts the scrolling banner when
 `CHYRON_SPEED` is set above zero.
 


### PR DESCRIPTION
## Summary
- rename History tab to Summaries
- update docs to reference the Summaries tab

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c1fc1efe8833382d35c544f7d03ca