### PR TITLE
Auto-detect FFmpeg hardware encoder

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import subprocess
@@ -330,10 +331,42 @@ def _ffmpeg_supports_hwaccel() -> bool:
         return False
 
 
+def _detect_best_encoder() -> str:
+    """Return the best hardware encoder ``ffmpeg`` supports.
+
+    The detection checks for common GPU encoder names and returns the
+    corresponding ``-hwaccel`` flag. ``"false"`` is returned when no supported
+    encoder is found or ``ffmpeg`` is missing.
+    """
+
+    try:
+        encoders = subprocess.check_output(
+            [FFMPEG_PATH, "-encoders", "-hide_banner"],
+            stderr=subprocess.STDOUT,
+            timeout=2,
+        ).decode()
+    except Exception:
+        return "false"
+
+    mappings = [
+        ("h264_nvenc", "cuda"),
+        ("h264_vaapi", "vaapi"),
+        ("h264_qsv", "qsv"),
+        ("h264_v4l2m2m", "v4l2m2m"),
+    ]
+    for codec, accel in mappings:
+        if re.search(codec, encoders):
+            return accel
+    return "false"
+
+
 # Enable GPU acceleration by default. "auto" lets ffmpeg pick the best
 # available method and falls back to software when no GPU is present.
 _hwaccel_cfg = get_setting("FFMPEG_HWACCEL", "auto")
-FFMPEG_HWACCEL = _hwaccel_cfg if _hwaccel_cfg.lower() != "auto" else "auto"
+if _hwaccel_cfg.lower() == "auto":
+    FFMPEG_HWACCEL = _detect_best_encoder()
+else:
+    FFMPEG_HWACCEL = _hwaccel_cfg
 
 # Number of threads FFmpeg should use when encoding/decoding
 FFMPEG_THREADS = int(get_setting("FFMPEG_THREADS", max(1, (os.cpu_count() or 1) // 2)))

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -179,8 +179,9 @@ Additional variables control AI behaviour and external tools:
 - `FFMPEG_PATH` – path to the `ffmpeg` binary (default `ffmpeg`)
 - `FFPROBE_PATH` – path to the `ffprobe` binary (default `ffprobe`)
 - `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (default `auto`).
-  The `auto` setting lets ffmpeg use GPU decoding when available and falls back
-  to software otherwise.
+  When set to `auto` Glimpser inspects available encoders and enables the first
+  supported GPU method (`cuda`, `vaapi`, `qsv`, `v4l2m2m`) or falls back to
+  software when none are detected.
 - When hardware acceleration is enabled and Chrome supports OpenGL, Glimpser
   automatically launches Chrome with `--use-gl=egl` for improved GPU use.
 - `FFMPEG_THREADS` – number of threads ffmpeg uses when encoding (default half the CPU cores)

--- a/tests/test_hw_encoder_detection.py
+++ b/tests/test_hw_encoder_detection.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.config import _detect_best_encoder
+
+
+class TestDetectBestEncoder(unittest.TestCase):
+    def test_detects_cuda(self):
+        sample = "Encoders:\n V..... h264_nvenc"
+        with patch("app.config.subprocess.check_output", return_value=sample.encode()):
+            self.assertEqual(_detect_best_encoder(), "cuda")
+
+    def test_returns_false_when_none(self):
+        with patch("app.config.subprocess.check_output", return_value=b""):
+            self.assertEqual(_detect_best_encoder(), "false")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect available GPU encoders via FFmpeg
- use detected encoder when `FFMPEG_HWACCEL` is set to `auto`
- document the new behaviour in configuration guide
- test detection logic

## Testing
- `pre-commit run --files app/config.py docs/configuration_guide.md tests/test_hw_encoder_detection.py`
- `pytest -q tests/test_hw_encoder_detection.py`

------
https://chatgpt.com/codex/tasks/task_e_684c23151f448333bacb51fcdfacc3a6