### PR TITLE
Add mypy config and type hints

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -122,7 +122,7 @@ def restart_server() -> None:
 
     logging.info("Restarting server...")
 
-    def delayed_restart():
+    def delayed_restart() -> None:
         time.sleep(1)  # 1-second delay
         os.execv(sys.executable, [sys.executable] + sys.argv)
 
@@ -144,14 +144,14 @@ class TemplateName:
             return False
         return True
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"TemplateName({self._name!r})"
 
 
-def generate_timed_hash():
+def generate_timed_hash() -> str:
     """Return a short‑lived hash derived from the API key.
 
     The resulting string combines a SHA-256 digest of the API key and an
@@ -180,11 +180,11 @@ def is_hash_valid(timed_hash: str) -> bool:
         return False
 
 
-def login_required(f: Callable) -> Callable:
+def login_required(f: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator enforcing session or API key authentication for routes."""
 
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args: Any, **kwargs: Any) -> Any:
         # Check for API key in headers, GET parameters, or POST form data
         api_key = (
             request.headers.get("X-API-Key")

--- a/app/utils/detect.py
+++ b/app/utils/detect.py
@@ -4,9 +4,12 @@ import numpy as np
 from PIL import Image
 from skimage.metrics import structural_similarity as ssim
 import logging
+from typing import Optional, Tuple
 
 
-def calculate_difference_fast(image_path_a, image_path_b, downsample_size=(100, 100)):
+def calculate_difference_fast(
+    image_path_a: str, image_path_b: str, downsample_size: Tuple[int, int] = (100, 100)
+) -> Optional[float]:
     """
     Calculate the difference between two images using the Structural Similarity Index (SSIM).
 

--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -3,6 +3,7 @@
 import os
 import time
 import logging
+from typing import List
 
 from app.config import (
     MAX_COMPRESSED_VIDEO_AGE,
@@ -12,7 +13,9 @@ from app.config import (
 )
 
 
-def get_files_sorted_by_creation_time(directory):
+def get_files_sorted_by_creation_time(directory: str) -> List[str]:
+    """Return a list of files in ``directory`` sorted by creation time."""
+
     if not os.path.isdir(directory):
         return []
 
@@ -30,7 +33,9 @@ def get_files_sorted_by_creation_time(directory):
     return files
 
 
-def delete_old_files(file_list, max_age, max_size, minimum=10):
+def delete_old_files(
+    file_list: List[str], max_age: int, max_size: int, minimum: int = 10
+) -> None:
     current_time = time.time()
     total_size = 0
 
@@ -67,7 +72,7 @@ def delete_old_files(file_list, max_age, max_size, minimum=10):
             logging.error("Error processing %s: %s", file_path, e)
 
 
-def retention_cleanup():
+def retention_cleanup() -> None:
     # For each camera, delete old or excess videos
     for camera_name in os.listdir(VIDEO_DIRECTORY):
         camera_dir = os.path.join(VIDEO_DIRECTORY, camera_name)

--- a/app/utils/video_details.py
+++ b/app/utils/video_details.py
@@ -1,17 +1,22 @@
 import os
 import logging
 from datetime import datetime
+from typing import Optional
 
 
-def get_latest_video_date(directory):
+def get_latest_video_date(directory: str) -> Optional[str]:
+    """Return the most recent video timestamp in ``directory``."""
+
     return get_latest_date(directory, ext="mp4")
 
 
-def get_latest_screenshot_date(directory):
+def get_latest_screenshot_date(directory: str) -> Optional[str]:
+    """Return the most recent screenshot timestamp in ``directory``."""
+
     return get_latest_date(directory, ext="png")
 
 
-def get_latest_file(directory, ext="png"):
+def get_latest_file(directory: str, ext: str = "png") -> Optional[str]:
 
     if not os.path.exists(directory):
         return None
@@ -38,7 +43,7 @@ def get_latest_file(directory, ext="png"):
     return latest_file
 
 
-def get_latest_date(directory, ext="png"):
+def get_latest_date(directory: str, ext: str = "png") -> Optional[str]:
     if not os.path.exists(directory):
         return None
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -41,9 +41,10 @@ to the web interface.
 
 ## Running Tests
 
-The project uses `pytest` for testing and `flake8` for linting. After activating your environment, run:
+The project uses `black` for formatting, `flake8` for linting, and `mypy` for static type checking. After activating your environment, run:
 ```sh
 flake8
+mypy
 pytest
 ```
 Running the full test suite helps ensure that your changes do not introduce regressions.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+check_untyped_defs = True


### PR DESCRIPTION
## Summary
- configure mypy for basic checking
- document static typing checks in the developer guide
- add explicit type hints to helper modules

## Testing
- `black app/utils/video_details.py app/utils/detect.py app/utils/retention_policy.py app/routes.py`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6854893447b48333bcffb47e09dee6ce