### PR TITLE
Add ruff to lint pipeline

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -23,13 +23,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-socket
+          pip install flake8 ruff pytest pytest-socket
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Lint with ruff
+        run: ruff check --exit-zero .
       - name: Test with pytest
         run: |
           pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff check --exit-zero .
+        language: system
+        types: [python]
+
+  - repo: local
+    hooks:
       # 4️⃣  mypy is expensive – run it only when you push (or manually)
       - id: mypy
         name: mypy (push only)

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ format:
 	prettier --write app/static/js/**/*.js app/static/css/**/*.css
 
 lint:
-	flake8
-	eslint 'app/static/js/**/*.js'
+        flake8
+        ruff check --exit-zero .
+        eslint 'app/static/js/**/*.js'
 
 test:
 	pytest

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ From [Developer Guide](docs/developer_guide.md):
 2. Verify hooks and run linters:
    ```sh
    pre-commit run --all-files
+   ruff check --exit-zero .
    flake8
    ```
 3. Execute the test suites:

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -6,7 +6,7 @@ and on pull requests targeting those branches.
 The workflow located at `.github/workflows/python-app.yml` performs the
 following tasks:
 
-- Formats Python code with `black`, sorts imports with `isort`, and lints with `flake8`.
+- Formats Python code with `black`, sorts imports with `isort`, and lints with `ruff` and `flake8`.
 - Checks type hints with `mypy`.
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites and uploads coverage.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -6,6 +6,7 @@ This guide provides tips for extending Glimpser, running tests, and contributing
 
 1. Clone the repository and create a virtual environment:
    ```sh
+ruff check --exit-zero .
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    python -m venv env
@@ -49,9 +50,10 @@ to the web interface.
 
 ## Running Tests
 
-The project uses `pytest` for testing and `flake8` for linting. After activating your environment, run:
+The project uses `pytest` for testing and lints Python with `ruff` and `flake8`. After activating your environment, run:
 
 ```sh
+ruff check --exit-zero .
 flake8
 pytest
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,9 +9,10 @@ python -m coverage html
 
 The HTML report will be generated in `htmlcov/index.html`.
 
-Before submitting a patch, lint the code with `flake8`:
+Before submitting a patch, lint the code with `ruff` and `flake8`:
 
 ```sh
+ruff check --exit-zero .
 flake8
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,19 @@ line-length = 88
 target-version = ["py311"]
 required-version = "25.1.0"
 
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "env",
+    ".venv",
+]
+
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Additional developer dependencies
 pre-commit>=3.6
 flake8>=7.2
+ruff>=0.4
 black>=25.1
 # --- static-typing toolchain ---
 mypy==1.16.*          # latest stable, 29 May 2025


### PR DESCRIPTION
## Summary
- enable ruff linting and configure it
- include ruff in pre-commit, Makefile and workflows
- document ruff usage in docs and README

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685063561f90833385368a482cc03e5a