### PR TITLE
Improve login autocomplete

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -21,6 +21,7 @@ content %}
         id="username"
         type="text"
         name="username"
+        autocomplete="username"
         placeholder="Username"
         required
         title="Enter your username"
@@ -32,6 +33,7 @@ content %}
         id="password"
         type="password"
         name="password"
+        autocomplete="current-password"
         placeholder="Password"
         required
         title="Enter your password"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -68,6 +68,13 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertTrue(inputs, "remember checkbox missing")
         self.assertEqual(inputs[0].get("type"), "checkbox")
 
+    def test_login_autocomplete_attributes(self):
+        """Username and password inputs should set autocomplete."""
+        parser = parse_template(Path("app/templates/login.html"))
+        inputs = {i.get("name"): i for i in parser.forms[0]["inputs"]}
+        self.assertEqual(inputs["username"].get("autocomplete"), "username")
+        self.assertEqual(inputs["password"].get("autocomplete"), "current-password")
+
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
         self.assertIn("template_form(", html)


### PR DESCRIPTION
## Summary
- add autocomplete attributes on username/password inputs
- test that login fields include autocomplete

## Testing
- `pre-commit run --all-files`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6855f149e37c83338d0caaebf3248476