### PR TITLE
Fix CI python workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -76,7 +76,7 @@ jobs:
       run: mypy .
     - name: Test with coverage
       run: |
-        python -m coverage run -m pytest
+        python -m coverage run -m pytest -p no:helpconfig --color=yes
         python -m coverage xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- disable helpconfig plugin so coverage succeeds

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `flake8` *(fails: command not found)*
- `pytest tests/test_noop.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684ca85f78108333a6691f0b06d96840