### PR TITLE
Improve dashboard accessibility

### DIFF
--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -34,12 +34,14 @@ confirm='Confirm', cancel='Cancel') -%}
 <div id="controls-wrapper">
   <section id="template-controls">
     {{ caller() }}
+    <label for="search-input" class="sr-only">Search</label>
     <input
       type="text"
       id="search-input"
       placeholder="Search cameras"
       title="Enter search terms or docs keywords"
     />
+    <label for="grid-width-slider" class="sr-only">Tile size</label>
     <input
       type="range"
       id="grid-width-slider"

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -16,9 +16,17 @@ The macro renders a modal with `delete-modal`, `delete-close` and related IDs so
 JavaScript can attach behavior consistently.
 
 ### Parameters
+
 - **name** – base identifier for generated element IDs.
 - **message** – text displayed inside the modal.
 - **confirm** – label for the confirm button.
 - **cancel** – label for the cancel button.
 
 Including this component ensures all dialogs share the same markup and style.
+
+## Accessible Form Controls
+
+When adding inputs like the dashboard search box or width slider, include a
+`label` element with the `sr-only` class for screen reader users.
+This keeps the visual layout clean while providing context for assistive
+technologies.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -135,6 +135,12 @@ class TestHtmlTemplates(unittest.TestCase):
         html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
         self.assertIn('<table id="thread-table"', html)
 
+    def test_index_has_control_labels(self):
+        """Dashboard search and slider inputs should have labels."""
+        html = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn('label for="search-input"', html)
+        self.assertIn('label for="grid-width-slider"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add screen reader labels for dashboard search and slider
- document accessible controls in the style guide
- test for these labels in the HTML template suite

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854805e18608333b213a095e4f5d8c7