### PR TITLE
Fix PyInstaller packaging prerequisites

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -70,6 +70,10 @@ jobs:
           python-version: "3.12"
       - name: Install PyInstaller
         run: python -m pip install --upgrade pip && pip install pyinstaller
+      - name: Install project requirements
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Build Windows executable
         run: python build_windows.py
       - name: Upload Windows executable
@@ -92,6 +96,10 @@ jobs:
           python-version: "3.12"
       - name: Install PyInstaller
         run: python -m pip install --upgrade pip && pip install pyinstaller
+      - name: Install project requirements
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Build macOS executable
         run: python build_macos.py
       - name: Upload macOS archive


### PR DESCRIPTION
## Summary
- install project requirements in the Windows and macOS release jobs

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cfe6467e083339a2976b24c3280f9