### PR TITLE
Fix tooltip placement

### DIFF
--- a/app/static/js/tooltips.js
+++ b/app/static/js/tooltips.js
@@ -12,6 +12,22 @@ export function initTooltips() {
       const x = e.pageX ?? e.clientX;
       const y = e.pageY ?? e.clientY;
 
+      const container = e.target.closest(".video-container");
+      if (container) {
+        const rect = container.getBoundingClientRect();
+        let left = rect.right + offset;
+        if (left + tooltipWidth > window.innerWidth) {
+          left = rect.left - tooltipWidth - offset;
+        }
+        let top = rect.top;
+        if (top + tooltipHeight > window.innerHeight) {
+          top = rect.bottom - tooltipHeight;
+        }
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `${top}px`;
+        return;
+      }
+
       let left = x + offset;
       if (left + tooltipWidth > window.innerWidth) {
         left = x - tooltipWidth - offset;

--- a/tests/js/lazy_poster.test.js
+++ b/tests/js/lazy_poster.test.js
@@ -43,6 +43,7 @@ test("poster loads when video becomes visible", async () => {
   const video = document.querySelector("video");
   expect(video.dataset.poster).toBe("/last_screenshot/cam1");
   expect(video.poster).toBe("");
+  await Promise.resolve();
   cb([{ target: video, isIntersecting: true }]);
   expect(video.poster.endsWith("/last_screenshot/cam1")).toBe(true);
 });

--- a/tests/js/tooltip_position.test.js
+++ b/tests/js/tooltip_position.test.js
@@ -1,8 +1,16 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `<span id="item" title="Hello"></span>`;
+document.body.innerHTML = `
+  <span id="item" title="Hello"></span>
+  <div class="video-container" style="position: absolute; top: 0; left: 0; width: 100px; height: 50px;">
+    <video id="vid" title="Video tooltip"></video>
+  </div>
+`;
 
 let initTooltips;
+let originalWidth;
+let originalHeight;
+let originalScrollY;
 
 beforeAll(async () => {
   const mod = await import("../../app/static/js/tooltips.js");
@@ -12,24 +20,105 @@ beforeAll(async () => {
 beforeEach(() => {
   jest.clearAllMocks();
   document.querySelector("#item").setAttribute("title", "Hello");
+  originalWidth = window.innerWidth;
+  originalHeight = window.innerHeight;
+  originalScrollY = window.scrollY;
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: originalWidth,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: originalHeight,
+  });
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    writable: true,
+    value: originalScrollY,
+  });
+  document
+    .querySelectorAll("[data-title]")
+    .forEach((el) =>
+      el.dispatchEvent(new Event("mouseout", { bubbles: true })),
+    );
 });
 
 test("repositions tooltip above when near bottom", () => {
-  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: 300 });
-  Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: 500 });
-  Object.defineProperty(window, "scrollY", { configurable: true, writable: true, value: 0 });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: 300,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: 500,
+  });
+  Object.defineProperty(window, "scrollY", {
+    configurable: true,
+    writable: true,
+    value: 0,
+  });
 
   initTooltips();
   document.dispatchEvent(new Event("DOMContentLoaded"));
 
   const tooltip = document.querySelector(".dynamic-tooltip");
-  Object.defineProperty(tooltip, "offsetWidth", { configurable: true, value: 50 });
-  Object.defineProperty(tooltip, "offsetHeight", { configurable: true, value: 40 });
+  Object.defineProperty(tooltip, "offsetWidth", {
+    configurable: true,
+    value: 50,
+  });
+  Object.defineProperty(tooltip, "offsetHeight", {
+    configurable: true,
+    value: 40,
+  });
 
   const el = document.getElementById("item");
   el.dispatchEvent(
-    new MouseEvent("mouseover", { clientX: 260, clientY: 490, bubbles: true })
+    new MouseEvent("mouseover", { clientX: 260, clientY: 490, bubbles: true }),
   );
 
   expect(tooltip.style.top).toBe("440px");
+});
+
+test("positions tooltip beside video containers", () => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: 300,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: 500,
+  });
+
+  initTooltips();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+
+  const tooltip = document.querySelector(".dynamic-tooltip");
+  Object.defineProperty(tooltip, "offsetWidth", {
+    configurable: true,
+    value: 50,
+  });
+  Object.defineProperty(tooltip, "offsetHeight", {
+    configurable: true,
+    value: 40,
+  });
+
+  const vid = document.getElementById("vid");
+  const container = document.querySelector(".video-container");
+  const rect = { top: 0, left: 0, right: 100, bottom: 50 };
+  jest.spyOn(container, "getBoundingClientRect").mockReturnValue(rect);
+
+  vid.dispatchEvent(
+    new MouseEvent("mouseover", { clientX: 10, clientY: 10, bubbles: true }),
+  );
+
+  expect(parseInt(tooltip.style.left, 10)).toBe(rect.right + 10);
 });


### PR DESCRIPTION
## Summary
- adjust tooltip logic to stay outside video tiles
- include tests for tooltip offset
- tweak lazy poster test to allow microtask completion

## Testing
- `pre-commit run --all-files`
- `npm test` *(fails: lazy_poster.test.js due to HTMLMediaElement not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_684c2de33cc48333ad2a7890d7ce04b6