### PR TITLE
Add autocomplete attrs to login form

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -25,6 +25,8 @@ content %}
         required
         title="Enter your username"
         aria-describedby="login-error"
+        autocomplete="username"
+        autofocus
       />
     </div>
     <div class="form-field">
@@ -37,6 +39,7 @@ content %}
         required
         title="Enter your password"
         aria-describedby="login-error"
+        autocomplete="current-password"
       />
       <button
         type="button"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -87,6 +87,18 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertEqual(username.get("aria-describedby"), "login-error")
         self.assertEqual(password.get("aria-describedby"), "login-error")
 
+    def test_login_autocomplete_and_focus(self):
+        parser = parse_template(Path("app/templates/login.html"))
+        username = next(
+            i for i in parser.forms[0]["inputs"] if i.get("id") == "username"
+        )
+        password = next(
+            i for i in parser.forms[0]["inputs"] if i.get("id") == "password"
+        )
+        self.assertEqual(username.get("autocomplete"), "username")
+        self.assertIn("autofocus", username)
+        self.assertEqual(password.get("autocomplete"), "current-password")
+
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
         self.assertIn("template_form(", html)


### PR DESCRIPTION
## Summary
- improve login form accessibility
- add new test coverage for autocomplete and autofocus attributes

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68561359bf688333b4f2f55dc824b968