### PR TITLE
Add init_db docstring

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -19,6 +19,7 @@ Base = declarative_base()
 
 
 def init_db():
+    """Import models and create database tables."""
     # Import models here so that SQLAlchemy is aware of them before creating
     # tables. This prevents circular import issues at module load time.
     import app.models  # noqa: F401


### PR DESCRIPTION
## Summary
- document that `init_db` imports models and creates DB tables

## Testing
- `black app/utils/db.py`
- `flake8 app/utils/db.py`
- `pre-commit run --all-files` *(fails: `ModuleNotFoundError: No module named 'yaml'`)*
- `pytest tests/test_db_ensure_column.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68518c8798cc833399d3dbe62d9d5976