### PR TITLE
Fix flake8 spacing in fuzz test

### DIFF
--- a/tests/test_fuzz_update_summary.py
+++ b/tests/test_fuzz_update_summary.py
@@ -65,7 +65,7 @@ class TestFuzzUpdateSummary(unittest.TestCase):
             "groups": ",".join(
                 random.choices(string.ascii_lowercase, k=random.randint(1, 5))
             ),
-            "last_caption_time": f"2023-{random.randint(1,12):02d}-{random.randint(1,28):02d} {random.randint(0,23):02d}:{random.randint(0,59):02d}:{random.randint(0,59):02d}",
+            "last_caption_time": f"2023-{random.randint(1, 12):02d}-{random.randint(1, 28):02d} {random.randint(0, 23):02d}:{random.randint(0, 59):02d}:{random.randint(0, 59):02d}",
             "notes": "".join(
                 random.choices(
                     string.ascii_letters + string.digits + string.punctuation + " ",


### PR DESCRIPTION
## Summary
- fix random randint spacing in `test_fuzz_update_summary`

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_fuzz_update_summary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684e2b5c75b083338e0b7f3866455b4c