### PR TITLE
Improve offline check

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -3,6 +3,25 @@ import os
 import socket
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
+import psutil
+
+
+def _has_active_lan() -> bool:
+    """Return ``True`` if any non-loopback interface is up with a valid IPv4 address."""
+
+    stats = psutil.net_if_stats()
+    for iface, addrs in psutil.net_if_addrs().items():
+        if iface == "lo" or not stats.get(iface) or not stats[iface].isup:
+            continue
+        for addr in addrs:
+            if addr.family != socket.AF_INET:
+                continue
+            ip = addr.address
+            if not ip or ip.startswith("127.") or ip.startswith("169.254."):
+                continue
+            return True
+    return False
+
 
 def _get_test_hosts():
     """Return list of hosts to probe for network connectivity."""
@@ -31,6 +50,10 @@ def is_system_online(timeout: int = 3) -> bool:
         for future in as_completed(futures):
             if future.result():
                 return True
+
+    if _has_active_lan():
+        logging.info("offline check fallback: LAN interface active")
+        return True
 
     logging.warning("offline check failed: all hosts unreachable")
     return False

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -6,7 +6,7 @@ The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.requ
 
 This approach keeps the application responsive even when external services are slow or offline.
 
-The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond. The target port can be overridden with `ONLINE_TEST_PORT` (default `443`).
+The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond. The target port can be overridden with `ONLINE_TEST_PORT` (default `443`). If none of the hosts respond but at least one non-loopback interface is up, the helper assumes local network connectivity and logs `offline check fallback: LAN interface active`.
 
 Skipped jobs are stored in the `offline_jobs` table. A background task checks connectivity every 30 seconds and re-runs any queued tasks once the system comes back online.
 

--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -1,7 +1,10 @@
 import os
+import socket
 import sys
 import unittest
 from unittest.mock import patch
+
+import psutil
 
 from app.utils.network import _get_test_hosts, is_system_online
 
@@ -55,6 +58,36 @@ class TestIsSystemOnline(unittest.TestCase):
             self.assertFalse(is_system_online(timeout=1))
         mock_conn.assert_called_once_with(("1.1.1.1", 443), timeout=1)
         mock_warn.assert_called_once()
+
+    @patch("app.utils.network.logging.info")
+    @patch("app.utils.network.psutil.net_if_addrs")
+    @patch("app.utils.network.psutil.net_if_stats")
+    @patch("app.utils.network.socket.create_connection", side_effect=OSError)
+    def test_lan_fallback(self, mock_conn, mock_stats, mock_addrs, mock_info):
+        snicstats = psutil._common.snicstats(
+            isup=True, duplex=0, speed=0, mtu=1500, flags=0
+        )
+        snicaddr = psutil._common.snicaddr(
+            family=socket.AF_INET,
+            address="192.168.1.5",
+            netmask="255.255.255.0",
+            broadcast="192.168.1.255",
+            ptp=None,
+        )
+        mock_stats.return_value = {"eth0": snicstats}
+        mock_addrs.return_value = {"eth0": [snicaddr]}
+        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1"}):
+            self.assertTrue(is_system_online(timeout=1))
+        mock_conn.assert_called_once_with(("1.1.1.1", 443), timeout=1)
+        mock_info.assert_called_once()
+
+    @patch("app.utils.network.psutil.net_if_addrs", return_value={})
+    @patch("app.utils.network.psutil.net_if_stats", return_value={})
+    @patch("app.utils.network.socket.create_connection", side_effect=OSError)
+    def test_offline_without_interfaces(self, mock_conn, mock_stats, mock_addrs):
+        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1"}):
+            self.assertFalse(is_system_online(timeout=1))
+        mock_conn.assert_called_once_with(("1.1.1.1", 443), timeout=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `is_system_online` to detect active LAN when internet hosts are unreachable
- document LAN fallback logic
- add tests for LAN fallback

## Testing
- `black app/utils/network.py tests/test_network_online.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*
- `pre-commit run --all-files` *(fails: executable `flake8` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f013d0f0833392e491f988b58618