### PR TITLE
Automate release build on tags

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, staging]
     tags:
       - "v*"
+  # Also handle releases created from the GitHub UI
+  release:
+    types: [published]
   pull_request:
     branches: [main, staging]
   workflow_dispatch:

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -11,7 +11,7 @@ The process is split across multiple runners:
 - **macOS** builds a self-contained application with `build_macos.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists
-status badges for the current tag.  This file becomes the body of the GitHub
+status badges for the current tag. This file becomes the body of the GitHub
 release so that each tagged version shows the latest CI status.
 
 Both artifacts are attached to the GitHub release created for the tag. When the
@@ -19,12 +19,16 @@ Both artifacts are attached to the GitHub release created for the tag. When the
 PyPI.
 
 Tags are normally created automatically when the version in `setup.py` is bumped
-on the `main` branch.  The `Tag Release` workflow runs
+on the `main` branch. The `Tag Release` workflow runs
 `scripts/auto_tag_release.py` to create a tag like `v0.2.7` and push it to
 GitHub, which then triggers the build jobs above.
 
 Since the tag is pushed by a workflow, the job must grant `workflow: write`
 permissions so that the subsequent release workflow is triggered.
+
+Publishing a release directly from the GitHub UI is also supported. When a
+release for an existing tag is published, the build workflow runs
+automatically to produce the same artifacts.
 
 You can still trigger a release manually by creating and pushing a tag:
 


### PR DESCRIPTION
## Summary
- trigger release workflow when a tag's GitHub release is published
- document that publishing a release also builds packages

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_6850f2eeb420833393440bc364637b49