### PR TITLE
Enable CI checks on staging branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/codeql_old.yml
+++ b/.github/workflows/codeql_old.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   schedule:
     - cron: '36 22 * * 3'
 

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -2,9 +2,9 @@ name: Dependency Scan (OWASP Dependency-Check)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   schedule:
     - cron: '0 6 * * 0'   # every Sunday 06:00 UTC
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@
 name: 'Dependency review'
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
 
 # If using a dependency submission action in this workflow this permission will need to be set to:
 #

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,7 +2,7 @@ name: Docs Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, staging ]
   pull_request:
 
 jobs:

--- a/.github/workflows/ethicalcheck.yml
+++ b/.github/workflows/ethicalcheck.yml
@@ -33,9 +33,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   # Customize trigger events based on your DevSecOps processes.
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   schedule:
     - cron: '16 18 * * 2'
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,9 +5,9 @@ name: Python application
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
 
 permissions:
   contents: read

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -2,11 +2,11 @@ name: Build Release Packages
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     tags:
       - "v*"
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -2,7 +2,7 @@ name: Tag Release
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "staging" ]
 
 jobs:
   tag_release:

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -1,6 +1,8 @@
 # Continuous Integration Checks
 
 Glimpser runs automated quality checks on every push and pull request.
+The workflows trigger when commits land on the `main` or `staging` branches
+and on pull requests targeting those branches.
 The workflow located at `.github/workflows/python-app.yml` performs the
 following tasks:
 


### PR DESCRIPTION
## Summary
- run all CI workflows on `staging` as well as `main`
- clarify docs that CI triggers on both branches

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d864d084883338425efe141d8c715