### PR TITLE
Add type hints to utility functions

### DIFF
--- a/app/utils/email_alerts.py
+++ b/app/utils/email_alerts.py
@@ -18,7 +18,7 @@ from app.config import (
 )
 
 
-def send_email_alert(subject, body):
+def send_email_alert(subject: str, body: str) -> None:
     """Send an email to the configured recipients.
 
     Parameters
@@ -58,7 +58,7 @@ def send_email_alert(subject, body):
         logging.error("Error sending email alert: %s", e)
 
 
-def email_alert(event_type, details):
+def email_alert(event_type: str, details: str) -> None:
     """Compose a standard alert email and send it.
 
     Parameters

--- a/app/utils/sms_alerts.py
+++ b/app/utils/sms_alerts.py
@@ -11,7 +11,7 @@ from app.config import (
 )
 
 
-def send_sms_alert(message):
+def send_sms_alert(message: str) -> None:
     """Send an SMS alert using Twilio.
 
     Parameters
@@ -45,7 +45,7 @@ def send_sms_alert(message):
         logging.error("Error sending SMS alert: %s", exc)
 
 
-def sms_alert(event_type, details):
+def sms_alert(event_type: str, details: str) -> None:
     """Format and send an SMS alert for an event.
 
     Parameters

--- a/generate_credentials.py
+++ b/generate_credentials.py
@@ -20,7 +20,7 @@ from werkzeug.security import generate_password_hash
 import app.config
 
 
-def upsert_setting(name, value, conn):
+def upsert_setting(name: str, value: str | None, conn: sqlite3.Connection) -> None:
     """Insert or update a setting in the database.
 
     Parameters
@@ -47,7 +47,7 @@ def upsert_setting(name, value, conn):
     conn.commit()
 
 
-def create_settings(conn):
+def create_settings(conn: sqlite3.Connection) -> None:
     """Create the ``settings`` table if it is missing.
 
     Parameters
@@ -67,7 +67,7 @@ def create_settings(conn):
     conn.commit()
 
 
-def create_users(conn):
+def create_users(conn: sqlite3.Connection) -> None:
     """Create the ``users`` table if it is missing.
 
     Parameters
@@ -88,7 +88,9 @@ def create_users(conn):
     conn.commit()
 
 
-def upsert_user(username, password_hash, role, conn):
+def upsert_user(
+    username: str, password_hash: str, role: str, conn: sqlite3.Connection
+) -> None:
     """Insert or update a user record.
 
     Parameters
@@ -114,7 +116,7 @@ def upsert_user(username, password_hash, role, conn):
     conn.commit()
 
 
-def generate_credentials(args):
+def generate_credentials(args: argparse.Namespace | None) -> None:
     """Create or update application credentials and settings.
 
     Parameters


### PR DESCRIPTION
## Summary
- annotate alert helper functions with type hints
- update credential generation helpers with typed parameters

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561a5e5a408333a4437a8be3f4f695