### PR TITLE
Fix mobile legend visibility

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -356,9 +356,6 @@ h2 {
   #template-controls input[type="text"] {
     width: 6rem;
   }
-  #status-legend {
-    display: none;
-  }
   #controls-wrapper {
     font-size: 0.75rem;
   }
@@ -683,6 +680,12 @@ body.high-contrast-mode {
 
 .status-box.error {
   border-color: red;
+}
+
+@media (max-width: 767px) {
+  #status-legend {
+    display: none;
+  }
 }
 
 /* Improve video controls on mobile */


### PR DESCRIPTION
## Summary
- hide the status legend in the control panel on small screens

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855ebfc7ca48333b238c8ed723b80e4