### PR TITLE
Improve offline detection

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -11,14 +11,24 @@ def _get_test_hosts():
 
 def is_system_online(timeout: int = 3) -> bool:
     """Return ``True`` if a network connection can be opened to any test host."""
-    port = int(os.getenv("ONLINE_TEST_PORT", "443"))
+    default_port = int(os.getenv("ONLINE_TEST_PORT", "443"))
 
-    def try_connect(host: str) -> bool:
+    def parse_target(target: str) -> tuple[str, int]:
+        if ":" in target:
+            host, p = target.rsplit(":", 1)
+            try:
+                return host, int(p)
+            except ValueError:
+                return host, default_port
+        return target, default_port
+
+    def try_connect(target: str) -> bool:
+        host, port = parse_target(target)
         try:
             socket.create_connection((host, port), timeout=timeout)
             return True
         except OSError as exc:  # pragma: no cover - network depends on environment
-            logging.debug("offline check failed for %s: %s", host, exc)
+            logging.debug("offline check failed for %s:%s: %s", host, port, exc)
             return False
 
     hosts = [h.strip() for h in _get_test_hosts() if h.strip()]

--- a/docs/api_resilience.md
+++ b/docs/api_resilience.md
@@ -6,7 +6,7 @@ The helper `request_with_retry` in `app/utils/api_utils.py` wraps `requests.requ
 
 This approach keeps the application responsive even when external services are slow or offline.
 
-The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond. The target port can be overridden with `ONLINE_TEST_PORT` (default `443`).
+The scheduler now calls `is_system_online` before launching subprocesses. If the system is offline, jobs are skipped and marked offline instead of failing with file descriptor errors. The helper checks each address listed in the `ONLINE_TEST_HOSTS` environment variable (default `8.8.8.8,1.1.1.1`) and returns online if any respond. Hosts can include a custom port using the `host:port` syntax, otherwise `ONLINE_TEST_PORT` (default `443`) is used.
 
 Skipped jobs are stored in the `offline_jobs` table. A background task checks connectivity every 30 seconds and re-runs any queued tasks once the system comes back online.
 

--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -48,6 +48,13 @@ class TestIsSystemOnline(unittest.TestCase):
             self.assertFalse(is_system_online(timeout=1))
             mock_conn.assert_called_once_with(("1.1.1.1", 321), timeout=1)
 
+    @patch("socket.create_connection")
+    def test_host_with_inline_port(self, mock_conn):
+        mock_conn.return_value = None
+        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "example.com:444"}):
+            self.assertTrue(is_system_online(timeout=1))
+            mock_conn.assert_called_once_with(("example.com", 444), timeout=1)
+
     @patch("app.utils.network.logging.warning")
     @patch("app.utils.network.socket.create_connection", side_effect=OSError("fail"))
     def test_logs_when_all_fail(self, mock_conn, mock_warn):


### PR DESCRIPTION
## Summary
- allow inline port in `ONLINE_TEST_HOSTS`
- document host:port syntax
- test new behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6851f6908b8083338e3468b79a7720e6