### PR TITLE
Remove unused livecaption flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   comparison implementation
 - Pinned numpy below version 2.0 due to compatibility issues
 - Removed nodriver and its screenshot helper
+- Removed the unused `livecaption` option and simplified forced caption timing
 - Updated default VERSION to 0.2.7 for footer display
 - The footer name now links to https://glimpser.net
 - Bulk tools menu is expanded by default on the captions page

--- a/app/routes.py
+++ b/app/routes.py
@@ -3757,8 +3757,6 @@ def init_routes(app: Flask) -> None:
                 in ["true", "1", "t", "y", "yes", "on"],
                 "browser": request.form.get("browser", "false").lower()
                 in ["true", "1", "t", "y", "yes", "on"],
-                "livecaption": request.form.get("livecaption", "false").lower()
-                in ["true", "1", "t", "y", "yes", "on"],
                 "danger": request.form.get("danger", "false").lower()
                 in ["true", "1", "t", "y", "yes", "on"],
             }

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -607,18 +607,14 @@ def update_camera(name, template, image_file=None, motion=False):
 
             # at least once a day.
             #  maybe at least once per every 8 frames
-            #  no more frequent than hourly
-            ldelta = 24
-            if int(template.get("frequency", 30)) <= 30:
-                ldelta = 8
-            if int(template.get("frequency", 30)) <= 5:
-                ldelta = 3
-
-            if (
-                template.get("livecaption", "") or ""
-            ) == "true":  # spending extra money...
-                lfreq = int(template.get("frequency", 30))
-                ldelta = max(1, lfreq / 7)
+            # Force a caption if the last one is too old. The interval is
+            # derived from the feed's capture frequency (in minutes) so that
+            # faster feeds caption more often while slower ones still caption at
+            # least once per day. Approximately every three capture cycles,
+            # capped between 1 and 24 hours.
+            lfreq = int(template.get("frequency", 30))
+            capture_interval_hours = lfreq / 60.0
+            ldelta = min(24, max(1, capture_interval_hours * 3))
 
             try:
                 last_caption_time = datetime.datetime.strptime(

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -72,7 +72,6 @@ class Template(db.Base):
     headless = Column(Boolean, default=True)
     stealth = Column(Boolean, default=False)
     browser = Column(Boolean, default=False)
-    livecaption = Column(Boolean, default=False)
     danger = Column(Boolean, default=False)
     motion = Column(Float, default=0.2)
     rollback_frames = Column(Integer, default=0)

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -239,7 +239,6 @@ def validate_update_data(data: dict) -> dict:
         "headless",
         "stealth",
         "browser",
-        "livecaption",
         "danger",
     ]:
         sanitized[key] = _to_bool(data.get(key, False))

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -31,7 +31,6 @@ class TestClipModelSetting(unittest.TestCase):
                 "notes": "",
                 "frequency": 30,
                 "motion": 0,
-                "livecaption": "false",
             }
 
             class DummySession:
@@ -105,7 +104,6 @@ class TestClipModelSetting(unittest.TestCase):
                 "notes": "",
                 "frequency": 30,
                 "motion": 0,
-                "livecaption": "false",
             }
 
             class DummyProcessor:


### PR DESCRIPTION
## Summary
- remove `livecaption` option from routes, validation and database model
- base forced caption timing on feed frequency only
- adjust scheduling tests
- document change in changelog

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c1eeabc348333bd2ade9ad678766e