### PR TITLE
Fix caption prompt layout and tab memory

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1454,6 +1454,7 @@ video.hover-video[data-timestamp]::after {
   color: var(--form-text-color);
   border: 1px solid var(--table-border-color);
   padding-right: 2rem;
+  box-sizing: border-box;
 }
 
 .update-button {
@@ -1463,6 +1464,11 @@ video.hover-video[data-timestamp]::after {
   width: auto;
   padding: 4px;
   margin-top: 0;
+  display: none;
+}
+
+.chat-prompt:focus-within .update-button {
+  display: inline-block;
 }
 
 /* Footer Styles */

--- a/app/static/icons/sprite.svg
+++ b/app/static/icons/sprite.svg
@@ -77,6 +77,16 @@
       stroke-linejoin="round"
     />
   </symbol>
+  <symbol id="send" viewBox="0 0 24 24">
+    <path
+      d="M10 8l4 4-4 4"
+      stroke="currentColor"
+      stroke-width="2"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </symbol>
   <symbol id="lock" viewBox="0 0 24 24">
     <rect
       x="3"

--- a/app/static/js/tabs.js
+++ b/app/static/js/tabs.js
@@ -4,6 +4,7 @@ export function initTabs() {
     const contents = document.querySelectorAll(".tab-content");
     const addContainer = document.getElementById("add-setting-container");
     const storageKey = `lastTab:${window.location.pathname}`;
+    const persist = window.location.pathname !== "/captions";
     if (!tabs.length) return;
 
     tabs.forEach((tab) => {
@@ -14,10 +15,12 @@ export function initTabs() {
         contents.forEach((c) => c.classList.remove("active"));
         tab.classList.add("active");
         document.getElementById(target)?.classList.add("active");
-        try {
-          localStorage.setItem(storageKey, target);
-        } catch {
-          /* ignore */
+        if (persist) {
+          try {
+            localStorage.setItem(storageKey, target);
+          } catch {
+            /* ignore */
+          }
         }
         if (addContainer) {
           if (target === "Other-tab") {
@@ -30,7 +33,8 @@ export function initTabs() {
     });
 
     const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab") || localStorage.getItem(storageKey);
+    const tab =
+      persist && (params.get("tab") || localStorage.getItem(storageKey));
     if (tab) {
       const btn = document.querySelector(`.tab-link[data-tab="${tab}"]`);
       btn?.click();

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -116,7 +116,7 @@ template_controls %} {% block content %}
               <form id="form-{{ camera }}" class="notes-form caption-box">
                 <div class="chat-box">
                   <div class="chat-prompt">
-                    <label for="notes-{{ camera }}">Prompt</label>
+                    <label for="notes-{{ camera }}" class="sr-only">Prompt</label>
                     <textarea
                       id="notes-{{ camera }}"
                       class="notes-textarea"
@@ -132,13 +132,13 @@ template_controls %} {% block content %}
                     >
                       <svg width="16" height="16" aria-hidden="true">
                         <use
-                          href="{{ url_for('static', filename='icons/sprite.svg') }}#login"
+                          href="{{ url_for('static', filename='icons/sprite.svg') }}#send"
                         />
                       </svg>
                     </button>
                   </div>
                   <div class="chat-response">
-                    <label id="last-caption-label-{{ camera }}"
+                    <label id="last-caption-label-{{ camera }}" class="sr-only"
                       >Last caption</label
                     >
                     <div

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -61,7 +61,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.
-10. Visit the **Captions** page to review and manage prompts. The view now has three tabs: **Prompts** (camera grid with filters), **Summaries** (recent captions table), and **Bulk Tools** for TSV updates. The Summaries tab is always expanded and provides search and date range filters. Use the search box or metric dropdown in the Prompts tab to instantly filter cameras as you type. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
+10. Visit the **Captions** page to review and manage prompts. The view now defaults to the **Prompts** tab and includes **Summaries** (recent captions) and **Bulk Tools** for TSV updates. The Summaries tab provides search and date range filters. Use the search box or metric dropdown in the Prompts tab to instantly filter cameras as you type. KPI and caption columns can be sorted by clicking their headers, which display a ↕ icon. Rows show relative timestamps, and thumbnails appear dimmed until hovered. A width slider resizes thumbnails and adjusts their height, capping them at 1080&nbsp;px.
 
 
 ## Next Steps

--- a/tests/js/tabs.test.js
+++ b/tests/js/tabs.test.js
@@ -38,4 +38,16 @@ describe("tabs", () => {
       true,
     );
   });
+
+  test("captions page does not persist", () => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      configurable: true,
+      value: { pathname: "/captions", search: "" },
+    });
+    initTabs();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    document.querySelector('[data-tab="two"]').click();
+    expect(localStorage.getItem("lastTab:/captions")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- don't remember last tab on captions page
- hide prompt/caption labels and confine textarea
- only show send button on focus
- switch prompt button icon to `send`
- document captions tab change
- test tabs skip memory for captions

## Testing
- `pre-commit run --files app/static/js/tabs.js app/static/css/style.css app/static/icons/sprite.svg app/templates/captions.html docs/getting_started.md tests/js/tabs.test.js`
- `pytest -k tabs.test -q`
- `npx jest tests/js/tabs.test.js` *(fails: SyntaxError)*


------
https://chatgpt.com/codex/tasks/task_e_684c4f54c8bc8333acf1cdc4f65a9ddb