### PR TITLE
Fix build by guarding telemetry fetch

### DIFF
--- a/app/static/js/telemetry.js
+++ b/app/static/js/telemetry.js
@@ -1,12 +1,10 @@
 export function sendTelemetry(event, data = {}) {
-  const result =
-    typeof fetch === "function"
-      ? fetch("/telemetry", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ event, data }),
-        })
-      : null;
+  if (typeof fetch !== "function") return;
+  const result = fetch("/telemetry", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event, data }),
+  });
   if (result && typeof result.catch === "function") {
     result.catch(() => {});
   }


### PR DESCRIPTION
## Summary
- guard `sendTelemetry` against missing `fetch`

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_684e3a478dc08333b5f9fd8afdd6a86b