### PR TITLE
Improve camera URL retest UX

### DIFF
--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -27,13 +27,21 @@ export function initUrlTester() {
     };
 
     let controller;
+    const debounce = (fn, delay) => {
+      let timer;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), delay);
+      };
+    };
     const defaultSrc = preview
       ? preview.dataset.placeholder || preview.src
       : "";
     const defaultUrl = input.dataset.defaultUrl;
-    const setStatus = (cls) => {
+    const setStatus = (cls, title = "") => {
       status.textContent = "";
       status.className = "url-status" + (cls ? ` ${cls}` : "");
+      status.title = title || "URL test result";
     };
 
     const check = async () => {
@@ -44,7 +52,7 @@ export function initUrlTester() {
       if (!url) return;
       controller?.abort();
       controller = new AbortController();
-      setStatus("pending");
+      setStatus("pending", "Testing...");
       try {
         const res = await fetch(
           `/templates/test_url?url=${encodeURIComponent(url)}`,
@@ -54,20 +62,25 @@ export function initUrlTester() {
         );
         const data = await res.json();
         if (res.ok && data.ok) {
-          setStatus("ok");
+          setStatus("ok", "URL reachable");
           if (submit) submit.disabled = false;
         } else {
-          setStatus("bad");
+          const msg = data.status
+            ? `HTTP ${data.status}`
+            : data.error || "Unreachable";
+          setStatus("bad", msg);
           if (submit) submit.disabled = true;
         }
         sendTelemetry("url_test", { url, ok: data.ok });
       } catch {
         if (controller.signal.aborted) return;
-        setStatus("bad");
+        setStatus("bad", "Unreachable");
         if (submit) submit.disabled = true;
         sendTelemetry("url_test", { url, ok: false });
       }
     };
+
+    const checkDebounced = debounce(check, 500);
 
     toggleDisabled();
 
@@ -81,12 +94,15 @@ export function initUrlTester() {
 
     input.addEventListener("input", () => {
       toggleDisabled();
-      setStatus(input.value.trim() ? "pending" : "");
+      const hasValue = input.value.trim() !== "";
+      setStatus(hasValue ? "pending" : "", hasValue ? "Testing..." : "");
       if (submit) submit.disabled = true;
+      if (hasValue) checkDebounced();
     });
     input.addEventListener("paste", () => {
       setTimeout(() => {
-        check();
+        setStatus("pending", "Testing...");
+        checkDebounced();
       }, 0);
     });
     input.addEventListener("blur", check);

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -21,23 +21,19 @@ beforeAll(async () => {
 
 describe("url_test", () => {
   test("shows status after fetch", async () => {
-    const responses = [
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ ok: true }),
-      }),
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ status: "ok" }),
-      }),
-    ];
-    global.fetch = jest.fn(() => responses.shift());
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    global.fetch = jest.fn(() => res);
     initUrlTester();
     document.dispatchEvent(new Event("DOMContentLoaded"));
     jest.clearAllTimers();
     const input = document.getElementById("url");
     input.value = "http://example.com";
-    input.dispatchEvent(new Event("change"));
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
     jest.runAllTimers();
     await Promise.resolve();
     await Promise.resolve();
@@ -82,5 +78,27 @@ describe("url_test", () => {
     const input = document.getElementById("url");
     expect(input.value).toBe("http://example.com/test");
     expect(fetch).toHaveBeenCalled();
+  });
+
+  test("shows tooltip on error", async () => {
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: false, status: 404 }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.clearAllTimers();
+    const input = document.getElementById("url");
+    const status = document.getElementById("url-status");
+    input.value = "http://bad";
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(status.classList.contains("bad")).toBe(true);
+    expect(status.title).toBe("HTTP 404");
   });
 });


### PR DESCRIPTION
## Summary
- retest camera URL on each keystroke
- disable submit until URL passes
- show HTTP errors in tooltip
- test url_test.js for new behavior

## Testing
- `pre-commit run --files app/static/js/url_test.js tests/js/url_test.test.js`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ea6fc5dc88333b31fb8ae1fdfd7b7