### PR TITLE
Bump version to v0.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ output.txt
 # Node artifacts
 node_modules/
 package-lock.json
+
+# Packaging artifacts
+debian/glimpser/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build details are hidden on small screens to avoid clutter.
 - Sanitized log messages in the UI to prevent XSS vulnerabilities
 
+## [0.2.8] - 2025-06-03
+
+### Changed
+
+- Bumped package version in setup.py to 0.2.8.
+
 ## [0.2.7] - 2025-06-02
 
 ### Changed
@@ -134,7 +140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appears blank.
 - Fixed timezone handling so feed status timestamps no longer show "in the future".
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.8
 [0.2.7]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.7
 [0.2.6]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.6
 [0.2.5]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
   - family-names: Kubicki
     given-names: Kristopher
 title: Glimpser
-version: "0.2.7"
-date-released: 2024-08-07
+version: "0.2.8"
+date-released: 2025-06-03
 url: https://github.com/KristopherKubicki/glimpser
 repository-code: https://github.com/KristopherKubicki/glimpser
 license: MIT

--- a/app/config.py
+++ b/app/config.py
@@ -233,7 +233,7 @@ TZ = get_setting("TZ", "UTC")
 try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
-    _PKG_VERSION = "0.2.7"
+    _PKG_VERSION = "0.2.8"
 sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -10,7 +10,7 @@ The process is split across multiple runners:
 - **macOS** builds a self-contained application with `build_macos.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists
-status badges for the current tag.  This file becomes the body of the GitHub
+status badges for the current tag. This file becomes the body of the GitHub
 release so that each tagged version shows the latest CI status.
 
 Both artifacts are attached to the GitHub release created for the tag. When the
@@ -18,8 +18,8 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 PyPI.
 
 Tags are normally created automatically when the version in `setup.py` is bumped
-on the `main` branch.  The `Tag Release` workflow runs
-`scripts/auto_tag_release.py` to create a tag like `v0.2.7` and push it to
+on the `main` branch. The `Tag Release` workflow runs
+`scripts/auto_tag_release.py` to create a tag like `v0.2.8` and push it to
 GitHub, which then triggers the build jobs above.
 
 Since the tag is pushed by a workflow, the job must grant `workflow: write`
@@ -28,8 +28,8 @@ permissions so that the subsequent release workflow is triggered.
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.7
-git push origin v0.2.7
+git tag v0.2.8
+git push origin v0.2.8
 ```
 
 Alternatively, run `scripts/auto_tag_release.py` to create and push the tag

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,10 @@ All tests run with `pytest-socket` active, preventing any outbound network
 requests. If a scenario truly requires network access call
 `pytest_socket.enable_socket()` within that test.
 
+Pytest ignores the Debian packaging directory. Running `build_packages.sh`
+creates a copy of the app under `debian/glimpser`, but `norecursedirs`
+prevents those files from being collected as tests.
+
 ## End-to-End Tests
 
 The `tests/test_e2e_web.py` module contains browser-based scenarios powered by

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glimpser",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "type": "module",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,6 @@ required-version = "25.1.0"
 python_version = "3.11"
 ignore_missing_imports = true
 check_untyped_defs = true
+
+[tool.pytest.ini_options]
+norecursedirs = ["debian"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="glimpser",
-    version="0.2.7",
+    version="0.2.8",
     author="Kristopher Kubicki",
     author_email="kristopher@glimpser.net",
     description="A real-time monitoring application for capturing and analyzing live data from various sources",


### PR DESCRIPTION
## Summary
- bump project version to v0.2.8
- update docs for release tag workflow
- note new version in the changelog

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed371cbb08333b484235de003a9a9