### PR TITLE
Disable mypy in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,6 +19,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.13"]
+    env:
+      ENABLE_MYPY: 'false'
 
     steps:
     - uses: actions/checkout@v4
@@ -72,6 +74,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Type check with mypy
+      if: env.ENABLE_MYPY == 'true'
       run: mypy .
     - name: Install pre-commit hooks
       run: pre-commit install-hooks


### PR DESCRIPTION
## Summary
- add `ENABLE_MYPY` environment variable to GitHub workflow
- gate `mypy` step on the variable so it's easy to re-enable later

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e25f7be98833397b7c307b553a2c0