### PR TITLE
Fix pre-commit step in workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Type check with mypy
       run: mypy .
     - name: Install pre-commit hooks
-        pre-commit install-hooks
+      run: pre-commit install-hooks
     - name: Run pre-commit
       run: pre-commit run --all-files
     - name: Test with coverage


### PR DESCRIPTION
## Summary
- fix `Install pre-commit hooks` step in `python-app` workflow so it runs

## Testing
- `pre-commit run --files .github/workflows/python-app.yml`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db520923c8333bc6a4933563a33e4