### PR TITLE
Use retry util for HTTP calls

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -14,7 +14,8 @@ from ipaddress import ip_address, ip_network
 from urllib.parse import urlparse
 
 import psutil
-import requests
+
+from app.utils.api_utils import request_with_retry
 
 from .oui_map import OUI_MAP as BUILTIN_OUI_MAP
 from .screenshots import is_port_open
@@ -128,7 +129,7 @@ def _remote_vendor_lookup(mac: str) -> str | None:
     """Return vendor name for ``mac`` via maclookup API."""
 
     try:  # network access might fail; ignore errors
-        resp = requests.get(MAC_VENDOR_API.format(mac), timeout=3)
+        resp = request_with_retry("GET", MAC_VENDOR_API.format(mac), timeout=3)
         if resp.status_code == 200:
             data = resp.json()
             vendor = data.get("company")
@@ -157,7 +158,7 @@ def _onvif_get_device_info(xaddr: str, timeout: int = 2) -> dict[str, str]:
     )
     info: dict[str, str] = {}
     try:
-        resp = requests.post(xaddr, data=body, timeout=timeout)
+        resp = request_with_retry("POST", xaddr, data=body, timeout=timeout)
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -207,7 +208,7 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
     )
     media_addr = None
     try:
-        resp = requests.post(xaddr, data=cap_body, timeout=timeout)
+        resp = request_with_retry("POST", xaddr, data=cap_body, timeout=timeout)
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -230,7 +231,7 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
     )
     token = None
     try:
-        resp = requests.post(media_addr, data=prof_body, timeout=timeout)
+        resp = request_with_retry("POST", media_addr, data=prof_body, timeout=timeout)
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"trt": "http://www.onvif.org/ver10/media/wsdl"}
@@ -259,7 +260,7 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
         "</s:Envelope>"
     )
     try:
-        resp = requests.post(media_addr, data=stream_body, timeout=timeout)
+        resp = request_with_retry("POST", media_addr, data=stream_body, timeout=timeout)
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -280,7 +281,7 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
         "</s:Envelope>"
     )
     try:
-        resp = requests.post(media_addr, data=snap_body, timeout=timeout)
+        resp = request_with_retry("POST", media_addr, data=snap_body, timeout=timeout)
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}

--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -7,11 +7,11 @@ import logging
 import os
 import re
 
-import requests
 from PIL import Image
 
 from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, LLM_MODEL_VERSION
 from app.utils import llm_cache
+from app.utils.api_utils import request_with_retry
 
 HEADER_PREFIX_RE = re.compile(r"^(caption|title|summary):\s*", re.IGNORECASE)
 
@@ -102,10 +102,12 @@ class ChatGPTImageComparison:
             "max_tokens": tokens,  # might even be less
         }
 
-        # Send the request to the API
+        # Send the request to the API with retry logic
         result = None
         try:
-            response = requests.post(self.url, headers=self.headers, json=payload)
+            response = request_with_retry(
+                "POST", self.url, headers=self.headers, json=payload, timeout=30
+            )
             if response.status_code == 429:
                 last_429_error_time = datetime.datetime.now()
                 logging.warning(

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -568,9 +568,10 @@ class TestCameraDiscovery(unittest.TestCase):
         self.assertEqual(cam.get("url"), "rtsp://1.2.3.4:554/")
         self.assertEqual(cam["info"].get("device_type"), "camera")
 
-    @patch("app.utils.camera_discovery.requests.post")
+    @patch("app.utils.camera_discovery.request_with_retry")
     def test_autodetect_onvif_endpoints(self, mock_post):
-        def _side_effect(url, data, timeout=3):
+        def _side_effect(method, url, **kwargs):
+            data = kwargs.get("data", "")
             if "GetCapabilities" in data:
                 xml = "<Envelope><Body><Capabilities><Media><XAddr>http://1.2.3.4/onvif/media_service</XAddr></Media></Capabilities></Body></Envelope>"
             elif "GetProfiles" in data:
@@ -598,7 +599,7 @@ class TestCameraDiscovery(unittest.TestCase):
             )
             self.assertIsNone(camera_discovery._mac_for_ip("10.0.0.8"))
 
-    @patch("app.utils.camera_discovery.requests.get")
+    @patch("app.utils.camera_discovery.request_with_retry")
     def test_mac_manufacturer_cached(self, mock_get):
         with patch.object(camera_discovery, "OUI_MAP", {"001122": "TestCo"}):
             camera_discovery._remote_vendor_lookup.cache_clear()
@@ -606,7 +607,7 @@ class TestCameraDiscovery(unittest.TestCase):
             self.assertEqual(vendor, "TestCo")
             mock_get.assert_not_called()
 
-    @patch("app.utils.camera_discovery.requests.get")
+    @patch("app.utils.camera_discovery.request_with_retry")
     def test_mac_manufacturer_remote_and_cache(self, mock_get):
         resp = SimpleNamespace(status_code=200, json=lambda: {"company": "RemoteCo"})
         mock_get.return_value = resp
@@ -619,7 +620,7 @@ class TestCameraDiscovery(unittest.TestCase):
             self.assertEqual(vendor2, "RemoteCo")
             self.assertEqual(mock_get.call_count, 1)
 
-    @patch("app.utils.camera_discovery.requests.get")
+    @patch("app.utils.camera_discovery.request_with_retry")
     def test_remote_vendor_lookup_success(self, mock_get):
         camera_discovery._remote_vendor_lookup.cache_clear()
         mock_get.return_value = SimpleNamespace(
@@ -628,7 +629,7 @@ class TestCameraDiscovery(unittest.TestCase):
         vendor = camera_discovery._remote_vendor_lookup("00:11:22:33:44:55")
         self.assertEqual(vendor, "AcmeCam")
 
-    @patch("app.utils.camera_discovery.requests.get")
+    @patch("app.utils.camera_discovery.request_with_retry")
     def test_remote_vendor_lookup_failure(self, mock_get):
         camera_discovery._remote_vendor_lookup.cache_clear()
         mock_get.side_effect = Exception("boom")

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -104,7 +104,7 @@ class TestImageProcessing(unittest.TestCase):
 
 
 class TestChatGPTImageComparison(unittest.TestCase):
-    @patch("app.utils.image_processing.requests.post")
+    @patch("app.utils.image_processing.request_with_retry")
     @patch("app.utils.image_processing.CHATGPT_KEY", "k")
     def test_compare_images(self, mock_post):
         # Create a ChatGPTImageComparison instance


### PR DESCRIPTION
## Summary
- use `request_with_retry` in image processing module
- use `request_with_retry` for camera discovery API calls
- update tests to mock `request_with_retry`

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561411483c8333b45546d88ec27560