### PR TITLE
Add live stream autoplay

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -11,6 +11,10 @@
   overflow: hidden;
 }
 
+.video-container.live-mode {
+  border: 2px solid #4ade80;
+}
+
 .clip-nav {
   position: absolute;
   top: 50%;

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -38,13 +38,17 @@ export function initTilePlayer() {
     spinner.classList.remove("bouncy", "visible");
   }
 
-  function playMjpg(group) {
-    if (!group) return;
+  const LIVE_CLASS = "live-mode";
+
+  function playMjpg(target, isCamera = false) {
+    if (!target) return;
     showSpinner(video);
     image.onload = () => hideSpinner(video);
     video.style.display = "none";
     image.style.display = "block";
-    image.src = `/stream.mjpg?group=${encodeURIComponent(group)}&time=${Date.now()}`;
+    const param = isCamera ? "camera" : "group";
+    image.src = `/stream.mjpg?${param}=${encodeURIComponent(target)}&time=${Date.now()}`;
+    if (container) container.classList.add(LIVE_CLASS);
   }
 
   function scheduleLive(group) {
@@ -111,6 +115,7 @@ export function initTilePlayer() {
     current = name;
     video.style.display = "block";
     image.style.display = "none";
+    if (container) container.classList.remove(LIVE_CLASS);
 
     if (name === "All") {
       const first = Object.keys(window.templateDetails || {})[0];
@@ -146,6 +151,17 @@ export function initTilePlayer() {
     } else {
       if (source) source.src = `/last_video/${name}`;
       video.setAttribute("data-hd-src", `/clip/${name}`);
+      video.addEventListener(
+        "ended",
+        () => {
+          showSpinner(video);
+          image.addEventListener("load", () => hideSpinner(video), {
+            once: true,
+          });
+          playMjpg(name, true);
+        },
+        { once: true },
+      );
     }
 
     video.load();
@@ -158,6 +174,16 @@ export function initTilePlayer() {
   }
 
   play(current);
+
+  if (container) {
+    const reset = () => {
+      if (container.classList.contains(LIVE_CLASS)) {
+        play(current);
+      }
+    };
+    container.addEventListener("mousedown", reset);
+    container.addEventListener("touchstart", reset);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", initTilePlayer);


### PR DESCRIPTION
## Summary
- auto-switch live view to MJPEG stream
- highlight player when in live mode

## Testing
- `pre-commit run --all-files` *(fails: unable to fetch detect-secrets)*
- `flake8`
- `pytest -q` *(fails: 3 failed, 525 passed, 3 skipped)*
- `npm test --silent` *(fails: 1 failed, 99 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c378cb9cc8333b57fc21c01577dda