### PR TITLE
Offset timestamp overlay on MJPEG streams

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -583,7 +583,7 @@ body.dark-mode {
 }
 
 .timestamp {
-  bottom: 0;
+  bottom: calc(var(--timestamp-font-size) + 4px);
   right: 0;
   font-size: var(--timestamp-font-size);
 }
@@ -1429,7 +1429,7 @@ video.hover-video[data-timestamp] {
 video.hover-video[data-timestamp]::after {
   content: attr(data-timestamp);
   position: absolute;
-  bottom: 0;
+  bottom: calc(var(--timestamp-font-size) + 4px);
   right: 0;
   padding: 5px;
   background-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Summary
- move CSS timestamp overlay slightly above burned-in time

## Testing
- `pre-commit run --files app/static/css/style.css`
- `flake8`
- `pytest tests/test_routes.py::TestRoutes::test_captions_status`


------
https://chatgpt.com/codex/tasks/task_e_684c4d4ba990833393314b06ce67e673