### PR TITLE
Ensure detect-secrets is used offline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 minimum_pre_commit_version: "3.6.0"
+# All hooks must be local to allow offline usage
 
 # ─── PYTHON ────────────────────────────────────────────────────────────────────
 # NOTE: hooks run in the order they appear – isort before black is critical.
@@ -40,7 +41,7 @@ repos:
         types: [python]
         stages: [pre-push]
 
-# ─── JAVASCRIPT / CSS ──────────────────────────────────────────────────────────
+  # ─── JAVASCRIPT / CSS ──────────────────────────────────────────────────────────
   - repo: local
     hooks:
       - id: lint-js
@@ -72,7 +73,9 @@ repos:
         language: system
         pass_filenames: false
 
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
+  - repo: local
     hooks:
       - id: detect-secrets
+        name: detect secrets
+        entry: detect-secrets-hook
+        language: system

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -963,7 +963,7 @@ nav a.active {
   /* Adjust slider for mobile */
   #speed-slider {
     writing-mode: bt-lr;
-    -webkit-appearance: slider-vertical;
+    appearance: slider-vertical;
     width: 30px;
     height: 120px;
     margin: 0 10px; /* Space left and right of the vertical slider */
@@ -1916,7 +1916,6 @@ details > summary {
   height: 100%;
 }
 
-
 .captions-table td:first-child {
   white-space: nowrap;
   width: 12rem;
@@ -2203,7 +2202,6 @@ details > summary {
   width: 4rem;
   text-align: center;
 }
-
 
 .capture-col {
   width: 2.5rem;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pylint>=3.1
 pyinstaller>=6.6
 mkdocs>=1.6
 pytest-socket>=0.7
+detect-secrets>=1.4


### PR DESCRIPTION
## Summary
- run the detect-secrets hook from a local repo
- list detect-secrets in developer requirements

## Testing
- `pre-commit run --all-files` *(fails: Executable `detect-secrets-hook` not found)*
- `pytest -q` *(fails: SchedulerAlreadyRunningError in 3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c3b24c4408333914f07385c7b39a1