### PR TITLE
Update dev install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,14 @@ If you cannot log in or see video feeds, double-check that your `.env` file matc
 To install Python packages required for development, run:
 
 ```sh
-pip install .
-pip install -r requirements-dev.txt
+pip install -e .[dev]
+```
+
+For air-gapped or bandwidth-constrained setups, include the optional
+`[agents]` extras to install an offline toolkit:
+
+```sh
+pip install -e .[dev,agents]
 ```
 
 Then install linters and JavaScript tools with `make setup` (or `scripts/setup_env.sh`).
@@ -206,8 +212,7 @@ To set up the project for development:
 3. Install Python dependencies:
 
    ```sh
-   pip install .
-   pip install -r requirements-dev.txt
+   pip install -e .[dev]
    ```
 
 4. Install developer tooling:
@@ -240,7 +245,7 @@ From [Developer Guide](docs/developer_guide.md):
 
 1. Install the tooling and Git hooks (or run `make setup`):
    ```sh
-   pip install -r requirements-dev.txt
+   pip install -e .[dev]
    npm install
    pre-commit install
    ```

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -6,7 +6,7 @@ This guide provides tips for extending Glimpser, running tests, and contributing
 
 1. Clone the repository and create a virtual environment:
    ```sh
-ruff check --exit-zero .
+   ruff check --exit-zero .
    git clone https://github.com/KristopherKubicki/glimpser.git
    cd glimpser
    python -m venv env
@@ -14,12 +14,16 @@ ruff check --exit-zero .
    ```
 2. Install Python dependencies:
    ```sh
-   pip install .  # installs runtime dependencies from `pyproject.toml`
-   pip install -r requirements-dev.txt
+   pip install -e .[dev]  # installs runtime and development packages
    ```
    Browser automation packages used for screenshots are grouped under the
    optional `browser` extras in `setup.py`. A minimal install only requires
    `wkhtmltoimage` for lightweight captures.
+   If you plan to work in an offline environment, install the optional
+   `agents` extras as well:
+   ```sh
+   pip install -e .[dev,agents]
+   ```
 3. Set up tooling:
    ```sh
    make setup  # installs pre-commit hooks and JS packages

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -2,9 +2,6 @@
 # Set up local development environment
 set -e
 
-pip install .
-if [ -f requirements-dev.txt ]; then
-    pip install -r requirements-dev.txt
-fi
+pip install -e .[dev]  # add '[agents]' for offline agent toolkit
 npm install
 pre-commit install


### PR DESCRIPTION
## Summary
- update instructions in README for editable dev installation
- mention optional `[agents]` extras for offline setups
- document offline extras in Developer Guide
- note optional extras in setup script

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_68518c752408833390b9179ba60669c4