### PR TITLE
Use fast stream in live view

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -973,7 +973,7 @@ function playMJPG() {
     image.src = `/stream.mjpg?group=all&time=${ts}`;
   } else {
     // URL for individual cameras
-    image.src = `/stream.mjpg?camera=${encodeURIComponent(currentCamera)}&time=${ts}`;
+    image.src = `/fast_stream.mjpg?camera=${encodeURIComponent(currentCamera)}&time=${ts}`;
   }
 }
 

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -47,7 +47,8 @@ export function initTilePlayer() {
     video.style.display = "none";
     image.style.display = "block";
     const param = isCamera ? "camera" : "group";
-    image.src = `/stream.mjpg?${param}=${encodeURIComponent(target)}&time=${Date.now()}`;
+    const route = isCamera ? "/fast_stream.mjpg" : "/stream.mjpg";
+    image.src = `${route}?${param}=${encodeURIComponent(target)}&time=${Date.now()}`;
     if (container) container.classList.add(LIVE_CLASS);
   }
 

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -122,6 +122,7 @@ available again while avoiding rapid restarts.
 Several other routes provide streaming functionality:
 
 - **GET /stream.mjpg** – Continuous MJPEG stream of the latest camera image. Optional `camera` or `group` query parameters limit the feed. Passing `group=all` shows the newest frame from any camera.
+- **GET /fast_stream.mjpg** – Fast MJPEG feed capturing a fresh frame whenever possible. The `/live` page uses this for near real-time playback. Requires a `camera` parameter.
 - **GET /stream.png** – Returns the most recent screenshot. Optional `camera` or `group` parameters filter the result.
 - **GET /motion.mjpg** – MJPEG stream containing only motion frames. Accepts `camera` or `group` as query parameters.
 - **GET /caption.mjpg** – MJPEG stream of the last caption frame for a group.

--- a/docs/video_image_endpoints.md
+++ b/docs/video_image_endpoints.md
@@ -22,7 +22,7 @@ Continuous MJPEG feed of the newest screenshot. Optional `camera` or `group` par
 
 ### GET `/fast_stream.mjpg`
 
-Similar to `/stream.mjpg` but captures a fresh frame as quickly as possible. Requires a `camera` parameter.
+Similar to `/stream.mjpg` but captures a fresh frame as quickly as possible. Requires a `camera` parameter. The `/live` page uses this endpoint for near real-time streaming.
 
 ### GET `/motion.mjpg`
 


### PR DESCRIPTION
## Summary
- use `/fast_stream.mjpg` when a single camera is viewed in Live page
- document the fast stream endpoint in API docs

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: `assert len(calls) == 1`)*
- `npm test` *(fails: TypeError from jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_684ce826f87083339350eeac598d4dec