### PR TITLE
Update settings email inputs

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -166,7 +166,7 @@ template_form %} {% block content %}
               </button>
               {% else %}
               <input
-                type="{{ 'number' if setting.name in numeric_fields else 'text' }}"
+                type="{{ 'number' if setting.name in numeric_fields else ('email' if setting.name in email_fields else 'text') }}"
                 name="{{ setting.name }}"
                 value="{{ setting.value }}"
                 title="Edit value for {{ setting.name }}"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -108,6 +108,10 @@ class TestHtmlTemplates(unittest.TestCase):
         html = Path("app/templates/settings.html").read_text(encoding="utf-8")
         self.assertIn('id="contrast-toggle"', html)
 
+    def test_email_fields_have_email_type(self):
+        html = Path("app/templates/settings.html").read_text(encoding="utf-8")
+        self.assertIn("email_fields", html)
+
     def test_captions_prompt_label(self):
         """Captions page prompt textarea should have a visible label."""
         html = Path("app/templates/captions.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- set type="email" for settings keys found in `EMAIL_FIELDS`
- test that the template references `email_fields`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855f1981adc8333b5de210b83b56681