### PR TITLE
Fix network online tests

### DIFF
--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -10,13 +10,19 @@ class TestIsSystemOnline(unittest.TestCase):
     @patch("socket.create_connection")
     def test_first_host_success(self, mock_conn):
         mock_conn.return_value = None
-        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1"}):
+        with patch.dict(
+            os.environ,
+            {"ONLINE_TEST_HOSTS": "1.1.1.1", "ONLINE_TEST_URLS": ""},
+        ):
             self.assertTrue(is_system_online(timeout=1))
             mock_conn.assert_called_once_with(("1.1.1.1", 443), timeout=1)
 
     @patch("socket.create_connection", side_effect=OSError)
     def test_all_hosts_fail(self, mock_conn):
-        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1,2.2.2.2"}):
+        with patch.dict(
+            os.environ,
+            {"ONLINE_TEST_HOSTS": "1.1.1.1,2.2.2.2", "ONLINE_TEST_URLS": ""},
+        ):
             self.assertFalse(is_system_online())
             self.assertEqual(mock_conn.call_count, 2)
 
@@ -28,14 +34,20 @@ class TestIsSystemOnline(unittest.TestCase):
     @patch("app.utils.network._get_test_hosts", return_value=[" ", "2.2.2.2"])
     def test_is_system_online_skips_blank(self, mock_hosts, mock_conn):
         mock_conn.return_value = None
-        self.assertTrue(is_system_online(timeout=2))
+        with patch.dict(os.environ, {"ONLINE_TEST_URLS": ""}):
+            self.assertTrue(is_system_online(timeout=2))
         mock_conn.assert_called_once_with(("2.2.2.2", 443), timeout=2)
 
     @patch("socket.create_connection")
     def test_custom_port_success(self, mock_conn):
         mock_conn.return_value = None
         with patch.dict(
-            os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1", "ONLINE_TEST_PORT": "123"}
+            os.environ,
+            {
+                "ONLINE_TEST_HOSTS": "1.1.1.1",
+                "ONLINE_TEST_PORT": "123",
+                "ONLINE_TEST_URLS": "",
+            },
         ):
             self.assertTrue(is_system_online(timeout=1))
             mock_conn.assert_called_once_with(("1.1.1.1", 123), timeout=1)
@@ -43,7 +55,12 @@ class TestIsSystemOnline(unittest.TestCase):
     @patch("socket.create_connection", side_effect=OSError)
     def test_custom_port_failure(self, mock_conn):
         with patch.dict(
-            os.environ, {"ONLINE_TEST_HOSTS": "1.1.1.1", "ONLINE_TEST_PORT": "321"}
+            os.environ,
+            {
+                "ONLINE_TEST_HOSTS": "1.1.1.1",
+                "ONLINE_TEST_PORT": "321",
+                "ONLINE_TEST_URLS": "",
+            },
         ):
             self.assertFalse(is_system_online(timeout=1))
             mock_conn.assert_called_once_with(("1.1.1.1", 321), timeout=1)
@@ -51,7 +68,10 @@ class TestIsSystemOnline(unittest.TestCase):
     @patch("socket.create_connection")
     def test_host_with_inline_port(self, mock_conn):
         mock_conn.return_value = None
-        with patch.dict(os.environ, {"ONLINE_TEST_HOSTS": "example.com:444"}):
+        with patch.dict(
+            os.environ,
+            {"ONLINE_TEST_HOSTS": "example.com:444", "ONLINE_TEST_URLS": ""},
+        ):
             self.assertTrue(is_system_online(timeout=1))
             mock_conn.assert_called_once_with(("example.com", 444), timeout=1)
 
@@ -77,7 +97,10 @@ class TestIsSystemOnline(unittest.TestCase):
     @patch("app.utils.network.logging.warning")
     @patch("app.utils.network.socket.create_connection", side_effect=OSError("fail"))
     def test_logs_when_all_fail(self, mock_conn, mock_warn):
-        with patch("app.utils.network._get_test_hosts", return_value=["1.1.1.1"]):
+        with (
+            patch("app.utils.network._get_test_hosts", return_value=["1.1.1.1"]),
+            patch.dict(os.environ, {"ONLINE_TEST_URLS": ""}),
+        ):
             self.assertFalse(is_system_online(timeout=1))
         mock_conn.assert_called_once_with(("1.1.1.1", 443), timeout=1)
         mock_warn.assert_called_once()


### PR DESCRIPTION
## Summary
- isolate `ONLINE_TEST_URLS` for host-only network tests

## Testing
- `pre-commit run --all-files`
- `pytest -k network_online -vv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68520bf8e2c083338bd1aad4dde4bb4c