### PR TITLE
Refactor tests for routes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,90 @@
 import os
+import sys
+from types import SimpleNamespace
+from datetime import datetime, timedelta
+
+import pytest
+from flask import Flask
 
 # Skip end-to-end tests unless explicitly enabled
 os.environ.setdefault("SKIP_E2E", "1")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.routes import init_routes
+
+
+@pytest.fixture
+def flask_app():
+    template_dir = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "../app/templates"
+    )
+    app = Flask(__name__, template_folder=template_dir)
+    app.config["SECRET_KEY"] = "my_secret_key"
+    init_routes(app)
+    return app
+
+
+@pytest.fixture
+def client(flask_app):
+    return flask_app.test_client()
+
+
+@pytest.fixture
+def dummy_user():
+    return SimpleNamespace(id=1, username="testuser", password_hash="hash")
+
+
+class DummyQuery:
+    def __init__(self, user):
+        self.user = user
+
+    def filter_by(self, **kwargs):
+        return self
+
+    def first(self):
+        return self.user
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def limit(self, *args, **kwargs):
+        return self
+
+    def all(self):
+        return []
+
+
+class DummySession:
+    def __init__(self, user):
+        self.user = user
+
+    def query(self, model):
+        return DummyQuery(self.user)
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def patch_session_local(monkeypatch, dummy_user):
+    session = DummySession(dummy_user)
+    monkeypatch.setattr("app.routes.SessionLocal", lambda: session)
+    return session
+
+
+@pytest.fixture
+def reset_login_attempts(monkeypatch):
+    monkeypatch.setattr("app.routes.login_attempts", {}, raising=False)
+
+
+@pytest.fixture
+def user_session(monkeypatch):
+    sess = {
+        "user_id": 1,
+        "expiry": (datetime.now() + timedelta(minutes=30)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        ),
+    }
+    monkeypatch.setattr("app.routes.session", sess, raising=False)
+    return sess

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,636 +1,241 @@
-# tests/test_routes.py
-
-import unittest
 import os
 import sys
 from unittest.mock import patch
-from flask import Flask
+from types import SimpleNamespace
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app.routes import init_routes
 from app.models import Summary
-from types import SimpleNamespace
 
 
-class TestRoutes(unittest.TestCase):
-    def setUp(self):
-        template_dir = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), "../app/templates"
+def test_health_check(client):
+    response = client.get("/health")
+    assert response.status_code == 302
+
+
+def test_login_success(client, patch_session_local, reset_login_attempts, monkeypatch):
+    monkeypatch.setattr("app.routes.check_password_hash", lambda h, p: True)
+    response = client.post(
+        "/login", data={"username": "testuser", "password": "testpassword"}
+    )
+    assert response.status_code == 302
+    assert "/" in response.headers["Location"]
+
+
+def test_login_failure(client, patch_session_local, reset_login_attempts):
+    with patch("app.routes.check_password_hash", return_value=False), patch(
+        "app.routes.render_template"
+    ) as render:
+        response = client.post(
+            "/login", data={"username": "testuser", "password": "wrong"}
         )
-        self.app = Flask(__name__, template_folder=template_dir)
-        self.app.config["SECRET_KEY"] = "my_secret_key"
-        init_routes(self.app)
-        self.client = self.app.test_client()
+        assert response.status_code == 200
+        render.assert_called_with("login.html", page_title="Login")
 
-    def test_health_check(self):
-        response = self.client.get("/health")
-        self.assertEqual(response.status_code, 302)
 
-    @patch("app.routes.check_password_hash")
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.login_attempts", {})
-    def test_login_success(self, mock_session_local, mock_check_password):
-        mock_check_password.return_value = True
-        dummy_user = SimpleNamespace(id=1, username="testuser", password_hash="hash")
+def test_login_missing_fields(client, patch_session_local, reset_login_attempts):
+    with patch("app.routes.render_template") as render:
+        response = client.post("/login", data={"username": "", "password": ""})
+        assert response.status_code == 400
+        render.assert_called_with("login.html", page_title="Login")
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
 
-            def first(self):
-                return dummy_user
+def test_logout(client, patch_session_local, user_session):
+    response = client.get("/logout")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
 
-        def order_by(self, *args, **kwargs):
-            return self
 
-        def limit(self, *args, **kwargs):
-            return self
-
-        def all(self):
-            return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        response = self.client.post(
-            "/login",
-            data={"username": "testuser", "password": "testpassword"},
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/", response.headers["Location"])
-
-    @patch("app.routes.check_password_hash")
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.login_attempts", {})
-    @patch("app.routes.render_template")
-    def test_login_failure(
-        self, mock_render_template, mock_session_local, mock_check_password
-    ):
-        mock_check_password.return_value = False
-        dummy_user = SimpleNamespace(id=1, username="testuser", password_hash="hash")
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        response = self.client.post(
-            "/login", data={"username": "testuser", "password": "wrongpassword"}
-        )
-        self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("login.html", page_title="Login")
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.login_attempts", {})
-    @patch("app.routes.render_template")
-    def test_login_missing_fields(self, mock_render_template, mock_session_local):
-        response = self.client.post("/login", data={"username": "", "password": ""})
-        self.assertEqual(response.status_code, 400)
-        mock_render_template.assert_called_with("login.html", page_title="Login")
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_logout(self, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        response = self.client.get("/logout")
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/login", response.headers["Location"])
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.render_template")
-    @patch("app.routes.template_manager.get_templates")
-    def test_index(self, mock_get_templates, mock_render_template, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-            def order_by(self, *args, **kwargs):
-                return self
-
-            def limit(self, *args, **kwargs):
-                return self
-
-            def all(self):
-                return []
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        mock_get_templates.return_value = {"camera": {}}
-        response = self.client.get("/")
-        self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with(
+def test_index(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.get_templates", return_value={"camera": {}}
+    ) as get_t, patch("app.routes.render_template") as render:
+        response = client.get("/")
+        assert response.status_code == 200
+        render.assert_called_with(
             "index.html", template_details={"camera": {}}, page_title="Dashboard"
         )
+        get_t.assert_called_once()
 
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.template_manager.get_templates")
-    @patch("app.routes.render_template")
-    def test_captions(
-        self, mock_render_template, mock_get_templates, mock_session_local
-    ):
-        dummy_user = SimpleNamespace(id=1)
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        mock_get_templates.return_value = {"template1": {}, "template2": {}}
-        response = self.client.get("/captions")
-        self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with(
+def test_captions(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.get_templates",
+        return_value={"template1": {}, "template2": {}},
+    ) as get_t, patch("app.routes.render_template") as render:
+        response = client.get("/captions")
+        assert response.status_code == 200
+        render.assert_called_with(
             "captions.html",
-            template_details=mock_get_templates.return_value,
+            template_details=get_t.return_value,
             lcaptions=[],
             page_title="Captions",
         )
 
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.template_manager.get_templates")
-    def test_get_templates(self, mock_get_templates, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
+def test_get_templates(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.get_templates",
+        return_value={"template1": {}, "template2": {}},
+    ) as get_t:
+        response = client.get("/templates?group=all")
+        assert response.status_code == 200
+        assert response.get_json() == get_t.return_value
 
-            def first(self):
-                return dummy_user
 
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        mock_get_templates.return_value = {"template1": {}, "template2": {}}
-        response = self.client.get("/templates?group=all")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), {"template1": {}, "template2": {}})
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.template_manager.save_template")
-    def test_save_template(self, mock_save_template, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        mock_save_template.return_value = True
-        response = self.client.post(
+def test_save_template(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.save_template", return_value=True
+    ) as save_t:
+        response = client.post(
             "/templates", json={"name": "new_template", "url": "http://example.com"}
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get_json(), {"status": "success", "message": "Template saved"}
-        )
+        assert response.status_code == 200
+        assert response.get_json() == {"status": "success", "message": "Template saved"}
+        save_t.assert_called_once()
 
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.template_manager.delete_template")
-    def test_delete_template(self, mock_delete_template, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
+def test_delete_template(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.delete_template", return_value=True
+    ) as delete_t:
+        response = client.delete("/templates", json={"name": "template_to_delete"})
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "status": "success",
+            "message": "Template deleted",
+        }
+        delete_t.assert_called_once()
 
-            def first(self):
-                return dummy_user
 
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
+def test_stream(client, patch_session_local, user_session):
+    with patch("app.routes.render_template") as render:
+        response = client.get("/stream")
+        assert response.status_code == 200
+        render.assert_called_with("stream.html", page_title="Stream")
 
-            def close(self):
-                pass
 
-        mock_session_local.return_value = DummySession()
-        mock_delete_template.return_value = True
-        response = self.client.delete("/templates", json={"name": "template_to_delete"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get_json(), {"status": "success", "message": "Template deleted"}
-        )
+def test_api_discover(client):
+    response = client.get("/api/discover")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert isinstance(data, dict)
+    assert "version" in data
+    assert "endpoints" in data and isinstance(data["endpoints"], list)
+    assert len(data["endpoints"]) > 0
+    for endpoint in data["endpoints"]:
+        assert {
+            "path",
+            "method",
+            "description",
+            "authentication_required",
+        } <= endpoint.keys()
 
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.render_template")
-    def test_stream(self, mock_render_template, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-        response = self.client.get("/stream")
-        self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("stream.html", page_title="Stream")
-
-    def test_api_discover(self):
-        response = self.client.get("/api/discover")
-        self.assertEqual(response.status_code, 200)
-        data = response.get_json()
-        self.assertIsInstance(data, dict)
-        self.assertIn("version", data)
-        self.assertIn("endpoints", data)
-        self.assertIsInstance(data["endpoints"], list)
-        self.assertTrue(len(data["endpoints"]) > 0)
-        for endpoint in data["endpoints"]:
-            self.assertIn("path", endpoint)
-            self.assertIn("method", endpoint)
-            self.assertIn("description", endpoint)
-            self.assertIn("authentication_required", endpoint)
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.camera_discovery.discover_cameras")
-    @patch("app.routes.render_template")
-    def test_discover_route(
-        self, mock_render_template, mock_discover, mock_session_local
-    ):
-        mock_discover.return_value = [
-            {"ip": "1.2.3.4", "protocol": "rtsp", "port": 554, "info": {}}
-        ]
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        with self.client.session_transaction() as sess:
-            sess["user_id"] = 1
-        response = self.client.get("/discover")
-        self.assertEqual(response.status_code, 200)
-        mock_discover.assert_not_called()
-        mock_render_template.assert_called_with(
+def test_discover_route(client, patch_session_local, user_session):
+    payload = {"name": "cam", "ip": "1.2.3.4", "protocol": "rtsp", "port": 554}
+    with patch(
+        "app.routes.camera_discovery.discover_cameras", return_value=[payload]
+    ) as discover, patch("app.routes.render_template") as render:
+        response = client.get("/discover")
+        assert response.status_code == 200
+        render.assert_called_with(
             "discover.html", cameras=[], page_title="Discover Cameras"
         )
 
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.camera_discovery.discover_cameras")
-    def test_discover_scan(self, mock_discover, mock_session_local):
-        mock_discover.return_value = [
-            {"ip": "1.2.3.4", "protocol": "rtsp", "port": 554, "info": {}}
-        ]
-        dummy_user = SimpleNamespace(id=1)
+        response = client.post("/discover/scan")
+        assert response.status_code == 200
+        discover.assert_called()
+        assert response.get_json() == discover.return_value
 
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
+    with patch(
+        "app.routes.template_manager.save_template", return_value=True
+    ) as save_t:
+        response = client.post("/discover/add", json=payload)
+        assert response.status_code == 200
+        save_t.assert_called()
 
-            def first(self):
-                return dummy_user
 
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        with self.client.session_transaction() as sess:
-            sess["user_id"] = 1
-        response = self.client.post("/discover/scan")
-        self.assertEqual(response.status_code, 200)
-        mock_discover.assert_called_once()
-        self.assertEqual(response.get_json(), mock_discover.return_value)
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.template_manager.save_template")
-    def test_discover_add(self, mock_save_template, mock_session_local):
-        mock_save_template.return_value = True
-        payload = {"name": "cam", "ip": "1.2.3.4", "protocol": "rtsp", "port": 554}
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        with self.client.session_transaction() as sess:
-            sess["user_id"] = 1
-        response = self.client.post("/discover/add", json=payload)
-        self.assertEqual(response.status_code, 200)
-        mock_save_template.assert_called()
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    @patch("app.routes.template_manager.get_template")
-    @patch("app.routes.render_template")
-    def test_live_single_camera(
-        self, mock_render_template, mock_get_template, mock_session_local
-    ):
-        """The live route should render only the requested camera."""
-
-        mock_get_template.return_value = {"url": "https://example.com"}
-
-        class DummyQuery:
-            def filter_by(self, **kwargs):
-                return self
-
-            def first(self):
-                return SimpleNamespace(id=1)
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery()
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        response = self.client.get("/live?camera=cam1")
-        self.assertEqual(response.status_code, 200)
-        mock_get_template.assert_called_with("cam1")
-        mock_render_template.assert_called_with(
+def test_live_single_camera(client, patch_session_local, user_session):
+    with patch(
+        "app.routes.template_manager.get_template",
+        return_value={"url": "https://example.com"},
+    ) as get_t, patch("app.routes.render_template") as render:
+        response = client.get("/live?camera=cam1")
+        assert response.status_code == 200
+        get_t.assert_called_with("cam1")
+        render.assert_called_with(
             "live.html",
-            template_details={"cam1": mock_get_template.return_value},
+            template_details={"cam1": get_t.return_value},
             page_title="Live View",
         )
 
-    @patch("app.routes.render_template")
-    @patch("app.routes.get_active_groups")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_group_page(self, mock_groups, mock_render_template):
-        mock_groups.return_value = ["group1", "group2"]
-        response = self.client.get("/group/group1")
-        self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with(
+
+def test_group_page(client, user_session):
+    with patch(
+        "app.routes.get_active_groups", return_value=["group1", "group2"]
+    ) as groups, patch("app.routes.render_template") as render:
+        response = client.get("/group/group1")
+        assert response.status_code == 200
+        render.assert_called_with(
             "group.html", group_name="group1", page_title="Group – group1"
         )
+        groups.assert_called_once()
 
-    @patch("app.routes.get_active_groups")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_group_page_not_found(self, mock_groups):
-        mock_groups.return_value = ["group1"]
-        response = self.client.get("/group/unknown")
-        self.assertEqual(response.status_code, 404)
 
-    @patch("app.routes.get_active_groups")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_group_page_all_redirect(self, mock_groups):
-        mock_groups.return_value = ["group1"]
-        response = self.client.get("/group/all")
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/", response.headers["Location"])
+def test_group_page_not_found(client, user_session):
+    with patch("app.routes.get_active_groups", return_value=["group1"]) as groups:
+        response = client.get("/group/unknown")
+        assert response.status_code == 404
+        groups.assert_called_once()
 
-    @patch("app.routes.get_active_groups")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_groups_endpoint_includes_all(self, mock_groups):
-        mock_groups.return_value = ["group1"]
-        response = self.client.get("/groups")
-        self.assertEqual(response.status_code, 200)
+
+def test_group_page_all_redirect(client, user_session):
+    with patch("app.routes.get_active_groups", return_value=["group1"]) as groups:
+        response = client.get("/group/all")
+        assert response.status_code == 302
+        assert "/" in response.headers["Location"]
+        groups.assert_called_once()
+
+
+def test_groups_endpoint_includes_all(client, user_session):
+    with patch("app.routes.get_active_groups", return_value=["group1"]) as groups:
+        response = client.get("/groups")
+        assert response.status_code == 200
         data = response.get_json()
-        self.assertIn("all", data)
-
-    @patch("app.routes.SessionLocal")
-    @patch("app.routes.session", {"user_id": 1})
-    def test_captions_status(self, mock_session_local):
-        dummy_user = SimpleNamespace(id=1)
-
-        class DummyQuery:
-            def __init__(self, model):
-                self.model = model
-                self.order_called = False
-
-            def filter_by(self, **kwargs):
-                self.filter_kwargs = kwargs
-                return self
-
-            def order_by(self, *args, **kwargs):
-                self.order_called = True
-                return self
-
-            def first(self):
-                if self.model is Summary:
-                    return SimpleNamespace(timestamp=0, content='{"summary":"hello"}')
-                return dummy_user
-
-        class DummySession:
-            def query(self, model):
-                return DummyQuery(model)
-
-            def close(self):
-                pass
-
-        mock_session_local.return_value = DummySession()
-
-        response = self.client.get("/captions_status")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get_json(),
-            {"caption": "hello", "timestamp": "1970-01-01 00:00:00"},
-        )
+        assert "all" in data
+        groups.assert_called_once()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_captions_status(client, patch_session_local, user_session):
+    class DummyQuery:
+        def __init__(self, model):
+            self.model = model
+
+        def filter_by(self, **kwargs):
+            return self
+
+        def order_by(self, *args, **kwargs):
+            return self
+
+        def first(self):
+            if self.model is Summary:
+                return SimpleNamespace(timestamp=0, content='{"summary":"hello"}')
+            return SimpleNamespace(id=1)
+
+    class DummySession:
+        def query(self, model):
+            return DummyQuery(model)
+
+        def close(self):
+            pass
+
+    with patch("app.routes.SessionLocal", return_value=DummySession()):
+        response = client.get("/captions_status")
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "caption": "hello",
+            "timestamp": "1970-01-01 00:00:00",
+        }


### PR DESCRIPTION
## Summary
- refactor `tests/test_routes.py` to pytest style
- add shared fixtures in `tests/conftest.py`

## Testing
- `pytest tests/test_routes.py -q`
- `flake8 tests/conftest.py tests/test_routes.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ff5676e083338d7e832cafe3d2c7