### PR TITLE
Handle safe redirects after login

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -498,6 +498,17 @@ def is_hash_valid(timed_hash: str) -> bool:
         return False
 
 
+def is_safe_redirect_url(target: str | None) -> bool:
+    """Return ``True`` when ``target`` is a safe relative URL."""
+
+    if not target:
+        return False
+    if "\n" in target or "\r" in target:
+        return False
+    parsed = urlparse(target)
+    return not parsed.scheme and not parsed.netloc
+
+
 def login_required(f: Callable) -> Callable:
     """Decorator enforcing session or API key authentication for routes."""
 
@@ -1862,6 +1873,7 @@ def init_routes(app: Flask) -> None:
 
     @app.route("/login", methods=["GET", "POST"])
     def login():
+        next_url = request.args.get("next")
         ip_address = request.remote_addr
         now = datetime.now()
 
@@ -1908,7 +1920,10 @@ def init_routes(app: Flask) -> None:
                     ip_address, None
                 )  # Reset attempts on successful login
                 logging.info("Successful login for %s from %s", username, ip_address)
-                return redirect(url_for("index"))
+                target = (
+                    next_url if is_safe_redirect_url(next_url) else url_for("index")
+                )
+                return redirect(target)
             else:
                 # Record the failed attempt
                 if ip_address not in login_attempts:

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -63,6 +63,74 @@ class TestAuthentication(unittest.TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertIn("/", response.headers["Location"])
 
+    def test_login_redirects_to_next_when_safe(self):
+        with (
+            patch("app.routes.SessionLocal") as mock_session_local,
+            patch("app.routes.login_attempts", {}),
+            patch("app.routes.check_password_hash", return_value=True),
+        ):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.post(
+                "/login?next=/protected",
+                data={
+                    "username": USER_NAME,
+                    "password": "correct_password",  # pragma: allowlist secret
+                },
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual("/protected", response.headers["Location"])
+
+    def test_login_redirects_ignores_unsafe_next(self):
+        with (
+            patch("app.routes.SessionLocal") as mock_session_local,
+            patch("app.routes.login_attempts", {}),
+            patch("app.routes.check_password_hash", return_value=True),
+        ):
+            dummy_user = SimpleNamespace(id=1, username=USER_NAME, password_hash="hash")
+
+            class DummyQuery:
+                def filter_by(self, **kwargs):
+                    return self
+
+                def first(self):
+                    return dummy_user
+
+            class DummySession:
+                def query(self, model):
+                    return DummyQuery()
+
+                def close(self):
+                    pass
+
+            mock_session_local.return_value = DummySession()
+
+            response = self.client.post(
+                "/login?next=http://evil.com",
+                data={
+                    "username": USER_NAME,
+                    "password": "correct_password",  # pragma: allowlist secret
+                },
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual("/", response.headers["Location"])
+
     def test_login_failure(self):
         with (
             patch("app.routes.SessionLocal") as mock_session_local,


### PR DESCRIPTION
## Summary
- ensure login uses safe redirect target from query parameter
- test redirect behavior on safe/unsafe next values

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_authentication.py::TestAuthentication::test_login_redirects_to_next_when_safe tests/test_authentication.py::TestAuthentication::test_login_redirects_ignores_unsafe_next -q`


------
https://chatgpt.com/codex/tasks/task_e_6856137250e88333bfe2ae369718223a