### PR TITLE
Add caching for template list

### DIFF
--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 from datetime import datetime
+from functools import lru_cache
 
 from sqlalchemy import Boolean, Column, Float, Integer, String, Text
 from sqlalchemy.orm import validates
@@ -399,6 +400,7 @@ class TemplateManager:
             session.close()
 
 
+@lru_cache(maxsize=1)
 def get_templates():
     """Return all templates enriched with filesystem metadata.
 
@@ -424,6 +426,12 @@ def get_templates():
         details["last_video_time"] = get_latest_video_date(video_path)
         details["snapshot_only"] = is_snapshot_url(details.get("url", ""))
     return templates
+
+
+def clear_template_cache() -> None:
+    """Clear cached template data."""
+
+    get_templates.cache_clear()
 
 
 def get_templates_sorted_by_last_caption_time():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -11,6 +11,7 @@ from flask import Flask
 
 from app.models import Summary
 from app.routes import init_routes
+from app.utils.template_manager import clear_template_cache
 
 
 class TestRoutes(unittest.TestCase):
@@ -22,6 +23,7 @@ class TestRoutes(unittest.TestCase):
         self.app.config["SECRET_KEY"] = "my_secret_key"  # pragma: allowlist secret
         init_routes(self.app)
         self.client = self.app.test_client()
+        clear_template_cache()
 
     def test_health_check(self):
         response = self.client.get("/health")

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from app.utils.template_manager import (
     Template,
     TemplateManager,
+    clear_template_cache,
     get_storage_usage,
     get_storage_usage_bytes,
     get_templates,
@@ -20,6 +21,7 @@ from app.utils.validators import validate_template_name
 class TestTemplateManager(unittest.TestCase):
     def setUp(self):
         self.template_manager = TemplateManager()
+        clear_template_cache()
 
     def tearDown(self):
         # Clean up any resources after each test if needed
@@ -379,6 +381,7 @@ class TestStorageUsage(unittest.TestCase):
 class TestSnapshotDetection(unittest.TestCase):
     @patch("app.utils.template_manager.SessionLocal")
     def test_snapshot_flag_in_get_templates(self, mock_session):
+        clear_template_cache()
         mock_sess = MagicMock()
         mock_session.return_value = mock_sess
         mock_query = mock_sess.query.return_value
@@ -395,6 +398,7 @@ class TestSnapshotDetection(unittest.TestCase):
 
     @patch("app.utils.template_manager.SessionLocal")
     def test_snapshot_flag_in_get_template(self, mock_session):
+        clear_template_cache()
         mock_sess = MagicMock()
         mock_session.return_value = mock_sess
         mock_query = mock_sess.query.return_value


### PR DESCRIPTION
## Summary
- cache `get_templates()` with `lru_cache(maxsize=1)`
- allow resetting via `clear_template_cache()`
- clear cache in template and route tests

## Testing
- `black app/utils/template_manager.py tests/test_template_manager.py tests/test_routes.py`
- `isort --profile=black tests/test_template_manager.py`
- `pytest` *(fails: ModuleNotFoundError for `pytest_socket`)*

------
https://chatgpt.com/codex/tasks/task_e_685208a8468c8333a32d11de22a78785