### PR TITLE
Remove duplicate config backup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -267,7 +267,6 @@ def create_app(
     # Send alerts when the application starts
     def _start_background_components() -> None:
         """Initialize scheduler and monitoring in a low priority thread."""
-        backup_config()
 
         if (
             schedule


### PR DESCRIPTION
## Summary
- remove duplicate `backup_config` call when starting background components

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*

------
https://chatgpt.com/codex/tasks/task_e_685208d99df8833391de26e38d0d6009