### PR TITLE
Add settings_row macro for table rows

### DIFF
--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -459,4 +459,102 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
     </div>
   </form>
 </div>
+{%- endmacro %} {%- macro settings_row(setting) -%}
+<tr>
+  <td title="{{ tooltips.get(setting.name, '') }}">{{ setting.name }}</td>
+  <td>
+    {% if setting.name in boolean_fields %}
+    <label class="switch">
+      <!-- prettier-ignore -->
+      <input
+          type="checkbox"
+          name="{{ setting.name }}"
+          value="True"
+          {% if setting.value == 'True' %}checked{% endif %}
+          data-boolean
+          {% if setting.name == 'DISCOVERY_AUTOSTART' %}data-ignore-unsaved{% endif %}
+          {% if setting.name in locked_settings %}disabled data-locked{% endif %}
+          {% if setting.name == 'FFMPEG_HWACCEL' and not metrics.ffmpeg_gpu_support %}disabled data-unavailable{% endif %}
+        />
+      <span class="slider round"></span>
+    </label>
+    {% elif 'KEY' in setting.name %} {% set sprite = url_for('static',
+    filename='icons/sprite.svg') %}
+    <input
+      id="{{ setting.name }}"
+      type="password"
+      name="{{ setting.name }}"
+      value="{{ setting.value }}"
+      title="Edit value for {{ setting.name }}"
+      {%
+      if
+      setting.name
+      in
+      locked_settings
+      %}disabled
+      data-locked{%
+      endif
+      %}
+    />
+    <button
+      type="button"
+      class="toggle-key-visibility"
+      data-input="{{ setting.name }}"
+      data-sprite="{{ sprite }}"
+      title="Show key"
+    >
+      <svg width="16" height="16">
+        <use href="{{ sprite }}#eye" />
+      </svg>
+    </button>
+    {% else %}
+    <input
+      type="{{ 'number' if setting.name in numeric_fields else 'text' }}"
+      name="{{ setting.name }}"
+      value="{{ setting.value }}"
+      title="Edit value for {{ setting.name }}"
+      {%
+      if
+      setting.name
+      in
+      placeholders
+      %}
+      placeholder="{{ placeholders[setting.name] }}"
+      {%
+      endif
+      %}
+      {%
+      if
+      setting.name
+      in
+      choices
+      %}list="{{ setting.name }}-list"
+      {%
+      endif
+      %}
+      {%
+      if
+      setting.name
+      in
+      locked_settings
+      %}disabled
+      data-locked{%
+      endif
+      %}
+    />
+    {% endif %}
+  </td>
+  <td class="advanced-only">
+    <button
+      type="submit"
+      name="action"
+      value="delete"
+      title="Delete {{ setting.name }}"
+      onclick="return confirmDeleteSetting('{{ setting.name }}')"
+      class="advanced-only"
+    >
+      Delete
+    </button>
+  </td>
+</tr>
 {%- endmacro %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %} {% from 'components.html' import card, confirm_modal,
-template_form %} {% block content %}
+template_form, settings_row with context %} {% block content %}
 <main class="container settings-page">
   {# Help content now appears directly in the table, so the collapsible menu was
   removed #}
@@ -114,107 +114,7 @@ template_form %} {% block content %}
           </tr>
         </thead>
         <tbody>
-          {% for setting in items %}
-          <tr>
-            <td title="{{ tooltips.get(setting.name, '') }}">
-              {{ setting.name }}
-            </td>
-            <td>
-              {% if setting.name in boolean_fields %}
-              <label class="switch">
-                <!-- prettier-ignore -->
-                <input
-                    type="checkbox"
-                    name="{{ setting.name }}"
-                    value="True"
-                    {% if setting.value == 'True' %}checked{% endif %}
-                    data-boolean
-                    {% if setting.name == 'DISCOVERY_AUTOSTART' %}data-ignore-unsaved{% endif %}
-                    {% if setting.name in locked_settings %}disabled data-locked{% endif %}
-                    {% if setting.name == 'FFMPEG_HWACCEL' and not metrics.ffmpeg_gpu_support %}disabled data-unavailable{% endif %}
-                  />
-                <span class="slider round"></span>
-              </label>
-              {% elif 'KEY' in setting.name %} {% set sprite = url_for('static',
-              filename='icons/sprite.svg') %}
-              <input
-                id="{{ setting.name }}"
-                type="password"
-                name="{{ setting.name }}"
-                value="{{ setting.value }}"
-                title="Edit value for {{ setting.name }}"
-                {%
-                if
-                setting.name
-                in
-                locked_settings
-                %}disabled
-                data-locked{%
-                endif
-                %}
-              />
-              <button
-                type="button"
-                class="toggle-key-visibility"
-                data-input="{{ setting.name }}"
-                data-sprite="{{ sprite }}"
-                title="Show key"
-              >
-                <svg width="16" height="16">
-                  <use href="{{ sprite }}#eye" />
-                </svg>
-              </button>
-              {% else %}
-              <input
-                type="{{ 'number' if setting.name in numeric_fields else 'text' }}"
-                name="{{ setting.name }}"
-                value="{{ setting.value }}"
-                title="Edit value for {{ setting.name }}"
-                {%
-                if
-                setting.name
-                in
-                placeholders
-                %}
-                placeholder="{{ placeholders[setting.name] }}"
-                {%
-                endif
-                %}
-                {%
-                if
-                setting.name
-                in
-                choices
-                %}list="{{ setting.name }}-list"
-                {%
-                endif
-                %}
-                {%
-                if
-                setting.name
-                in
-                locked_settings
-                %}disabled
-                data-locked{%
-                endif
-                %}
-              />
-              {% endif %}
-            </td>
-            <td class="advanced-only">
-              <button
-                type="submit"
-                name="action"
-                value="delete"
-                title="Delete {{ setting.name }}"
-                onclick="return confirmDeleteSetting('{{ setting.name }}')"
-                class="advanced-only"
-              >
-                Delete
-              </button>
-            </td>
-          </tr>
-          {% endfor %}
+          {% for setting in items %} {{ settings_row(setting) }} {% endfor %}
         </tbody>
       </table>
       {% endcall %} {% if group == 'Admin' %} {% call card('Configuration

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -4,6 +4,8 @@ import unittest
 from html.parser import HTMLParser
 from pathlib import Path
 
+from jinja2 import Environment, FileSystemLoader
+
 
 class TemplateParser(HTMLParser):
     """Simple HTML parser to capture img tags and form inputs."""
@@ -144,6 +146,26 @@ class TestHtmlTemplates(unittest.TestCase):
         html = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('label for="search-input"', html)
         self.assertIn('label for="grid-width-slider"', html)
+
+    def test_settings_row_macro_renders(self):
+        env = Environment(loader=FileSystemLoader("app/templates"))
+        tmpl = env.from_string(
+            '{% from "components.html" import settings_row with context %}{{ settings_row(setting) }}'
+        )
+        context = {
+            "setting": {"name": "TEST_BOOL", "value": "True"},
+            "boolean_fields": {"TEST_BOOL"},
+            "numeric_fields": set(),
+            "choices": {},
+            "placeholders": {},
+            "locked_settings": set(),
+            "tooltips": {},
+            "metrics": {"ffmpeg_gpu_support": True},
+        }
+        html = tmpl.render(**context)
+        self.assertIn("<tr>", html)
+        self.assertIn('name="TEST_BOOL"', html)
+        self.assertIn('type="checkbox"', html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- define `settings_row` macro in `components.html`
- use macro in `settings.html`
- test macro rendering in HTML template tests

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_dashboard.py tests/test_html_templates.py tests/test_jinja_macros.py`

------
https://chatgpt.com/codex/tasks/task_e_6855f1cd12c08333af0249ef0f49700e