### PR TITLE
Fix live view to start MJPEG playback

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -112,63 +112,19 @@ export function initTilePlayer() {
     }
   }
 
+  // Switch the UI to live MJPEG playback immediately. Archived clips are
+  // skipped entirely so the image element always shows the current stream.
   function play(name) {
     if (!name) return;
     current = name;
-    video.style.display = "block";
-    image.style.display = "none";
-    if (container) container.classList.remove(LIVE_CLASS);
-
-    if (name === "All") {
-      const first = Object.keys(window.templateDetails || {})[0];
-      if (first && source) source.src = `/last_video/${first}`;
-      video.setAttribute("data-hd-src", "/stream.mp4");
-      video.addEventListener(
-        "ended",
-        () => {
-          showSpinner(video);
-          image.addEventListener("load", () => hideSpinner(video), {
-            once: true,
-          });
-          playMjpg("all");
-        },
-        { once: true },
-      );
-    } else if (name.startsWith("group-")) {
-      const raw = name.slice(6);
-      const group = encodeURIComponent(raw);
-      if (source) source.src = `/last_teaser?group=${group}`;
-      video.setAttribute("data-hd-src", `/stream.mp4?group=${group}`);
-      video.addEventListener(
-        "ended",
-        () => {
-          showSpinner(video);
-          image.addEventListener("load", () => hideSpinner(video), {
-            once: true,
-          });
-          playMjpg(raw);
-        },
-        { once: true },
-      );
-    } else {
-      if (source) source.src = `/last_video/${name}`;
-      video.setAttribute("data-hd-src", `/clip/${name}`);
-      video.addEventListener(
-        "ended",
-        () => {
-          showSpinner(video);
-          image.addEventListener("load", () => hideSpinner(video), {
-            once: true,
-          });
-          playMjpg(name, true);
-        },
-        { once: true },
-      );
-    }
-
-    video.load();
     hideBounce();
-    loadHdClip();
+    if (name === "All") {
+      playMjpg("all");
+    } else if (name.startsWith("group-")) {
+      playMjpg(name.slice(6));
+    } else {
+      playMjpg(name, true);
+    }
   }
 
   if (camSelect) {

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -12,10 +12,7 @@
     preload="none"
     poster="/last_screenshot/{{ template_details.keys()|list|first }}"
   >
-    <source
-      src="/last_video/{{ template_details.keys()|list|first }}"
-      type="video/mp4"
-    />
+    <source type="video/mp4" />
     Your browser does not support the video tag.
   </video>
 </div>

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -14,32 +14,20 @@ beforeAll(async () => {
   changeGroup = mod.changeGroup;
 });
 
-test("loads first camera", () => {
+test("loads first camera as mjpeg", () => {
   init();
-  const src = document.querySelector("#live-video source").src;
-  expect(src).toMatch(/\/last_video\/cam1$/);
+  const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/fast_stream\.mjpg\?camera=cam1&time=\d+$/);
 });
 
-test("swaps to clip after preload", async () => {
-  const video = document.getElementById("live-video");
-  video.load = jest.fn(() => {
-    video.dispatchEvent(new Event("loadedmetadata"));
-  });
-
-  global.fetch = jest.fn(() =>
-    Promise.resolve({
-      ok: true,
-      blob: () => Promise.resolve(new Blob(["hi"], { type: "video/mp4" })),
-    }),
-  );
-
+test("no clip fetch occurs", async () => {
+  global.fetch = jest.fn();
   init();
   await Promise.resolve();
-  await Promise.resolve();
-  expect(fetch).toHaveBeenCalledWith("/clip/cam1", expect.any(Object));
+  expect(fetch).not.toHaveBeenCalled();
 });
 
-test("group change updates video src", () => {
+test("group change updates image src", () => {
   document.body.innerHTML = `
     <video id="live-video"><source></source></video>
     <select id="camera-selector"></select>
@@ -52,10 +40,8 @@ test("group change updates video src", () => {
 
   init();
   changeGroup("kitchen");
-  const src = document.querySelector("#live-video source").src;
-  const hd = document.querySelector("#live-video").dataset.hdSrc;
-  expect(src).toMatch(/\/last_teaser\?group=kitchen$/);
-  expect(hd).toMatch(/\/stream.mp4\?group=kitchen$/);
+  const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=kitchen&time=\d+$/);
 });
 
 test("fallback to nav camera dropdown", () => {
@@ -71,11 +57,11 @@ test("fallback to nav camera dropdown", () => {
 
   init();
   changeGroup("foo");
-  const src = document.querySelector("#live-video source").src;
-  expect(src).toMatch(/\/last_teaser\?group=foo$/);
+  const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=foo&time=\d+$/);
 });
 
-test("all group uses last_video clip", () => {
+test("all group uses group mjpeg", () => {
   document.body.innerHTML = `
     <video id="live-video"><source></source></video>
     <select id="camera-selector"><option>All</option></select>
@@ -85,8 +71,8 @@ test("all group uses last_video clip", () => {
 
   init();
   changeGroup("all");
-  const src = document.querySelector("#live-video source").src;
-  expect(src).toMatch(/\/last_video\/cam1$/);
+  const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
 });
 
 test("context menu is suppressed", () => {


### PR DESCRIPTION
## Summary
- ensure live view uses MJPEG stream immediately
- drop archived clip preload in `tile_player.js`
- remove last_video source from `live.html`
- update Jest tests for new MJPEG behavior

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test` *(fails: url_test.test.js, cost_tab.test.js, lazy_poster.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684d01f1c61083338bbb9c917377305d