### PR TITLE
Fix last caption display size

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1781,7 +1781,7 @@ body.advanced-enabled .advanced-only {
 }
 
 .caption-box .last-caption {
-  max-height: 6rem;
+  flex: 1;
   overflow-y: auto;
   white-space: pre-wrap;
 }
@@ -1815,6 +1815,8 @@ body.advanced-enabled .advanced-only {
 }
 
 .chat-response .last-caption {
+  flex: 1;
+  overflow-y: auto;
   background-color: var(--form-bg-color);
   padding: 0.5rem;
   border-radius: 4px;
@@ -1905,6 +1907,13 @@ details > summary {
 .cost-table tr:hover {
   background-color: var(--table-hover-bg-color);
 }
+.camera-table .camera-row {
+  height: var(--grid-item-height);
+}
+.camera-table .caption-box {
+  height: 100%;
+}
+
 
 .captions-table td:first-child {
   white-space: nowrap;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -67,6 +67,7 @@ export function setCaptionsVisibility(value) {
   captionsVisible = value;
   localStorage.setItem("showCaptions", value.toString());
   applyCaptionVisibility(parseFloat(slider?.value || "0"));
+  updateTableLayout(parseFloat(slider?.value || "0"));
 }
 
 export function applyCaptionVisibility(width) {
@@ -88,6 +89,20 @@ export function applyCaptionVisibility(width) {
         : "Show caption overlays"
       : "Increase tile size to enable captions";
   }
+}
+
+function updateTableLayout(width) {
+  const rows = document.querySelectorAll("#camera-table .camera-row");
+  rows.forEach((row) => {
+    const preview = row.querySelector(".templateDiv");
+    if (!preview) return;
+    const height = preview.offsetHeight;
+    row.style.height = `${height}px`;
+    const caption = row.querySelector(".last-caption");
+    if (caption) {
+      caption.classList.toggle("hidden", width < 150);
+    }
+  });
 }
 
 export function initTemplates() {
@@ -184,6 +199,7 @@ export function initTemplates() {
         captionsVisible = !captionsVisible;
         localStorage.setItem("showCaptions", captionsVisible.toString());
         applyCaptionVisibility(parseFloat(slider?.value || "0"));
+        updateTableLayout(parseFloat(slider?.value || "0"));
       });
       setTimeout(() => {
         captionToggle.classList.add("flash-caption");
@@ -243,6 +259,7 @@ export function initTemplates() {
           `${timestampFontSize}px`,
         );
         applyCaptionVisibility(value);
+        updateTableLayout(value);
       };
 
       slider.addEventListener("input", handleSlider);
@@ -312,6 +329,7 @@ export function initTemplates() {
     updateHumanizedTimes();
     setInterval(updateHumanizedTimes, 60000);
     applyCaptionVisibility(parseFloat(slider?.value || "0"));
+    updateTableLayout(parseFloat(slider?.value || "0"));
   });
 
   window.showStructuredInput = showStructuredInput;
@@ -951,6 +969,7 @@ export async function loadTemplates() {
     updateStatusCounts();
     applyStatusFilter();
     applyCaptionVisibility(parseFloat(sliderElement?.value || "0"));
+    updateTableLayout(parseFloat(sliderElement?.value || "0"));
   } catch (error) {
     console.error("Error loading templates:", error);
     const errorMsg =


### PR DESCRIPTION
## Summary
- collapse last caption when thumbnail is small
- adjust layout of caption rows

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test` *(fails: lazy_poster.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e76cb288333a094823f2d345d5a