### PR TITLE
Add default test pattern for new cameras

### DIFF
--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -30,6 +30,7 @@ export function initUrlTester() {
     const defaultSrc = preview
       ? preview.dataset.placeholder || preview.src
       : "";
+    const defaultUrl = input.dataset.defaultUrl;
     const setStatus = (cls) => {
       status.textContent = "";
       status.className = "url-status" + (cls ? ` ${cls}` : "");
@@ -69,6 +70,13 @@ export function initUrlTester() {
     };
 
     toggleDisabled();
+    if (!input.value && defaultUrl) {
+      input.value = defaultUrl;
+      toggleDisabled();
+      setTimeout(() => {
+        check();
+      }, 1000);
+    }
     input.addEventListener("input", () => {
       toggleDisabled();
       setStatus(input.value.trim() ? "pending" : "");

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -128,10 +128,12 @@
     >ℹ️</span
   >' | safe) %}
   <div class="wizard-step" title="Form to add a new camera">
-    {{ template_form( 'add-template-form', '/templates',
-    preview_src='/test_pattern.mjpg?pattern=geometric',
+    {{ template_form( 'add-template-form', '/templates', template={'url':
+    url_for('test_pattern_mjpg', _external=True)},
+    preview_src=url_for('test_pattern_mjpg', pattern='geometric'),
     preview_id='url-preview', object_tokens=object_tokens,
-    clip_model=clip_model, clip_gpu=clip_gpu ) }}
+    clip_model=clip_model, clip_gpu=clip_gpu,
+    default_url=url_for('test_pattern_mjpg', _external=True) ) }}
   </div>
   {% endcall %}
 </div>

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -81,7 +81,7 @@ confirm='Confirm', cancel='Cancel') -%}
 </div>
 {%- endmacro %} {%- macro template_form(form_id, action, template=None,
 preview_src=None, preview_id=None, include_name=True, submit_label='Submit',
-object_tokens=None, clip_model=None, clip_gpu=False) -%}
+object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
 <div class="edit-template-container">
   {% if preview_src or preview_id %}
   <div class="edit-template-preview">
@@ -131,8 +131,9 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
           value="{{ template.url if template else '' }}"
           required
           pattern="https?://.+"
-          placeholder="https://example.com/video"
+          placeholder="{{ url_for('test_pattern_mjpg', _external=True) }}"
           title="Enter the URL to monitor"
+          data-default-url="{{ default_url or '' }}"
         />
         <span id="url-status" class="url-status" title="URL test result"></span>
       </div>

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,6 +1,11 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview"><input type="submit"></form>`;
+const formHtml =
+  '<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview"><input type="submit"></form>';
+
+beforeEach(() => {
+  document.body.innerHTML = formHtml;
+});
 
 let initUrlTester;
 

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 
-document.body.innerHTML = `<form><input id="url"><span id="url-status"></span><img id="url-preview"><input type="submit"></form>`;
+document.body.innerHTML = `<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview"><input type="submit"></form>`;
 
 let initUrlTester;
 
@@ -50,5 +50,21 @@ describe("url_test", () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(fetch).toHaveBeenCalled();
     expect(submit.disabled).toBe(false);
+  });
+
+  test("auto populates default url", async () => {
+    jest.useFakeTimers();
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    const input = document.getElementById("url");
+    expect(input.value).toBe("http://example.com/test");
+    expect(fetch).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- autofill Add Camera form with the test pattern stream
- show the test pattern URL as the placeholder in camera forms
- delay automatic URL validation until one second after load
- test auto-populate logic for the default URL

## Testing
- `pre-commit run --files app/static/js/url_test.js app/templates/_discover_tab.html app/templates/components.html tests/js/url_test.test.js`
- `pytest` *(fails: SchedulerAlreadyRunningError)*
- `npm test` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c6d71f5e48333991e0dcb5f91f03d