### PR TITLE
Add architecture overview diagram

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -56,6 +56,10 @@ This guide provides a high-level look at Glimpser's core components and how they
                      Utility Functions ----> Scheduler Jobs / Background Tasks
 ```
 
+The diagram below provides a visual version of the component flow:
+
+![Component Flow](images/architecture_overview.svg)
+
 - Routes handle incoming API or web requests.
 - Models define the database schema.
 - Utility functions perform processing and are called by both routes and scheduled jobs.

--- a/docs/images/architecture_overview.svg
+++ b/docs/images/architecture_overview.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="180" viewBox="0 0 640 180">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="black" />
+    </marker>
+    <style>
+      rect {
+        fill: #f2f2f2;
+        stroke: #333;
+        stroke-width: 1;
+      }
+      text {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+      }
+    </style>
+  </defs>
+  <!-- Top row -->
+  <rect x="10" y="20" width="120" height="30" />
+  <text x="70" y="40" text-anchor="middle">Client Request</text>
+
+  <rect x="160" y="20" width="160" height="30" />
+  <text x="240" y="40" text-anchor="middle">Routes (app/routes.py)</text>
+
+  <rect x="360" y="20" width="160" height="30" />
+  <text x="440" y="40" text-anchor="middle">Models (app/models/)</text>
+
+  <rect x="540" y="20" width="90" height="30" />
+  <text x="585" y="40" text-anchor="middle">Database</text>
+
+  <!-- Bottom row -->
+  <rect x="210" y="120" width="150" height="30" />
+  <text x="285" y="140" text-anchor="middle">Utility Functions</text>
+
+  <rect x="390" y="120" width="220" height="30" />
+  <text x="500" y="140" text-anchor="middle">Scheduler Jobs / Background Tasks</text>
+
+  <!-- Arrows top row -->
+  <line x1="130" y1="35" x2="160" y2="35" stroke="black" marker-end="url(#arrow)" />
+  <line x1="320" y1="35" x2="360" y2="35" stroke="black" marker-end="url(#arrow)" />
+  <line x1="520" y1="35" x2="540" y2="35" stroke="black" marker-end="url(#arrow)" />
+
+  <!-- Down arrows to utility functions -->
+  <line x1="240" y1="50" x2="285" y2="120" stroke="black" marker-end="url(#arrow)" />
+  <line x1="440" y1="50" x2="285" y2="120" stroke="black" marker-end="url(#arrow)" />
+
+  <!-- Arrow from utility functions to scheduler jobs -->
+  <line x1="360" y1="135" x2="390" y2="135" stroke="black" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- add an SVG illustrating how core components interact
- embed the new diagram in `architecture_overview.md`

## Testing
- `pre-commit run --all-files` *(fails: unable to fetch detect-secrets)*
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c318376c48333a94349c5818d4a9f