### PR TITLE
Add reset option for settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3659,6 +3659,11 @@ def init_routes(app: Flask) -> None:
                 name_to_delete = request.form.get("name_to_delete")
                 if name_to_delete:
                     delete_setting(name_to_delete)
+            elif action == "reset":
+                name_to_reset = request.form.get("name_to_reset")
+                if name_to_reset and hasattr(config, name_to_reset):
+                    default_val = getattr(config, name_to_reset)
+                    update_setting(name_to_reset, str(default_val))
             elif action == "update_email":
                 for setting in email_settings:
                     value = request.form.get(setting)

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -212,6 +212,16 @@ template_form %} {% block content %}
               >
                 Delete
               </button>
+              <button
+                type="submit"
+                name="action"
+                value="reset"
+                title="Reset {{ setting.name }} to default"
+                onclick="document.getElementById('name_to_reset').value='{{ setting.name }}'"
+                class="advanced-only"
+              >
+                Reset
+              </button>
             </td>
           </tr>
           {% endfor %}
@@ -337,6 +347,13 @@ template_form %} {% block content %}
         name="name_to_delete"
         value=""
         title="Name of setting to delete"
+      />
+      <input
+        type="hidden"
+        id="name_to_reset"
+        name="name_to_reset"
+        value=""
+        title="Name of setting to reset"
       />
       {% endif %}
       <button type="submit" title="Save all changes">Save Changes</button>

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -222,6 +222,27 @@ class TestSettingsRoute(unittest.TestCase):
         self.assertEqual(self._get_value("SMS_ENABLED"), "True")
         self.assertEqual(self._get_value("CAP_ENABLED"), "False")
 
+    def test_reset_setting(self):
+        with (
+            patch("app.routes.session", {"user_id": 1}),
+            patch("app.routes.login_required", lambda x: x),
+        ):
+            self.client.post("/settings", data={"CHYRON_SPEED": "5"})
+        self.assertEqual(self._get_value("CHYRON_SPEED"), "5")
+
+        with (
+            patch("app.routes.session", {"user_id": 1}),
+            patch("app.routes.login_required", lambda x: x),
+        ):
+            response = self.client.post(
+                "/settings",
+                data={"action": "reset", "name_to_reset": "CHYRON_SPEED"},
+            )
+        self.assertEqual(response.status_code, 302)
+        import app.config as config
+
+        self.assertEqual(self._get_value("CHYRON_SPEED"), str(config.CHYRON_SPEED))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow resetting settings to defaults
- expose reset button in settings template
- cover resetting in tests

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_settings_route.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6855f1bdbc808333b7706f5421b91e2a