### PR TITLE
Improve status feed layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2118,6 +2118,11 @@ details > summary {
   border: 1px solid var(--table-border-color);
   white-space: nowrap;
 }
+.feed-status td:first-child {
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .feed-status thead th {
   position: sticky;
   top: 0;
@@ -2188,13 +2193,14 @@ details > summary {
   text-align: center;
 }
 
+
 .capture-col {
-  width: 3rem;
+  width: 2.5rem;
   text-align: center;
 }
 
 .time-col {
-  width: 5rem;
+  width: 4rem;
   text-align: center;
 }
 

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -103,7 +103,7 @@
           data-type="string"
           title="Capture activity"
         >
-          Capturing
+          Cap.
         </th>
         <th
           class="sortable status-col"
@@ -117,14 +117,14 @@
           data-type="date"
           title="Most recent caption time"
         >
-          Last Caption
+          Caption
         </th>
         <th
           class="sortable time-col"
           data-type="date"
           title="Most recent screenshot time"
         >
-          Last Image
+          Image
         </th>
         <th class="sortable" data-type="number" title="Total screenshots">
           Shots
@@ -137,7 +137,7 @@
           LLM
         </th>
         <th class="sortable" data-type="number" title="Estimated LLM cost">
-          LLM Cost
+          LLM $
         </th>
       </tr>
     </thead>
@@ -179,7 +179,7 @@
         </td>
         <td
           class="capture-col"
-          data-label="Capturing"
+          data-label="Cap."
           data-value="{{ '1' if feed.capturing else '0' }}"
         >
           <span
@@ -210,7 +210,7 @@
           ></span>
         </td>
         <td
-          data-label="Last Caption"
+          data-label="Caption"
           class="time-col"
           data-value="{{ feed.last_caption_time or '' }}"
         >
@@ -225,7 +225,7 @@
           {% else %} N/A {% endif %}
         </td>
         <td
-          data-label="Last Image"
+          data-label="Image"
           class="time-col"
           data-value="{{ feed.last_screenshot_time or '' }}"
         >
@@ -259,7 +259,7 @@
         >
           {{ feed.llm_response_count }}
         </td>
-        <td data-label="LLM Cost" data-value="{{ feed.llm_cost_estimate }}">
+        <td data-label="LLM $" data-value="{{ feed.llm_cost_estimate }}">
           {{ feed.llm_cost_estimate }}
         </td>
       </tr>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1353,7 +1353,7 @@ def get_feed_status():
     user_idle = not check_user_activity(timeout=1)
 
     def _humanize(ts: str | None) -> str | None:
-        """Return a simple "time ago" string for the given timestamp."""
+        """Return a short "time ago" string like "5m ago"."""
         if not ts:
             return None
         try:
@@ -1365,17 +1365,17 @@ def get_feed_status():
         if diff < 0:
             return "in the future"
         intervals = (
-            ("year", 31536000),
-            ("month", 2592000),
-            ("day", 86400),
-            ("hour", 3600),
-            ("minute", 60),
-            ("second", 1),
+            ("y", 31536000),
+            ("mo", 2592000),
+            ("d", 86400),
+            ("h", 3600),
+            ("m", 60),
+            ("s", 1),
         )
-        for label, seconds in intervals:
+        for short, seconds in intervals:
             count = int(diff // seconds)
             if count >= 1:
-                return f"{count} {label}{'s' if count > 1 else ''} ago"
+                return f"{count}{short} ago"
         return "just now"
 
     def _iso(ts: str | None) -> str | None:


### PR DESCRIPTION
## Summary
- shorten time ago strings to reduce width
- compress feed status table headers and set column widths
- trim long feed names in the table

## Testing
- `pre-commit run --files app/static/css/style.css app/templates/_status_tab.html app/utils/scheduling.py`
- `pytest -q` *(fails: SchedulerAlreadyRunningError, test pattern assertion)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f2642fc8333861c06c459fef563