### PR TITLE
Fix CI by installing Pillow for tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ pip-audit>=2.7
 setuptools>=78.1.1
 types-python-dateutil>=2.9
 types-requests>=2.31
+Pillow==11.2.1


### PR DESCRIPTION
## Summary
- revert optional import fallbacks
- include Pillow in requirements-dev

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eabaf4adc8333bcfde08b20fd1e2c