### PR TITLE
Add docstring for settings route

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3625,6 +3625,7 @@ def init_routes(app: Flask) -> None:
     @app.route("/settings", methods=["GET", "POST"])
     @login_required
     def settings():
+        """Render settings page and handle configuration updates via POST."""
         if request.method == "POST":
             email_settings = [
                 "EMAIL_ENABLED",


### PR DESCRIPTION
## Summary
- document the settings page route

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f181cd4083338be40be008a52a09