### PR TITLE
Improve build scripts and add tests

### DIFF
--- a/build_macos.py
+++ b/build_macos.py
@@ -1,31 +1,44 @@
 #!/usr/bin/env python3
-"""Build a macOS bundle using PyInstaller."""
+"""Helper for building the macOS bundle with PyInstaller."""
+
 import os
+from pathlib import Path
 
 import PyInstaller.__main__
 
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
+ARGS = [
+    "app/__init__.py",
+    "--name=Glimpser",
+    "--onefile",
+    "--windowed",
+    "--add-data=app/templates:templates",
+    "--add-data=app/static:static",
+    "--hidden-import=flask",
+    "--hidden-import=flask_apscheduler",
+    "--hidden-import=sqlalchemy",
+    "--hidden-import=werkzeug",
+    "--hidden-import=jinja2",
+    "--hidden-import=PIL",
+    "--hidden-import=numpy",
+    "--hidden-import=selenium",
+    "--hidden-import=undetected_chromedriver",
+    "--hidden-import=yt_dlp",
+    "--hidden-import=pdf2image",
+    "--hidden-import=pyvirtualdisplay",
+    "--icon=app/static/favicon.ico",
+]
 
-PyInstaller.__main__.run(
-    [
-        "app/__init__.py",
-        "--name=Glimpser",
-        "--onefile",
-        "--windowed",
-        "--add-data=app/templates:templates",
-        "--add-data=app/static:static",
-        "--hidden-import=flask",
-        "--hidden-import=flask_apscheduler",
-        "--hidden-import=sqlalchemy",
-        "--hidden-import=werkzeug",
-        "--hidden-import=jinja2",
-        "--hidden-import=PIL",
-        "--hidden-import=numpy",
-        "--hidden-import=selenium",
-        "--hidden-import=undetected_chromedriver",
-        "--hidden-import=yt_dlp",
-        "--hidden-import=pdf2image",
-        "--hidden-import=pyvirtualdisplay",
-        "--icon=app/static/favicon.ico",
-    ]
-)
+
+def build() -> None:
+    """Invoke PyInstaller with macOS settings."""
+    os.chdir(Path(__file__).resolve().parent)
+    PyInstaller.__main__.run(ARGS)
+
+
+def main() -> None:
+    """Command-line entry point."""
+    build()
+
+
+if __name__ == "__main__":
+    main()

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Exit on error
-set -e
+# Exit on error and undefined variables, fail on pipeline errors
+set -euo pipefail
 
 # Function to check if a command exists
 command_exists() {

--- a/build_windows.py
+++ b/build_windows.py
@@ -1,33 +1,44 @@
-#!env/bin/python3
-#  build_windows.py
+#!/usr/bin/env python3
+"""Build the Windows executable using PyInstaller."""
 
 import os
+from pathlib import Path
 
 import PyInstaller.__main__
 
-# Ensure we're in the correct directory
-os.chdir(os.path.dirname(os.path.abspath(__file__)))
+ARGS = [
+    "app/__init__.py",  # Entry point of the application
+    "--name=Glimpser",  # Name of the executable
+    "--onefile",  # Create a one-file bundled executable
+    "--windowed",  # Disable console window
+    "--add-data=app/templates:templates",  # Include templates directory
+    "--add-data=app/static:static",  # Include static directory
+    "--hidden-import=flask",  # Include hidden import flask
+    "--hidden-import=flask_apscheduler",  # Include hidden import flask_apscheduler
+    "--hidden-import=sqlalchemy",  # Include hidden import sqlalchemy
+    "--hidden-import=werkzeug",  # Include hidden import werkzeug
+    "--hidden-import=jinja2",  # Include hidden import jinja2
+    "--hidden-import=PIL",  # Include hidden import PIL
+    "--hidden-import=numpy",  # Include hidden import numpy
+    "--hidden-import=selenium",  # Include hidden import selenium
+    "--hidden-import=undetected_chromedriver",  # Include hidden import undetected_chromedriver
+    "--hidden-import=yt_dlp",  # Include hidden import yt_dlp
+    "--hidden-import=pdf2image",  # Include hidden import pdf2image
+    "--hidden-import=pyvirtualdisplay",  # Include hidden import pyvirtualdisplay
+    "--icon=app/static/favicon.ico",  # Path to the icon file
+]
 
-PyInstaller.__main__.run(
-    [
-        "app/__init__.py",  # Entry point of the application
-        "--name=Glimpser",  # Name of the executable
-        "--onefile",  # Create a one-file bundled executable
-        "--windowed",  # Disable console window
-        "--add-data=app/templates:templates",  # Include templates directory
-        "--add-data=app/static:static",  # Include static directory
-        "--hidden-import=flask",  # Include hidden import flask
-        "--hidden-import=flask_apscheduler",  # Include hidden import flask_apscheduler
-        "--hidden-import=sqlalchemy",  # Include hidden import sqlalchemy
-        "--hidden-import=werkzeug",  # Include hidden import werkzeug
-        "--hidden-import=jinja2",  # Include hidden import jinja2
-        "--hidden-import=PIL",  # Include hidden import PIL
-        "--hidden-import=numpy",  # Include hidden import numpy
-        "--hidden-import=selenium",  # Include hidden import selenium
-        "--hidden-import=undetected_chromedriver",  # Include hidden import undetected_chromedriver
-        "--hidden-import=yt_dlp",  # Include hidden import yt_dlp
-        "--hidden-import=pdf2image",  # Include hidden import pdf2image
-        "--hidden-import=pyvirtualdisplay",  # Include hidden import pyvirtualdisplay
-        "--icon=app/static/favicon.ico",  # Path to the icon file
-    ]
-)
+
+def build() -> None:
+    """Invoke PyInstaller with Windows settings."""
+    os.chdir(Path(__file__).resolve().parent)
+    PyInstaller.__main__.run(ARGS)
+
+
+def main() -> None:
+    """Command-line entry point."""
+    build()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_scripts.py
+++ b/tests/test_build_scripts.py
@@ -1,0 +1,36 @@
+import subprocess
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+import build_macos
+import build_windows
+
+
+class TestBuildMacOS(TestCase):
+    @patch("build_macos.PyInstaller.__main__.run")
+    def test_build_invokes_pyinstaller(self, mock_run):
+        build_macos.build()
+        mock_run.assert_called_once()
+        args = mock_run.call_args.args[0]
+        self.assertIn("--name=Glimpser", args)
+
+
+class TestBuildWindows(TestCase):
+    @patch("build_windows.PyInstaller.__main__.run")
+    def test_build_invokes_pyinstaller(self, mock_run):
+        build_windows.build()
+        mock_run.assert_called_once()
+        args = mock_run.call_args.args[0]
+        self.assertIn("--name=Glimpser", args)
+
+
+def test_build_packages_missing_deps(tmp_path):
+    script = Path("build_packages.sh")
+    result = subprocess.run(
+        ["bash", "-c", f"PATH={tmp_path} ./{script.name}"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "dpkg-deb is not installed" in result.stdout


### PR DESCRIPTION
## Summary
- refactor build_macos.py and build_windows.py into callable modules
- harden build_packages.sh with safer bash options
- add unit tests for build scripts

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_build_scripts.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d861632788333a73327841e0c6252