### PR TITLE
Improve system metrics thread list

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1916,7 +1916,6 @@ details > summary {
   height: 100%;
 }
 
-
 .captions-table td:first-child {
   white-space: nowrap;
   width: 12rem;
@@ -2204,7 +2203,6 @@ details > summary {
   text-align: center;
 }
 
-
 .capture-col {
   width: 2.5rem;
   text-align: center;
@@ -2285,6 +2283,17 @@ details > summary {
 
 #thread-cpu-list {
   font-family: monospace;
+}
+
+.thread-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.thread-list li {
+  display: flex;
+  justify-content: space-between;
 }
 
 .metric-bar {

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -44,9 +44,19 @@ export function updatePerformanceMetrics() {
 
       const cpuList = document.getElementById("thread-cpu-list");
       if (cpuList) {
-        cpuList.textContent = (metrics.top_threads || [])
-          .map((t) => `${t.id} (${t.cpu}%)`)
-          .join(", ");
+        cpuList.innerHTML = "";
+        (metrics.top_threads || []).forEach((t) => {
+          const li = document.createElement("li");
+          const nameSpan = document.createElement("span");
+          nameSpan.className = "thread-name";
+          nameSpan.textContent = t.name;
+          const cpuSpan = document.createElement("span");
+          cpuSpan.className = "thread-cpu";
+          cpuSpan.textContent = `${t.cpu}%`;
+          li.appendChild(nameSpan);
+          li.appendChild(cpuSpan);
+          cpuList.appendChild(li);
+        });
       }
 
       const uptimeVal = document.getElementById("uptime-value");

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -73,7 +73,14 @@
   </li>
   <li title="Top threads by CPU usage">
     <span class="metric-label">Top Threads:</span>
-    <span id="thread-cpu-list">{{ metrics.top_threads }}</span>
+    <ul id="thread-cpu-list" class="thread-list">
+      {% for t in metrics.top_threads %}
+      <li>
+        <span class="thread-name">{{ t.name }}</span>
+        <span class="thread-cpu">{{ t.cpu }}%</span>
+      </li>
+      {% endfor %}
+    </ul>
   </li>
   <li title="System uptime">
     <span class="metric-label">Uptime:</span>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1183,6 +1183,7 @@ metrics_thread = None
 log_caching_thread = None
 thread_cpu_times = {}
 last_thread_sample = time.time()
+child_procs = []
 
 
 def ffmpeg_version() -> str:
@@ -1220,8 +1221,14 @@ def collect_system_metrics():
     # Prime psutil's CPU measurement to avoid blocking on the first call
     psutil.cpu_percent(interval=None)
     proc = psutil.Process()
-    global thread_cpu_times, last_thread_sample
+    global thread_cpu_times, last_thread_sample, child_procs
     proc.cpu_percent(interval=None)
+    child_procs = proc.children(recursive=True)
+    for child in child_procs:
+        try:
+            child.cpu_percent(interval=None)
+        except Exception:
+            continue
     while not stop_event.is_set():
         start = time.time()
         # Non-blocking call since we primed above
@@ -1235,9 +1242,21 @@ def collect_system_metrics():
         for tid, ttime in current.items():
             prev = thread_cpu_times.get(tid, ttime)
             cpu = ((ttime - prev) / interval) * 100 / psutil.cpu_count()
-            usages.append({"id": tid, "cpu": round(cpu, 1)})
+            name = next(
+                (t.name for t in threading.enumerate() if t.ident == tid),
+                f"Thread {tid}",
+            )
+            usages.append({"id": tid, "name": name, "cpu": round(cpu, 1)})
         thread_cpu_times = current
         last_thread_sample = start
+        for child in proc.children(recursive=True):
+            try:
+                cpu = child.cpu_percent(interval=None)
+                name = os.path.basename(child.name())
+                if cpu:
+                    usages.append({"id": child.pid, "name": name, "cpu": round(cpu, 1)})
+            except Exception:
+                continue
         usages.sort(key=lambda x: x["cpu"], reverse=True)
         system_metrics["top_threads"] = usages[:5]
         time.sleep(5)  # Collect metrics every 5 seconds

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -42,7 +42,7 @@ name, last image time, last caption time, any KPI column, or status.
 - **Disk Usage** – percentage of disk space used on the main volume
 - **Open Files** – number of file descriptors opened by the process
 - **Thread Count** – active thread count for the application
-- **Top Threads** – list of threads using the most CPU time
+- **Top Threads** – stacked list of thread and child process names sorted by CPU usage (includes `ffmpeg` when active)
 - **Uptime** – elapsed time since the app started
 - **FFmpeg Version** – version string and path to the ffmpeg binary
 - **Machine HW Accel** – whether GPU devices are detected

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -132,6 +132,10 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('id="memory-sparkline"', html)
         self.assertIn('id="disk-sparkline"', html)
 
+    def test_status_tab_thread_list(self):
+        html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
+        self.assertIn('<ul id="thread-cpu-list"', html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -136,7 +136,7 @@ class TestGetSystemMetrics(unittest.TestCase):
                 "cpu_usage": 1.234,
                 "memory_usage": 2.345,
                 "thread_count": 5,
-                "top_threads": [{"id": 123, "cpu": 10.0}],
+                "top_threads": [{"id": 123, "name": "Thread-1", "cpu": 10.0}],
                 "start_time": time.time() - 3661,
             }
         )
@@ -158,7 +158,9 @@ class TestGetSystemMetrics(unittest.TestCase):
         self.assertTrue(metrics["gpu_support"])
         self.assertTrue(metrics["ffmpeg_gpu_enabled"])
         self.assertTrue(metrics["danger_mode"])
-        self.assertEqual(metrics["top_threads"], [{"id": 123, "cpu": 10.0}])
+        self.assertEqual(
+            metrics["top_threads"], [{"id": 123, "name": "Thread-1", "cpu": 10.0}]
+        )
 
 
 class TestOfflineJobQueue(unittest.TestCase):


### PR DESCRIPTION
## Summary
- display top threads and child processes by name
- render thread list as stacked list on the Status tab
- style thread list and update JS metrics updater
- document new metric behaviour
- adjust tests for updated HTML and metrics

## Testing
- `pre-commit run --all-files` *(fails: unable to fetch detect-secrets)*
- `pytest -q` *(fails: several unrelated tests)*
- `pytest tests/test_scheduling_more.py tests/test_html_templates.py -q`
- `npm test` *(fails: 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_684c3bbdc0c4833383ab1dc9769e85b1