### PR TITLE
Fix timezone mismatch in file timestamp helpers

### DIFF
--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -121,13 +121,11 @@ def get_latest_date(directory, ext="png"):
     try:
         # Construct the full path to the latest file
         latest_file_path = os.path.join(directory, latest_file)
-        # Get the creation time of the latest file
+        # Get the modification time of the latest file
         latest_file_mtime = os.path.getmtime(latest_file_path)
     except Exception as e:
         logging.warning("file error %s", e)
         return None
 
-    # Convert the timestamp to UTC datetime string
-    # return datetime.utcfromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")
-    #  I think there is a risk of double timestamping here, so I removed the UTC conversion
-    return datetime.fromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")
+    # Always return timestamps in UTC for consistency across the codebase
+    return datetime.utcfromtimestamp(latest_file_mtime).strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/test_video_details.py
+++ b/tests/test_video_details.py
@@ -15,7 +15,7 @@ spec.loader.exec_module(video_details)
 def _make_file(tmp_path, name: str, days_ago: int = 0):
     path = tmp_path / name
     path.write_text("data")
-    ts = datetime.now() - timedelta(days=days_ago)
+    ts = datetime.utcnow() - timedelta(days=days_ago)
     os.utime(path, (ts.timestamp(), ts.timestamp()))
     return path
 
@@ -23,7 +23,7 @@ def _make_file(tmp_path, name: str, days_ago: int = 0):
 def test_get_latest_video_date(tmp_path):
     _make_file(tmp_path, "old.mp4", days_ago=2)
     latest = _make_file(tmp_path, "new.mp4", days_ago=0)
-    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+    expected = datetime.utcfromtimestamp(latest.stat().st_mtime).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
     assert video_details.get_latest_video_date(str(tmp_path)) == expected
@@ -32,7 +32,7 @@ def test_get_latest_video_date(tmp_path):
 def test_get_latest_screenshot_date(tmp_path):
     _make_file(tmp_path, "shot1.png", days_ago=1)
     latest = _make_file(tmp_path, "shot2.png", days_ago=0)
-    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+    expected = datetime.utcfromtimestamp(latest.stat().st_mtime).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
     assert video_details.get_latest_screenshot_date(str(tmp_path)) == expected
@@ -51,7 +51,7 @@ def test_get_latest_file(tmp_path):
 def test_get_latest_date(tmp_path):
     _make_file(tmp_path, "a.txt", days_ago=2)
     latest = _make_file(tmp_path, "b.txt", days_ago=0)
-    expected = datetime.fromtimestamp(latest.stat().st_mtime).strftime(
+    expected = datetime.utcfromtimestamp(latest.stat().st_mtime).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
     assert video_details.get_latest_date(str(tmp_path), ext="txt") == expected


### PR DESCRIPTION
## Summary
- ensure file timestamp retrieval uses UTC in `video_details.get_latest_date`
- update tests to expect UTC timestamps

## Testing
- `pre-commit run --files app/utils/video_details.py tests/test_video_details.py`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e01d400833398e7f96b75bd7577