### PR TITLE
Add autofocus to login form

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -21,6 +21,7 @@ content %}
         id="username"
         type="text"
         name="username"
+        autofocus
         placeholder="Username"
         required
         title="Enter your username"

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -87,6 +87,16 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertEqual(username.get("aria-describedby"), "login-error")
         self.assertEqual(password.get("aria-describedby"), "login-error")
 
+    def test_login_username_autofocus_and_label(self):
+        """Username input should have autofocus and an associated label."""
+        html = Path("app/templates/login.html").read_text(encoding="utf-8")
+        self.assertIn('<label for="username"', html)
+        parser = parse_template(Path("app/templates/login.html"))
+        username = next(
+            i for i in parser.forms[0]["inputs"] if i.get("id") == "username"
+        )
+        self.assertIn("autofocus", username)
+
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
         self.assertIn("template_form(", html)


### PR DESCRIPTION
## Summary
- autofocus username field on login page
- ensure login page username has label and autofocus via new test

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/test_html_templates.py`


------
https://chatgpt.com/codex/tasks/task_e_68561384fad08333b074f0b276eead15