### PR TITLE
Cache ffmpeg version

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1195,18 +1195,28 @@ thread_cpu_times = {}
 last_thread_sample = time.time()
 child_procs = []
 
+# Cache ffmpeg version after the first lookup to avoid repeated subprocess calls.
+FFMPEG_VERSION: str | None = None
+
 
 def ffmpeg_version() -> str:
-    """Return the installed FFmpeg version or 'unavailable'."""
+    """Return the installed FFmpeg version or 'unavailable'.
+
+    The result is cached in ``FFMPEG_VERSION`` after the first lookup.
+    """
+    global FFMPEG_VERSION
+    if FFMPEG_VERSION is not None:
+        return FFMPEG_VERSION
     try:
         output = subprocess.check_output(
             [FFMPEG_PATH, "-version"], stderr=subprocess.STDOUT, timeout=2
         ).decode()
         first = output.splitlines()[0]
         match = re.search(r"ffmpeg version\s+([^\s]+)", first)
-        return match.group(1) if match else first
+        FFMPEG_VERSION = match.group(1) if match else first
     except Exception:
-        return "unavailable"
+        FFMPEG_VERSION = "unavailable"
+    return FFMPEG_VERSION
 
 
 def machine_supports_hwaccel() -> bool:
@@ -1291,6 +1301,7 @@ def get_system_metrics():
     else:
         open_files = len(process.open_files())
     ffmpeg_path = shutil.which(FFMPEG_PATH) or FFMPEG_PATH
+    ffmpeg_version_str = ffmpeg_version()
     ffmpeg_gpu_support = ffmpeg_supports_hwaccel()
     return {
         "cpu_usage": round(system_metrics["cpu_usage"], 1),
@@ -1300,7 +1311,7 @@ def get_system_metrics():
         "thread_count": system_metrics["thread_count"],
         "top_threads": system_metrics.get("top_threads", []),
         "uptime": f"{int(uptime // 3600)}h {int((uptime % 3600) // 60)}m {int(uptime % 60)}s",
-        "ffmpeg_version": ffmpeg_version(),
+        "ffmpeg_version": ffmpeg_version_str,
         "ffmpeg_path": ffmpeg_path,
         "machine_hwaccel": machine_supports_hwaccel(),
         "ffmpeg_hwaccel": ffmpeg_gpu_support,

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -131,7 +131,7 @@ class TestAddMotionAndCaption(unittest.TestCase):
 
 class TestGetSystemMetrics(unittest.TestCase):
     @patch("app.utils.scheduling.psutil")
-    @patch("app.utils.scheduling.ffmpeg_version", return_value="6.0")
+    @patch.object(scheduling, "FFMPEG_VERSION", "6.0")
     @patch("app.utils.scheduling.machine_supports_hwaccel", return_value=True)
     @patch("app.utils.scheduling.ffmpeg_supports_hwaccel", return_value=True)
     @patch("app.utils.scheduling.shutil.which", return_value="/usr/bin/ffmpeg")
@@ -141,7 +141,6 @@ class TestGetSystemMetrics(unittest.TestCase):
         mock_which,
         mock_ffmpeg_supports,
         mock_machine,
-        mock_version,
         mock_psutil,
     ):
         scheduling.system_metrics.update(


### PR DESCRIPTION
## Summary
- cache ffmpeg version in `scheduling`
- use the cached value in `get_system_metrics`
- update test to patch new variable

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852349696dc833396881be1cef66d2c