### PR TITLE
Add live stream connectivity check

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -776,6 +776,16 @@ def generate_video_stream(
         logging.debug("Restarting video stream")
 
 
+def check_url_accessible(url: str) -> bool:
+    """Return ``True`` if the URL responds to a HEAD request."""
+    try:
+        resp = requests.head(url, timeout=5)
+        return resp.ok
+    except Exception as exc:  # pragma: no cover
+        logging.error("Connectivity check failed for %s: %s", url, exc)
+        return False
+
+
 def generate_live_stream(url: str) -> Generator[bytes, None, None]:
     """Yield video data directly from a remote URL using ``ffmpeg``.
 
@@ -853,6 +863,12 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
     failures = 0
     last_log = 0.0
     while True:
+        if parsed.scheme in ("http", "https") and not check_url_accessible(url):
+            failures += 1
+            delay = 2 if failures == 0 else min(2**failures, 30)
+            time.sleep(delay)
+            continue
+
         process: subprocess.Popen | None = None
         try:
             process = subprocess.Popen(

--- a/docs/braille_spinner.md
+++ b/docs/braille_spinner.md
@@ -16,6 +16,7 @@ When system metrics exceed safe thresholds the `/clip` endpoint now falls
 back to `/last_video` immediately. The response includes an
 `X-Degraded-Service: busy` header and the spinner switches to a dotted
 pattern to indicate reduced quality.
+Clips are cached for two minutes and the service worker reuses them during that period to avoid re-rendering.
 
 If `/clip` hasn't finished rendering yet the server adds an
 `X-Clip-Status: waiting` header. The braille glyph becomes a bouncing dot in the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -236,6 +236,9 @@ snapshot image rather than a true video stream.
 - Some cameras reject ffmpeg if it does not send browser-style headers. The
   live stream now includes the configured `UA`, `referer` and `origin` headers.
   Adjust these settings if your camera expects a specific user agent.
+- The server now checks connectivity with a HEAD request before starting
+  `ffmpeg`. When the camera is offline the live view waits and retries
+  instead of immediately spawning a process that will fail.
 - When ffmpeg repeatedly fails, the server now waits progressively longer
   between restart attempts to reduce log noise.
 

--- a/docs/video_image_endpoints.md
+++ b/docs/video_image_endpoints.md
@@ -11,6 +11,7 @@ Stream the current MP4 for a camera or group. Pass `camera` or `group` as query 
 ### GET `/live_video`
 
 Stream a camera directly from its configured URL. Provide `camera` as a query parameter. The server automatically restarts the underlying FFmpeg process if it exits unexpectedly.
+It now performs a quick HEAD request first and skips launching `ffmpeg` when the camera is unreachable.
 
 ### GET `/stream.m3u8`
 

--- a/tests/test_live_connectivity.py
+++ b/tests/test_live_connectivity.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest.mock import patch
+
+import app.routes as routes
+
+
+class TestLiveConnectivity(unittest.TestCase):
+    @patch("app.routes.requests.head")
+    def test_check_url_accessible_success(self, mock_head):
+        mock_head.return_value.ok = True
+        self.assertTrue(routes.check_url_accessible("http://example.com"))
+
+    @patch("app.routes.requests.head", side_effect=Exception("fail"))
+    def test_check_url_accessible_failure(self, mock_head):
+        self.assertFalse(routes.check_url_accessible("http://bad"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `check_url_accessible` and skip ffmpeg when the camera is offline
- document connection checks for `/live_video`
- note clip caching in braille spinner docs
- explain connectivity checks in troubleshooting guide
- test the new connectivity helper

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_live_connectivity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce2a846cc83338391e4a81dfbcf7f