### PR TITLE
Add date range picker and calls metric to cost tab

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3675,7 +3675,9 @@ def init_routes(app: Flask) -> None:
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
         danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
-        cost_summary, total_tokens, total_cost = template_manager.get_llm_cost_summary()
+        cost_summary, total_tokens, total_cost, total_calls = (
+            template_manager.get_llm_cost_summary()
+        )
         cost_summary = template_manager.group_cost_summary(cost_summary, top=10)
 
         chrome_path = get_chrome_path()
@@ -3714,6 +3716,7 @@ def init_routes(app: Flask) -> None:
             cost_summary=cost_summary,
             total_tokens=total_tokens,
             total_cost=total_cost,
+            total_calls=total_calls,
             danger_info=danger_info,
             shortcut_options=shortcut_opts,
             choices=SETTINGS_CHOICES,
@@ -4070,13 +4073,14 @@ def init_routes(app: Flask) -> None:
     def api_llm_cost_summary():
         start = request.args.get("start")
         end = request.args.get("end")
-        summary, _, _ = template_manager.get_llm_cost_summary(
+        summary, _, _, _ = template_manager.get_llm_cost_summary(
             start_date=start, end_date=end
         )
         costs = {
             entry["name"]: {
                 "tokens": entry["tokens"],
                 "cost": entry["cost"],
+                "calls": entry.get("calls", 0),
             }
             for entry in summary
         }

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -10,9 +10,10 @@ export function groupSmallValues(rows, limit = 15) {
     (acc, r) => {
       acc.tokens += r.tokens;
       acc.cost += r.cost;
+      acc.calls += r.calls ?? 0;
       return acc;
     },
-    { name: "Other", tokens: 0, cost: 0 },
+    { name: "Other", tokens: 0, cost: 0, calls: 0 },
   );
   const remaining = sorted.slice(limit).sort((a, b) => b.cost - a.cost);
   return [...remaining, other];
@@ -22,8 +23,8 @@ export function initCosts() {
   document.addEventListener("DOMContentLoaded", () => {
     const dataEl = document.getElementById("cost-data");
     if (!dataEl) return;
-    const range = document.getElementById("cost-range");
-    const label = document.getElementById("cost-range-label");
+    const startInput = document.getElementById("cost-start");
+    const endInput = document.getElementById("cost-end");
     const topSlider = document.getElementById("cost-top");
     const topLabel = document.getElementById("cost-top-label");
     const tbody = document.querySelector("#cost-table tbody");
@@ -39,13 +40,13 @@ export function initCosts() {
       tbody.innerHTML = "";
       for (const row of grouped) {
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${row.name}</td><td data-value="${row.tokens}">${row.tokens}</td><td data-value="${row.cost}">$${row.cost.toFixed(2)}</td>`;
+        tr.innerHTML = `<td>${row.name}</td><td data-value="${row.calls}">${row.calls}</td><td data-value="${row.tokens}">${row.tokens}</td><td data-value="${row.cost}">$${row.cost.toFixed(2)}</td>`;
         tbody.appendChild(tr);
       }
       if (!ctx) return;
       const labels = grouped.map((r) => r.name);
       const values = grouped.map((r) => r.cost);
-      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
+      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},40%,45%)`);
       const chartData = {
         labels,
         datasets: [{ data: values, backgroundColor: bg }],
@@ -66,22 +67,22 @@ export function initCosts() {
     };
 
     const fetchData = async () => {
-      if (!range) {
+      if (!startInput || !endInput) {
         rowsData = JSON.parse(dataEl.textContent);
         render();
         return;
       }
-      const days = parseInt(range.value, 10);
-      const end = new Date().toISOString().slice(0, 10);
-      const start = new Date(Date.now() - days * 86400000)
-        .toISOString()
-        .slice(0, 10);
-      const resp = await fetch(
-        `/api/llm_cost_summary?start=${start}&end=${end}`,
-      );
+      const params = [];
+      if (startInput.value) params.push(`start=${startInput.value}`);
+      if (endInput.value) params.push(`end=${endInput.value}`);
+      const url = params.length
+        ? `/api/llm_cost_summary?${params.join("&")}`
+        : "/api/llm_cost_summary";
+      const resp = await fetch(url);
       const data = await resp.json();
       const rows = Object.entries(data).map(([name, info]) => ({
         name,
+        calls: info.calls ?? 0,
         tokens: info.tokens,
         cost: parseFloat(info.cost.replace("$", "")),
       }));
@@ -89,10 +90,8 @@ export function initCosts() {
       render();
     };
 
-    range?.addEventListener("input", () => {
-      if (label) label.textContent = `Last ${range.value} days`;
-    });
-    range?.addEventListener("change", fetchData);
+    startInput?.addEventListener("change", fetchData);
+    endInput?.addEventListener("change", fetchData);
 
     topSlider?.addEventListener("input", () => {
       if (topLabel) topLabel.textContent = `Top ${topSlider.value}`;
@@ -100,6 +99,12 @@ export function initCosts() {
     });
 
     setupTableSorting("cost-table");
+    if (startInput && endInput) {
+      const today = new Date();
+      endInput.value = today.toISOString().slice(0, 10);
+      const start = new Date(Date.now() - 7 * 86400000);
+      startInput.value = start.toISOString().slice(0, 10);
+    }
     fetchData();
   });
 }
@@ -134,7 +139,7 @@ export function initCostSummary(startTime) {
       const grouped = groupSmallValues(rows);
       const labels = grouped.map((r) => r.name);
       const values = grouped.map((r) => r.cost);
-      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`);
+      const bg = labels.map((_, i) => `hsl(${(i * 60) % 360},40%,45%)`);
       const chartData = {
         labels,
         datasets: [

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -1,31 +1,26 @@
 {% call card('LLM Cost Summary') %}
 <div id="cost-controls">
-  <label for="cost-range">Range:</label>
-  <input
-    type="range"
-    id="cost-range"
-    min="1"
-    max="30"
-    value="7"
-    title="Select cost range"
-  />
-  <span id="cost-range-label">Last 7 days</span>
+  <label for="cost-start">From:</label>
+  <input type="date" id="cost-start" title="Start date" />
+  <label for="cost-end">To:</label>
+  <input type="date" id="cost-end" title="End date" />
   <label for="cost-top" class="ml-4">Top:</label>
   <input
     type="range"
     id="cost-top"
     min="5"
-    max="20"
+    max="50"
     value="10"
     title="Number of top templates"
   />
   <span id="cost-top-label">Top 10</span>
 </div>
-<canvas id="costChart" width="500" height="500"></canvas>
+<canvas id="costChart" width="250" height="250"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>
       <th class="sortable">Template</th>
+      <th class="sortable" data-type="number">Calls</th>
       <th class="sortable" data-type="number">Tokens</th>
       <th class="sortable" data-type="number">Cost</th>
     </tr>
@@ -34,6 +29,7 @@
     {% for entry in cost_summary %}
     <tr>
       <td>{{ entry.name }}</td>
+      <td>{{ entry.calls }}</td>
       <td>{{ entry.tokens }}</td>
       <td>{{ entry.cost }}</td>
     </tr>
@@ -42,6 +38,7 @@
   <tfoot>
     <tr>
       <th>Total</th>
+      <th>{{ total_calls }}</th>
       <th>{{ total_tokens }}</th>
       <th>{{ total_cost }}</th>
     </tr>

--- a/app/templates/cost_summary.html
+++ b/app/templates/cost_summary.html
@@ -13,7 +13,7 @@ content %}
   <button type="button" id="load-cost" title="Load cost data">Load</button>
 </form>
 {% endcall %}
-<canvas id="costChart" width="500" height="500"></canvas>
+<canvas id="costChart" width="250" height="250"></canvas>
 <table id="cost-table" class="cost-table">
   <thead>
     <tr>

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -788,7 +788,7 @@ def get_llm_cost_estimate(
 
 def get_llm_cost_summary(
     start_date: str | None = None, end_date: str | None = None
-) -> tuple[list[dict[str, object]], int, str]:
+) -> tuple[list[dict[str, object]], int, str, int]:
     """Return LLM usage totals and overall cost within an optional date range."""
 
     try:
@@ -799,11 +799,13 @@ def get_llm_cost_summary(
 
     summary = []
     total_tokens = 0
+    total_calls = 0
     sd = datetime.fromisoformat(start_date).date() if start_date else None
     ed = datetime.fromisoformat(end_date).date() if end_date else None
     for name in sorted(data):
         entry = data.get(name, 0)
         tokens = 0
+        calls = 0
         if isinstance(entry, dict) and "entries" in entry:
             entries = entry.get("entries", [])
             for e in entries:
@@ -817,23 +819,36 @@ def get_llm_cost_summary(
                     continue
                 try:
                     tokens += int(e.get("tokens", 0))
+                    calls += 1
                 except Exception:
                     continue
             if not start_date and not end_date:
                 tokens = entry.get("total", tokens)
+                calls = len(entries)
         else:
             if isinstance(entry, list):
                 tokens = sum(int(t) for t in entry)
+                calls = len(entry)
             elif isinstance(entry, dict):
                 tokens = int(entry.get("total", 0))
+                calls = len(entry.get("entries", []))
             elif isinstance(entry, int):
                 tokens = entry
+                calls = 1 if entry > 0 else 0
         total_tokens += tokens
+        total_calls += calls
         cost = tokens * LLM_COST_PER_TOKEN
-        summary.append({"name": name, "tokens": tokens, "cost": f"${cost:.3f}"})
+        summary.append(
+            {
+                "name": name,
+                "tokens": tokens,
+                "cost": f"${cost:.3f}",
+                "calls": calls,
+            }
+        )
 
     total_cost = total_tokens * LLM_COST_PER_TOKEN
-    return summary, total_tokens, f"${total_cost:.3f}"
+    return summary, total_tokens, f"${total_cost:.3f}", total_calls
 
 
 def group_cost_summary(
@@ -854,7 +869,15 @@ def group_cost_summary(
     keep = rows[: top - 1]
     other_tokens = sum(r.get("tokens", 0) for r in rows[top - 1 :])
     other_cost = sum(_cost_val(r) for r in rows[top - 1 :])
-    keep.append({"name": "Other", "tokens": other_tokens, "cost": f"${other_cost:.3f}"})
+    other_calls = sum(r.get("calls", 0) for r in rows[top - 1 :])
+    keep.append(
+        {
+            "name": "Other",
+            "tokens": other_tokens,
+            "cost": f"${other_cost:.3f}",
+            "calls": other_calls,
+        }
+    )
     return keep
 
 

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -5,12 +5,13 @@ Token counts are stored in `data/llm_usage.json` keyed by template name.
 Costs are calculated at `$0.005` per thousand tokens.
 Use the captions page to view each template's estimated cost.
 An overall cost summary now appears under **Settings → Costs**. This tab now
-includes a small pie chart and sortable columns. Adjust the date range with the
-slider to view recent spending.
+includes a small pie chart and sortable columns. Choose a start and end date to
+view recent spending.
 
 The Settings cost tab shows the most expensive templates and groups the rest
 into a single **Other** row. Use the **Top** slider to adjust how many
-individual templates appear before grouping occurs.
+individual templates appear before grouping occurs. The table now shows the
+number of LLM calls for each template.
 
 An additional **LLM Cost Summary** page now provides a date range picker to
 review costs for a specific period. Use the **Since Last Restart** shortcut to

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -1,8 +1,8 @@
 import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
-  <input id="cost-range" type="range" value="7">
-  <span id="cost-range-label"></span>
+  <input id="cost-start" type="date">
+  <input id="cost-end" type="date">
   <input id="cost-top" type="range" value="10">
   <span id="cost-top-label"></span>
   <table id="cost-table"><tbody></tbody></table>
@@ -21,7 +21,7 @@ beforeAll(async () => {
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
-    json: () => Promise.resolve({ cam1: { cost: "$1.00", tokens: 1 } }),
+    json: () => Promise.resolve({ cam1: { cost: "$1.00", tokens: 1, calls: 1 } }),
   }),
 );
 
@@ -29,15 +29,15 @@ global.Chart = jest.fn(function () {
   this.update = jest.fn();
 });
 
-test("slider triggers fetch", async () => {
+test("date picker triggers fetch", async () => {
   initCosts();
   document.dispatchEvent(new Event("DOMContentLoaded"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
-  const slider = document.getElementById("cost-range");
+  const start = document.getElementById("cost-start");
   fetch.mockClear();
-  slider.value = "10";
-  slider.dispatchEvent(new Event("change"));
+  start.value = "2023-01-01";
+  start.dispatchEvent(new Event("change"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
 });
@@ -59,6 +59,7 @@ test("groups bottom rows", () => {
     name: `cam${i}`,
     tokens: 1,
     cost: i,
+    calls: 1,
   }));
   const grouped = groupSmallValues(rows, 15);
   expect(grouped.length).toBe(6); // 5 top + Other
@@ -72,6 +73,7 @@ test("limits to top 10 rows", () => {
     name: `cam${i}`,
     tokens: 1,
     cost: i + 1,
+    calls: 1,
   }));
   const grouped = groupSmallValues(rows, rows.length - 9);
   expect(grouped.length).toBe(10);

--- a/tests/test_llm_cost_summary.py
+++ b/tests/test_llm_cost_summary.py
@@ -22,15 +22,22 @@ class TestLLMCostSummary(unittest.TestCase):
     def test_summary_totals(self):
         with open(LLM_USAGE_PATH, "w") as f:
             json.dump({"cam1": 500, "cam2": 1500}, f)
-        summary, tokens, cost = get_llm_cost_summary()
+        summary, tokens, cost, calls = get_llm_cost_summary()
         self.assertEqual(tokens, 2000)
         expected_cost = round(2000 * LLM_COST_PER_TOKEN, 3)
         self.assertEqual(cost, f"${expected_cost:.3f}")
         self.assertEqual(len(summary), 2)
+        self.assertEqual(calls, 2)
 
     def test_group_cost_summary(self):
         summary = [
-            {"name": f"cam{i}", "tokens": i, "cost": f"${i:.3f}"} for i in range(1, 12)
+            {
+                "name": f"cam{i}",
+                "tokens": i,
+                "cost": f"${i:.3f}",
+                "calls": 1,
+            }
+            for i in range(1, 12)
         ]
         grouped = group_cost_summary(summary, top=10)
         self.assertEqual(len(grouped), 10)


### PR DESCRIPTION
## Summary
- allow choosing a date range in the Costs tab
- show number of LLM calls
- make pie chart smaller and dark-mode friendly
- increase "Top" slider limit to 50
- document updated controls

## Testing
- `pre-commit run --files app/routes.py app/utils/template_manager.py app/static/js/costs.js app/templates/_costs_tab.html app/templates/cost_summary.html tests/js/cost_tab.test.js tests/test_llm_cost_summary.py docs/cost_tracking.md`
- `pytest -k llm_cost_summary -q`
- `npm run test:js -- tests/js/cost_tab.test.js`
- `npm test` *(fails: poster loads when video becomes visible)*

------
https://chatgpt.com/codex/tasks/task_e_684c304e60a08333872945a3146d3faf