### PR TITLE
Add camera delete option

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -463,6 +463,24 @@ select:hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 
+.delete-camera-btn {
+  position: absolute;
+  top: calc(10px * var(--tile-scale, 1));
+  right: calc(10px * var(--tile-scale, 1));
+  background-color: rgba(231, 76, 60, 0.8);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: calc(2px * var(--tile-scale, 1)) calc(4px * var(--tile-scale, 1));
+  font-size: calc(14px * var(--tile-scale, 1));
+  cursor: pointer;
+  z-index: 6;
+}
+
+.delete-camera-btn:hover {
+  background-color: rgba(231, 76, 60, 1);
+}
+
 :root {
   --tile-size: 360px;
   --grid-item-width: var(--tile-size);

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -55,6 +55,7 @@ function createTemplateCard(name, template, index, mobile) {
       </div>
     </a>
     <a href='${template.url}' target='_blank' class='open-url-link' title='Open monitored page' aria-label='Open monitored page'>↗</a>
+    <button class='delete-camera-btn advanced-only' onclick="window.confirmDeleteCamera('${name}')" title='Delete this camera' aria-label='Delete camera'>✖</button>
   `;
   return div;
 }
@@ -1189,3 +1190,35 @@ export function setupBrowserOptions() {
     updateBrowserOptions();
   });
 }
+
+export function confirmDeleteCamera(name) {
+  const modal = document.getElementById("delete-camera-modal");
+  const msg = document.getElementById("delete-camera-modal-message");
+  const confirmBtn = document.getElementById("delete-camera-confirm");
+  const cancelBtn = document.getElementById("delete-camera-cancel");
+  const closeBtn = document.getElementById("delete-camera-close");
+  if (!modal || !msg || !confirmBtn) return;
+  msg.textContent = `Delete camera ${name}?`;
+  modal.style.display = "block";
+  const hide = () => {
+    modal.style.display = "none";
+  };
+  const onConfirm = () => {
+    hide();
+    fetch("/templates", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    })
+      .then((resp) => resp.json())
+      .then(() => {
+        document.querySelector(`.templateDiv[data-name='${name}']`)?.remove();
+      })
+      .catch((err) => console.error("Error:", err));
+  };
+  confirmBtn.addEventListener("click", onConfirm, { once: true });
+  cancelBtn?.addEventListener("click", hide, { once: true });
+  closeBtn?.addEventListener("click", hide, { once: true });
+}
+
+window.confirmDeleteCamera = confirmDeleteCamera;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -46,5 +46,6 @@
     <button id="welcome-ok" title="Dismiss this guide">Got it!</button>
   </div>
 </div>
-
-{% endblock %}
+{% from 'components.html' import confirm_modal %} {{
+confirm_modal('delete-camera', 'Delete this camera?', 'Delete', 'Cancel') }} {%
+endblock %}

--- a/tests/js/delete_camera.test.js
+++ b/tests/js/delete_camera.test.js
@@ -1,0 +1,35 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="delete-camera-modal" class="modal">
+    <p id="delete-camera-modal-message"></p>
+    <button id="delete-camera-confirm"></button>
+    <button id="delete-camera-cancel"></button>
+    <span id="delete-camera-close"></span>
+  </div>
+  <div class="templateDiv" data-name="cam1"></div>
+`;
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ status: "success" }),
+  }),
+);
+
+let confirmDeleteCamera;
+
+beforeAll(async () => {
+  ({ confirmDeleteCamera } = await import("../../app/static/js/templates.js"));
+});
+
+test("confirmDeleteCamera shows modal and sends request", () => {
+  confirmDeleteCamera("cam1");
+  expect(document.getElementById("delete-camera-modal").style.display).toBe(
+    "block",
+  );
+  document.getElementById("delete-camera-confirm").click();
+  expect(fetch).toHaveBeenCalledWith(
+    "/templates",
+    expect.objectContaining({ method: "DELETE" }),
+  );
+});


### PR DESCRIPTION
## Summary
- allow deleting cameras from the index page
- include Delete button styles and confirmation modal
- expose `confirmDeleteCamera` in `templates.js`
- test camera deletion modal behavior

## Testing
- `pre-commit run --files app/static/js/templates.js app/templates/index.html app/static/css/style.css tests/js/delete_camera.test.js`
- `pytest` *(fails: SchedulerAlreadyRunningError)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c28fb870c83338375244212bcc975