### PR TITLE
Improve onnxruntime fallback

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -189,7 +189,7 @@ Additional variables control AI behaviour and external tools:
 - `CLIP_MODEL_NAME` – CLIP model used for object filtering (default `openai/clip-vit-base-patch32`)
   Example: `openai/clip-vit-large-patch14`
   This setting is read-only until Advanced Options are enabled.
-- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. Non-macOS systems install `onnxruntime-gpu~=1.18` by default, while macOS falls back to the CPU-only `onnxruntime` package.
+- `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. Non-macOS systems install `onnxruntime-gpu~=1.18` and falls back to `onnxruntime~=1.18` when necessary. If neither package is available, object filtering is disabled.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/scripts/install_onnxruntime.py
+++ b/scripts/install_onnxruntime.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Install an appropriate onnxruntime package if available."""
+import platform
+import subprocess
+import sys
+
+
+def try_install(package: str) -> bool:
+    """Attempt to install a package and return True on success."""
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", package],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.returncode == 0
+
+
+def main() -> None:
+    # On non-mac platforms prefer the GPU build and fall back to CPU.
+    packages = ["onnxruntime-gpu~=1.18", "onnxruntime~=1.18"]
+    if platform.system() == "Darwin":
+        packages = ["onnxruntime~=1.18"]
+
+    for pkg in packages:
+        if try_install(pkg):
+            print(f"Installed {pkg}")
+            return
+    print("onnxruntime packages not available; object filtering will be disabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -6,5 +6,7 @@ pip install -r requirements.txt
 if [ -f requirements-dev.txt ]; then
     pip install -r requirements-dev.txt
 fi
+# Try installing onnxruntime packages with a fallback
+python scripts/install_onnxruntime.py || true
 npm install
 pre-commit install


### PR DESCRIPTION
## Summary
- attempt GPU install first and fall back to CPU-only onnxruntime
- run the fallback installer during environment setup
- document the install behaviour

## Testing
- `pre-commit run --files requirements.txt docs/configuration_guide.md scripts/setup_env.sh scripts/install_onnxruntime.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d8619e794833393dd7f1e2cc8bf27