### PR TITLE
Fix release tagging workflow

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -20,8 +20,8 @@ jobs:
         id: detect
         run: |
           git fetch --tags
-          NEW_VERSION=$(grep -oP '(?<=version=")[^"]+' setup.py)
-          OLD_VERSION=$(git show ${{ github.event.before }}:setup.py 2>/dev/null | grep -oP '(?<=version=")[^"]+' || echo "")
+          NEW_VERSION=$(grep -oP '(?<=^version = ")[^"]+' pyproject.toml)
+          OLD_VERSION=$(git show ${{ github.event.before }}:pyproject.toml 2>/dev/null | grep -oP '(?<=^version = ")[^"]+' || echo "")
           echo "old=$OLD_VERSION" >> "$GITHUB_OUTPUT"
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped package version in setup.py to 0.2.7.
+- Bumped package version in pyproject.toml to 0.2.7.
 
 ## [0.2.6] - 2025-06-01
 

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -18,7 +18,7 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 `PYPI_API_TOKEN` secret is available, Python distributions are also published to
 PyPI.
 
-Tags are normally created automatically when the version in `setup.py` is bumped
+Tags are normally created automatically when the version in `pyproject.toml` is bumped
 on the `main` branch.  The `Tag Release` workflow runs
 `scripts/auto_tag_release.py` to create a tag like `v0.2.7` and push it to
 GitHub, which then triggers the build jobs above.

--- a/scripts/auto_tag_release.py
+++ b/scripts/auto_tag_release.py
@@ -1,15 +1,19 @@
+import re
 import subprocess
 import sys
 from pathlib import Path
 
-VERSION_FILE = Path("setup.py")
+VERSION_FILE = Path("pyproject.toml")
 
 
-def get_version():
-    for line in VERSION_FILE.read_text().splitlines():
-        if "version=" in line:
-            return line.split('"')[1]
-    raise RuntimeError("Version not found in setup.py")
+def get_version() -> str:
+    """Return the version string from pyproject.toml."""
+
+    content = VERSION_FILE.read_text()
+    match = re.search(r'^version = "(?P<ver>[^"]+)"', content, flags=re.MULTILINE)
+    if not match:
+        raise RuntimeError("Version not found in pyproject.toml")
+    return match.group("ver")
 
 
 def tag_exists(tag):

--- a/tests/test_auto_tag_release.py
+++ b/tests/test_auto_tag_release.py
@@ -1,6 +1,8 @@
 import os
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from scripts import auto_tag_release  # noqa: E402
@@ -27,6 +29,13 @@ class TestAutoTagRelease(unittest.TestCase):
                     unittest.mock.call(["git", "push", "origin", "v1.2.3"]),
                 ],
             )
+
+    def test_get_version_parses_pyproject(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject = Path(tmpdir) / "pyproject.toml"
+            pyproject.write_text('[project]\nversion = "9.9.9"\n')
+            with patch.object(auto_tag_release, "VERSION_FILE", pyproject):
+                self.assertEqual(auto_tag_release.get_version(), "9.9.9")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- detect version from `pyproject.toml` instead of `setup.py`
- parse version from `pyproject.toml` in auto-tag script
- adjust release workflow docs and changelog
- test `get_version` with a temporary `pyproject`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_6850ede0860c8333ba1c4a528bbfa9c9