### PR TITLE
Fix debug logging for corrupt screenshots

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -803,7 +803,7 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
                 frame_files.append(f)
             except Exception:
                 logging.warning("skipping corrupt screenshot %s", f)
-                print("skipp", f)
+                logging.debug("skipping corrupt screenshot %s", f)
 
         if not frame_files:
             return


### PR DESCRIPTION
## Summary
- log skipped corrupt screenshots at debug level in `video_archiver`

## Testing
- `pre-commit run --files app/utils/video_archiver.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68561a5397548333a205132ff60af75c