### PR TITLE
Limit config upload size in settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -148,6 +148,8 @@ SEGMENT_SEC = 10
 
 
 FFMPEG = config.FFMPEG_PATH  # shortcut
+# Limit configuration uploads to 5 MB to avoid excessive memory usage
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024
 
 
 # ---------- tiny helpers ----------------------------------------------------
@@ -3700,9 +3702,18 @@ def init_routes(app: Flask) -> None:
                     if file.filename == "":
                         flash("No selected file", "error")
                     elif file and allowed_file(file.filename):
-                        file.save(BACKUP_PATH)
-                        restore_config()
-                        flash("Configuration restored successfully", "success")
+                        file.stream.seek(0, os.SEEK_END)
+                        size = file.stream.tell()
+                        file.stream.seek(0)
+                        if size > MAX_UPLOAD_SIZE:
+                            flash("File exceeds 5 MB limit", "error")
+                        else:
+                            file.save(BACKUP_PATH)
+                            restore_config()
+                            flash(
+                                "Configuration restored successfully",
+                                "success",
+                            )
                     else:
                         flash("Invalid file type", "error")
             elif action == "test_email":

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -168,6 +168,27 @@ class TestSettingsRoute(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(self._get_value("A"), "2")
 
+    def test_upload_too_large_rejected(self):
+        big_path = os.path.join(self.temp_dir.name, "big.json")
+        from app.routes import MAX_UPLOAD_SIZE
+
+        with open(big_path, "wb") as f:
+            f.write(b"0" * (MAX_UPLOAD_SIZE + 1))
+        with (
+            patch("app.routes.session", {"user_id": 1}),
+            patch("app.routes.login_required", lambda x: x),
+        ):
+            with open(big_path, "rb") as file_data:
+                response = self.client.post(
+                    "/settings",
+                    data={"action": "upload", "file": (file_data, "big.json")},
+                    content_type="multipart/form-data",
+                )
+        self.assertEqual(response.status_code, 302)
+        with self.client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        self.assertIn(("error", "File exceeds 5 MB limit"), flashes)
+
     def test_download_without_backup(self):
         """Downloading settings should not crash when no backup exists."""
         if os.path.exists(self.backup_path):


### PR DESCRIPTION
## Summary
- limit uploaded configuration file size to 5 MB
- flash an error when a file is oversized
- test oversized uploads are rejected

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f1a3b7fc8333a46060afd2e709b3