### PR TITLE
Add thread table to system metrics

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2343,19 +2343,28 @@ details > summary {
   margin-left: 0.25rem;
 }
 
-#thread-cpu-list {
-  font-family: monospace;
-}
-
-.thread-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.thread-list li {
+.metrics-container {
   display: flex;
-  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.thread-table {
+  border-collapse: collapse;
+}
+
+.thread-table th,
+.thread-table td {
+  padding: 0 0.25rem;
+  border: 1px solid var(--table-border-color);
+}
+
+.thread-table th {
+  background-color: var(--table-header-bg-color);
+}
+
+#thread-table-body {
+  font-family: monospace;
 }
 
 .metric-bar {

--- a/app/static/js/performance.js
+++ b/app/static/js/performance.js
@@ -42,20 +42,20 @@ export function updatePerformanceMetrics() {
       const threadCount = document.getElementById("thread-count");
       if (threadCount) threadCount.textContent = metrics.thread_count;
 
-      const cpuList = document.getElementById("thread-cpu-list");
-      if (cpuList) {
-        cpuList.innerHTML = "";
+      const threadTable = document.getElementById("thread-table-body");
+      if (threadTable) {
+        threadTable.innerHTML = "";
         (metrics.top_threads || []).forEach((t) => {
-          const li = document.createElement("li");
-          const nameSpan = document.createElement("span");
-          nameSpan.className = "thread-name";
-          nameSpan.textContent = t.name;
-          const cpuSpan = document.createElement("span");
-          cpuSpan.className = "thread-cpu";
-          cpuSpan.textContent = `${t.cpu}%`;
-          li.appendChild(nameSpan);
-          li.appendChild(cpuSpan);
-          cpuList.appendChild(li);
+          const row = document.createElement("tr");
+          const nameCell = document.createElement("td");
+          nameCell.className = "thread-name";
+          nameCell.textContent = t.name;
+          const cpuCell = document.createElement("td");
+          cpuCell.className = "thread-cpu";
+          cpuCell.textContent = `${t.cpu}%`;
+          row.appendChild(nameCell);
+          row.appendChild(cpuCell);
+          threadTable.appendChild(row);
         });
       }
 

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -1,5 +1,6 @@
 {% call card('System Metrics') %}
-<ul class="metrics-list">
+<div class="metrics-container">
+  <ul class="metrics-list">
   <li title="Start or stop the scheduler">
     <span class="metric-label">Scheduler:</span>
     <button
@@ -73,14 +74,6 @@
   </li>
   <li title="Top threads by CPU usage">
     <span class="metric-label">Top Threads:</span>
-    <ul id="thread-cpu-list" class="thread-list">
-      {% for t in metrics.top_threads %}
-      <li>
-        <span class="thread-name">{{ t.name }}</span>
-        <span class="thread-cpu">{{ t.cpu }}%</span>
-      </li>
-      {% endfor %}
-    </ul>
   </li>
   <li title="System uptime">
     <span class="metric-label">Uptime:</span>
@@ -98,7 +91,24 @@
       ></span>
     </a>
   </li>
-</ul>
+  </ul>
+  <table id="thread-table" class="thread-table" title="CPU usage by thread">
+    <thead>
+      <tr>
+        <th>Thread</th>
+        <th>CPU %</th>
+      </tr>
+    </thead>
+    <tbody id="thread-table-body">
+      {% for t in metrics.top_threads %}
+      <tr>
+        <td class="thread-name">{{ t.name }}</td>
+        <td class="thread-cpu">{{ t.cpu }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
 {% endcall %} {% call card('Feed Status') %}
 <div class="table-container">
   <table id="feed-status" class="feed-status">

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -134,7 +134,7 @@ class TestHtmlTemplates(unittest.TestCase):
 
     def test_status_tab_thread_list(self):
         html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
-        self.assertIn('<ul id="thread-cpu-list"', html)
+        self.assertIn('<table id="thread-table"', html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- display top threads in a table alongside metrics
- update performance JS to populate table rows
- style thread table with flex layout
- adjust template tests

## Testing
- `pre-commit run --files app/templates/_status_tab.html app/static/js/performance.js app/static/css/style.css tests/test_html_templates.py`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c4e613ed483339c7452372b68b065