### PR TITLE
Show GPU detection status on camera form

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -108,6 +108,21 @@ from app.utils.settings_tooltips import (
     SETTINGS_TOOLTIPS,
 )
 
+try:
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - optional dependency
+    ort = None
+
+
+@lru_cache(maxsize=1)
+def clip_gpu_available() -> bool:
+    """Return True when ONNXRuntime can use CUDA."""
+    if ort is None:
+        return False
+    providers = getattr(ort, "get_available_providers", lambda: [])()
+    return "CUDAExecutionProvider" in providers
+
+
 # Names of settings that store file paths.
 FILE_LOCATION_NAMES = [
     "DATABASE_PATH",
@@ -3367,6 +3382,7 @@ def init_routes(app: Flask) -> None:
             videos=lvideos,
             object_tokens=object_tokens,
             clip_model=CLIP_MODEL_NAME,
+            clip_gpu=clip_gpu_available(),
             page_title="Camera Details",
         )
 
@@ -3827,6 +3843,7 @@ def init_routes(app: Flask) -> None:
             existing_urls=existing_urls,
             object_tokens=object_tokens,
             clip_model=CLIP_MODEL_NAME,
+            clip_gpu=clip_gpu_available(),
             page_title="Discover Cameras",
         )
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1234,6 +1234,15 @@ body.advanced-enabled .settings-table input[data-locked] {
   cursor: pointer;
 }
 
+.object-filter-container {
+  display: flex;
+  align-items: center;
+}
+
+.object-filter-container .status-dot {
+  margin-left: 0.5rem;
+}
+
 #delete-btn {
   padding: 10px 20px;
   background-color: #e74c3c;

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -130,8 +130,8 @@
   <div class="wizard-step" title="Form to add a new camera">
     {{ template_form( 'add-template-form', '/templates',
     preview_src='/test_pattern.mjpg?pattern=geometric',
-    preview_id='url-preview', object_tokens=object_tokens, clip_model=clip_model
-    ) }}
+    preview_id='url-preview', object_tokens=object_tokens,
+    clip_model=clip_model, clip_gpu=clip_gpu ) }}
   </div>
   {% endcall %}
 </div>

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -81,7 +81,7 @@ confirm='Confirm', cancel='Cancel') -%}
 </div>
 {%- endmacro %} {%- macro template_form(form_id, action, template=None,
 preview_src=None, preview_id=None, include_name=True, submit_label='Submit',
-object_tokens=None, clip_model=None) -%}
+object_tokens=None, clip_model=None, clip_gpu=False) -%}
 <div class="edit-template-container">
   {% if preview_src or preview_id %}
   <div class="edit-template-preview">
@@ -205,15 +205,23 @@ object_tokens=None, clip_model=None) -%}
           title="Filter for specific objects using {{ clip_model }}"
           >Object Filter:</label
         >
-        <input
-          type="text"
-          id="object_filter"
-          name="object_filter"
-          value="{{ template.object_filter if template else '' }}"
-          placeholder="person,car"
-          list="object-filter-options"
-          title="Enter object types to filter (e.g., 'person,car')"
-        />
+        <div class="object-filter-container">
+          <input
+            type="text"
+            id="object_filter"
+            name="object_filter"
+            value="{{ template.object_filter if template else '' }}"
+            placeholder="person,car"
+            list="object-filter-options"
+            title="Enter object types to filter (e.g., 'person,car')"
+          />
+          <span
+            id="object-gpu-status"
+            class="status-dot {{ 'ok' if clip_gpu else 'error' }}"
+            title="{{ 'GPU detection enabled' if clip_gpu else 'GPU detection disabled' }}"
+            aria-label="{{ 'GPU detection enabled' if clip_gpu else 'GPU detection disabled' }}"
+          ></span>
+        </div>
         <label
           for="object_confidence"
           title="Minimum confidence for object detection"

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -101,7 +101,7 @@ template_form %} {% block content %}
     template=template_details, preview_src='/stream.mjpg?camera=' ~
     template_name, preview_id='mini-live-preview', include_name=False,
     submit_label='Update Template', object_tokens=object_tokens,
-    clip_model=clip_model ) }}
+    clip_model=clip_model, clip_gpu=clip_gpu ) }}
   </div>
   <div id="delete-template" class="form-actions">
     <button
@@ -542,7 +542,8 @@ template_form %} {% block content %}
     {{ template_form( 'edit-template-form', '/update_template/' ~ template_name,
     template=template_details, preview_src='/stream.mjpg?camera=' ~
     template_name, preview_id='mini-live-preview', include_name=False,
-    submit_label='Save', object_tokens=object_tokens, clip_model=clip_model ) }}
+    submit_label='Save', object_tokens=object_tokens, clip_model=clip_model,
+    clip_gpu=clip_gpu ) }}
   </div>
 </div>
 

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -123,6 +123,10 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('<select id="groups"', components)
 
+    def test_object_filter_gpu_icon_present(self):
+        components = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn("object-gpu-status", components)
+
     def test_status_tab_has_sparklines(self):
         html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
         self.assertIn('id="memory-sparkline"', html)


### PR DESCRIPTION
## Summary
- add `clip_gpu_available()` helper
- show GPU detection icon next to Object Filter field
- display GPU status in Add/Edit Camera form
- add simple container styling
- test for GPU status icon

## Testing
- `pre-commit run --files app/routes.py app/static/css/style.css app/templates/_discover_tab.html app/templates/components.html app/templates/template_details.html tests/test_html_templates.py`
- `pytest -q` *(fails: test_captions_status, test_discover_route, test_scheduler_starts_once, test_grey_patch)*

------
https://chatgpt.com/codex/tasks/task_e_684c2961b99883339843b45c1886ed4c