### PR TITLE
Add capture countdown indicator

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2275,6 +2275,21 @@ details > summary {
   background-color: gray;
 }
 
+.capture-dot.countdown::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: conic-gradient(
+    dodgerblue var(--capture-angle, 0deg),
+    transparent 0deg
+  );
+  mask: radial-gradient(farthest-side, transparent 55%, #000 56%);
+}
+
 .capture-dot.active {
   background-color: dodgerblue;
 }

--- a/app/static/js/capture_status.js
+++ b/app/static/js/capture_status.js
@@ -1,0 +1,38 @@
+export function computeProgress(now, next, frequencyMinutes) {
+  const total = frequencyMinutes * 60000;
+  if (!total) return 0;
+  const diff = new Date(next).getTime() - now;
+  const progress = 1 - diff / total;
+  return Math.max(0, Math.min(1, progress));
+}
+
+export function initCaptureCountdown() {
+  const update = () => {
+    document.querySelectorAll(".capture-dot[data-next]").forEach((dot) => {
+      const next = dot.getAttribute("data-next");
+      const freq = parseFloat(dot.getAttribute("data-frequency")) || 0;
+      if (!next || !freq) return;
+      if (dot.classList.contains("active")) {
+        dot.style.removeProperty("--capture-angle");
+        dot.title = "Capturing...";
+        return;
+      }
+      const progress = computeProgress(Date.now(), next, freq);
+      const angle = progress * 360;
+      dot.style.setProperty("--capture-angle", `${angle}deg`);
+      const diff = new Date(next).getTime() - Date.now();
+      const secs = Math.max(0, Math.ceil(diff / 1000));
+      dot.title = `Next in ${secs}s`;
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      update();
+      setInterval(update, 1000);
+    });
+  } else {
+    update();
+    setInterval(update, 1000);
+  }
+}

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -190,7 +190,9 @@
           data-value="{{ '1' if feed.capturing else '0' }}"
         >
           <span
-            class="capture-dot{% if feed.capturing %} active countdown{% endif %}"
+            class="capture-dot countdown{% if feed.capturing %} active{% endif %}"
+            data-next="{{ feed.next_capture_time or '' }}"
+            data-frequency="{{ feed.frequency }}"
           ></span>
         </td>
         <td

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -355,6 +355,10 @@ template_form %} {% block content %}
 ></script>
 <script
   type="module"
+  src="{{ url_for('static', filename='js/capture_status.js') }}"
+></script>
+<script
+  type="module"
   src="{{ url_for('static', filename='js/tabs.js') }}"
 ></script>
 <script>

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -4,4 +4,8 @@ content %} {% include '_status_tab.html' %}
   type="module"
   src="{{ url_for('static', filename='js/performance.js') }}"
 ></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/capture_status.js') }}"
+></script>
 {% endblock %}

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1494,6 +1494,15 @@ def get_feed_status():
             job = active_jobs.get(name)
             capturing = bool(job and job.is_alive())
 
+        next_capture = None
+        if frequency and last_shot:
+            try:
+                shot_dt = datetime.datetime.strptime(last_shot, "%Y-%m-%d %H:%M:%S")
+                next_dt = shot_dt + datetime.timedelta(minutes=frequency)
+                next_capture = next_dt.isoformat() + "Z"
+            except Exception:
+                pass
+
         feeds.append(
             {
                 "name": name,
@@ -1514,6 +1523,8 @@ def get_feed_status():
                 "danger": danger,
                 "danger_reason": danger_reason,
                 "capturing": capturing,
+                "next_capture_time": next_capture,
+                "frequency": frequency,
             }
         )
 

--- a/tests/js/capture_status.test.js
+++ b/tests/js/capture_status.test.js
@@ -1,0 +1,11 @@
+import { computeProgress } from "../../app/static/js/capture_status.js";
+
+describe("computeProgress", () => {
+  test("progress clamps between 0 and 1", () => {
+    const next = 60000;
+    expect(computeProgress(0, next, 1)).toBeCloseTo(0);
+    expect(computeProgress(30000, next, 1)).toBeCloseTo(0.5);
+    expect(computeProgress(60000, next, 1)).toBeCloseTo(1);
+    expect(computeProgress(70000, next, 1)).toBeCloseTo(1);
+  });
+});


### PR DESCRIPTION
## Summary
- show capture interval progress on camera status pages
- include next capture time in status data
- test progress calculations

## Testing
- `pre-commit run --files app/static/css/style.css app/templates/_status_tab.html app/templates/settings.html app/templates/status.html app/utils/scheduling.py app/static/js/capture_status.js tests/js/capture_status.test.js`
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test --silent` *(fails: 2 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_684c498862c483338fd1ea40ebc0c10f