### PR TITLE
Improve live stream throttling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import csv
+import email.utils
 import fcntl
 import glob
 import hashlib
@@ -820,6 +821,26 @@ def check_url_accessible(url: str) -> bool:
         return False
 
 
+def parse_cache_delay(headers: typing.Mapping[str, str]) -> float:
+    """Return the time-to-live from HTTP cache headers."""
+
+    cc = headers.get("Cache-Control", "")
+    m = re.search(r"max-age=(\d+)", cc)
+    if m:
+        try:
+            return float(m.group(1))
+        except ValueError:
+            pass
+    expires = headers.get("Expires")
+    if expires:
+        try:
+            dt = email.utils.parsedate_to_datetime(expires)
+            return max(0.0, dt.timestamp() - time.time())
+        except Exception:
+            pass
+    return 0.0
+
+
 def generate_live_stream(url: str) -> Generator[bytes, None, None]:
     """Yield video data directly from a remote URL using ``ffmpeg``.
 
@@ -837,12 +858,22 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
         session = screenshots.http_session()
         failures = 0
         base_delay = 1 / max(config.LIVE_FALLBACK_FPS, 1)
+        last_hash = b""
+
         while True:
             try:
                 resp = session.get(url, timeout=5, stream=True)
                 if resp.status_code == 200:
-                    yield resp.content
-                    failures = 0
+                    data = resp.content
+                    digest = hashlib.sha256(data).digest()
+                    unchanged = digest == last_hash
+                    last_hash = digest
+                    yield data
+                    if unchanged:
+                        failures = min(failures + 1, 5)
+                    else:
+                        failures = 0
+                    delay = max(base_delay, parse_cache_delay(resp.headers))
                 else:
                     logging.error(
                         "Failed to fetch image from %s (HTTP %s)",
@@ -850,14 +881,15 @@ def generate_live_stream(url: str) -> Generator[bytes, None, None]:
                         resp.status_code,
                     )
                     failures += 1
+                    delay = base_delay * (2**failures)
             except GeneratorExit:
                 break
             except Exception as e:
                 logging.error("Error fetching image from %s: %s", url, e)
                 failures += 1
+                delay = base_delay * (2**failures)
 
-            delay = min(base_delay * (2**failures), 30)
-            time.sleep(delay)
+            time.sleep(min(delay, config.LIVE_MAX_RETRY_DELAY))
         return
 
     command = [config.FFMPEG_PATH]

--- a/tests/test_parse_cache_delay.py
+++ b/tests/test_parse_cache_delay.py
@@ -1,0 +1,20 @@
+import unittest
+from datetime import datetime, timedelta
+
+import app.routes as routes
+
+
+class TestParseCacheDelay(unittest.TestCase):
+    def test_cache_control_max_age(self):
+        headers = {"Cache-Control": "public, max-age=60"}
+        self.assertEqual(routes.parse_cache_delay(headers), 60)
+
+    def test_expires_header(self):
+        future = datetime.utcnow() + timedelta(seconds=30)
+        headers = {"Expires": future.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+        ttl = routes.parse_cache_delay(headers)
+        self.assertTrue(0 <= ttl <= 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- obey Cache-Control/Expires headers with `parse_cache_delay`
- throttle `/live` fallback polling when frames repeat
- test parsing of cache headers

## Testing
- `pre-commit run --files app/routes.py tests/test_parse_cache_delay.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d02d339bc8333b08ce4933dd08630