### PR TITLE
Improve Danger Mode shortcut info

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -423,6 +423,7 @@ from app.utils.validators import (
 from scripts.update_chrome_shortcut import (
     LINUX_PATHS,
     first_shortcut_path,
+    shortcut_exec_line,
     shortcuts_need_patch,
     update_chrome_shortcuts_info,
 )
@@ -1604,6 +1605,7 @@ def init_routes(app: Flask) -> None:
                 "path": browser_path,
                 "version": (get_chrome_version(browser_path) if browser_path else None),
                 "shortcut": str(first_shortcut_path() or ""),
+                "exec_line": shortcut_exec_line(first_shortcut_path()) or "",
                 "patched": patched,
             }
         )
@@ -1757,6 +1759,7 @@ def init_routes(app: Flask) -> None:
             "path": chrome_path or "N/A",
             "version": (get_chrome_version(chrome_path) if chrome_path else "N/A"),
             "shortcut": str(first_shortcut_path() or "N/A"),
+            "exec_line": shortcut_exec_line(first_shortcut_path()) or "N/A",
             "patched": not shortcuts_need_patch(),
             "running": is_chrome_debug_port_open("127.0.0.1", 9222),
         }
@@ -3820,6 +3823,7 @@ def init_routes(app: Flask) -> None:
             "path": chrome_path or "N/A",
             "version": (get_chrome_version(chrome_path) if chrome_path else "N/A"),
             "shortcut": str(first_shortcut_path() or "N/A"),
+            "exec_line": shortcut_exec_line(first_shortcut_path()) or "N/A",
             "patched": not shortcuts_need_patch(),
             "running": is_chrome_debug_port_open("127.0.0.1", 9222),
         }

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -87,6 +87,7 @@
       running it, restart Chrome and open the browser with the profile you want
       Danger Mode to use.
     </p>
+    <p class="exec-line">Exec: {{ danger_info.exec_line }}</p>
     <form method="post">
       <label for="shortcut-path" class="sr-only">Chrome shortcut</label>
       <input

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -258,6 +258,7 @@ template_form %} {% block content %}
         <li>Path: {{ danger_info.path }}</li>
         <li>Version: {{ danger_info.version }}</li>
         <li>Shortcut: {{ danger_info.shortcut }}</li>
+        <li>Exec: {{ danger_info.exec_line }}</li>
         <li>
           Shortcut Patched:
           <span

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -19,6 +19,7 @@ After Chrome updates, shortcuts may revert to their original command line. Two a
 - **Manual update**: Edit the desktop shortcut each time Chrome updates.
 - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the _Update Chrome Shortcut_ button on the Settings page or the _Patch Chrome Shortcuts_ button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
 - **Dropdown selector**: The Danger page lets you choose a detected shortcut from a dropdown or enter a custom path before patching.
+- **Exec line display**: The Settings and Danger pages now show the current `Exec` line from the selected shortcut.
 - **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
 - **Default shortcut locations**: `%USERPROFILE%\Desktop`, `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs`. On Linux, try `/usr/share/applications/google-chrome.desktop` or `~/.local/share/applications/google-chrome.desktop`. The Settings page lists any writable shortcuts it discovers.
 

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -8,7 +8,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Admin** – buttons are organized into cards for a cleaner layout.
-- **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
+- **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. The exact `Exec` line is displayed so you can confirm the debugging flag is present. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Settings Reference** – expand the table to read explanations for each setting.
 - **Column Search** – click a header to filter rows by that column.

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -168,5 +168,26 @@ def first_shortcut_path() -> Path | None:
     return None
 
 
+def shortcut_exec_line(path: Path | None) -> str | None:
+    """Return the Exec command for the given shortcut."""
+    if path is None or not path.exists():
+        return None
+    if os.name == "nt" and win32com is not None and path.suffix.lower() == ".lnk":
+        shell = win32com.client.Dispatch("WScript.Shell")
+        sc = shell.CreateShortcut(str(path))
+        target = sc.TargetPath or ""
+        args = sc.Arguments or ""
+        cmd = f"{target} {args}".strip()
+        return cmd or None
+
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("Exec="):
+                return line[len("Exec=") :].strip()
+    except Exception:
+        return None
+    return None
+
+
 if __name__ == "__main__":  # pragma: no cover - manual usage
     sys.exit(0 if update_chrome_shortcuts() else 1)

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -21,12 +21,20 @@ class TestDangerStatusEndpoint(unittest.TestCase):
 
     @patch("app.routes.get_chrome_version", return_value=120)
     @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
+    @patch("app.routes.shortcut_exec_line", return_value="/usr/bin/chrome --flag")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=True)
     @patch("app.routes.check_user_activity", return_value=False)
     def test_danger_ready(
-        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+        self,
+        mock_idle,
+        mock_port,
+        mock_patch,
+        mock_path,
+        mock_exec,
+        mock_shortcut,
+        mock_ver,
     ):
         resp = self.client.get("/danger_status")
         self.assertEqual(resp.status_code, 200)
@@ -41,18 +49,27 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "path": "/usr/bin/chrome",
                 "version": 120,
                 "shortcut": "/tmp/Chrome.lnk",
+                "exec_line": "/usr/bin/chrome --flag",
                 "patched": True,
             },
         )
 
     @patch("app.routes.get_chrome_version", return_value=120)
     @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
+    @patch("app.routes.shortcut_exec_line", return_value="/usr/bin/chrome --flag")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=False)
     @patch("app.routes.check_user_activity", return_value=False)
     def test_danger_port_closed(
-        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+        self,
+        mock_idle,
+        mock_port,
+        mock_patch,
+        mock_path,
+        mock_exec,
+        mock_shortcut,
+        mock_ver,
     ):
         """Should report not ready when the debug port is closed."""
         resp = self.client.get("/danger_status")
@@ -68,18 +85,27 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "path": "/usr/bin/chrome",
                 "version": 120,
                 "shortcut": "/tmp/Chrome.lnk",
+                "exec_line": "/usr/bin/chrome --flag",
                 "patched": True,
             },
         )
 
     @patch("app.routes.get_chrome_version", return_value=120)
     @patch("app.routes.first_shortcut_path", return_value="/tmp/Chrome.lnk")
+    @patch("app.routes.shortcut_exec_line", return_value="/usr/bin/chrome --flag")
     @patch("app.routes.get_chrome_path", return_value="/usr/bin/chrome")
     @patch("app.routes.shortcuts_need_patch", return_value=False)
     @patch("app.routes.is_chrome_debug_port_open", return_value=True)
     @patch("app.routes.check_user_activity", return_value=True)
     def test_danger_user_active(
-        self, mock_idle, mock_port, mock_patch, mock_path, mock_shortcut, mock_ver
+        self,
+        mock_idle,
+        mock_port,
+        mock_patch,
+        mock_path,
+        mock_exec,
+        mock_shortcut,
+        mock_ver,
     ):
         """Should report not ready when user activity is detected."""
         resp = self.client.get("/danger_status")
@@ -95,6 +121,7 @@ class TestDangerStatusEndpoint(unittest.TestCase):
                 "path": "/usr/bin/chrome",
                 "version": 120,
                 "shortcut": "/tmp/Chrome.lnk",
+                "exec_line": "/usr/bin/chrome --flag",
                 "patched": True,
             },
         )

--- a/tests/test_shortcut_exec_line.py
+++ b/tests/test_shortcut_exec_line.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from scripts import update_chrome_shortcut
+
+
+class TestShortcutExecLine(unittest.TestCase):
+    def test_linux_exec_line(self):
+        tmp = Path("/tmp/test.desktop")
+        tmp.write_text("Exec=/usr/bin/chrome --flag\n", encoding="utf-8")
+        line = update_chrome_shortcut.shortcut_exec_line(tmp)
+        self.assertEqual(line, "/usr/bin/chrome --flag")
+        tmp.unlink()
+
+    def test_windows_exec_line(self):
+        stub = SimpleNamespace(
+            client=SimpleNamespace(
+                Dispatch=lambda *_: SimpleNamespace(
+                    CreateShortcut=lambda *_: SimpleNamespace(
+                        TargetPath="chrome.exe", Arguments="--port"
+                    )
+                )
+            )
+        )
+        path = Path("Chrome.lnk")
+        path.touch()
+        with (
+            patch.object(update_chrome_shortcut, "os", SimpleNamespace(name="nt")),
+            patch.object(update_chrome_shortcut, "win32com", stub),
+        ):
+            line = update_chrome_shortcut.shortcut_exec_line(path)
+        self.assertEqual(line, "chrome.exe --port")
+        path.unlink()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- show full Exec line for Danger Mode shortcuts
- expose exec line via `/danger_status` and on both Danger page and Settings page
- document the new display in Danger Mode docs
- add shortcut exec-line parser and tests

## Testing
- `pre-commit run --files scripts/update_chrome_shortcut.py app/routes.py app/templates/settings.html app/templates/danger.html docs/danger_mode.md docs/settings_page.md tests/test_danger_status_endpoint.py tests/test_shortcut_exec_line.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8cd23e1883339e72510cc1784322