### PR TITLE
Add URL connection status indicator

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -186,17 +186,32 @@ main {
 .scrub-tooltip.visible {
   opacity: 1;
 }
+.url-input-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.url-input {
+  width: 90%;
+}
+
 .url-status {
   display: inline-block;
-  width: 1em;
-  text-align: center;
+  width: 12px;
+  height: 12px;
   margin-left: 4px;
+  border-radius: 50%;
+  background-color: gray;
+}
+.url-status.pending {
+  background-color: #f0ad4e;
 }
 .url-status.ok {
-  color: #5cb85c;
+  background-color: #5cb85c;
 }
 .url-status.bad {
-  color: #d9534f;
+  background-color: #d9534f;
 }
 .link {
   color: rgb(192, 192, 192);
@@ -1916,7 +1931,6 @@ details > summary {
   height: 100%;
 }
 
-
 .captions-table td:first-child {
   white-space: nowrap;
   width: 12rem;
@@ -2203,7 +2217,6 @@ details > summary {
   width: 4rem;
   text-align: center;
 }
-
 
 .capture-col {
   width: 2.5rem;

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -27,15 +27,19 @@ export function initUrlTester() {
     const defaultSrc = preview
       ? preview.dataset.placeholder || preview.src
       : "";
+    const setStatus = (cls) => {
+      status.textContent = "";
+      status.className = "url-status" + (cls ? ` ${cls}` : "");
+    };
+
     const check = async () => {
       const url = input.value.trim();
-      status.textContent = "";
-      status.className = "url-status";
+      setStatus("");
       if (preview) preview.src = url || defaultSrc;
       if (!url) return;
       controller?.abort();
       controller = new AbortController();
-      status.textContent = "…";
+      setStatus("pending");
       try {
         const res = await fetch(
           `/templates/test_url?url=${encodeURIComponent(url)}`,
@@ -45,23 +49,23 @@ export function initUrlTester() {
         );
         const data = await res.json();
         if (res.ok && data.ok) {
-          status.textContent = "✓";
-          status.classList.add("ok");
+          setStatus("ok");
         } else {
-          status.textContent = "✗";
-          status.classList.add("bad");
+          setStatus("bad");
         }
         sendTelemetry("url_test", { url, ok: data.ok });
       } catch {
         if (controller.signal.aborted) return;
-        status.textContent = "✗";
-        status.classList.add("bad");
+        setStatus("bad");
         sendTelemetry("url_test", { url, ok: false });
       }
     };
 
     toggleDisabled();
-    input.addEventListener("input", toggleDisabled);
+    input.addEventListener("input", () => {
+      toggleDisabled();
+      setStatus(input.value.trim() ? "pending" : "");
+    });
     input.addEventListener("blur", check);
     input.addEventListener("change", () => {
       check();

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -122,17 +122,20 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
     {% endif %}
     <div class="form-row">
       <label for="url" title="URL to monitor">URL:</label>
-      <input
-        type="url"
-        id="url"
-        name="url"
-        value="{{ template.url if template else '' }}"
-        required
-        pattern="https?://.+"
-        placeholder="https://example.com/video"
-        title="Enter the URL to monitor"
-      />
-      <span id="url-status" class="url-status" title="URL test result"></span>
+      <div class="url-input-container">
+        <input
+          type="url"
+          id="url"
+          name="url"
+          class="url-input"
+          value="{{ template.url if template else '' }}"
+          required
+          pattern="https?://.+"
+          placeholder="https://example.com/video"
+          title="Enter the URL to monitor"
+        />
+        <span id="url-status" class="url-status" title="URL test result"></span>
+      </div>
     </div>
     <div class="form-row double-row">
       <label for="frequency" title="How often to check the URL (minutes)"

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -29,7 +29,7 @@ describe("url_test", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fetch).toHaveBeenCalledTimes(2);
     const status = document.getElementById("url-status");
-    expect(status.textContent).toBe("✓");
+    expect(status.textContent).toBe("");
     expect(status.classList.contains("ok")).toBe(true);
     const preview = document.getElementById("url-preview");
     expect(preview.src).toContain("http://example.com");


### PR DESCRIPTION
## Summary
- show connection status next to camera URL
- tweak layout and style for URL input
- update URL tester logic and tests

## Testing
- `pre-commit run --all-files` *(fails: CalledProcessError: git fetch origin --tags)*
- `pytest -q` *(fails: 3 failed, 378 passed, 3 skipped)*
- `npm test --silent` *(fails: 1 failed, 99 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c3ce5494883339b19946877253156