### PR TITLE
Add JSDoc for advanced mode toggle

### DIFF
--- a/app/static/js/advanced.js
+++ b/app/static/js/advanced.js
@@ -1,3 +1,9 @@
+/**
+ * Toggle advanced mode for the current session.
+ *
+ * The state is persisted in `sessionStorage` as "advanced-enabled" so
+ * user preference survives page reloads until the session ends.
+ */
 export function initAdvanced() {
   document.addEventListener("DOMContentLoaded", () => {
     const toggle = document.getElementById("advanced-toggle");


### PR DESCRIPTION
## Summary
- document advanced mode session storage behavior

## Testing
- `npm run lint:js`
- `npm test`
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685613f4575c833385b9ea45fde3ba7a