### PR TITLE
Fix metrics thread wait mechanism

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1272,7 +1272,8 @@ def collect_system_metrics():
                 continue
         usages.sort(key=lambda x: x["cpu"], reverse=True)
         system_metrics["top_threads"] = usages[:10]
-        time.sleep(5)  # Collect metrics every 5 seconds
+        # Wait up to 5 seconds, exiting sooner if stop_event is set
+        stop_event.wait(5)
 
 
 def start_metrics_collection():


### PR DESCRIPTION
## Summary
- use stop_event.wait() in collect_system_metrics

## Testing
- `flake8` *(fails: command not found)*
- `pre-commit run --all-files` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_68520730dcf48333aa16408f1c2832cc