### PR TITLE
Improve discovery exports

### DIFF
--- a/app/static/js/discovery.js
+++ b/app/static/js/discovery.js
@@ -30,6 +30,14 @@ export function initDiscoveryToggle() {
       } else if (Number.isFinite(d.age) && d.status !== "none") {
         text += ` (${minutes(d.age)} ago)`;
       }
+      if (
+        !d.running &&
+        Array.isArray(d.results) &&
+        d.results.length === 0 &&
+        d.status !== "none"
+      ) {
+        text += ", no cameras found";
+      }
       if (d.next_run_in) {
         text += `, next in ${minutes(d.next_run_in)}`;
       }

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -166,6 +166,11 @@
     };
 
     let results = [];
+    const updateExportState = () => {
+      if (exportJson) exportJson.disabled = results.length === 0;
+      if (exportCsv) exportCsv.disabled = results.length === 0;
+    };
+    updateExportState();
 
     if (button) {
       button.addEventListener("click", async () => {
@@ -183,6 +188,7 @@
         progress.value = 0;
         body.innerHTML = "";
         results = [];
+        updateExportState();
         const cidr = document.getElementById("cidr-input").value.trim();
         const url = cidr
           ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}`
@@ -194,6 +200,7 @@
           if (known.has(key)) return;
           known.add(key);
           results.push(cam);
+          updateExportState();
           const tr = document.createElement("tr");
           let url = cam.url || `${cam.protocol}://${cam.ip}:${cam.port}`;
           const existing = existingMap[url];


### PR DESCRIPTION
## Summary
- disable export buttons when there are no results
- show `no cameras found` if the latest background discovery had zero results

## Testing
- `pre-commit run --files app/templates/_discover_tab.html app/static/js/discovery.js`
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ce8e4b11c83338d0666cd5083cbec