### PR TITLE
Add prompt audit feature

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3536,6 +3536,14 @@ def init_routes(app: Flask) -> None:
         prompt = prompt_optimizer.generate_prompt(template_name)
         return jsonify({"prompt": prompt})
 
+    @app.route("/audit_prompts", methods=["POST"])
+    @login_required
+    def audit_prompts_route():
+        """Return suggested improvements for all caption prompts."""
+
+        suggestions = prompt_optimizer.audit_prompts()
+        return jsonify(suggestions)
+
     @app.route("/suggest_fix/<string:template_name>", methods=["POST"])
     @login_required
     def suggest_fix_route(template_name: TemplateName):

--- a/app/static/js/captions.js
+++ b/app/static/js/captions.js
@@ -230,6 +230,17 @@ export function initCaptions() {
       window.dispatchEvent(new CustomEvent("showChyron", { detail: latest }));
     }
 
+    document
+      .getElementById("audit-prompts-btn")
+      ?.addEventListener("click", async () => {
+        const resp = await fetch("/audit_prompts", { method: "POST" });
+        const data = await resp.json();
+        Object.entries(data).forEach(([name, prompt]) => {
+          const el = document.getElementById(`notes-${name}`);
+          if (el) el.value = prompt;
+        });
+      });
+
     setupLiveHistoryUpdates();
   };
   if (document.readyState === "loading") {

--- a/app/templates/captions.html
+++ b/app/templates/captions.html
@@ -272,6 +272,14 @@ template_controls %} {% block content %}
             Upload TSV
           </button>
         </form>
+        <button
+          id="audit-prompts-btn"
+          class="btn btn-secondary"
+          type="button"
+          title="Suggest better prompts"
+        >
+          Audit Prompts
+        </button>
       </div>
       <p class="tsv-help">
         Download the TSV file, edit in a spreadsheet application, then upload to

--- a/app/utils/prompt_optimizer.py
+++ b/app/utils/prompt_optimizer.py
@@ -3,10 +3,11 @@
 import os
 
 import app.utils.image_processing as img_proc
-from app.config import CHATGPT_KEY, SCREENSHOT_DIRECTORY
+from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, SCREENSHOT_DIRECTORY
+from app.utils.llm import ask_question
 
 from .image_processing import ChatGPTImageComparison
-from .template_manager import get_screenshots_for_template
+from .template_manager import get_screenshots_for_template, get_templates
 
 
 def generate_prompt(template_name: str, num_images: int = 3) -> str:
@@ -43,3 +44,27 @@ def generate_prompt(template_name: str, num_images: int = 3) -> str:
         img_proc.LLM_CAPTION_PROMPT = original_prompt
 
     return result or ""
+
+
+def audit_prompts() -> dict[str, str]:
+    """Return improved prompts for all templates using ChatGPT."""
+
+    if not CHATGPT_KEY:
+        return {}
+
+    templates = get_templates()
+    suggestions: dict[str, str] = {}
+    for name, details in templates.items():
+        note = details.get("notes", "").strip()
+        if not note:
+            continue
+        question = (
+            "Glimpser captions images using this core prompt: "
+            f"{LLM_CAPTION_PROMPT}.\n"
+            f"Current prompt for {name!r}: {note}\n"
+            "Rewrite it more concisely. Return only the new text."
+        )
+        response = ask_question(question)
+        if response:
+            suggestions[name] = response.strip()
+    return suggestions

--- a/docs/prompt_audit.md
+++ b/docs/prompt_audit.md
@@ -1,0 +1,3 @@
+# Prompt Audit
+
+The **Prompt Audit** tool reviews each custom caption prompt and requests improvements from ChatGPT. Open the Captions page and switch to the **Bulk Tools** tab. Click **Audit Prompts** to fetch suggestions. Textareas update automatically so you can review the proposed wording before saving.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Live View Scrubbing: live_scrub.md
       - Clip Navigation: clip_navigation.md
       - LLM Prompt Settings: llm_prompts.md
+      - Prompt Audit: prompt_audit.md
       - MCP Integration: mcp_integration.md
       - In-App Onboarding: onboarding.md
       - OpenSSF Scorecard: scorecard.md

--- a/tests/test_audit_prompts_route.py
+++ b/tests/test_audit_prompts_route.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.routes import init_routes
+
+
+class TestAuditPromptsRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.prompt_optimizer.audit_prompts")
+    def test_audit_prompts(self, mock_audit):
+        mock_audit.return_value = {"cam1": "Better"}
+        resp = self.client.post("/audit_prompts")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"cam1": "Better"})
+        mock_audit.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -54,6 +54,37 @@ class TestPromptOptimizer(unittest.TestCase):
         self.assertEqual(img_proc.LLM_CAPTION_PROMPT, original)
         mock_compare.assert_not_called()
 
+    @patch("app.utils.prompt_optimizer.ask_question", return_value="Better")
+    @patch("app.utils.prompt_optimizer.get_templates")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "k")
+    def test_audit_prompts(self, mock_get, mock_ask):
+        mock_get.return_value = {"cam1": {"notes": "old"}}
+
+        result = prompt_optimizer.audit_prompts()
+
+        self.assertEqual(result, {"cam1": "Better"})
+        mock_ask.assert_called_once()
+
+    @patch("app.utils.prompt_optimizer.ask_question")
+    @patch("app.utils.prompt_optimizer.get_templates")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "")
+    def test_audit_prompts_no_key(self, mock_get, mock_ask):
+        result = prompt_optimizer.audit_prompts()
+
+        self.assertEqual(result, {})
+        mock_ask.assert_not_called()
+
+    @patch("app.utils.prompt_optimizer.ask_question")
+    @patch("app.utils.prompt_optimizer.get_templates")
+    @patch("app.utils.prompt_optimizer.CHATGPT_KEY", "k")
+    def test_audit_prompts_no_notes(self, mock_get, mock_ask):
+        mock_get.return_value = {"cam1": {"notes": ""}}
+
+        result = prompt_optimizer.audit_prompts()
+
+        self.assertEqual(result, {})
+        mock_ask.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `audit_prompts` helper
- expose new route `/audit_prompts`
- wire up button on Captions page
- document Prompt Audit
- test prompt audit utilities and route

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test` *(fails: Test Suites 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ddac2c4188333a3b780e5ce77ea41