### PR TITLE
Fix test imports

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import os
 import sys
+from pathlib import Path
 
 import pytest
 import pytest_socket
 from apscheduler.schedulers.background import BackgroundScheduler
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from app.utils.scheduling import scheduler
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,13 +1,8 @@
 # tests/test_authentication.py
 
+import datetime
 import os
 import sys
-import unittest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-
-import datetime
 import time
 import unittest
 from types import SimpleNamespace

--- a/tests/test_auto_tag_release.py
+++ b/tests/test_auto_tag_release.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from scripts import auto_tag_release  # noqa: E402
 
 

--- a/tests/test_bool_settings.py
+++ b/tests/test_bool_settings.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import get_all_settings
 from app.utils.validators import is_bool_string
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import mock_open, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app import config
 from app.utils import camera_discovery
 

--- a/tests/test_camera_discovery_ouis.py
+++ b/tests/test_camera_discovery_ouis.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import camera_discovery
 
 

--- a/tests/test_cap_alerts.py
+++ b/tests/test_cap_alerts.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.cap_alerts import cap_alert, send_cap_alert
 
 

--- a/tests/test_captions_chat_route.py
+++ b/tests/test_captions_chat_route.py
@@ -5,8 +5,6 @@ from unittest.mock import MagicMock, patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_capture_file_url.py
+++ b/tests/test_capture_file_url.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.screenshots as ss
 
 

--- a/tests/test_capture_pipeline.py
+++ b/tests/test_capture_pipeline.py
@@ -7,8 +7,6 @@ from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import capture_screenshot_and_har
 
 try:

--- a/tests/test_capture_status_errors.py
+++ b/tests/test_capture_status_errors.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.screenshots as ss
 
 

--- a/tests/test_chatgpt_compare.py
+++ b/tests/test_chatgpt_compare.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.image_processing import chatgpt_compare
 
 

--- a/tests/test_check_danger_mode.py
+++ b/tests/test_check_danger_mode.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestCheckDangerMode(unittest.TestCase):
     def _run_main(self, port_open: bool, needs_patch: bool):

--- a/tests/test_chrome_debug_port.py
+++ b/tests/test_chrome_debug_port.py
@@ -3,8 +3,6 @@ import socket
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import is_chrome_debug_port_open
 
 

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -8,8 +8,6 @@ from unittest.mock import patch
 import numpy as np
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.scheduling as scheduling
 
 

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.config as config
 import app.routes as routes
 from app.routes import init_routes

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,8 +6,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app
 import app.config as config
 import app.routes as routes

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -8,8 +8,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestJSONParsing(unittest.TestCase):
 

--- a/tests/test_color_formatter.py
+++ b/tests/test_color_formatter.py
@@ -4,8 +4,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.logging_utils import ColorFormatter
 
 

--- a/tests/test_compile_teaser_route.py
+++ b/tests/test_compile_teaser_route.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -5,8 +5,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.routes as routes
 
 

--- a/tests/test_config_get_setting.py
+++ b/tests/test_config_get_setting.py
@@ -8,8 +8,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestGetSetting(unittest.TestCase):
     def _reload_config(self, db_path):

--- a/tests/test_config_singleton.py
+++ b/tests/test_config_singleton.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestConfigSingleton(unittest.TestCase):
     def test_env_loaded_once_and_engine_reused(self):

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import get_arp_output, is_address_reachable, parse_url
 
 

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,9 +1,6 @@
 import os
 import sys
 import unittest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from unittest.mock import patch
 
 import app

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestInitDb(unittest.TestCase):
     def setUp(self):

--- a/tests/test_db_ensure_column.py
+++ b/tests/test_db_ensure_column.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestDirectoryManagement(unittest.TestCase):
 

--- a/tests/test_discover_subnets_endpoint.py
+++ b/tests/test_discover_subnets_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_discovery_status_endpoint.py
+++ b/tests/test_discovery_status_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_docs_endpoint.py
+++ b/tests/test_docs_endpoint.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -22,7 +22,6 @@ def _has_network() -> bool:
 if os.environ.get("SKIP_E2E") == "1" or not _has_network():
     pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app import create_app
 

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -6,11 +6,8 @@ import sys
 from threading import Thread
 from unittest.mock import patch
 
-from werkzeug.serving import make_server
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import pytest
+from werkzeug.serving import make_server
 
 if os.environ.get("NO_NETWORK") == "1" or os.environ.get("SKIP_E2E") == "1":
     pytest.skip("E2E tests disabled due to no network", allow_module_level=True)

--- a/tests/test_email_alerts.py
+++ b/tests/test_email_alerts.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.email_alerts import email_alert, send_email_alert
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import mock_open, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestEnvironmentVariables(unittest.TestCase):
 

--- a/tests/test_except.py
+++ b/tests/test_except.py
@@ -4,8 +4,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestExceptionHandling(unittest.TestCase):
 

--- a/tests/test_exclude_docs.py
+++ b/tests/test_exclude_docs.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from scripts import check_exclude_docs  # noqa: E402
 
 

--- a/tests/test_fast_mjpg_route.py
+++ b/tests/test_fast_mjpg_route.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 from flask import Flask
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_feed_status_tooltip.py
+++ b/tests/test_feed_status_tooltip.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import scheduling
 
 

--- a/tests/test_ffmpeg_missing.py
+++ b/tests/test_ffmpeg_missing.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.screenshots as ss
 
 

--- a/tests/test_file_location_metrics.py
+++ b/tests/test_file_location_metrics.py
@@ -5,8 +5,6 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import file_location_metrics
 
 

--- a/tests/test_find_closest_image.py
+++ b/tests/test_find_closest_image.py
@@ -6,8 +6,6 @@ from datetime import datetime
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.scheduling import find_closest_image
 
 

--- a/tests/test_generate_credentials.py
+++ b/tests/test_generate_credentials.py
@@ -6,8 +6,6 @@ import tempfile
 import unittest
 from unittest.mock import call, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.config as config  # noqa: E402
 import generate_credentials  # noqa: E402
 

--- a/tests/test_generate_prompt_route.py
+++ b/tests/test_generate_prompt_route.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_generate_release_badges_script.py
+++ b/tests/test_generate_release_badges_script.py
@@ -2,8 +2,6 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from scripts import generate_release_badges
 
 

--- a/tests/test_get_screenshots_for_template.py
+++ b/tests/test_get_screenshots_for_template.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.template_manager import get_screenshots_for_template  # noqa: E402
 
 

--- a/tests/test_get_videos_for_template.py
+++ b/tests/test_get_videos_for_template.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.template_manager import get_videos_for_template
 
 

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -4,8 +4,6 @@ import unittest
 from html.parser import HTMLParser
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TemplateParser(HTMLParser):
     """Simple HTML parser to capture img tags and form inputs."""

--- a/tests/test_hw_encoder_detection.py
+++ b/tests/test_hw_encoder_detection.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.config import _detect_best_encoder
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -5,8 +5,6 @@ import unittest
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.retention_policy import delete_old_files
 from app.utils.screenshots import add_timestamp, is_mostly_blank, remove_background
 

--- a/tests/test_image_comparison.py
+++ b/tests/test_image_comparison.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.detect import calculate_difference_fast
 
 

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.image_processing import ChatGPTImageComparison, chatgpt_compare
 from app.utils.screenshots import (
     add_timestamp,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,8 +4,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from flask import Flask
 
 from app import create_app

--- a/tests/test_installation_and_first_use.py
+++ b/tests/test_installation_and_first_use.py
@@ -3,18 +3,16 @@ import shutil
 import sys
 import tempfile
 import unittest
+from importlib import reload
 
 from flask import Flask
-
-# Add the parent directory to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-from importlib import reload
 
 import app.config as config
 from app import create_app
 from app.utils import db
 from app.utils.template_manager import TemplateManager
+
+# Add the parent directory to the Python path
 
 
 class TestInstallationAndFirstUse(unittest.TestCase):

--- a/tests/test_last_teaser_route.py
+++ b/tests/test_last_teaser_route.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.config as config
 import app.routes as routes
 from app.routes import init_routes

--- a/tests/test_listing_endpoints.py
+++ b/tests/test_listing_endpoints.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -8,10 +8,9 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
-# Add the parent directory to the Python path to import the app module
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.llm import summarize
+
+# Add the parent directory to the Python path to import the app module
 
 
 class TestLLM(unittest.TestCase):

--- a/tests/test_llm_cache_module.py
+++ b/tests/test_llm_cache_module.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import llm_cache
 
 

--- a/tests/test_llm_cache_usage.py
+++ b/tests/test_llm_cache_usage.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import image_processing, llm_cache
 from app.utils.llm import summarize
 

--- a/tests/test_llm_response_count.py
+++ b/tests/test_llm_response_count.py
@@ -3,8 +3,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.template_manager import LLM_USAGE_PATH, get_llm_response_count
 
 

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import read_logs_from_memory
 
 

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,8 +6,6 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.config as config
 import main
 

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import main  # noqa: E402
 
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -4,8 +4,6 @@ import sys
 import unittest
 from unittest.mock import AsyncMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import mcp
 
 

--- a/tests/test_mcp_endpoints.py
+++ b/tests/test_mcp_endpoints.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_micro_barcode.py
+++ b/tests/test_micro_barcode.py
@@ -4,8 +4,6 @@ import tempfile
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.qrcode_overlay import add_micro_barcode, generate_micro_barcode
 
 

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app import create_app
 
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -7,8 +7,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.retention_policy import get_files_sorted_by_creation_time
 from app.utils.screenshots import (
     get_arp_output,

--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.network import _get_test_hosts, is_system_online
 
 

--- a/tests/test_network_status_endpoint.py
+++ b/tests/test_network_status_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_network_testing_utils.py
+++ b/tests/test_network_testing_utils.py
@@ -1,8 +1,6 @@
+import json
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import json
 import threading
 import unittest
 from unittest.mock import patch

--- a/tests/test_oui_map.py
+++ b/tests/test_oui_map.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 
 from app.utils.oui_map import OUI_MAP

--- a/tests/test_png_validation.py
+++ b/tests/test_png_validation.py
@@ -7,8 +7,6 @@ import unittest
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import _is_valid_png
 
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from flask import Flask
 
 from app.routes import init_routes

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.image_processing as img_proc  # noqa: E402
 from app.utils import prompt_optimizer  # noqa: E402
 

--- a/tests/test_push_alerts.py
+++ b/tests/test_push_alerts.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 from unittest.mock import call, patch
 

--- a/tests/test_rate_limit_filter.py
+++ b/tests/test_rate_limit_filter.py
@@ -5,8 +5,6 @@ import sys
 import time
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.logging_utils import RateLimitFilter
 
 

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -5,9 +5,6 @@ import sys
 import tempfile
 import time
 import unittest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from unittest.mock import patch
 
 import app.utils.retention_policy as retention_policy

--- a/tests/test_robots_txt_endpoint.py
+++ b/tests/test_robots_txt_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3,14 +3,11 @@
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import patch
 
 from flask import Flask
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-from types import SimpleNamespace
 
 from app.models import Summary
 from app.routes import init_routes

--- a/tests/test_routes_more.py
+++ b/tests/test_routes_more.py
@@ -1,8 +1,5 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import unittest  # noqa: E402
 from unittest.mock import patch  # noqa: E402
 

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -1,7 +1,5 @@
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_scheduler_simple_job.py
+++ b/tests/test_scheduler_simple_job.py
@@ -4,8 +4,6 @@ import time
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from app import create_app

--- a/tests/test_scheduler_start_once.py
+++ b/tests/test_scheduler_start_once.py
@@ -3,8 +3,6 @@ import sys
 import time
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from app import create_app

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.scheduling import find_closest_image, scheduler, start_log_caching
 
 

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -10,8 +10,6 @@ from unittest.mock import patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import scheduling
 from app.utils.scheduling import (
     add_motion_and_caption,

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -9,8 +9,6 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import capture_screenshot_and_har, download_image
 
 

--- a/tests/test_screenshots_additional.py
+++ b/tests/test_screenshots_additional.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.utils.screenshots as ss
 
 

--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -1,12 +1,9 @@
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, sentinel
 
 from requests.structures import CaseInsensitiveDict
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-from unittest.mock import patch, sentinel
 
 import app.utils.screenshots as ss
 

--- a/tests/test_screenshots_utils.py
+++ b/tests/test_screenshots_utils.py
@@ -5,8 +5,6 @@ import tempfile
 import time
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.screenshots import cleanup_old_tempdirs, run_cmd
 
 

--- a/tests/test_search_suggestions.py
+++ b/tests/test_search_suggestions.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -4,8 +4,6 @@ import unittest
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes  # noqa: E402
 
 

--- a/tests/test_serve_screenshot.py
+++ b/tests/test_serve_screenshot.py
@@ -8,8 +8,6 @@ from unittest.mock import patch
 from flask import Flask
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_setting_validation.py
+++ b/tests/test_setting_validation.py
@@ -1,10 +1,7 @@
 import os
+import socket
 import sys
 import unittest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-import socket
 
 from app.utils.validators import MAX_WORKERS_MAX, validate_setting
 

--- a/tests/test_settings_download_route.py
+++ b/tests/test_settings_download_route.py
@@ -6,8 +6,6 @@ from unittest.mock import mock_open, patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -6,8 +6,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestSettingsRoute(unittest.TestCase):
     def setUp(self):

--- a/tests/test_settings_tooltips.py
+++ b/tests/test_settings_tooltips.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import app.config as config
 from app.utils.settings_tooltips import SETTINGS_CHOICES, SETTINGS_TOOLTIPS
 

--- a/tests/test_shortcuts_need_patch.py
+++ b/tests/test_shortcuts_need_patch.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from scripts import update_chrome_shortcut  # noqa: E402
 
 

--- a/tests/test_sms_alerts.py
+++ b/tests/test_sms_alerts.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.sms_alerts import send_sms_alert, sms_alert
 
 

--- a/tests/test_status_cache.py
+++ b/tests/test_status_cache.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils import screenshots as ss
 
 

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -7,8 +7,6 @@ from unittest.mock import patch
 from flask import Flask
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_submit_image_route.py
+++ b/tests/test_submit_image_route.py
@@ -8,8 +8,6 @@ from unittest.mock import patch
 from flask import Flask
 from PIL import Image
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_take_screenshot_route.py
+++ b/tests/test_take_screenshot_route.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -4,8 +4,6 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.template_manager import (
     Template,
     TemplateManager,

--- a/tests/test_test_mjpg_route.py
+++ b/tests/test_test_mjpg_route.py
@@ -3,8 +3,6 @@ import sys
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app import create_app
 
 

--- a/tests/test_throttle_routes.py
+++ b/tests/test_throttle_routes.py
@@ -6,8 +6,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_toggle_discovery_endpoint.py
+++ b/tests/test_toggle_discovery_endpoint.py
@@ -5,8 +5,6 @@ from unittest.mock import patch
 
 from flask import Flask
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.routes import init_routes
 
 

--- a/tests/test_update_validation.py
+++ b/tests/test_update_validation.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.validators import validate_update_data
 
 

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -8,7 +8,6 @@ import pytest
 import requests
 from werkzeug.serving import make_server
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from app import create_app
 
 

--- a/tests/test_validate_proxy.py
+++ b/tests/test_validate_proxy.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.validators import validate_proxy
 
 

--- a/tests/test_validate_url.py
+++ b/tests/test_validate_url.py
@@ -2,8 +2,6 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.utils.validators import validate_url
 
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -6,8 +6,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 class TestVersionSync(unittest.TestCase):
     def setUp(self):

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -5,8 +5,6 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from app.config import VIDEO_DIRECTORY
 from app.utils.validators import validate_template_name
 from app.utils.video_archiver import (


### PR DESCRIPTION
## Summary
- remove sys.path hacks from tests
- ensure project root is on the path via `conftest`
- add `tests/__init__.py`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: test_routes.py::TestRoutes::test_captions_status, test_scheduler_start_once.py::test_scheduler_starts_once)*

------
https://chatgpt.com/codex/tasks/task_e_684ce7524a188333a9a8af51dd05606a