### PR TITLE
Add test pattern default for new camera

### DIFF
--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -128,10 +128,11 @@
     >ℹ️</span
   >' | safe) %}
   <div class="wizard-step" title="Form to add a new camera">
-    {{ template_form( 'add-template-form', '/templates',
-    preview_src='/test_pattern.mjpg?pattern=geometric',
+    {{ template_form( 'add-template-form', '/templates', template={'url':
+    url_for('test_pattern_mjpg', _external=True)},
+    preview_src=url_for('test_pattern_mjpg') ~ '?pattern=geometric',
     preview_id='url-preview', object_tokens=object_tokens,
-    clip_model=clip_model, clip_gpu=clip_gpu ) }}
+    clip_model=clip_model, clip_gpu=clip_gpu, ) }}
   </div>
   {% endcall %}
 </div>

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -131,7 +131,7 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
           value="{{ template.url if template else '' }}"
           required
           pattern="https?://.+"
-          placeholder="https://example.com/video"
+          placeholder="{{ url_for('test_pattern_mjpg', _external=True) }}"
           title="Enter the URL to monitor"
         />
         <span id="url-status" class="url-status" title="URL test result"></span>


### PR DESCRIPTION
## Summary
- default to the test pattern stream in Add Camera form
- update placeholder text for URL field

## Testing
- `pre-commit run --all-files` *(fails: Potential secrets about to be committed)*
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c67906a888333a9ba33d2cec06914