### PR TITLE
Set process name when spawning jobs

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -246,7 +246,14 @@ def run_with_timeout(func, args=(), timeout=300):
             if existing and existing.is_alive():
                 logging.info("job already running")
                 return
-            process = multiprocessing.Process(target=_run_target, args=(func, args))
+            proc_title = getattr(func, "__name__", "job")
+            if args and isinstance(args[0], str):
+                proc_title += f":{args[0]}"
+            process = multiprocessing.Process(
+                target=_run_target,
+                args=(func, args),
+                name=f"glimpser {proc_title}",
+            )
             active_jobs[key] = process
         process.start()
     except OSError as exc:

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -102,6 +102,21 @@ class TestRunWithTimeout(unittest.TestCase):
             run_with_timeout(lambda: None, timeout=1)
             mock_proc.assert_not_called()
 
+    @patch("app.utils.scheduling.psutil.cpu_percent", return_value=10)
+    @patch("app.utils.scheduling.is_system_online", return_value=True)
+    def test_process_title_set(self, _online, _cpu):
+        def my_job(name):
+            return name
+
+        with patch("app.utils.scheduling.multiprocessing.Process") as mock_proc:
+            run_with_timeout(my_job, args=("cam1",), timeout=1)
+            mock_proc.assert_called_once()
+            _, kwargs = mock_proc.call_args
+            self.assertEqual(kwargs["name"], "glimpser my_job:cam1")
+
+        scheduling.job_backoff_until.clear()
+        scheduling.job_failures.clear()
+
 
 class TestAddMotionAndCaption(unittest.TestCase):
     def test_image_updated_with_caption_and_motion(self):


### PR DESCRIPTION
## Summary
- set a descriptive name when creating worker processes
- test that spawned processes include custom name

## Testing
- `pre-commit run --files app/utils/scheduling.py tests/test_scheduling_more.py`
- `flake8 app/utils/scheduling.py tests/test_scheduling_more.py`
- `pytest -q tests/test_scheduling_more.py`

------
https://chatgpt.com/codex/tasks/task_e_684c50a3f7608333802dba156d5bbbb1