### PR TITLE
Fix context menu issue on live player

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -3,6 +3,7 @@ import { showSpinner, hideSpinner, showErrorIndicator } from "./video.js";
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
+  video.addEventListener("contextmenu", (e) => e.preventDefault());
   const source = video.querySelector("source");
   const camSelect =
     document.getElementById("camera-selector") ||

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -88,3 +88,17 @@ test("all group uses last_video clip", () => {
   const src = document.querySelector("#live-video source").src;
   expect(src).toMatch(/\/last_video\/cam1$/);
 });
+
+test("context menu is suppressed", () => {
+  document.body.innerHTML = `
+    <video id="live-video"><source></source></video>
+  `;
+
+  window.templateDetails = { cam1: {} };
+
+  init();
+  const video = document.getElementById("live-video");
+  const event = new Event("contextmenu", { bubbles: true, cancelable: true });
+  video.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(true);
+});


### PR DESCRIPTION
## Summary
- suppress context menu on live player element
- test that context menu is prevented

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test` *(fails: lazy_poster, url_test, cost_tab)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6ee5dc88333b606505f87b99528