### PR TITLE
Fix CI by updating setuptools for pip-audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,7 @@ dev = [
   "pyinstaller>=6.14.1",
   "pylint>=3.3.7",
   "pip-audit",
+  "setuptools>=78.1.1",
   
   # ──────── NEW “super-human” goodies ────────
   "ruff>=0.4.4",          # lightning-fast linter/formatter


### PR DESCRIPTION
## Summary
- add `setuptools>=78.1.1` to dev dependencies

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest`
- `pip-audit`

------
https://chatgpt.com/codex/tasks/task_e_6851911058848333a2249618ce96a05e