### PR TITLE
Improve camera template UX

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1192,6 +1192,10 @@ a {
   width: 6rem;
 }
 
+#template-form #name {
+  max-width: 20rem;
+}
+
 .checkbox-row {
   display: flex;
   align-items: center;

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -339,14 +339,15 @@ export function initTemplates() {
 export async function loadGroups() {
   const groupDropdown = document.getElementById("group-dropdown");
   const groupsSelect = document.getElementById("groups");
+  const groupDatalist = document.getElementById("group-options");
   if (!groupDropdown && !groupsSelect) return;
   if (groupDropdown) {
     groupDropdown.innerHTML = '<option value="all">Loading groups...</option>';
     groupDropdown.disabled = true;
   }
   if (groupsSelect) {
-    groupsSelect.innerHTML = '<option value="">Loading...</option>';
     groupsSelect.disabled = true;
+    if (groupDatalist) groupDatalist.innerHTML = "";
   }
 
   try {
@@ -355,8 +356,8 @@ export async function loadGroups() {
     if (groupDropdown) {
       groupDropdown.innerHTML = '<option value="all">All Groups</option>';
     }
-    if (groupsSelect) {
-      groupsSelect.innerHTML = '<option value="">Select a group</option>';
+    if (groupsSelect && groupDatalist) {
+      groupDatalist.innerHTML = "";
     }
     groups.forEach((group) => {
       if (groupDropdown) {
@@ -365,11 +366,10 @@ export async function loadGroups() {
         option.textContent = group;
         groupDropdown.appendChild(option);
       }
-      if (groupsSelect) {
+      if (groupsSelect && groupDatalist) {
         const option = document.createElement("option");
         option.value = group;
-        option.textContent = group;
-        groupsSelect.appendChild(option);
+        groupDatalist.appendChild(option);
       }
     });
   } catch (error) {
@@ -377,8 +377,8 @@ export async function loadGroups() {
     if (groupDropdown) {
       groupDropdown.innerHTML = '<option value="all">All Groups</option>';
     }
-    if (groupsSelect) {
-      groupsSelect.innerHTML = '<option value="">Select a group</option>';
+    if (groupsSelect && groupDatalist) {
+      groupDatalist.innerHTML = "";
     }
   } finally {
     if (groupDropdown) groupDropdown.disabled = false;

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -69,6 +69,7 @@ export function initUrlTester() {
     };
 
     toggleDisabled();
+    check();
     input.addEventListener("input", () => {
       toggleDisabled();
       setStatus(input.value.trim() ? "pending" : "");

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -108,7 +108,7 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
   >
     {% if include_name %}
     <div class="form-row">
-      <label for="name" title="Name of the template">Template Name:</label>
+      <label for="name" title="Name of the template">Name:</label>
       <input
         type="text"
         id="name"
@@ -145,7 +145,7 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
         type="number"
         id="frequency"
         name="frequency"
-        value="{{ template.frequency if template else 30 }}"
+        value="{{ template.frequency if template else 5 }}"
         min="0"
         max="43200"
         step="1"
@@ -164,9 +164,16 @@ object_tokens=None, clip_model=None, clip_gpu=False) -%}
         <option value="360"></option>
         <option value="1440"></option>
       </datalist>
-      <label for="groups" title="Select an existing group">Group:</label>
+      <label for="groups" title="Select or create a group">Group:</label>
       <!-- prettier-ignore -->
-      <select id="groups" name="groups" class="sm-select" title="Choose a group"></select>
+      <input
+        id="groups"
+        name="groups"
+        list="group-options"
+        class="sm-select"
+        title="Choose or enter a group"
+      />
+      <datalist id="group-options"></datalist>
     </div>
     <input
       type="hidden"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -119,9 +119,10 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('min="0"', components)
         self.assertIn('datalist id="object-filter-options"', components)
 
-    def test_groups_field_is_select(self):
+    def test_groups_field_has_datalist(self):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
-        self.assertIn('<select id="groups"', components)
+        self.assertIn('id="groups"', components)
+        self.assertIn('datalist id="group-options"', components)
 
     def test_object_filter_gpu_icon_present(self):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- allow custom groups via datalist
- preset frequency to 5 minutes
- check URL immediately so status icon turns green
- label template name as "Name" and narrow width
- update tests for new markup

## Testing
- `pre-commit run --all-files` *(fails: detect-secrets)*
- `pytest` *(fails: SchedulerAlreadyRunningError in 2 tests)*
- `npm test` *(fails: cost_tab.test.js, lazy_poster.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684c7b3121648333b34b4b8c63e11168