### PR TITLE
Annotate chatgpt_compare

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -6,6 +6,7 @@ import io
 import logging
 import os
 import re
+from typing import List, Optional
 
 import requests
 from PIL import Image
@@ -135,7 +136,15 @@ class ChatGPTImageComparison:
             return None, 0
 
 
-def chatgpt_compare(prompt, image_paths, template_name=None):
+def chatgpt_compare(
+    prompt: str, image_paths: List[str], template_name: Optional[str] = None
+) -> Optional[str]:
+    """Return a caption for images via ChatGPT.
+
+    Cached responses are reused and token usage is recorded when
+    ``template_name`` is provided. Returns ``None`` on API failure or a
+    descriptive message when inputs are invalid.
+    """
 
     # Check if all images exist
     for image in image_paths:

--- a/tests/test_chatgpt_compare.py
+++ b/tests/test_chatgpt_compare.py
@@ -20,16 +20,46 @@ class TestChatGPTCompare(unittest.TestCase):
         self.assertEqual(result, "Missing ChatGPT key")
         mock_compare.assert_not_called()
 
+    @patch("app.utils.llm_cache.store")
+    @patch("app.utils.llm_cache.get", return_value=None)
     @patch("app.utils.image_processing.ChatGPTImageComparison.compare_images")
     @patch("app.utils.template_manager.record_llm_usage")
     @patch("app.utils.image_processing.os.path.exists", return_value=True)
     @patch("app.utils.image_processing.CHATGPT_KEY", "k")
-    def test_success_records_usage(self, mock_exists, mock_record, mock_compare):
+    def test_success_records_usage(
+        self, mock_exists, mock_record, mock_compare, mock_get, mock_store
+    ):
         mock_compare.return_value = ("ok", 5)
         result = chatgpt_compare("p", ["img.png"], template_name="cam1")
         self.assertEqual(result, "ok")
         mock_compare.assert_called_once()
         mock_record.assert_called_once_with("cam1", 5)
+
+    @patch("app.utils.llm_cache.store")
+    @patch("app.utils.llm_cache.get", return_value=None)
+    @patch("app.utils.image_processing.ChatGPTImageComparison.compare_images")
+    @patch("app.utils.template_manager.record_llm_usage")
+    @patch("app.utils.image_processing.os.path.exists", return_value=True)
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
+    def test_no_tokens_no_record(
+        self, mock_exists, mock_record, mock_compare, mock_get, mock_store
+    ):
+        mock_compare.return_value = ("ok", 0)
+        result = chatgpt_compare("p", ["img.png"], template_name="cam1")
+        self.assertEqual(result, "ok")
+        mock_record.assert_not_called()
+
+    @patch("app.utils.llm_cache.store")
+    @patch("app.utils.llm_cache.get", return_value=None)
+    @patch("app.utils.image_processing.ChatGPTImageComparison.compare_images")
+    @patch("app.utils.image_processing.os.path.exists", return_value=True)
+    @patch("app.utils.image_processing.CHATGPT_KEY", "k")
+    def test_api_failure_returns_none(
+        self, mock_exists, mock_compare, mock_get, mock_store
+    ):
+        mock_compare.return_value = (None, 0)
+        result = chatgpt_compare("p", ["img.png"])
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add type hints and docstring for `chatgpt_compare`
- extend tests for additional error cases

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest tests/test_chatgpt_compare.py tests/test_image_processing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6856141ae9c8833392f5aaadc0cf7f53