### PR TITLE
Add missing module docstrings

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,3 +1,5 @@
+"""Database utilities for initializing the SQLite engine and schema."""
+
 import os
 
 from sqlalchemy import create_engine, text
@@ -19,8 +21,11 @@ Base = declarative_base()
 
 
 def init_db():
-    # Import models here so that SQLAlchemy is aware of them before creating
-    # tables. This prevents circular import issues at module load time.
+    """Create all database tables defined in :mod:`app.models`."""
+
+    # Import models so SQLAlchemy registers them before table creation. This
+    # import is intentionally local to avoid circular dependencies at module
+    # load time.
     import app.models  # noqa: F401
 
     Base.metadata.create_all(bind=engine)

--- a/app/utils/profiling.py
+++ b/app/utils/profiling.py
@@ -1,3 +1,5 @@
+"""Tools for measuring and reporting route latency during development."""
+
 import json
 import os
 import time
@@ -8,7 +10,8 @@ LOG_PATH = "data/latency_log.json"
 _lock = Lock()
 
 
-def _load_log():
+def _load_log() -> list:
+    """Return the current latency log from ``LOG_PATH`` if it exists."""
     if os.path.exists(LOG_PATH):
         try:
             with open(LOG_PATH, "r") as f:
@@ -18,7 +21,8 @@ def _load_log():
     return []
 
 
-def _save_log(entries):
+def _save_log(entries: list) -> None:
+    """Persist latency log entries to ``LOG_PATH``."""
     os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
     with open(LOG_PATH, "w") as f:
         json.dump(entries, f)


### PR DESCRIPTION
## Summary
- add module docs to db utils
- add module docs to profiling helpers
- document init_db and internal functions

## Testing
- `flake8` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: pre-commit not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_68518c37508c8333a4469027babdada4