### PR TITLE
Fix default all camera view

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -8,8 +8,16 @@ export function initTilePlayer() {
   const camSelect =
     document.getElementById("camera-selector") ||
     document.getElementById("nav-camera-dropdown");
-  let current =
-    camSelect?.value || Object.keys(window.templateDetails || {})[0];
+
+  // Ensure the synthetic "All" group exists so playback can default
+  // to cycling through every camera when no specific selection is made.
+  if (!window.templateDetails["All"]) {
+    window.templateDetails["All"] = {
+      groupCameras: Object.keys(window.templateDetails || {}),
+    };
+  }
+
+  let current = camSelect && camSelect.value ? camSelect.value : "All";
 
   let abortCtl;
   let liveTimer;

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -14,10 +14,10 @@ beforeAll(async () => {
   changeGroup = mod.changeGroup;
 });
 
-test("loads first camera as mjpeg", () => {
+test("defaults to all cameras", () => {
   init();
   const img = document.getElementById("live-image");
-  expect(img.src).toMatch(/\/fast_stream\.mjpg\?camera=cam1&time=\d+$/);
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
 });
 
 test("no clip fetch occurs", async () => {


### PR DESCRIPTION
## Summary
- default to rotating all cameras in live view
- update tile_player tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ea69123488333a756fa7a11d3f9f0