### PR TITLE
Fix tooltip overlay positioning

### DIFF
--- a/app/static/js/tooltips.js
+++ b/app/static/js/tooltips.js
@@ -11,23 +11,6 @@ export function initTooltips() {
 
       const x = e.pageX ?? e.clientX;
       const y = e.pageY ?? e.clientY;
-
-      const container = e.target.closest(".video-container");
-      if (container) {
-        const rect = container.getBoundingClientRect();
-        let left = rect.right + offset;
-        if (left + tooltipWidth > window.innerWidth) {
-          left = rect.left - tooltipWidth - offset;
-        }
-        let top = rect.top;
-        if (top + tooltipHeight > window.innerHeight) {
-          top = rect.bottom - tooltipHeight;
-        }
-        tooltip.style.left = `${left}px`;
-        tooltip.style.top = `${top}px`;
-        return;
-      }
-
       let left = x + offset;
       if (left + tooltipWidth > window.innerWidth) {
         left = x - tooltipWidth - offset;

--- a/tests/js/tooltip_position.test.js
+++ b/tests/js/tooltip_position.test.js
@@ -1,11 +1,6 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `
-  <span id="item" title="Hello"></span>
-  <div class="video-container" style="position: absolute; top: 0; left: 0; width: 100px; height: 50px;">
-    <video id="vid" title="Video tooltip"></video>
-  </div>
-`;
+document.body.innerHTML = `<span id="item" title="Hello"></span>`;
 
 let initTooltips;
 let originalWidth;
@@ -84,41 +79,4 @@ test("repositions tooltip above when near bottom", () => {
   );
 
   expect(tooltip.style.top).toBe("440px");
-});
-
-test("positions tooltip beside video containers", () => {
-  Object.defineProperty(window, "innerWidth", {
-    configurable: true,
-    writable: true,
-    value: 300,
-  });
-  Object.defineProperty(window, "innerHeight", {
-    configurable: true,
-    writable: true,
-    value: 500,
-  });
-
-  initTooltips();
-  document.dispatchEvent(new Event("DOMContentLoaded"));
-
-  const tooltip = document.querySelector(".dynamic-tooltip");
-  Object.defineProperty(tooltip, "offsetWidth", {
-    configurable: true,
-    value: 50,
-  });
-  Object.defineProperty(tooltip, "offsetHeight", {
-    configurable: true,
-    value: 40,
-  });
-
-  const vid = document.getElementById("vid");
-  const container = document.querySelector(".video-container");
-  const rect = { top: 0, left: 0, right: 100, bottom: 50 };
-  jest.spyOn(container, "getBoundingClientRect").mockReturnValue(rect);
-
-  vid.dispatchEvent(
-    new MouseEvent("mouseover", { clientX: 10, clientY: 10, bubbles: true }),
-  );
-
-  expect(parseInt(tooltip.style.left, 10)).toBe(rect.right + 10);
 });


### PR DESCRIPTION
## Summary
- keep tooltips inside tiles
- update tooltip positioning test

## Testing
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*
- `npm test` *(fails: cost_tab.test.js, lazy_poster.test.js)*
- `pre-commit run --all-files` *(fails: detect-secrets)*


------
https://chatgpt.com/codex/tasks/task_e_684c4fb523cc8333aadb3d346feed93e