### PR TITLE
Add diagrams to docs

### DIFF
--- a/docs/auto_update.md
+++ b/docs/auto_update.md
@@ -7,3 +7,7 @@ branch. If all CI checks for that commit pass, the release is installed via
 `pip` and the process restarts automatically. Use `None` (the default) to
 disable automatic updates.
 
+The timeline below summarizes this process:
+
+![Automatic Update Process](images/auto_update_process.svg)
+

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -1,6 +1,10 @@
 # Camera Discovery
 
 Glimpser includes a simple discovery feature to help find network cameras on your local LAN. The **Discover** tab on the **Settings** page now loads immediately and only scans when you click the **Discover** button. Starting a scan automatically enables hourly background discovery if it isn't already running. Use the **Stop Discovery** button to halt it. A progress bar displays the number of completed stages so you know the scan is making progress. The page also shows which discovery stage is currently executing. The logic in `app/utils/camera_discovery.py` runs in parallel threads so results return faster. To keep the scan quick, each interface is limited to a `/24` subnet even if the reported mask is larger. Interfaces that are down or using loopback or link-local addresses are ignored so the default scan only targets routable LAN networks.
+
+The flow below illustrates the major discovery stages:
+
+![Camera Discovery Flow](images/camera_discovery_flow.svg)
 The subnet list is now deduplicated so machines with multiple addresses per interface are scanned only once. Unreachable ports fail fast so discovery always completes even when some networks are inaccessible.
 The page layout now uses card sections and wider progress indicators for a more professional feel while keeping controls grouped logically.
 Background discovery can run automatically every hour when the `DISCOVERY_AUTOSTART` setting is enabled. When disabled (the default), the search icon appears white until you start the scan from the Discover tab. The icon turns green when a scan completed recently, yellow while scanning, and red if the last run failed. Hovering over the icon now shows when the last scan finished and when the next one will run. The Discover tab also displays a colored status dot beside the background discovery text so you can quickly see if scanning is active or disabled.

--- a/docs/images/auto_update_process.svg
+++ b/docs/images/auto_update_process.svg
@@ -1,0 +1,22 @@
+<svg width="220" height="290" viewBox="0 0 220 290" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Check Release</text>
+  <line x1="110" y1="40" x2="110" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="90" font-size="12" text-anchor="middle" fill="#333">Download</text>
+  <line x1="110" y1="100" x2="110" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="150" font-size="12" text-anchor="middle" fill="#333">Install</text>
+  <line x1="110" y1="160" x2="110" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="210" font-size="12" text-anchor="middle" fill="#333">Restart</text>
+</svg>

--- a/docs/images/camera_discovery_flow.svg
+++ b/docs/images/camera_discovery_flow.svg
@@ -1,0 +1,25 @@
+<svg width="220" height="320" viewBox="0 0 220 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Start Scan</text>
+  <line x1="110" y1="40" x2="110" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="90" font-size="12" text-anchor="middle" fill="#333">ONVIF</text>
+  <line x1="110" y1="100" x2="110" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="150" font-size="12" text-anchor="middle" fill="#333">RTSP</text>
+  <line x1="110" y1="160" x2="110" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="210" font-size="12" text-anchor="middle" fill="#333">Traceroute</text>
+  <line x1="110" y1="220" x2="110" y2="250" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="250" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="270" font-size="12" text-anchor="middle" fill="#333">Stream Results</text>
+</svg>

--- a/docs/images/mcp_integration_flow.svg
+++ b/docs/images/mcp_integration_flow.svg
@@ -1,0 +1,19 @@
+<svg width="220" height="220" viewBox="0 0 220 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Glimpser</text>
+  <line x1="110" y1="40" x2="110" y2="80" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="80" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="100" font-size="12" text-anchor="middle" fill="#333">/mcp/tool/&lt;name&gt;</text>
+  <line x1="110" y1="110" x2="110" y2="150" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="150" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="170" font-size="12" text-anchor="middle" fill="#333">MCP Server</text>
+</svg>

--- a/docs/images/system_monitoring_flow.svg
+++ b/docs/images/system_monitoring_flow.svg
@@ -1,0 +1,19 @@
+<svg width="220" height="260" viewBox="0 0 220 260" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Collect Metrics</text>
+  <line x1="110" y1="40" x2="110" y2="80" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="80" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="100" font-size="12" text-anchor="middle" fill="#333">/status &amp; /health</text>
+  <line x1="110" y1="110" x2="110" y2="150" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="150" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="170" font-size="12" text-anchor="middle" fill="#333">Dashboard</text>
+</svg>

--- a/docs/images/video_archiver_pipeline.svg
+++ b/docs/images/video_archiver_pipeline.svg
@@ -1,0 +1,22 @@
+<svg width="240" height="320" viewBox="0 0 240 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="60" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="120" y="30" font-size="12" text-anchor="middle" fill="#333">Capture</text>
+  <line x1="120" y1="40" x2="120" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="60" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="120" y="90" font-size="12" text-anchor="middle" fill="#333">Convert to MP4</text>
+  <line x1="120" y1="100" x2="120" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="60" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="120" y="150" font-size="12" text-anchor="middle" fill="#333">Concatenate</text>
+  <line x1="120" y1="160" x2="120" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="60" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="120" y="210" font-size="12" text-anchor="middle" fill="#333">Rotate</text>
+</svg>

--- a/docs/mcp_integration.md
+++ b/docs/mcp_integration.md
@@ -4,6 +4,8 @@ Glimpser can delegate actions to an external **Model Control Plane (MCP)**. The
 MCP server exposes a list of tools that can be invoked from the web interface or
 through the `/mcp/tool/<name>` endpoint.
 
+![MCP Integration Flow](images/mcp_integration_flow.svg)
+
 ## Configuration
 Set `MCP_SERVER_COMMAND` or `MCP_SERVER_URL` in `app/config.py` to point to the
 MCP server. When neither is configured, Glimpser falls back to a lightweight

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -2,6 +2,8 @@
 
 This guide explains how to check Glimpser's health metrics and view live logs.
 
+![System Monitoring Flow](images/system_monitoring_flow.svg)
+
 ## System Status Endpoint
 
 **GET /status**

--- a/docs/video_archiver.md
+++ b/docs/video_archiver.md
@@ -5,6 +5,10 @@ files are rotated when they grow too large or when their creation date exceeds
 `MAX_COMPRESSED_VIDEO_AGE` days. FFmpeg stdout and stderr are logged to aid
 troubleshooting.
 
+The pipeline below summarizes this process:
+
+![Video Archiver Pipeline](images/video_archiver_pipeline.svg)
+
 Concatenation now uses FFmpeg's **concat demuxer** with `-c copy` so that
 existing segments are joined without re-encoding. This keeps the CPU overhead
 low and preserves the original image quality.


### PR DESCRIPTION
## Summary
- add diagrams illustrating key workflows
- show the new images in the corresponding documentation pages

## Testing
- `pre-commit run --all-files` *(fails: unable to fetch detect-secrets)*
- `flake8`
- `pytest -q` *(fails: 3 failed, 525 passed, 3 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684c3582cd4c8333a4697c266a3972d0