### PR TITLE
Improve login error accessibility

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -24,6 +24,7 @@ content %}
         placeholder="Username"
         required
         title="Enter your username"
+        aria-describedby="login-error"
       />
     </div>
     <div class="form-field">
@@ -35,9 +36,15 @@ content %}
         placeholder="Password"
         required
         title="Enter your password"
+        aria-describedby="login-error"
       />
     </div>
-    <div id="login-error" class="form-error hidden"></div>
+    <div
+      id="login-error"
+      class="form-error hidden"
+      role="alert"
+      aria-live="assertive"
+    ></div>
 
     <div class="checkbox-row">
       <input id="remember" type="checkbox" name="remember" />

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -68,6 +68,23 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertTrue(inputs, "remember checkbox missing")
         self.assertEqual(inputs[0].get("type"), "checkbox")
 
+    def test_login_error_has_alert_role(self):
+        html = Path("app/templates/login.html").read_text(encoding="utf-8")
+        self.assertIn('id="login-error"', html)
+        self.assertIn('role="alert"', html)
+        self.assertIn('aria-live="assertive"', html)
+
+    def test_login_inputs_described_by_error(self):
+        parser = parse_template(Path("app/templates/login.html"))
+        username = next(
+            i for i in parser.forms[0]["inputs"] if i.get("id") == "username"
+        )
+        password = next(
+            i for i in parser.forms[0]["inputs"] if i.get("id") == "password"
+        )
+        self.assertEqual(username.get("aria-describedby"), "login-error")
+        self.assertEqual(password.get("aria-describedby"), "login-error")
+
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
         self.assertIn("template_form(", html)


### PR DESCRIPTION
## Summary
- add `aria-describedby` to login fields
- mark the login error with `role="alert"` and `aria-live="assertive"`
- test for the new login accessibility attributes

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855f14d8d4883339eee2eb9d62ca708