### PR TITLE
Improve captions prompt layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1451,14 +1451,20 @@ video.hover-video[data-timestamp]::after {
 
 .notes-textarea {
   width: 100%;
-  height: 60px;
   margin-top: 5px;
-  resize: vertical;
+  resize: none;
   background-color: var(--form-bg-color);
   color: var(--form-text-color);
   border: 1px solid var(--table-border-color);
   padding-right: 2rem;
   box-sizing: border-box;
+  max-height: 4rem;
+  overflow: hidden;
+  transition: max-height 0.2s ease;
+}
+
+.camera-row:hover .notes-textarea {
+  max-height: none;
 }
 
 .update-button {
@@ -1831,8 +1837,14 @@ body.advanced-enabled .advanced-only {
 
 .caption-box .last-caption {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
   white-space: pre-wrap;
+  max-height: 4rem;
+  transition: max-height 0.2s ease;
+}
+
+.camera-row:hover .caption-box .last-caption {
+  max-height: none;
 }
 
 .field-toggle {
@@ -1851,7 +1863,7 @@ body.advanced-enabled .advanced-only {
 .chat-box {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .chat-prompt,
@@ -1865,10 +1877,16 @@ body.advanced-enabled .advanced-only {
 
 .chat-response .last-caption {
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
   background-color: var(--form-bg-color);
   padding: 0.5rem;
   border-radius: 4px;
+  max-height: 4rem;
+  transition: max-height 0.2s ease;
+}
+
+.camera-row:hover .chat-response .last-caption {
+  max-height: none;
 }
 
 .chat-response .last-caption.ellipsis {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -116,7 +116,8 @@ template_controls %} {% block content %}
               <form id="form-{{ camera }}" class="notes-form caption-box">
                 <div class="chat-box">
                   <div class="chat-prompt">
-                    <label for="notes-{{ camera }}" class="sr-only">Prompt</label>
+                    <!-- prettier-ignore -->
+                    <label class="sr-only" for="notes-{{ camera }}">Prompt</label>
                     <textarea
                       id="notes-{{ camera }}"
                       class="notes-textarea"
@@ -143,7 +144,7 @@ template_controls %} {% block content %}
                     >
                     <div
                       id="last-caption-{{ camera }}"
-                      class="last-caption"
+                      class="last-caption ellipsis"
                       aria-labelledby="last-caption-label-{{ camera }}"
                     >
                       {{ template_details[camera]['last_caption'] }}


### PR DESCRIPTION
## Summary
- allow prompt textarea and response to expand on hover
- tighten spacing between prompts and responses
- mark last caption block ellipsis in captions template

## Testing
- `pre-commit run --files app/static/css/style.css app/templates/captions.html`
- `pytest -q` *(fails: grey patch color mismatch)*
- `npm test` *(fails: jsdom not implemented errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d874a122c8333af6ec6fe8f1c22ee