### PR TITLE
Remove duplicate sqlite3 import

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -135,7 +135,6 @@ FILE_LOCATION_NAMES = [
     "SUMMARIES_DIRECTORY",
 ]
 
-import sqlite3
 from typing import Any, Callable, Dict, Generator, List, Optional
 
 from sqlalchemy.exc import OperationalError, SQLAlchemyError


### PR DESCRIPTION
## Summary
- remove second sqlite3 import from `app/routes.py`

## Testing
- `flake8` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: check-exclude-docs requires yaml)*
- `pytest -q` *(fails: ModuleNotFoundError: pytest_socket)*

------
https://chatgpt.com/codex/tasks/task_e_68518c6db0488333ae1cd9eb22b46753