### PR TITLE
Fix pytest picking up packaging files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ output.txt
 # Node artifacts
 node_modules/
 package-lock.json
+
+# Packaging artifacts
+debian/glimpser/

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,10 @@ All tests run with `pytest-socket` active, preventing any outbound network
 requests. If a scenario truly requires network access call
 `pytest_socket.enable_socket()` within that test.
 
+Pytest ignores the Debian packaging directory. Running `build_packages.sh`
+creates a copy of the app under `debian/glimpser`, but `norecursedirs`
+prevents those files from being collected as tests.
+
 ## End-to-End Tests
 
 The `tests/test_e2e_web.py` module contains browser-based scenarios powered by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ required-version = "25.1.0"
 python_version = "3.11"
 ignore_missing_imports = true
 check_untyped_defs = true
+
+[tool.pytest.ini_options]
+norecursedirs = ["debian"]


### PR DESCRIPTION
## Summary
- ignore `debian/glimpser` in `.gitignore`
- exclude Debian packaging directory from pytest discovery
- document the exclusion in testing guide

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eb64a70d083339560144e03a9bc5c