### PR TITLE
Add OWASP Dependency Check and SBOM

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,37 @@
+name: OWASP Dependency Check
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run OWASP Dependency Check
+        uses: dependency-check/Dependency-Check_Action@v3.1.0
+        with:
+          project: glimpser
+          path: .
+          format: 'SARIF'
+          out: reports
+          fail_on_cvss: 7
+          fail_on_severity: high
+      - name: Upload dependency-check report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: reports
+      - name: Generate CycloneDX SBOM
+        run: pipx run cyclonedx-bom -o sbom.xml
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,3 +71,8 @@ repos:
         entry: python scripts/check_exclude_docs.py
         language: system
         pass_filenames: false
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets

--- a/docs/dependency_check.md
+++ b/docs/dependency_check.md
@@ -1,0 +1,7 @@
+# OWASP Dependency Check
+
+Glimpser scans third‑party packages with the OWASP Dependency‑Check action.
+The workflow defined in `.github/workflows/dependency-check.yml` runs on every
+push and pull request. It fails the build if vulnerabilities with a CVSS score
+of 7.0 or higher ("High" severity) are detected. The SARIF report and a
+CycloneDX SBOM are uploaded as workflow artefacts.

--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -1,0 +1,6 @@
+# Software Bill of Materials
+
+The build workflow produces a CycloneDX Software Bill of Materials using
+`cyclonedx-bom`. The SBOM is generated automatically in the
+`dependency-check` job and uploaded as an artefact. Include it when creating
+releases so consumers can audit the dependencies shipped with Glimpser.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ nav:
       - Docs Build Workflow: docs_build.md
       - CodeQL Security Scanning: codeql.md
       - Dependency Review: dependency_review.md
+      - OWASP Dependency Check: dependency_check.md
+      - Software Bill of Materials: sbom.md
       - EthicalCheck Workflow: ethicalcheck.md
       - FAQ: faq.md
       - Getting Started: getting_started.md


### PR DESCRIPTION
## Summary
- add OWASP Dependency Check workflow with CycloneDX SBOM output
- integrate detect-secrets in pre-commit
- document dependency checking and SBOM generation

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: unable to fetch detect-secrets)*
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c2bf6c6b083339c81c474565479e0