### PR TITLE
Add OWASP Dependency Check workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,26 @@
+name: Dependency Check
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run OWASP Dependency Check
+        uses: dependency-check/Dependency-Check_Action@v3
+        with:
+          project: glimpser
+          path: .
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: odc-reports

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -9,6 +9,7 @@ following tasks:
 - Executes `pytest` and `jest` test suites and uploads coverage.
 - Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
 - Scans dependencies using `pip safety` and `npm audit`.
+- Runs OWASP Dependency Check via `.github/workflows/dependency-check.yml` to detect vulnerable packages.
 - Caches Python and Node dependencies to speed up builds.
 
 These checks help catch regressions and security issues before code is merged.


### PR DESCRIPTION
## Summary
- add workflow for OWASP dependency check
- document new dependency scan step

## Testing
- `pytest -q`
- `flake8` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb05cae20833394127c0456d0c64a