### PR TITLE
Implement mobile fade for controls

### DIFF
--- a/app/static/js/controls.js
+++ b/app/static/js/controls.js
@@ -3,11 +3,6 @@ export function initControlsDropdown() {
     const wrapper = document.getElementById("controls-wrapper");
     if (!wrapper) return;
 
-    const isMobile = window.matchMedia("(max-width: 767px)").matches;
-    if (isMobile) {
-      return;
-    }
-
     let fadeTimeout;
     const showControls = () => {
       wrapper.classList.remove("fade-out");
@@ -20,7 +15,7 @@ export function initControlsDropdown() {
       clearTimeout(fadeTimeout);
     };
 
-    ["mousemove", "scroll"].forEach((evt) => {
+    ["mousemove", "scroll", "touchstart"].forEach((evt) => {
       document.addEventListener(evt, showControls);
     });
     wrapper.addEventListener("mouseenter", pauseFade);

--- a/tests/js/controls.test.js
+++ b/tests/js/controls.test.js
@@ -29,7 +29,7 @@ describe("controls dropdown", () => {
     expect(wrapper.classList.contains("fade-out")).toBe(true);
   });
 
-  test("remains visible on mobile", () => {
+  test("fades out after inactivity on mobile", () => {
     window.matchMedia = jest.fn().mockImplementation(() => ({
       matches: true,
       addListener: jest.fn(),
@@ -38,8 +38,8 @@ describe("controls dropdown", () => {
     const wrapper = document.getElementById("controls-wrapper");
     initControlsDropdown();
     document.dispatchEvent(new Event("DOMContentLoaded"));
-    jest.advanceTimersByTime(5000);
-    expect(wrapper.classList.contains("fade-out")).toBe(false);
+    jest.advanceTimersByTime(3000);
+    expect(wrapper.classList.contains("fade-out")).toBe(true);
   });
 
   test("stays visible when hovered", () => {
@@ -48,6 +48,16 @@ describe("controls dropdown", () => {
     document.dispatchEvent(new Event("DOMContentLoaded"));
     wrapper.dispatchEvent(new Event("mouseenter"));
     jest.advanceTimersByTime(5000);
+    expect(wrapper.classList.contains("fade-out")).toBe(false);
+  });
+
+  test("touchstart shows controls", () => {
+    const wrapper = document.getElementById("controls-wrapper");
+    initControlsDropdown();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.advanceTimersByTime(3000);
+    expect(wrapper.classList.contains("fade-out")).toBe(true);
+    document.dispatchEvent(new Event("touchstart"));
     expect(wrapper.classList.contains("fade-out")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- fade the template controls on mobile after inactivity
- update JS tests for new mobile fade behavior

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68548ad2f0a48333a9c5415cba48dc63