### PR TITLE
Fix settings download stream

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -17,6 +17,7 @@ import sqlite3
 import struct
 import subprocess
 import sys
+import typing
 import tempfile
 import textwrap
 import time
@@ -3549,19 +3550,24 @@ def init_routes(app: Flask) -> None:
                 else:
                     flash("Failed to backup configuration", "error")
             elif action == "download":
-                # Always create a fresh backup before serving the file so the
-                # user gets the most up‐to‐date configuration. If the file did
-                # not exist previously ``backup_config`` will create it.
-                backup_config()
 
-                if os.path.exists(BACKUP_PATH):
-                    return send_file(
-                        BACKUP_PATH,
-                        as_attachment=True,
-                        download_name="config_backup.json",
-                    )
-                else:
-                    flash("No backup file found", "error")
+                def generate() -> typing.Generator[bytes, None, None]:
+                    """Stream the configuration JSON after triggering a backup."""
+                    yield b""
+                    backup_config()
+                    if os.path.exists(BACKUP_PATH):
+                        with open(BACKUP_PATH, "rb") as f:
+                            for chunk in iter(lambda: f.read(8192), b""):
+                                yield chunk
+
+                headers = {
+                    "Content-Disposition": "attachment; filename=config_backup.json"
+                }
+                return Response(
+                    stream_with_context(generate()),
+                    mimetype="application/json",
+                    headers=headers,
+                )
             elif action == "upload":
                 if "file" not in request.files:
                     flash("No file part", "error")

--- a/tests/test_settings_download_route.py
+++ b/tests/test_settings_download_route.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 
 from flask import Flask
 
@@ -28,17 +28,17 @@ class TestSettingsDownloadRoute(unittest.TestCase):
         self.path_patch.stop()
         self.temp_dir.cleanup()
 
-    @patch("app.routes.send_file")
+    @patch("app.routes.open", new_callable=mock_open, read_data=b"{}")
     @patch("app.routes.backup_config", return_value=True)
     @patch("app.routes.os.path.exists", return_value=True)
-    def test_download_triggers_backup(self, mock_exists, mock_backup, mock_send):
+    def test_download_triggers_backup(self, mock_exists, mock_backup, mock_file):
         resp = self.client.post("/settings", data={"action": "download"})
         self.assertEqual(resp.status_code, 200)
+        resp.get_data()  # trigger generator
         mock_backup.assert_called_once()
-        mock_send.assert_called_once_with(
-            self.backup_path,
-            as_attachment=True,
-            download_name="config_backup.json",
+        self.assertEqual(
+            resp.headers.get("Content-Disposition"),
+            "attachment; filename=config_backup.json",
         )
 
 


### PR DESCRIPTION
## Summary
- stream config download so the response starts immediately
- update tests for new streaming behavior

## Testing
- `flake8 app/routes.py tests/test_settings_download_route.py`
- `pytest tests/test_settings_download_route.py::TestSettingsDownloadRoute::test_download_triggers_backup -q`
- `npm test` *(fails: Test Suites: 1 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c3c50a6dc8333a1a10c5be514571f