### PR TITLE
Add pytest-socket to dev setup

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,9 @@ All tests run with `pytest-socket` active, preventing any outbound network
 requests. If a scenario truly requires network access call
 `pytest_socket.enable_socket()` within that test.
 
+Even the optional end-to-end tests run with sockets disabled unless they
+explicitly enable them.
+
 Pytest ignores the Debian packaging directory. Running `build_packages.sh`
 creates a copy of the app under `debian/glimpser`, but `norecursedirs`
 prevents those files from being collected as tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,4 +107,5 @@ dev = [
     "pyinstaller>=6.6",
     "pylint>=3.1",
     "pytest>=8.3,<8.5",
+    "pytest-socket>=0.7",
 ]


### PR DESCRIPTION
## Summary
- ensure pytest-socket is part of the dev dependency group
- note that even e2e tests run with the socket blocked

## Testing
- `pre-commit run --all-files` *(fails: detect-secrets not installed)*
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: pytest_socket)*

------
https://chatgpt.com/codex/tasks/task_e_6850a837f7608333a7008a1945083fcf