### PR TITLE
Update scheduler docs

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -42,6 +42,7 @@ This guide provides a high-level look at Glimpser's core components and how they
 
 - Uses APScheduler to run periodic tasks.
 - Jobs include crawler scheduling, video archiving, discovery and summarization.
+- Additional tasks refresh clips, process queued offline jobs, clean up old data, collect system metrics and check for updates.
 - Tasks run asynchronously so functions like `schedule_discovery` and `schedule_summarization` never block the caller.
 - Background components start in a low-priority thread so Flask can serve requests immediately.
 - Exposes a `GracefulAPScheduler` instance used by the Flask app.

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -22,6 +22,8 @@ The primary application script accepts the following options:
 | `--screenshot-dir` | Directory for storing screenshots.                               |
 | `--video-dir`      | Directory for storing video files.                               |
 | `--summaries-dir`  | **Deprecated:** summaries are now stored in the database.        |
+The background scheduler orchestrates all recurring jobs. It creates teaser clips, archives screenshots, refreshes clip previews, cleans up old files, processes queued offline jobs, collects system metrics and checks for application updates. Use `--no-scheduler` to disable every scheduled task or `--no-crawlers` when only camera captures should be skipped.
+
 
 ## generate_credentials.py
 


### PR DESCRIPTION
## Summary
- clarify what the background scheduler does in the command line docs
- list additional scheduler jobs in the architecture overview

## Testing
- `pre-commit run --files docs/command_line.md docs/architecture_overview.md`
- `flake8`
- `pytest -q` *(fails: SchedulerAlreadyRunningError)*

------
https://chatgpt.com/codex/tasks/task_e_684c689fba14833380fdfad0dc38c8bc