### PR TITLE
Fix cost summary filter controls

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1921,7 +1921,8 @@ body.advanced-enabled .advanced-only {
   padding: 0.5rem;
 }
 
-#cost-range {
+#cost-start,
+#cost-end {
   vertical-align: middle;
   margin: 0 0.5rem;
 }

--- a/app/static/js/costs.js
+++ b/app/static/js/costs.js
@@ -23,8 +23,10 @@ export function initCosts() {
   document.addEventListener("DOMContentLoaded", () => {
     const dataEl = document.getElementById("cost-data");
     if (!dataEl) return;
-    const rangeInput = document.getElementById("cost-range");
-    const rangeLabel = document.getElementById("cost-range-label");
+    const startSlider = document.getElementById("cost-start");
+    const endSlider = document.getElementById("cost-end");
+    const startLabel = document.getElementById("cost-start-label");
+    const endLabel = document.getElementById("cost-end-label");
     const groupSelect = document.getElementById("cost-group");
     const topSlider = document.getElementById("cost-top");
     const topLabel = document.getElementById("cost-top-label");
@@ -67,20 +69,26 @@ export function initCosts() {
       }
     };
 
+    const base = new Date();
+    base.setMonth(base.getMonth() - 6);
+
+    const toDate = (val) => {
+      const d = new Date(base.getTime());
+      d.setDate(base.getDate() + parseInt(val, 10));
+      return d;
+    };
+
     const fetchData = async () => {
-      if (!rangeInput) {
+      if (!startSlider || !endSlider) {
         rowsData = JSON.parse(dataEl.textContent);
         render();
         return;
       }
       const params = [];
-      if (rangeInput) {
-        const days = parseInt(rangeInput.value, 10);
-        const end = new Date();
-        const start = new Date(Date.now() - days * 86400000);
-        params.push(`start=${start.toISOString().slice(0, 10)}`);
-        params.push(`end=${end.toISOString().slice(0, 10)}`);
-      }
+      const start = toDate(startSlider.value);
+      const end = toDate(endSlider.value);
+      params.push(`start=${start.toISOString().slice(0, 10)}`);
+      params.push(`end=${end.toISOString().slice(0, 10)}`);
       if (groupSelect && groupSelect.value && groupSelect.value !== "all") {
         params.push(`group=${groupSelect.value}`);
       }
@@ -99,8 +107,28 @@ export function initCosts() {
       render();
     };
 
-    rangeInput?.addEventListener("input", () => {
-      if (rangeLabel) rangeLabel.textContent = `${rangeInput.value} days`;
+    const updateLabels = () => {
+      if (startLabel)
+        startLabel.textContent = toDate(startSlider.value)
+          .toISOString()
+          .slice(0, 10);
+      if (endLabel)
+        endLabel.textContent = toDate(endSlider.value)
+          .toISOString()
+          .slice(0, 10);
+    };
+    startSlider?.addEventListener("input", () => {
+      if (parseInt(startSlider.value, 10) > parseInt(endSlider.value, 10)) {
+        startSlider.value = endSlider.value;
+      }
+      updateLabels();
+      fetchData();
+    });
+    endSlider?.addEventListener("input", () => {
+      if (parseInt(endSlider.value, 10) < parseInt(startSlider.value, 10)) {
+        endSlider.value = startSlider.value;
+      }
+      updateLabels();
       fetchData();
     });
     groupSelect?.addEventListener("change", fetchData);
@@ -112,8 +140,8 @@ export function initCosts() {
 
     setupTableSorting("cost-table");
     loadGroups();
-    if (rangeInput && rangeLabel) {
-      rangeLabel.textContent = `${rangeInput.value} days`;
+    if (startSlider && endSlider) {
+      updateLabels();
     }
     fetchData();
   });
@@ -121,14 +149,16 @@ export function initCosts() {
 
 export function initCostSummary(startTime) {
   document.addEventListener("DOMContentLoaded", () => {
-    const rangeInput = document.getElementById("cost-range");
-    const rangeLabel = document.getElementById("cost-range-label");
+    const startSlider = document.getElementById("cost-start");
+    const endSlider = document.getElementById("cost-end");
+    const startLabel = document.getElementById("cost-start-label");
+    const endLabel = document.getElementById("cost-end-label");
     const groupSelect = document.getElementById("cost-group");
     const loadBtn = document.getElementById("load-cost");
     const sinceBtn = document.getElementById("since-restart");
     const tbody = document.querySelector("#cost-table tbody");
     const ctx = document.getElementById("costChart");
-    if (!rangeInput || !loadBtn || !tbody) return;
+    if (!startSlider || !endSlider || !loadBtn || !tbody) return;
     let chart;
 
     const render = (data) => {
@@ -176,10 +206,18 @@ export function initCostSummary(startTime) {
       }
     };
 
+    const base = new Date();
+    base.setMonth(base.getMonth() - 6);
+
+    const toDate = (val) => {
+      const d = new Date(base.getTime());
+      d.setDate(base.getDate() + parseInt(val, 10));
+      return d;
+    };
+
     const loadData = async () => {
-      const days = parseInt(rangeInput.value, 10);
-      const end = new Date();
-      const start = new Date(Date.now() - days * 86400000);
+      const start = toDate(startSlider.value);
+      const end = toDate(endSlider.value);
       const params = [
         `start=${start.toISOString().slice(0, 10)}`,
         `end=${end.toISOString().slice(0, 10)}`,
@@ -192,21 +230,45 @@ export function initCostSummary(startTime) {
       render(data);
     };
 
+    const updateLabels = () => {
+      if (startLabel)
+        startLabel.textContent = toDate(startSlider.value)
+          .toISOString()
+          .slice(0, 10);
+      if (endLabel)
+        endLabel.textContent = toDate(endSlider.value)
+          .toISOString()
+          .slice(0, 10);
+    };
+
     loadBtn.addEventListener("click", loadData);
-    rangeInput.addEventListener("input", () => {
-      if (rangeLabel) rangeLabel.textContent = `${rangeInput.value} days`;
+    startSlider.addEventListener("input", () => {
+      if (parseInt(startSlider.value, 10) > parseInt(endSlider.value, 10)) {
+        startSlider.value = endSlider.value;
+      }
+      updateLabels();
+    });
+    endSlider.addEventListener("input", () => {
+      if (parseInt(endSlider.value, 10) < parseInt(startSlider.value, 10)) {
+        endSlider.value = startSlider.value;
+      }
+      updateLabels();
     });
     groupSelect?.addEventListener("change", loadData);
     sinceBtn?.addEventListener("click", () => {
       const dt = new Date(startTime * 1000);
       const diff = Math.ceil((Date.now() - dt.getTime()) / 86400000);
-      rangeInput.value = String(diff);
-      if (rangeLabel) rangeLabel.textContent = `${rangeInput.value} days`;
+      const val = Math.min(diff, 180);
+      startSlider.value = String(0);
+      endSlider.value = String(val);
+      updateLabels();
       loadData();
     });
 
     loadGroups();
-    if (rangeLabel) rangeLabel.textContent = `${rangeInput.value} days`;
+    if (startSlider && endSlider) {
+      updateLabels();
+    }
     loadData();
   });
 }

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -337,7 +337,10 @@ export function initTemplates() {
 }
 
 export async function loadGroups() {
-  const groupDropdown = document.getElementById("group-dropdown");
+  // Support group selection in multiple pages
+  const groupDropdown =
+    document.getElementById("group-dropdown") ||
+    document.getElementById("cost-group");
   const groupsSelect = document.getElementById("groups");
   const groupDatalist = document.getElementById("group-options");
   if (!groupDropdown && !groupsSelect) return;

--- a/app/templates/_costs_tab.html
+++ b/app/templates/_costs_tab.html
@@ -2,16 +2,26 @@
 <div id="cost-controls">
   <label for="cost-group">Group:</label>
   <select id="cost-group" title="Filter by group"></select>
-  <label for="cost-range" class="ml-4">Days:</label>
+  <label for="cost-start" class="ml-4">Start:</label>
   <input
     type="range"
-    id="cost-range"
-    min="1"
-    max="30"
-    value="7"
-    title="Number of days"
+    id="cost-start"
+    min="0"
+    max="180"
+    value="150"
+    title="Start date"
   />
-  <span id="cost-range-label">7 days</span>
+  <span id="cost-start-label"></span>
+  <label for="cost-end" class="ml-4">End:</label>
+  <input
+    type="range"
+    id="cost-end"
+    min="0"
+    max="180"
+    value="180"
+    title="End date"
+  />
+  <span id="cost-end-label"></span>
   <label for="cost-top" class="ml-4">Top:</label>
   <input
     type="range"

--- a/app/templates/cost_summary.html
+++ b/app/templates/cost_summary.html
@@ -5,16 +5,26 @@ content %}
 <form id="cost-form" class="cost-form">
   <label for="cost-group">Group:</label>
   <select id="cost-group" title="Filter by group"></select>
-  <label for="cost-range" class="ml-4">Days:</label>
+  <label for="cost-start" class="ml-4">Start:</label>
   <input
     type="range"
-    id="cost-range"
-    min="1"
-    max="30"
-    value="7"
-    title="Number of days"
+    id="cost-start"
+    min="0"
+    max="180"
+    value="150"
+    title="Start date"
   />
-  <span id="cost-range-label">7 days</span>
+  <span id="cost-start-label"></span>
+  <label for="cost-end" class="ml-4">End:</label>
+  <input
+    type="range"
+    id="cost-end"
+    min="0"
+    max="180"
+    value="180"
+    title="End date"
+  />
+  <span id="cost-end-label"></span>
   <button type="button" id="since-restart" title="Use start time from restart">
     Since Last Restart
   </button>

--- a/docs/cost_tracking.md
+++ b/docs/cost_tracking.md
@@ -5,7 +5,7 @@ Token counts are stored in `data/llm_usage.json` keyed by template name.
 Costs are calculated at `$0.005` per thousand tokens.
 Use the captions page to view each template's estimated cost.
 An overall cost summary now appears under **Settings → Costs**. This tab now
-includes a small pie chart and sortable columns. Use the **Days** slider to
+includes a small pie chart and sortable columns. Use the date range sliders to
 select how far back to look when reviewing recent spending. A group dropdown
 allows filtering the results.
 
@@ -14,9 +14,9 @@ into a single **Other** row. Use the **Top** slider to adjust how many
 individual templates appear before grouping occurs. The table now shows the
 number of LLM calls for each template.
 
-An additional **LLM Cost Summary** page now provides a slider-based range
-selection to review costs for a specific period. Use the **Since Last Restart**
-shortcut to fill the slider with the time since the server started. A pie chart
+An additional **LLM Cost Summary** page now provides a date range selection
+to review costs for a specific period. Use the **Since Last Restart**
+shortcut to fill the sliders with the time since the server started. A pie chart
 shows how costs are
 distributed across templates. When more than 15 templates are present, the chart
 automatically groups the least expensive templates into a single **Other** slice

--- a/tests/js/cost_summary.test.js
+++ b/tests/js/cost_summary.test.js
@@ -2,7 +2,8 @@ import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
   <select id="cost-group"></select>
-  <input id="cost-range" type="range" value="7">
+  <input id="cost-start" type="range" value="150">
+  <input id="cost-end" type="range" value="180">
   <button id="since-restart"></button>
   <button id="load-cost"></button>
   <table id="cost-table"><tbody></tbody></table>
@@ -32,7 +33,7 @@ describe("cost summary", () => {
     const btn = document.getElementById("since-restart");
     btn.click();
     await Promise.resolve();
-    const range = document.getElementById("cost-range");
-    expect(parseInt(range.value, 10)).toBeGreaterThan(0);
+    const end = document.getElementById("cost-end");
+    expect(parseInt(end.value, 10)).toBeGreaterThan(0);
   });
 });

--- a/tests/js/cost_tab.test.js
+++ b/tests/js/cost_tab.test.js
@@ -2,7 +2,8 @@ import { jest } from "@jest/globals";
 
 document.body.innerHTML = `
   <select id="cost-group"></select>
-  <input id="cost-range" type="range" value="7">
+  <input id="cost-start" type="range" value="150">
+  <input id="cost-end" type="range" value="180">
   <input id="cost-top" type="range" value="10">
   <span id="cost-top-label"></span>
   <table id="cost-table"><tbody></tbody></table>
@@ -30,14 +31,14 @@ global.Chart = jest.fn(function () {
   this.update = jest.fn();
 });
 
-test("range slider triggers fetch", async () => {
+test("date sliders trigger fetch", async () => {
   initCosts();
   document.dispatchEvent(new Event("DOMContentLoaded"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
-  const range = document.getElementById("cost-range");
+  const start = document.getElementById("cost-start");
   fetch.mockClear();
-  range.dispatchEvent(new Event("input"));
+  start.dispatchEvent(new Event("input"));
   await Promise.resolve();
   expect(fetch).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Summary
- support `cost-group` dropdown in `loadGroups`
- allow selecting date range with two sliders
- update CSS and docs
- adjust tests for new slider behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: AssertionError in scheduler and captions tests)*
- `npm test` *(fails: several jsdom not implemented errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ceabc9fc08333a5debf8c54ab2dab