### PR TITLE
Add usage docs for credential generator

### DIFF
--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 # generate_credentials.py
+"""Create or update Glimpser credentials and settings.
+
+Run the script without arguments to interactively set up the initial
+``settings`` and ``users`` tables in the SQLite database. Command-line
+options allow specifying the database path, username, password and secret
+key, or updating only specific values.
+"""
 
 import argparse
 import getpass


### PR DESCRIPTION
## Summary
- explain what generate_credentials.py does and how to use it

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685613afa4e48333adb8632bfa19ab62