### PR TITLE
Add password toggle to login

### DIFF
--- a/app/static/js/password_toggle.js
+++ b/app/static/js/password_toggle.js
@@ -1,0 +1,24 @@
+export function initPasswordToggle() {
+  const setup = () => {
+    const toggle = document.getElementById("password-toggle");
+    const input = document.getElementById("password");
+    if (!toggle || !input) return;
+    const useEl = toggle.querySelector("use");
+    const sprite = useEl ? useEl.getAttribute("href").split("#")[0] : "";
+    toggle.addEventListener("click", () => {
+      const showing = input.type === "text";
+      input.type = showing ? "password" : "text";
+      if (useEl) {
+        useEl.setAttribute("href", `${sprite}#${showing ? "eye" : "eye-off"}`);
+      }
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setup);
+  } else {
+    setup();
+  }
+}
+
+initPasswordToggle();

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -36,6 +36,18 @@ content %}
         required
         title="Enter your password"
       />
+      <button
+        type="button"
+        id="password-toggle"
+        aria-label="Show password"
+        class="toggle-password"
+      >
+        <svg width="16" height="16">
+          <use
+            href="{{ url_for('static', filename='icons/sprite.svg') }}#eye"
+          />
+        </svg>
+      </button>
     </div>
     <div id="login-error" class="form-error hidden"></div>
 
@@ -59,5 +71,9 @@ content %}
 <script
   type="module"
   src="{{ url_for('static', filename='js/login.js') }}"
+></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/password_toggle.js') }}"
 ></script>
 {% endblock %}

--- a/tests/js/password_toggle.test.js
+++ b/tests/js/password_toggle.test.js
@@ -1,0 +1,28 @@
+import { jest } from "@jest/globals";
+
+let initPasswordToggle;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/password_toggle.js");
+  initPasswordToggle = mod.initPasswordToggle;
+});
+
+test("click toggles password visibility", () => {
+  document.body.innerHTML = `
+    <input id="password" type="password" />
+    <button id="password-toggle" aria-label="Show password">
+      <svg><use href="icons.svg#eye"></use></svg>
+    </button>
+  `;
+  initPasswordToggle();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  const input = document.getElementById("password");
+  const btn = document.getElementById("password-toggle");
+  const useEl = btn.querySelector("use");
+  btn.click();
+  expect(input.type).toBe("text");
+  expect(useEl.getAttribute("href")).toBe("icons.svg#eye-off");
+  btn.click();
+  expect(input.type).toBe("password");
+  expect(useEl.getAttribute("href")).toBe("icons.svg#eye");
+});


### PR DESCRIPTION
## Summary
- add a small JS module to toggle password field visibility
- expose toggle button in `login.html`
- test password toggle behaviour

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855f15c3aa883339010837177736327