### PR TITLE
Isolate APScheduler between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,26 @@
 import os
+import sys
 
+import pytest
 import pytest_socket
+from apscheduler.schedulers.background import BackgroundScheduler
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils.scheduling import scheduler
 
 # Skip end-to-end tests unless explicitly enabled
 os.environ.setdefault("SKIP_E2E", "1")
 
 # Block network access during tests to avoid accidental HTTP requests.
 pytest_socket.disable_socket()
+
+
+@pytest.fixture(autouse=True)
+def reset_scheduler():
+    """Provide a fresh scheduler instance for each test."""
+    scheduler.shutdown(wait=False)
+    scheduler.set_scheduler(BackgroundScheduler())
+    yield
+    scheduler.shutdown(wait=False)
+    scheduler.set_scheduler(BackgroundScheduler())

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -1,0 +1,10 @@
+from app.utils.scheduling import scheduler
+
+
+def test_start_scheduler():
+    scheduler.start()
+    assert scheduler.running
+
+
+def test_scheduler_reset():
+    assert not scheduler.running


### PR DESCRIPTION
## Summary
- reset the scheduler before and after each test
- add tests ensuring the scheduler fixture works

## Testing
- `pre-commit run --all-files` *(fails: detect-secrets)*
- `pytest tests/test_scheduler_cleanup.py tests/test_routes.py::TestRoutes::test_captions_status -vv`

------
https://chatgpt.com/codex/tasks/task_e_684c6eb2d50c8333af1aa3ba999f0187