### PR TITLE
Add extra pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,31 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
+  - repo: local
     hooks:
+      - id: isort
+        name: isort (black-profile)
+        entry: isort --profile=black
+        language: system
       - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
-    hooks:
+        name: black
+        entry: black
+        language: system
       - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+      - id: detect-secrets
+        name: detect-secrets
+        entry: detect-secrets-hook --baseline .secrets.baseline
+        language: system
+      - id: lint-js
+        name: lint js
+        entry: npm run lint:js
+        language: system
+      - id: format-js
+        name: format js write
+        entry: npm run format:js:write
+        language: system
+      - id: lint-css
+        name: lint css
+        entry: npm run lint:css
+        language: system

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "plugins_used": [],
+  "results": {}
+}

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -15,9 +15,10 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    ```sh
    pip install -e ".[dev]"
    ```
-3. Install the `pre-commit` tool and set up the Git hooks:
+3. Install the `pre-commit` tool and its helper hooks, then set up the Git hooks.
+   The hooks in this project are all local so they work without network access:
    ```sh
-   pip install pre-commit
+   pip install pre-commit isort detect-secrets
    pre-commit install
    ```
 4. Copy the provided example environment file and update the values. Important
@@ -33,6 +34,7 @@ This guide provides tips for extending Glimpser, running tests, and contributing
    ```
 
 ## Understanding the Architecture
+
 Before diving into new features, read
 [Architecture Overview](architecture_overview.md). It describes how Flask routes,
 background jobs and utility modules cooperate. The "Data Flow from Camera to UI"
@@ -42,10 +44,12 @@ to the web interface.
 ## Running Tests
 
 The project uses `pytest` for testing and `flake8` for linting. After activating your environment, run:
+
 ```sh
 flake8
 pytest
 ```
+
 Running the full test suite helps ensure that your changes do not introduce regressions.
 
 ## Contribution Workflow
@@ -66,6 +70,7 @@ For more details, see [CONTRIBUTING.md](https://github.com/KristopherKubicki/gli
 - Configuration defaults are defined in `app/config.py`.
 
 When adding new features, include corresponding tests under the `tests/` directory.
+
 - Utilities for network testing now have dedicated tests in `tests/test_network_testing_utils.py`.
 - Configuration lookup logic is verified by `tests/test_config_get_setting.py`.
 - Scheduler helpers are tested in `tests/test_scheduling_more.py`.


### PR DESCRIPTION
## Summary
- run pre-commit hooks locally so network access is not needed
- clarify developer guide about local hooks

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9dcf1dfc83338210970120a5c95a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit configuration to use local hooks for code formatting, linting, and secret detection.
  - Added support for JavaScript and CSS linting/formatting in pre-commit checks.
  - Included a baseline file for secret scanning.

- **Documentation**
  - Improved developer guide with clearer setup instructions for pre-commit hooks and additional details on testing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->