### PR TITLE
Expand thread metrics list

### DIFF
--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -72,9 +72,6 @@
     <span class="metric-label">Thread Count:</span>
     <span id="thread-count">{{ metrics.thread_count }}</span>
   </li>
-  <li title="Top threads by CPU usage">
-    <span class="metric-label">Top Threads:</span>
-  </li>
   <li title="System uptime">
     <span class="metric-label">Uptime:</span>
     <span id="uptime-value">{{ metrics.uptime }}</span>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1259,13 +1259,16 @@ def collect_system_metrics():
         for child in proc.children(recursive=True):
             try:
                 cpu = child.cpu_percent(interval=None)
-                name = os.path.basename(child.name())
+                cmd = child.cmdline()
+                name = (
+                    os.path.basename(cmd[0]) if cmd else os.path.basename(child.name())
+                )
                 if cpu:
                     usages.append({"id": child.pid, "name": name, "cpu": round(cpu, 1)})
             except Exception:
                 continue
         usages.sort(key=lambda x: x["cpu"], reverse=True)
-        system_metrics["top_threads"] = usages[:5]
+        system_metrics["top_threads"] = usages[:10]
         time.sleep(5)  # Collect metrics every 5 seconds
 
 

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -42,7 +42,7 @@ name, last image time, last caption time, any KPI column, or status.
 - **Disk Usage** – percentage of disk space used on the main volume
 - **Open Files** – number of file descriptors opened by the process
 - **Thread Count** – active thread count for the application
-- **Top Threads** – stacked list of thread and child process names sorted by CPU usage (includes `ffmpeg` when active)
+- **Top Threads** – top 10 threads and child processes sorted by CPU usage (includes `ffmpeg` when active)
 - **Uptime** – elapsed time since the app started
 - **FFmpeg Version** – version string and path to the ffmpeg binary
 - **Machine HW Accel** – whether GPU devices are detected


### PR DESCRIPTION
## Summary
- extend system metrics to track top 10 threads
- drop "Top Threads" label row from status table
- document expanded list in system monitoring docs

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_routes.py::TestRoutes::test_captions_status tests/test_scheduler_start_once.py::test_scheduler_starts_once -q`
- `pytest -q` *(fails: tests/test_routes.py::TestRoutes::test_captions_status, tests/test_scheduler_start_once.py::test_scheduler_starts_once)*

------
https://chatgpt.com/codex/tasks/task_e_684ce9362230833396600ad75d2ebb94