### PR TITLE
Add mypy to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,12 @@ repos:
 
   - repo: local
     hooks:
-      # 4️⃣  mypy is expensive – run it only when you push (or manually)
+      # 4️⃣  Run mypy on changed files
       - id: mypy
-        name: mypy (push only)
-        entry: mypy --config-file=mypy.ini
+        name: mypy
+        entry: mypy --config-file pyproject.toml
         language: system
         types: [python]
-        stages: [pre-push]
 
   # ─── JAVASCRIPT / CSS ──────────────────────────────────────────────────────────
   - repo: local


### PR DESCRIPTION
## Summary
- enable mypy in `.pre-commit-config.yaml` so it runs like other Python checks

## Testing
- `pre-commit run --all-files` *(fails: mypy reports 240 errors)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1db3a61883338e7b314a166b3ed8