### PR TITLE
Ensure webdriver sessions close properly

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -2581,6 +2581,7 @@ def _capture_danger_mode(
     # This part uses normal Selenium for the attach:
     danger_options = webdriver.ChromeOptions()
     danger_options.debugger_address = "127.0.0.1:9222"
+    danger_options.add_experimental_option("detach", True)
 
     driver = None
     original_window = None
@@ -2608,7 +2609,9 @@ def _capture_danger_mode(
         # Attempt dark mode if desired
         if dark and not invert:
             try:
-                driver.execute_cdp_cmd("Emulation.setAutoDarkModeOverride", {"enabled": True})
+                driver.execute_cdp_cmd(
+                    "Emulation.setAutoDarkModeOverride", {"enabled": True}
+                )
             except Exception as e:
                 logging.debug(f"[danger_mode] setAutoDarkModeOverride failed: {e}")
         time.sleep(5)
@@ -2654,10 +2657,16 @@ def _capture_danger_mode(
             try:
                 driver.switch_to.window(original_window)
             except Exception as ex:
-                logging.debug(f"Could not switch to original window in danger mode: {ex}")
+                logging.debug(
+                    f"Could not switch to original window in danger mode: {ex}"
+                )
 
-        # DO NOT do driver.quit() in Danger mode: that kills the user's entire Chrome
-        driver = None
+        # Close driver session without killing the user's browser
+        if driver:
+            try:
+                driver.quit()
+            except Exception as ex:
+                logging.debug(f"driver.quit() failed in danger mode: {ex}")
 
 
 def _remove_popup(driver, popup_xpath):

--- a/tests/test_capture_pipeline.py
+++ b/tests/test_capture_pipeline.py
@@ -54,11 +54,13 @@ def browser():
     driver = _create_driver()
     if driver is None:
         pytest.skip("Web driver not available")
-    yield driver
     try:
-        driver.quit()
-    except Exception:
-        pass
+        yield driver
+    finally:
+        try:
+            driver.quit()
+        except Exception:
+            pass
 
 
 @pytest.fixture()

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -98,8 +98,10 @@ def browser():
     driver = _create_driver()
     if driver is None:
         pytest.skip("Web driver not available")
-    yield driver
-    driver.quit()
+    try:
+        yield driver
+    finally:
+        driver.quit()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- configure Selenium danger mode to detach and quit safely
- guarantee webdriver fixtures always quit with try/finally

## Testing
- `pre-commit run --files app/utils/screenshots.py tests/test_capture_pipeline.py tests/test_e2e_web.py`
- `pytest tests/test_capture_pipeline.py tests/test_e2e_web.py -q`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c2446508333bed67e696fb559de