### PR TITLE
Implement build env var to skip DB init

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
 
+_SKIP_DB_INIT = os.getenv("GLIMPSER_SKIP_DB_INIT") == "1"
+
 _DOTENV_LOADED = False
 
 
@@ -96,7 +98,29 @@ def _get_session():
     callable is used.  Otherwise the engine and sessionmaker are created on
     first use and cached so repeated imports don't create multiple engines.
     """
+
     global _engine, SessionLocal
+
+    if _SKIP_DB_INIT:
+
+        class _DummyResult:
+            def fetchone(self):
+                return None
+
+            def fetchall(self):
+                return []
+
+        class _DummySession:
+            def execute(self, *args, **kwargs):
+                return _DummyResult()
+
+            def commit(self):
+                pass
+
+            def close(self):
+                pass
+
+        return _DummySession()
 
     if SessionLocal is not None:
         return SessionLocal()

--- a/build_windows.py
+++ b/build_windows.py
@@ -25,14 +25,24 @@ ARGS = [
     "--hidden-import=yt_dlp",  # Include hidden import yt_dlp
     "--hidden-import=pdf2image",  # Include hidden import pdf2image
     "--hidden-import=pyvirtualdisplay",  # Include hidden import pyvirtualdisplay
+    "--exclude-module=urllib3.contrib.emscripten",  # Skip optional module
+    "--exclude-module=curl_cffi",  # Skip optional module
     "--icon=app/static/favicon.ico",  # Path to the icon file
 ]
 
 
 def build() -> None:
     """Invoke PyInstaller with Windows settings."""
+    prev = os.environ.get("GLIMPSER_SKIP_DB_INIT")
+    os.environ["GLIMPSER_SKIP_DB_INIT"] = "1"
     os.chdir(Path(__file__).resolve().parent)
-    PyInstaller.__main__.run(ARGS)
+    try:
+        PyInstaller.__main__.run(ARGS)
+    finally:
+        if prev is None:
+            os.environ.pop("GLIMPSER_SKIP_DB_INIT", None)
+        else:
+            os.environ["GLIMPSER_SKIP_DB_INIT"] = prev
 
 
 def main() -> None:

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -7,6 +7,7 @@ The process is split across multiple runners:
   script now uses `rsync` to copy directories so unchanged files are skipped,
   speeding up repeated builds.
 - **Windows** builds the standalone executable using `build_windows.py`.
+- The build sets `GLIMPSER_SKIP_DB_INIT=1` to prevent database access during analysis.
 - **macOS** builds a self-contained application with `build_macos.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists


### PR DESCRIPTION
## Summary
- avoid database initialization during PyInstaller runs
- exclude optional modules from Windows build
- document GLIMPSER_SKIP_DB_INIT usage in release workflow

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebcbb57c083338ca32484d1380a05