### PR TITLE
Add dashboard grid presets

### DIFF
--- a/app/static/js/templates.js
+++ b/app/static/js/templates.js
@@ -279,6 +279,16 @@ export function initTemplates() {
       } else {
         handleSlider();
         setupTileResizeDrag(slider);
+        document
+          .querySelectorAll("#grid-presets button[data-grid]")
+          .forEach((btn) => {
+            btn.addEventListener("click", () => {
+              const tiles = parseInt(btn.dataset.grid, 10);
+              const size = tileSizeForGrid(tiles);
+              slider.value = size.toString();
+              slider.dispatchEvent(new Event("input"));
+            });
+          });
       }
     }
 
@@ -462,6 +472,32 @@ export function computeBorderColor(ageMinutes, isError) {
   }
   const alpha = Math.pow(0.5, step);
   return `rgba(${base[0]}, ${base[1]}, ${base[2]}, ${alpha})`;
+}
+
+export function tileSizeForGrid(total) {
+  const slider = document.getElementById("grid-width-slider");
+  const list = document.getElementById("template-list");
+  if (!slider || !list) return 0;
+  const gap = parseFloat(getComputedStyle(list).gap || "0") || 0;
+  const ASPECT = 9 / 16;
+  const cols = Math.ceil(Math.sqrt(total));
+  const rows = Math.ceil(total / cols);
+  const maxHoriz = Math.floor((window.innerWidth - gap * (cols - 1)) / cols);
+  const headerHeight = document.querySelector("header")?.offsetHeight || 0;
+  const bannerHeight =
+    document.getElementById("network-banner")?.offsetHeight || 0;
+  const footerSpace = parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      "--footer-space",
+    ) || "0",
+  );
+  const availableHeight =
+    window.innerHeight - headerHeight - bannerHeight - footerSpace;
+  const maxVert = Math.floor(
+    (availableHeight - gap * (rows - 1)) / (rows * ASPECT),
+  );
+  const width = Math.min(parseFloat(slider.max), maxHoriz, maxVert);
+  return Math.max(parseFloat(slider.min), width);
 }
 
 export function setupTileResizeDrag(slider) {

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -50,6 +50,12 @@ confirm='Confirm', cancel='Cancel') -%}
       value="360"
       title="Adjust the width of the template grid"
     />
+    <div id="grid-presets">
+      <button type="button" data-grid="1">1×1</button>
+      <button type="button" data-grid="4">2×2</button>
+      <button type="button" data-grid="9">3×3</button>
+      <button type="button" data-grid="16">4×4</button>
+    </div>
     {{ status_legend() }}
     <button
       id="caption-toggle"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -141,6 +141,11 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('label for="search-input"', html)
         self.assertIn('label for="grid-width-slider"', html)
 
+    def test_grid_presets_present(self):
+        html = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn('id="grid-presets"', html)
+        self.assertIn('data-grid="4"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add grid size preset buttons to components.html
- compute tile sizes from grid presets in templates.js
- test for new grid preset markup

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68549ee529b08333b98511c385ed7a94