### PR TITLE
Improve summary prompt with camera cues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -295,7 +295,16 @@ if LLM_MODEL_VERSION not in ALLOWED_LLM_MODELS:
 # note that $datetime is a special keyword that will be replaced with the datetime in iso Z format
 LLM_SUMMARY_PROMPT = get_setting(
     "LLM_SUMMARY_PROMPT",
-    "Return one single line of plain text—no line breaks, numbers, or bullet lists—beginning with a brief greeting plus today’s date, local time, and Chicago temperature, then densely packed clauses separated by “ | ”, each clause giving grouped insights, forecasts, and local take-aways drawn from the logs and any provided history; mark critical items with ⚠️, routine-but-watchworthy items with ℹ️ (info symbol), and resolved items with ✔️; weave a coherent bigger story rather than camera-by-camera notes, avoid repetition, drop boiler-plate, use precise technical language, and include uncommon insights or likely next events whenever possible; if nothing is noteworthy output exactly “All systems nominal — no actionable items.” The time is $datetime UTC.",
+    (
+        "Craft about sixty short lines for a five‑minute narration. "
+        "Prefix each line with the camera name in brackets, such as [cam1]. "
+        "Include standalone [pause] markers where brief silence should fill the "
+        "timeline. Speak in a warm, conversational tone that weaves the latest "
+        "events into a story. Avoid repetition and boiler‑plate. Mark urgent "
+        "items with ⚠️ and successes with ✔️. If nothing is noteworthy output "
+        "exactly 'All systems nominal — no actionable items.' The time is "
+        "$datetime UTC."
+    ),
     # "Below are caption logs from multiple live sources. Produce a 10-line technical digest for a highly educated Chicago-area listener who glances for <30 s. Format: line 0 → greeting + date/time + current temperature + one-sentence “big picture”; lines 1-9 → plain-text bullets of ≤90 chars each, no timestamps, each tagged with ⚠️ for immediate action, ℹ️ for watch/interesting, ✔️ for resolved/nominal. Group related items logically; emphasise local (Chicago/Lincolnwood/Kenosha), include concrete facts (counts, magnitudes, street names, runways, K-index, etc.), omit boiler-plate and repeated info unless it’s a new alert. Tie items into a bigger narrative (weather → transit → power → cosmic events) rather than a camera list. If nothing merits mention, output exactly “All systems nominal — no actionable items.” The time is $datetime UTC.",
     # "Summarize the following logs into a concise, technical transcript. Focus on providing clear, actionable insights and key takeaways. Keep the summary brief and organized, with one line per segment, separated by newlines. Start with a brief overview, including any major events or trends. Prioritize clarity and relevance, ensuring the summary is easy to understand and useful for decision-making. Avoid repetition unless necessary. Conclude with a brief summary or closing note. The time is $datetime.",
 )

--- a/docs/llm_prompts.md
+++ b/docs/llm_prompts.md
@@ -21,6 +21,11 @@ Mark critical items with ⚠️ and resolved items with ✔️.
 The time is \$datetime UTC."
 ```
 
+The default prompt now aims for a five‑minute narration. It instructs the model
+to write around sixty short lines, each starting with the camera name in square
+brackets such as `[cam1]`. Stand‑alone `[pause]` lines mark brief silences so
+the output works as a caption script when paired with video clips.
+
 ## LLM_CAPTION_PROMPT
 
 `LLM_CAPTION_PROMPT` controls how image captions are generated. It requests a short headline and a brief explanation, replying with `UNREADABLE` if the frame lacks useful detail.


### PR DESCRIPTION
## Summary
- teach the LLM summary prompt to include camera cues and pauses
- document how the prompt now outputs `[cam1]` tags and `[pause]` markers for a five‑minute script

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd95105b083339aeae5fc55b7e6ec