### PR TITLE
Clamp caption responses to thumbnail height

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1871,6 +1871,20 @@ body.advanced-enabled .advanced-only {
   border-radius: 4px;
 }
 
+.chat-response .last-caption.ellipsis {
+  overflow: hidden;
+  position: relative;
+}
+
+.chat-response .last-caption.ellipsis::after {
+  content: "\2026"; /* ellipsis */
+  position: absolute;
+  right: 0.25rem;
+  bottom: 0.25rem;
+  background: var(--form-bg-color);
+  padding-left: 0.25rem;
+}
+
 .chat-box label {
   font-weight: 600;
 }

--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -91,7 +91,7 @@ export function applyCaptionVisibility(width) {
   }
 }
 
-function updateTableLayout(width) {
+export function updateTableLayout(width) {
   const rows = document.querySelectorAll("#camera-table .camera-row");
   rows.forEach((row) => {
     const preview = row.querySelector(".templateDiv");
@@ -99,9 +99,13 @@ function updateTableLayout(width) {
     const height = preview.offsetHeight;
     row.style.height = `${height}px`;
     const caption = row.querySelector(".last-caption");
-    if (caption) {
-      caption.classList.toggle("hidden", width < 150);
-    }
+    const prompt = row.querySelector(".chat-prompt textarea");
+    if (!caption || !prompt) return;
+    caption.classList.toggle("hidden", width < 150);
+    const available = height - prompt.offsetHeight - 10;
+    const needsClamp = available < caption.scrollHeight;
+    caption.style.maxHeight = needsClamp ? `${Math.max(available, 0)}px` : "";
+    caption.classList.toggle("ellipsis", needsClamp);
   });
 }
 

--- a/docs/caption_prompt_toggle.md
+++ b/docs/caption_prompt_toggle.md
@@ -1,3 +1,5 @@
 # Caption or Prompt Toggle
 
 The Captions page now lets you choose whether to view each camera's last caption or its saved prompt. Use the toggle above the table to switch modes. Both fields are stacked in a single column, and switching modes simply hides one to keep the layout compact. Your selection persists in `localStorage` so it is remembered on the next visit. Sorting works on whichever field is visible.
+
+When thumbnails are narrow, long responses fade out with an ellipsis so the row height stays aligned with the preview.

--- a/tests/js/caption_truncate.test.js
+++ b/tests/js/caption_truncate.test.js
@@ -1,0 +1,32 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <table id="camera-table"><tbody>
+    <tr class="camera-row">
+      <td><div class="templateDiv" style="height:60px"></div></td>
+      <td>
+        <form class="caption-box">
+          <div class="chat-box">
+            <div class="chat-prompt"><textarea style="height:40px"></textarea></div>
+            <div class="chat-response"><div class="last-caption">long text</div></div>
+          </div>
+        </form>
+      </td>
+    </tr>
+  </tbody></table>
+  <input id="grid-width-slider" type="range" value="100">
+`;
+
+let updateTableLayout;
+
+beforeAll(async () => {
+  ({ updateTableLayout } = await import("../../app/static/js/templates.js"));
+});
+
+test("caption clamps when space limited", () => {
+  const caption = document.querySelector(".last-caption");
+  Object.defineProperty(caption, "scrollHeight", { value: 120 });
+  updateTableLayout(100);
+  expect(caption.classList.contains("ellipsis")).toBe(true);
+  expect(caption.style.maxHeight).not.toBe("");
+});


### PR DESCRIPTION
## Summary
- clamp caption response height on the prompts page
- show ellipsis when truncated
- document new clipping behavior
- cover clamping with a Jest test

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: AssertionError in scheduler tests)*
- `npm test` *(fails: several jsdom not implemented errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ceb15c4b88333b4c4f6bfd13016c6