### PR TITLE
Fix shebang paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-#!./env/bin/python3
+#!/usr/bin/env python3
 #  main.py
 
 import argparse

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,4 +1,4 @@
-#!env/bin/python3
+#!/usr/bin/env python3
 # tests/test_cmd.py
 
 import json


### PR DESCRIPTION
## Summary
- switch to `/usr/bin/env python3` shebang in `main.py`
- use the same env-based shebang in `tests/test_cmd.py`

## Testing
- `black main.py tests/test_cmd.py`
- `.venv/bin/flake8`
- `.venv/bin/pytest -ra`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68518c5d9a608333815a0564b6f76607