### PR TITLE
Add prettier check for YAML files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,12 @@ repos:
         name: detect secrets
         entry: ./detect-secrets-hook
         language: system
+
+  - repo: local
+    hooks:
+      - id: check-yaml-format
+        name: prettier yaml
+        entry: prettier --check '*.yml'
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: format lint test test-js precommit setup
+.PHONY: format format-yaml lint test test-js precommit setup
 
 format:
-	black .
-	prettier --write app/static/js/**/*.js app/static/css/**/*.css
+        black .
+        prettier --write app/static/js/**/*.js app/static/css/**/*.css
+
+format-yaml:
+        prettier --write '*.yml'
 
 lint:
         flake8


### PR DESCRIPTION
## Summary
- enforce prettier on YAML via pre-commit
- allow running prettier on YAML via `make format-yaml`

## Testing
- `flake8` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68516532a9808333938d6e30daa7c848