### PR TITLE
Add login script tests

### DIFF
--- a/tests/js/login.test.js
+++ b/tests/js/login.test.js
@@ -1,0 +1,88 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <form id="login-form">
+    <input id="username" name="username" />
+    <input id="password" name="password" />
+    <div id="login-error" class="hidden"></div>
+    <input id="remember" type="checkbox" name="remember" />
+  </form>
+`;
+
+let initLogin;
+let attemptAutoLogin;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/login.js");
+  initLogin = mod.initLogin;
+  attemptAutoLogin = mod.attemptAutoLogin;
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.clearAllMocks();
+});
+
+test("shows error when fields empty", () => {
+  initLogin();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const form = document.getElementById("login-form");
+  const evt = new Event("submit", { bubbles: true, cancelable: true });
+  form.dispatchEvent(evt);
+  const err = document.getElementById("login-error");
+  expect(evt.defaultPrevented).toBe(true);
+  expect(err.classList.contains("hidden")).toBe(false);
+  expect(err.textContent).toBe("Username and password are required.");
+});
+
+test("stores credentials when remember checked", () => {
+  initLogin();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const form = document.getElementById("login-form");
+  form.elements.username.value = "alice";
+  form.elements.password.value = "secret";
+  form.elements.remember.checked = true;
+  const evt = new Event("submit", { bubbles: true, cancelable: true });
+  form.dispatchEvent(evt);
+  const stored = localStorage.getItem("autoLogin");
+  expect(stored).toBe(
+    JSON.stringify({ username: "alice", password: "secret" }),
+  );
+});
+
+test("clears stored credentials when checkbox unchecked", () => {
+  localStorage.setItem(
+    "autoLogin",
+    JSON.stringify({ username: "alice", password: "secret" }),
+  );
+  initLogin();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const form = document.getElementById("login-form");
+  form.elements.username.value = "alice";
+  form.elements.password.value = "secret";
+  form.elements.remember.checked = false;
+  const evt = new Event("submit", { bubbles: true, cancelable: true });
+  form.dispatchEvent(evt);
+  expect(localStorage.getItem("autoLogin")).toBeNull();
+});
+
+test("attemptAutoLogin posts credentials and redirects", async () => {
+  localStorage.setItem(
+    "autoLogin",
+    JSON.stringify({ username: "bob", password: "pw" }),
+  );
+  Object.defineProperty(window, "location", {
+    writable: true,
+    configurable: true,
+    value: { pathname: "/login", href: "/login" },
+  });
+  global.fetch = jest.fn(() => Promise.resolve({ redirected: true, url: "/" }));
+  const result = await attemptAutoLogin();
+  expect(fetch).toHaveBeenCalledWith(
+    "/login",
+    expect.objectContaining({ method: "POST" }),
+  );
+  expect(result).toBe(true);
+  expect(window.location.href).toBe("/");
+  expect(window.IS_LOGGED_IN).toBe(true);
+});


### PR DESCRIPTION
## Summary
- test validation and localStorage behaviour on the login form
- verify auto login posts credentials and redirects

## Testing
- `pytest`
- `npm test`
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6855f169f3588333a7b587728a263150