### PR TITLE
Fix CI for YAML formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
     hooks:
       - id: check-yaml-format
         name: prettier yaml
-        entry: prettier --check '*.yml'
+        entry: npx prettier --check '*.yml'
         language: system
         pass_filenames: false
         stages: [pre-commit]


### PR DESCRIPTION
## Summary
- update pre-commit configuration to use `npx prettier`

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `flake8` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_68517bd1618483339596c0a23d527f07