### PR TITLE
Add global search shortcut

### DIFF
--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -28,6 +28,7 @@ import { initCliHelp } from "./cli_help.js";
 import { initNetworkBanner } from "./network_banner.js";
 import { initUnsavedIndicator } from "./unsaved.js";
 import { initVideoZoom } from "./zoom.js";
+import { initSearchShortcut } from "./search_shortcut.js";
 
 initTemplates();
 initVideoControls();
@@ -60,3 +61,4 @@ initKeyVisibility();
 initUnsavedIndicator();
 initCliHelp();
 initVideoZoom();
+initSearchShortcut();

--- a/app/static/js/search_shortcut.js
+++ b/app/static/js/search_shortcut.js
@@ -1,0 +1,28 @@
+export function initSearchShortcut() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const input = document.getElementById("search-input");
+    const container = document.getElementById("search-container");
+    if (!input) return;
+    const focusSearch = () => {
+      if (container) {
+        container.classList.remove("fade-out");
+        container.style.display = "";
+      }
+      input.focus();
+      input.select();
+    };
+    document.addEventListener("keydown", (e) => {
+      const tag = e.target.tagName;
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "f") {
+        if (
+          tag !== "INPUT" &&
+          tag !== "TEXTAREA" &&
+          !e.target.isContentEditable
+        ) {
+          e.preventDefault();
+          focusSearch();
+        }
+      }
+    });
+  });
+}

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -30,7 +30,7 @@ On the **Live** page, pick a camera from the drop-down menu. The **Video Source*
 
 Click **Live All** to switch every tile to a real-time feed and **Play All** to toggle between playing or pausing archived clips. When watching a single stream you can drag the jog‑shuttle or time slider to scrub forward or backward.
 
-Keyboard shortcuts help you navigate quickly: `Space` or `k` toggles play or pause, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type. A vertical speed slider also appears when you hover over the player so you can fine‑tune playback without extra clutter.
+Keyboard shortcuts help you navigate quickly: press `Ctrl+F` or `⌘+F` to jump to the page search box, `Space` or `k` toggles play or pause, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type. A vertical speed slider also appears when you hover over the player so you can fine‑tune playback without extra clutter.
 
 Navigate back to the main interface using the **Back to Glimpser** link at the bottom of the help page.
 

--- a/tests/js/search_shortcut.test.js
+++ b/tests/js/search_shortcut.test.js
@@ -1,0 +1,37 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div id="search-container" class="fade-out"></div>
+  <input id="search-input" />
+  <input id="other" />
+`;
+
+let initSearchShortcut;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/search_shortcut.js");
+  initSearchShortcut = mod.initSearchShortcut;
+});
+
+test("ctrl+f focuses search input", () => {
+  initSearchShortcut();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const input = document.getElementById("search-input");
+  const evt = new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
+  const prevent = jest.spyOn(evt, "preventDefault");
+  document.dispatchEvent(evt);
+  expect(prevent).toHaveBeenCalled();
+  expect(document.activeElement).toBe(input);
+});
+
+test("does not override typing in inputs", () => {
+  initSearchShortcut();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const other = document.getElementById("other");
+  other.focus();
+  const evt = new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
+  const prevent = jest.spyOn(evt, "preventDefault");
+  other.dispatchEvent(evt);
+  expect(prevent).not.toHaveBeenCalled();
+  expect(document.activeElement).toBe(other);
+});


### PR DESCRIPTION
## Summary
- intercept Ctrl+F and ⌘+F to focus the page search box
- document the keyboard shortcut in the help page
- test new shortcut logic

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854897e999483339bba5a2d3b103cc8