### PR TITLE
Drop extra live stream modes

### DIFF
--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -29,13 +29,7 @@
                 <button id="full-screen" title='fullscreen' aria-label="Toggle fullscreen"><i class="fas fa-expand"></i></button>
                 <button id="toggle-details" title="Show details" aria-label="Toggle details"><i class="fas fa-info-circle"></i></button>
 
-    <select id="video-source" onchange="changeVideoSource()">
-        <option value="png" title="View a series of PNG images">PNG Stream</option>
-	<!-- <option value="m3u8" title="View an HLS (HTTP Live Streaming) video stream">M3U8 Stream</option> -->
-        <option value="loop" title="Loop through available video clips">Loop Videos</option>
-        <option value="mp4" title="View an MP4 video stream">MP4 Stream</option>
-        <option value="live" title="View the direct live stream">Live Video</option>
-        <option value="motion" title="View motion-detected frames">Motion</option>
+    <select id="video-source" onchange="changeVideoSource()" hidden>
         <option value="mjpg" selected title="View an MJPEG (Motion JPEG) stream">MJPG</option>
     </select>
 
@@ -274,16 +268,6 @@
 
 
         function computeVideoUrl(cameraName, source) {
-            if (source === 'mp4' || source === 'loop') {
-                if (cameraName.startsWith('group-')) {
-                    const groupName = cameraName.split('group-')[1];
-                    return `/stream.mp4?group=${encodeURIComponent(groupName)}`;
-                } else if (cameraName === 'All') {
-                    return '/stream.mp4';
-                }
-                return '/last_video/' + cameraName;
-            }
-
             if (source === 'live') {
                 if (cameraName.startsWith('group-') || cameraName === 'All') {
                     const groupCams = cameraName === 'All'
@@ -473,7 +457,7 @@ function changeCamera() {
 
             if (
                 preloadedCamera === currentCamera &&
-                ['mp4', 'live', 'loop'].includes(source) &&
+                ['live'].includes(source) &&
                 preloadVideo.src
             ) {
                 video.style.display = 'block';
@@ -491,14 +475,8 @@ function changeCamera() {
                 case 'm3u8':
                     playM3U8();
                     break;
-                case 'loop':
-                    playLoop();
-                    break;
                 case 'png':
                     playPNG();
-                    break;
-                case 'mp4':
-                    playMP4();
                     break;
                 case 'live':
                     playLive();

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,17 +10,20 @@ This guide will walk you through the process of setting up Glimpser and running 
 ## Installation
 
 1. Clone the Glimpser repository:
+
    ```
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    ```
 
 2. Install the required dependencies:
+
    ```
    pip install -r requirements.txt
    ```
 
 3. Run the application:
+
    ```
    python3 main.py
    ```
@@ -50,8 +53,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 6. Go to the "Monitoring" section to view your live data feed.
 
-7. On the **Live** page, select your camera. MJPG is selected by default, but choose **Live Video** from the
-   "Video Source" dropdown for direct streaming.
+7. On the **Live** page, select your camera. The view always streams MJPG frames; direct video playback is no longer available.
 
 8. Explore the auto-generated captions and summaries.
 9. Use the **Suggest Prompt** button on a template's detail page to have the system propose better caption text.

--- a/docs/guided_setup.md
+++ b/docs/guided_setup.md
@@ -12,7 +12,7 @@ Navigate to the template's detail page and review the caption prompt. Use **Sugg
 
 ## Step 3: Start Monitoring
 
-Return to the **Live** page and select your camera. The page shows an MJPG stream by default. Choose **Live Video** for real-time playback. If no data appears, you will see an error message suggesting you check the URL or network connection.
+Return to the **Live** page and select your camera. The page now always displays an MJPG stream of recent frames. If no data appears, check the URL or network connection.
 
 Status messages at the top of the page confirm when templates save successfully or when a capture starts. Use these cues to verify your actions.
 

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -19,14 +19,12 @@ Key topics covered include:
 
 ## Viewing Captures
 
-On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** if you want a direct real-time feed. Glimpser remembers your last selected camera, video source, and playback speed to streamline future visits.
+On the **Live** page, pick a camera from the drop-down menu. The stream shows MJPG frames so you immediately see the latest images. Glimpser remembers your last selected camera to streamline future visits.
 
 When watching a live stream, you can click directly on the video to pause or resume playback. Keyboard shortcuts also work:
 `Space` or `k` toggles play/pause, `m` toggles mute, `f` toggles fullscreen.
-Left/Right arrows change the selected camera, Up/Down arrows cycle through the
-available media types, and `[`/`]` adjust playback speed. On phones and tablets,
-swipe left or right on the video to switch cameras or swipe up or down to change
-the media type quickly.
+Left/Right arrows change the selected camera, and `[`/`]` adjust playback speed.
+On phones and tablets, swipe left or right on the video to switch cameras.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the
 bottom of the help page.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,6 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 - [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)
 - [Live All Playback](live_all.md)
-- [Live View Scrubbing](live_scrub.md)
 - [Jog-Shuttle Control](jog_shuttle.md)
 - [Developer Guide](developer_guide.md)
 - [Testing and Coverage](testing.md)

--- a/docs/jog_shuttle.md
+++ b/docs/jog_shuttle.md
@@ -1,5 +1,5 @@
 # Jog-Shuttle Control
 
-The live viewer offers a jog-shuttle widget for cameras that support video playback. Drag within the circle to scrub forward or backward. The farther you drag from the center the faster playback runs (1x, 2x, 4x and so on). Crossing the center reverses direction. Releasing the control pauses and snaps back to neutral.
-
-The jog-shuttle appears only when an individual camera is selected and the **MP4** or **Loop** source is active. Other sources like MJPG or live streams are not seekable, so the control is hidden.
+Previous releases included a jog-shuttle widget for scrubbing video clips. This
+control was removed along with **MP4** and **Loop** playback. The live view now
+focuses solely on real-time image streams, so the jog-shuttle no longer appears.

--- a/docs/live_scrub.md
+++ b/docs/live_scrub.md
@@ -1,5 +1,0 @@
-# Live View Scrubbing
-
-The live viewer shows a time slider whenever **MP4** or **Loop** playback is selected. Drag the slider to seek within the current clip. The video pauses while scrubbing and resumes once released. You can also click the video to toggle play or pause.
-
-Scrubbing works only for individual cameras. When other sources such as MJPG or Live video are selected, the slider is hidden because those streams aren't seekable. If you don't see the scrub bar, switch the media source to **MP4** or **Loop** for that camera.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -223,14 +223,9 @@ source. That could cause extra network requests and confusing behavior.
 
 ### Problem: Loop video or the "All" camera shows `Format error`
 
-This typically happens when Glimpser cannot locate a recent MP4 clip for a
-camera. The player attempts to load the file and the browser reports a *Format
-error* because the response is missing or invalid.
-
-**Solution:**
-- Ensure the `compile_to_teaser` job is running so group videos are generated.
-- When a clip fails to load, the live player now skips to the next camera
-  instead of stalling on the error message.
+Older versions supported looping archived videos. That code has been removed, so
+this error should no longer appear. If you still see it, clear your browser
+cache to ensure the latest JavaScript is loaded.
 
 ## 12. Layout Issues
 


### PR DESCRIPTION
## Summary
- restrict live view to MJPG
- update docs for new default video source

## Testing
- `black app/routes.py`
- `flake8 app/routes.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ca3716fe483338f254d96496bf531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The live video page now streams only MJPG (Motion JPEG) frames, with all other video source options removed and the selector hidden for a simplified viewing experience.

- **Documentation**
	- Updated all relevant guides, help pages, and troubleshooting sections to reflect the exclusive use of MJPG streaming and removal of MP4/loop playback features.
	- Removed documentation for the jog-shuttle control and live view scrubbing functionality.
	- Improved readability and consistency across setup and help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->