### PR TITLE
feat: log http status when skipping blank frame

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -106,6 +106,7 @@ from .screenshots import (
     capture_or_download,
     cas_error,
     check_user_activity,
+    get_cached_status_code,
     is_chrome_debug_port_open,
     is_mostly_blank,
     load_font,
@@ -553,9 +554,11 @@ def update_camera(name, template, image_file=None, motion=False):
         try:
             with Image.open(latest_image_path) as img:
                 if is_mostly_blank(img):
+                    status = get_cached_status_code(url)
                     logging.info(
-                        "Skipping blank frame for motion detection: %s",
+                        "Skipping blank frame for motion detection: %s (HTTP status: %s)",
                         latest_image_path,
+                        status if status is not None else "unknown",
                     )
                     return
         except Exception as e:

--- a/tests/test_blank_frame_logging.py
+++ b/tests/test_blank_frame_logging.py
@@ -1,0 +1,39 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from PIL import Image
+
+from app.utils import scheduling
+
+
+class TestBlankFrameLogging(unittest.TestCase):
+    def test_blank_frame_logs_status(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cam_dir = os.path.join(tmp, "cam1")
+            os.makedirs(cam_dir)
+            shot = os.path.join(cam_dir, "cam1_20240101000000.png")
+            Image.new("RGB", (10, 10)).save(shot)
+
+            template = {"name": "cam1", "url": "http://example.com", "motion": 1}
+
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("app.utils.scheduling.capture_or_download", return_value=True),
+                patch("app.utils.scheduling.get_template", return_value=template),
+                patch("app.utils.scheduling.is_mostly_blank", return_value=True),
+                patch("app.utils.scheduling.os.symlink"),
+                patch("app.utils.scheduling.os.rename"),
+                patch("app.utils.scheduling.os.unlink"),
+                patch("app.utils.scheduling.get_cached_status_code", return_value=404),
+            ), self.assertLogs(level="INFO") as logs:
+                scheduling.update_camera("cam1", template)
+
+            joined = "\n".join(logs.output)
+            self.assertIn("Skipping blank frame for motion detection", joined)
+            self.assertIn("HTTP status: 404", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- log cached HTTP status when motion detection skips a blank frame
- test logging when a blank screenshot is skipped

## Testing
- `flake8 app/utils/scheduling.py tests/test_blank_frame_logging.py` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*


------
https://chatgpt.com/codex/tasks/task_e_684d0307b0e88333b1b1fc733500e618