### PR TITLE
Remove pip safety mention

### DIFF
--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -11,7 +11,7 @@ following tasks:
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites and uploads coverage.
 - Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
-- Scans dependencies using `pip safety` and `npm audit`.
+- Scans dependencies using `npm audit`.
 - Caches Python and Node dependencies to speed up builds.
 
 Running `pre-commit run --all-files` locally will execute the same Black,


### PR DESCRIPTION
## Summary
- update CI checks docs to remove reference to `pip safety`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_6850fe2d789c8333811cba9720eaa8c9