### PR TITLE
Update version references to 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build details are hidden on small screens to avoid clutter.
 - Sanitized log messages in the UI to prevent XSS vulnerabilities
 
+## [0.2.8] - 2025-06-17
+
+### Changed
+
+- Bumped package version in pyproject.toml to 0.2.8.
+
 ## [0.2.7] - 2025-06-02
 
 ### Changed
@@ -134,7 +140,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appears blank.
 - Fixed timezone handling so feed status timestamps no longer show "in the future".
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.8
 [0.2.7]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.7
 [0.2.6]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.6
 [0.2.5]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.5

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Kubicki
     given-names: Kristopher
 title: Glimpser
-version: "0.2.7"
+version: "0.2.8"
 date-released: 2024-08-07
 url: https://github.com/KristopherKubicki/glimpser
 repository-code: https://github.com/KristopherKubicki/glimpser

--- a/app/config.py
+++ b/app/config.py
@@ -257,7 +257,7 @@ TZ = get_setting("TZ", "UTC")
 try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
-    _PKG_VERSION = "0.2.7"
+    _PKG_VERSION = "0.2.8"
 sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -20,7 +20,7 @@ PyPI.
 
 Tags are normally created automatically when the version in `pyproject.toml` is bumped
 on the `main` branch.  The `Tag Release` workflow runs
-`scripts/auto_tag_release.py` to create a tag like `v0.2.7` and push it to
+`scripts/auto_tag_release.py` to create a tag like `v0.2.8` and push it to
 GitHub, which then triggers the build jobs above.
 
 Since the tag is pushed by a workflow, the job must grant `workflow: write`
@@ -29,8 +29,8 @@ permissions so that the subsequent release workflow is triggered.
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.7
-git push origin v0.2.7
+git tag v0.2.8
+git push origin v0.2.8
 ```
 
 Alternatively, run `scripts/auto_tag_release.py` to create and push the tag

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-  "name": "glimpser",
-  "version": "0.2.7",
-  "type": "module",
-  "private": true,
-  "scripts": {
-    "lint:css": "stylelint 'app/static/css/**/*.css'",
-    "lint:js": "eslint 'app/static/js/**/*.js'",
-    "format:js": "prettier --check 'app/static/js/**/*.js'",
-    "format:js:write": "prettier --write 'app/static/js/**/*.js'",
-    "format": "npm run format:js:write",
-    "test:js": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=jsdom",
-    "test": "npm run test:js",
-    "size-audit": "node scripts/size-audit.js"
-  },
-  "devDependencies": {
-    "eslint": "^8.57.0",
-    "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "prettier": "^3.5.3",
-    "stylelint": "^15.10.0",
-    "stylelint-config-standard": "^34.0.0"
-  }
+    "name": "glimpser",
+    "version": "0.2.8",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "lint:css": "stylelint 'app/static/css/**/*.css'",
+        "lint:js": "eslint 'app/static/js/**/*.js'",
+        "format:js": "prettier --check 'app/static/js/**/*.js'",
+        "format:js:write": "prettier --write 'app/static/js/**/*.js'",
+        "format": "npm run format:js:write",
+        "test:js": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env=jsdom",
+        "test": "npm run test:js",
+        "size-audit": "node scripts/size-audit.js"
+    },
+    "devDependencies": {
+        "eslint": "^8.57.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "prettier": "^3.5.3",
+        "stylelint": "^15.10.0",
+        "stylelint-config-standard": "^34.0.0"
+    }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ skips = ["B101"]  # assert-used
 # commitizen – keep Conventional Commits & changelog automation tidy
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.7"
+version = "0.2.8"
 tag_format = "v$version"
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -630,7 +630,7 @@ wheels = [
 
 [[package]]
 name = "glimpser"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- bump commitizen version
- update citation file for new version
- document new release steps
- keep package.json and config in sync
- update uv lock file
- add CHANGELOG entry for 0.2.8

## Testing
- `flake8 app/config.py` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_68518c82ff508333b496c686ac2c9715