### PR TITLE
Fix CI by removing obsolete pytest option

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -75,7 +75,7 @@ jobs:
       run: mypy .
     - name: Test with coverage
       run: |
-        python -m coverage run -m pytest -p no:helpconfig --color=yes
+        python -m coverage run -m pytest --color=yes
         python -m coverage xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- remove unsupported helpconfig plugin disable flag from workflow

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e287f34388333860da22d85676426