### PR TITLE
Fix macOS build dependency

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -189,7 +189,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. `onnxruntime` is now the default dependency. Install `onnxruntime-gpu` to enable CUDA acceleration.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. Non-macOS systems install `onnxruntime-gpu~=1.18` by default, while macOS falls back to the CPU-only `onnxruntime` package.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ pyvirtualdisplay==3.0
 selenium==4.33.0
 SQLAlchemy==2.0.41
 pywebpush==2.0.3
-onnxruntime-gpu==1.18.0
+onnxruntime-gpu~=1.18; sys_platform != "darwin"
+onnxruntime~=1.18; sys_platform == "darwin"
 undetected-chromedriver==3.5.5
 webdriver-manager==4.0.2
 Werkzeug==3.1.3


### PR DESCRIPTION
## Summary
- use conditional dependency for `onnxruntime` on macOS
- clarify docs about GPU package fallback

## Testing
- `flake8`
- `pre-commit run --files requirements.txt docs/configuration_guide.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d0d3a9e00833398e6f572b695bb49