### PR TITLE
fix tests

### DIFF
--- a/tests/test_blank_frame_logging.py
+++ b/tests/test_blank_frame_logging.py
@@ -27,8 +27,9 @@ class TestBlankFrameLogging(unittest.TestCase):
                 patch("app.utils.scheduling.os.rename"),
                 patch("app.utils.scheduling.os.unlink"),
                 patch("app.utils.scheduling.get_cached_status_code", return_value=404),
-            ), self.assertLogs(level="INFO") as logs:
-                scheduling.update_camera("cam1", template)
+            ):
+                with self.assertLogs(level="INFO") as logs:
+                    scheduling.update_camera("cam1", template)
 
             joined = "\n".join(logs.output)
             self.assertIn("Skipping blank frame for motion detection", joined)


### PR DESCRIPTION
## Summary
- fix multiple patch context managers in blank frame logging test

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `pytest -q tests/test_blank_frame_logging.py`

------
https://chatgpt.com/codex/tasks/task_e_684d090363c083338def978d1aefbf97