### PR TITLE
Fix watchdog handle counting

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -219,10 +219,16 @@ def create_app(
                         cpu_usage > WATCHDOG_CPU_THRESHOLD
                         or mem_usage > WATCHDOG_MEMORY_THRESHOLD
                     ):
-                        open_files = current_process.open_files()
-                        if len(open_files) > max_file_handles:
+                        # psutil exposes num_fds() on POSIX systems. Prefer
+                        # this to avoid fetching the entire open_files list.
+                        if hasattr(current_process, "num_fds"):
+                            open_file_count = current_process.num_fds()
+                        else:
+                            open_file_count = len(current_process.open_files())
+
+                        if open_file_count > max_file_handles:
                             raise Exception(
-                                f"Too many open file handles: {len(open_files)}"
+                                f"Too many open file handles: {open_file_count}"
                             )
 
                 except Exception as e:

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1284,7 +1284,11 @@ def start_metrics_collection():
 def get_system_metrics():
     uptime = time.time() - system_metrics["start_time"]
     disk_usage = psutil.disk_usage("/").percent
-    open_files = len(psutil.Process().open_files())
+    process = psutil.Process()
+    if hasattr(process, "num_fds"):
+        open_files = process.num_fds()
+    else:
+        open_files = len(process.open_files())
     ffmpeg_path = shutil.which(FFMPEG_PATH) or FFMPEG_PATH
     ffmpeg_gpu_support = ffmpeg_supports_hwaccel()
     return {

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -154,7 +154,11 @@ class TestGetSystemMetrics(unittest.TestCase):
             }
         )
         mock_psutil.disk_usage.return_value = SimpleNamespace(percent=55.5)
-        mock_psutil.Process.return_value.open_files.return_value = [1, 2, 3]
+        process_mock = mock_psutil.Process.return_value
+        if hasattr(process_mock, "num_fds"):
+            process_mock.num_fds.return_value = 3
+        else:
+            process_mock.open_files.return_value = [1, 2, 3]
         metrics = get_system_metrics()
         self.assertEqual(metrics["cpu_usage"], 1.2)
         self.assertEqual(metrics["memory_usage"], 2.3)


### PR DESCRIPTION
## Summary
- prefer `psutil.Process.num_fds()` for open file count
- fall back to `open_files()` when unavailable
- adjust system metrics logic
- update watchdog metrics test

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6851b237a6d0833395d8e1a420f00728