### PR TITLE
Fix recent videos ordering

### DIFF
--- a/app/static/js/recent_videos.js
+++ b/app/static/js/recent_videos.js
@@ -9,7 +9,7 @@ export function initRecentVideosModal(list, camera) {
   items.sort((a, b) => collator.compare(a, b));
   if (lastIndex !== -1) items.push("last_video.mp4");
 
-  let index = 0;
+  let index = items.length - 1;
   const video = document.getElementById("live-video");
   const source = video?.querySelector("source");
   const prev = document.getElementById("prev-clip-btn");

--- a/tests/js/recent_videos_modal.test.js
+++ b/tests/js/recent_videos_modal.test.js
@@ -1,20 +1,28 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `
-  <div id="videos-modal" class="modal">
-    <video data-file="clip1.mp4"></video>
-    <video data-file="last_video.mp4"></video>
-  </div>
-  <video id="live-video"><source /></video>
-  <button id="prev-clip-btn"></button>
-  <button id="next-clip-btn"></button>
-`;
+function setupDom() {
+  document.body.innerHTML = `
+    <div id="videos-modal" class="modal">
+      <video data-file="clip1.mp4"></video>
+      <video data-file="last_video.mp4"></video>
+    </div>
+    <video id="live-video"><source /></video>
+    <button id="prev-clip-btn"></button>
+    <button id="next-clip-btn"></button>
+  `;
+}
+
+setupDom();
 
 let init;
 
 beforeAll(async () => {
   const mod = await import("../../app/static/js/recent_videos.js");
   init = mod.initRecentVideosModal;
+});
+
+beforeEach(() => {
+  setupDom();
 });
 
 test("clicking a modal video loads clip and closes modal", () => {
@@ -25,4 +33,12 @@ test("clicking a modal video loads clip and closes modal", () => {
   const src = document.querySelector("#live-video source").src;
   expect(src).toMatch(/\/videos\/cam1\/clip1.mp4$/);
   expect(window.closeGenericModal).toHaveBeenCalledWith("videos-modal");
+});
+
+test("initial clip is most recent with live button enabled", () => {
+  init(["clip1.mp4", "clip2.mp4", "last_video.mp4"], "cam1");
+  const prev = document.getElementById("prev-clip-btn");
+  const next = document.getElementById("next-clip-btn");
+  expect(prev.disabled).toBe(false);
+  expect(next.textContent).toBe("Live");
 });


### PR DESCRIPTION
## Summary
- ensure recent videos carousel starts on the newest clip
- test the updated ordering logic

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: tests/test_routes.py::TestRoutes::test_captions_status, tests/test_scheduler_start_once.py::test_scheduler_starts_once, tests/test_test_pattern.py::TestTestPattern::test_grey_patch)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c2a354a648333afcbaa984de63713