### PR TITLE
Add REMOTE_SUBNETS support to discovery

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -478,6 +478,11 @@ WATCHDOG_MEMORY_THRESHOLD = int(get_setting("WATCHDOG_MEMORY_THRESHOLD", 80))
 # to ``True`` to run an hourly scan automatically.
 DISCOVERY_AUTOSTART = get_setting("DISCOVERY_AUTOSTART", "False") == "True"
 
+# Optional additional networks scanned during discovery. Provide a comma or
+# whitespace separated list of CIDR ranges such as "10.0.0.0/24,192.168.50.0/24".
+_REMOTE_SUBNETS_RAW = get_setting("REMOTE_SUBNETS", "")
+REMOTE_SUBNETS = [s for s in re.split(r"[,\s]+", _REMOTE_SUBNETS_RAW) if s]
+
 # Email settings
 EMAIL_ENABLED = get_setting("EMAIL_ENABLED", "False")
 EMAIL_SENDER = get_setting("EMAIL_SENDER", "")

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -420,6 +420,20 @@ def _local_subnets(max_prefixlen: int = 24):
     return sorted(subnets, key=lambda n: (n.network_address.packed, n.prefixlen))
 
 
+def _remote_subnets() -> list[ip_network]:
+    """Return networks listed in :data:`app.config.REMOTE_SUBNETS`."""
+
+    from app import config
+
+    nets: list[ip_network] = []
+    for cidr in getattr(config, "REMOTE_SUBNETS", []):
+        try:
+            nets.append(ip_network(cidr, strict=False))
+        except ValueError:
+            logging.warning("invalid REMOTE_SUBNETS entry %s", cidr)
+    return nets
+
+
 def _probe_onvif(timeout=2):
     cameras = []
     message_id = uuid.uuid4()
@@ -928,6 +942,12 @@ def discover_cameras(progress_callback=None, subnets=None):
         except Exception as e:  # pragma: no cover - system dependent
             logging.warning("subnet discovery error: %s", e)
             subnets = []
+    else:
+        subnets = list(subnets)
+
+    for net in _remote_subnets():
+        if net not in subnets:
+            subnets.append(net)
 
     tasks = {
         "onvif": _probe_onvif,

--- a/docs/camera_discovery.md
+++ b/docs/camera_discovery.md
@@ -216,8 +216,9 @@ Locally attached USB webcams (for example, Logitech devices) will appear under
 `/dev/video*`.
 
 Remote sources such as **GOES16**, **ZoomEarth**, and **Doppler** can be added
-manually, but they are not discovered automatically because they are hosted
-outside the local network. Selecting **internet** in the subnet field loads a
+manually. You may also set `REMOTE_SUBNETS` with a comma-separated list of CIDR
+ranges to include additional networks in the scan. These ranges are merged with
+the local interfaces. Selecting **internet** in the subnet field loads a
 curated list of public feeds including `time.gov` and other reference cameras.
 
 When creating a new template you can now supply just the camera's base
@@ -228,4 +229,4 @@ tools like Blue Iris.
 
 ## Future improvements
 
-Discovering cameras on remote networks remains on the roadmap. Authentication for protected feeds has been enhanced – you can now store a username and password with each template, and the capture routines will automatically supply these credentials.
+Scanning remote networks is supported via `REMOTE_SUBNETS`. Authentication for protected feeds has been enhanced – you can now store a username and password with each template, and the capture routines will automatically supply these credentials.

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -619,6 +619,42 @@ class TestCameraDiscovery(unittest.TestCase):
             self.assertEqual(vendor2, "RemoteCo")
             self.assertEqual(mock_get.call_count, 1)
 
+    def test_remote_subnets_parsing(self):
+        with patch.object(config, "REMOTE_SUBNETS", ["10.0.0.0/30", "bad"]):
+            with patch.object(camera_discovery, "logging") as mock_log:
+                nets = camera_discovery._remote_subnets()
+        self.assertIn(ip_network("10.0.0.0/30"), nets)
+        self.assertEqual(len(nets), 1)
+        mock_log.warning.assert_called_once()
+
+    @patch("app.utils.camera_discovery._scan_rtsp_ports", return_value=[])
+    @patch("app.utils.camera_discovery._probe_ssdp", return_value=[])
+    @patch("app.utils.camera_discovery._probe_mdns", return_value=[])
+    @patch("app.utils.camera_discovery._probe_onvif", return_value=[])
+    @patch("app.utils.camera_discovery._local_video_devices", return_value=[])
+    @patch("app.utils.camera_discovery._local_subnets")
+    def test_discover_includes_remote_subnets(
+        self,
+        mock_local_subnets,
+        *_mocks,
+    ):
+        mock_local_subnets.return_value = [ip_network("192.168.1.0/30")]
+        with patch.object(
+            camera_discovery,
+            "_remote_subnets",
+            return_value=[ip_network("10.0.0.0/30")],
+        ):
+            seen = {}
+
+            def fake_rtsp(nets):
+                seen["nets"] = nets
+                return []
+
+            _mocks[-1].side_effect = fake_rtsp  # patch for _scan_rtsp_ports
+            camera_discovery.discover_cameras()
+        self.assertIn(ip_network("192.168.1.0/30"), seen["nets"])
+        self.assertIn(ip_network("10.0.0.0/30"), seen["nets"])
+
     @patch("app.utils.camera_discovery.requests.get")
     def test_remote_vendor_lookup_success(self, mock_get):
         camera_discovery._remote_vendor_lookup.cache_clear()


### PR DESCRIPTION
## Summary
- add `REMOTE_SUBNETS` config option
- merge remote subnets into discovery
- document scanning remote networks
- test remote subnet parsing and integration

## Testing
- `pre-commit run --all-files` *(fails: stylelint not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854846731f0833393f4a6f26dae43ae