### PR TITLE
Add type hints to utils

### DIFF
--- a/app/utils/email_alerts.py
+++ b/app/utils/email_alerts.py
@@ -16,7 +16,7 @@ from app.config import (
 )
 
 
-def send_email_alert(subject, body):
+def send_email_alert(subject: str, body: str) -> None:
     """Send an email to the configured recipients.
 
     Parameters
@@ -54,7 +54,7 @@ def send_email_alert(subject, body):
         logging.error("Error sending email alert: %s", e)
 
 
-def email_alert(event_type, details):
+def email_alert(event_type: str, details: str) -> None:
     """Compose a standard alert email and send it.
 
     Parameters

--- a/app/utils/http_callbacks.py
+++ b/app/utils/http_callbacks.py
@@ -1,17 +1,19 @@
 import logging
 import time
+from typing import Any, Dict, Optional
+
 import requests
 
 
 def send_http_callback(
-    url,
-    event_type,
-    payload,
+    url: str,
+    event_type: str,
+    payload: Dict[str, Any],
     *,
-    timeout=5,
-    headers=None,
-    retries=0,
-):
+    timeout: int = 5,
+    headers: Optional[Dict[str, str]] = None,
+    retries: int = 0,
+) -> None:
     """Send an HTTP POST callback if a URL is provided.
 
     Parameters

--- a/app/utils/network_testing.py
+++ b/app/utils/network_testing.py
@@ -1,9 +1,19 @@
 import json
 import time
+from typing import List, Optional, Tuple
+
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
 
 
-def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=False):
+def network_idle_condition(
+    driver: WebDriver,
+    url: str,
+    timeout: int = 30,
+    idle_time: float = 0.25,
+    stealth: bool = False,
+) -> Tuple[bool, int]:
     """
     Returns a function that can be used as a condition for WebDriverWait.
     It checks if the network has been idle for a specified amount of time.
@@ -61,7 +71,9 @@ def network_idle_condition(driver, url, timeout=30, idle_time=0.25, stealth=Fals
     return True, lstatus
 
 
-def check_network_errors(driver, url, timeout=30):
+def check_network_errors(
+    driver: WebDriver, url: str, timeout: int = 30
+) -> Tuple[bool, List[str]]:
     """
     Check for network errors during page load.
 
@@ -91,7 +103,9 @@ def check_network_errors(driver, url, timeout=30):
     return False, errors
 
 
-def wait_for_element(driver, selector, timeout=10):
+def wait_for_element(
+    driver: WebDriver, selector: str, timeout: int = 10
+) -> Optional[WebElement]:
     """
     Wait for an element to be present on the page.
 

--- a/app/utils/profiling.py
+++ b/app/utils/profiling.py
@@ -3,12 +3,13 @@ import os
 import time
 from functools import wraps
 from threading import Lock
+from typing import Any, Callable, Dict, List
 
 LOG_PATH = "data/latency_log.json"
 _lock = Lock()
 
 
-def _load_log():
+def _load_log() -> List[Dict[str, Any]]:
     if os.path.exists(LOG_PATH):
         try:
             with open(LOG_PATH, "r") as f:
@@ -18,20 +19,22 @@ def _load_log():
     return []
 
 
-def _save_log(entries):
+def _save_log(entries: List[Dict[str, Any]]) -> None:
     os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
     with open(LOG_PATH, "w") as f:
         json.dump(entries, f)
 
 
-def profile_route(name=None):
+def profile_route(
+    name: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator for measuring route execution time."""
 
-    def decorator(func):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         route_name = name or func.__name__
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             start = time.time()
             try:
                 return func(*args, **kwargs)
@@ -53,7 +56,7 @@ def profile_route(name=None):
     return decorator
 
 
-def get_latency_stats():
+def get_latency_stats() -> Dict[str, Dict[str, float | int]]:
     """Return aggregated latency statistics."""
     with _lock:
         data = _load_log()

--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -3,6 +3,7 @@
 import os
 import time
 import logging
+from typing import List
 
 from app.config import (
     MAX_COMPRESSED_VIDEO_AGE,
@@ -12,7 +13,7 @@ from app.config import (
 )
 
 
-def get_files_sorted_by_creation_time(directory):
+def get_files_sorted_by_creation_time(directory: str) -> List[str]:
     if not os.path.isdir(directory):
         return []
 
@@ -30,7 +31,9 @@ def get_files_sorted_by_creation_time(directory):
     return files
 
 
-def delete_old_files(file_list, max_age, max_size, minimum=10):
+def delete_old_files(
+    file_list: List[str], max_age: int, max_size: int, minimum: int = 10
+) -> None:
     current_time = time.time()
     total_size = 0
 
@@ -67,7 +70,7 @@ def delete_old_files(file_list, max_age, max_size, minimum=10):
             logging.error("Error processing %s: %s", file_path, e)
 
 
-def retention_cleanup():
+def retention_cleanup() -> None:
     # For each camera, delete old or excess videos
     for camera_name in os.listdir(VIDEO_DIRECTORY):
         camera_dir = os.path.join(VIDEO_DIRECTORY, camera_name)

--- a/app/utils/sms_alerts.py
+++ b/app/utils/sms_alerts.py
@@ -5,7 +5,7 @@ import logging
 from app.config import TWILIO_SID, TWILIO_TOKEN, TWILIO_NUMBER
 
 
-def send_sms_alert(message):
+def send_sms_alert(message: str) -> None:
     """Send an SMS alert using Twilio.
 
     Parameters
@@ -34,7 +34,7 @@ def send_sms_alert(message):
         logging.error("Error sending SMS alert: %s", exc)
 
 
-def sms_alert(event_type, details):
+def sms_alert(event_type: str, details: str) -> None:
     """Format and send an SMS alert for an event.
 
     Parameters

--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -1,17 +1,18 @@
 import os
 import logging
 from datetime import datetime
+from typing import Optional
 
 
-def get_latest_video_date(directory):
+def get_latest_video_date(directory: str) -> Optional[str]:
     return get_latest_date(directory, ext="mp4")
 
 
-def get_latest_screenshot_date(directory):
+def get_latest_screenshot_date(directory: str) -> Optional[str]:
     return get_latest_date(directory, ext="png")
 
 
-def get_latest_file(directory, ext="png"):
+def get_latest_file(directory: str, ext: str = "png") -> Optional[str]:
 
     if not os.path.exists(directory):
         return None
@@ -38,7 +39,7 @@ def get_latest_file(directory, ext="png"):
     return latest_file
 
 
-def get_latest_date(directory, ext="png"):
+def get_latest_date(directory: str, ext: str = "png") -> Optional[str]:
     if not os.path.exists(directory):
         return None
 


### PR DESCRIPTION
## Summary
- annotate return types for video utilities
- add typing to HTTP callbacks
- type hints for email and SMS alerts
- update retention policy helpers with types
- add typing to profiling utilities
- improve network testing functions with type hints

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6854892bcf5c83338db5c86caf5dbe23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code clarity and maintainability by adding type annotations to various utility functions. No changes to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->