### PR TITLE
Add session support for API requests

### DIFF
--- a/app/utils/api_utils.py
+++ b/app/utils/api_utils.py
@@ -1,8 +1,11 @@
 import logging
 import time
-from typing import Any
+from typing import Any, Optional
 
 import requests
+
+# Reuse a module-level session for better connection pooling
+SESSION = requests.Session()
 
 
 def request_with_retry(
@@ -12,14 +15,28 @@ def request_with_retry(
     retries: int = 2,
     timeout: int = 30,
     backoff_factor: float = 1.0,
+    session: Optional[requests.Session] = None,
     **kwargs: Any,
 ) -> requests.Response:
-    """Send an HTTP request with retries and exponential backoff."""
+    """Send an HTTP request with retries and exponential backoff.
+
+    Args:
+        method: HTTP method to use.
+        url: Request URL.
+        retries: Number of retry attempts.
+        timeout: Request timeout in seconds.
+        backoff_factor: Factor for exponential backoff between retries.
+        session: Optional :class:`requests.Session` to use.
+
+    Returns:
+        The ``requests.Response`` object.
+    """
 
     attempt = 0
+    sess = session or SESSION
     while True:
         try:
-            return requests.request(method, url, timeout=timeout, **kwargs)
+            return sess.request(method, url, timeout=timeout, **kwargs)
         except Exception as exc:
             attempt += 1
             logging.warning("request error: %s", exc)

--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 import psutil
 
+from app.utils.api_utils import SESSION as API_SESSION
 from app.utils.api_utils import request_with_retry
 
 from .oui_map import OUI_MAP as BUILTIN_OUI_MAP
@@ -129,7 +130,9 @@ def _remote_vendor_lookup(mac: str) -> str | None:
     """Return vendor name for ``mac`` via maclookup API."""
 
     try:  # network access might fail; ignore errors
-        resp = request_with_retry("GET", MAC_VENDOR_API.format(mac), timeout=3)
+        resp = request_with_retry(
+            "GET", MAC_VENDOR_API.format(mac), timeout=3, session=API_SESSION
+        )
         if resp.status_code == 200:
             data = resp.json()
             vendor = data.get("company")
@@ -158,7 +161,9 @@ def _onvif_get_device_info(xaddr: str, timeout: int = 2) -> dict[str, str]:
     )
     info: dict[str, str] = {}
     try:
-        resp = request_with_retry("POST", xaddr, data=body, timeout=timeout)
+        resp = request_with_retry(
+            "POST", xaddr, data=body, timeout=timeout, session=API_SESSION
+        )
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -208,7 +213,9 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
     )
     media_addr = None
     try:
-        resp = request_with_retry("POST", xaddr, data=cap_body, timeout=timeout)
+        resp = request_with_retry(
+            "POST", xaddr, data=cap_body, timeout=timeout, session=API_SESSION
+        )
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -231,7 +238,9 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
     )
     token = None
     try:
-        resp = request_with_retry("POST", media_addr, data=prof_body, timeout=timeout)
+        resp = request_with_retry(
+            "POST", media_addr, data=prof_body, timeout=timeout, session=API_SESSION
+        )
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"trt": "http://www.onvif.org/ver10/media/wsdl"}
@@ -260,7 +269,9 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
         "</s:Envelope>"
     )
     try:
-        resp = request_with_retry("POST", media_addr, data=stream_body, timeout=timeout)
+        resp = request_with_retry(
+            "POST", media_addr, data=stream_body, timeout=timeout, session=API_SESSION
+        )
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}
@@ -281,7 +292,9 @@ def autodetect_onvif_endpoints(url: str, timeout: int = 3) -> dict[str, str]:
         "</s:Envelope>"
     )
     try:
-        resp = request_with_retry("POST", media_addr, data=snap_body, timeout=timeout)
+        resp = request_with_retry(
+            "POST", media_addr, data=snap_body, timeout=timeout, session=API_SESSION
+        )
         if resp.ok:
             xml = ET.fromstring(resp.content)
             ns = {"tt": "http://www.onvif.org/ver10/schema"}

--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, LLM_MODEL_VERSION
 from app.utils import llm_cache
+from app.utils.api_utils import SESSION as API_SESSION
 from app.utils.api_utils import request_with_retry
 
 HEADER_PREFIX_RE = re.compile(r"^(caption|title|summary):\s*", re.IGNORECASE)
@@ -107,7 +108,12 @@ class ChatGPTImageComparison:
         result = None
         try:
             response = request_with_retry(
-                "POST", self.url, headers=self.headers, json=payload, timeout=30
+                "POST",
+                self.url,
+                headers=self.headers,
+                json=payload,
+                timeout=30,
+                session=API_SESSION,
             )
             if response.status_code == 429:
                 last_429_error_time = datetime.datetime.now()

--- a/app/utils/llm.py
+++ b/app/utils/llm.py
@@ -10,6 +10,7 @@ from typing import Optional
 from app.config import CHATGPT_KEY, LLM_MODEL_VERSION, LLM_SUMMARY_PROMPT
 from app.utils import llm_cache
 
+from .api_utils import SESSION as API_SESSION
 from .api_utils import request_with_retry
 
 last_429_error_time = None
@@ -105,6 +106,7 @@ def summarize(
             json=payload,
             timeout=timeout,
             retries=retries,
+            session=API_SESSION,
         )
         if response.status_code == 429:
             last_429_error_time = datetime.datetime.now()
@@ -193,6 +195,7 @@ def ask_question(question: str, history: str = "", *, timeout: int = 30) -> str 
             headers=headers,
             json=payload,
             timeout=timeout,
+            session=API_SESSION,
         )
         result = response.json()
         return (

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -8,7 +8,7 @@ class TestRequestWithRetry(unittest.TestCase):
     def test_success_first_try(self):
         resp = MagicMock()
         with patch(
-            "app.utils.api_utils.requests.request", return_value=resp
+            "app.utils.api_utils.SESSION.request", return_value=resp
         ) as mock_req:
             result = request_with_retry("get", "http://ex")
             self.assertIs(result, resp)
@@ -18,7 +18,7 @@ class TestRequestWithRetry(unittest.TestCase):
         resp = MagicMock()
         with (
             patch(
-                "app.utils.api_utils.requests.request",
+                "app.utils.api_utils.SESSION.request",
                 side_effect=[Exception("fail"), resp],
             ) as mock_req,
             patch("time.sleep") as mock_sleep,
@@ -28,10 +28,26 @@ class TestRequestWithRetry(unittest.TestCase):
             self.assertEqual(mock_req.call_count, 2)
             mock_sleep.assert_called_once()
 
+    def test_custom_session_retry(self):
+        resp = MagicMock()
+        session = MagicMock()
+        session.request.side_effect = [Exception("fail"), resp]
+        with patch("time.sleep") as mock_sleep:
+            result = request_with_retry(
+                "get",
+                "http://ex",
+                retries=1,
+                backoff_factor=0,
+                session=session,
+            )
+        self.assertIs(result, resp)
+        self.assertEqual(session.request.call_count, 2)
+        mock_sleep.assert_called_once()
+
     def test_retry_exhausted_raises(self):
         with (
             patch(
-                "app.utils.api_utils.requests.request", side_effect=Exception("fail")
+                "app.utils.api_utils.SESSION.request", side_effect=Exception("fail")
             ) as mock_req,
             patch("time.sleep"),
         ):


### PR DESCRIPTION
## Summary
- support reusing a `requests.Session` in `request_with_retry`
- pass the shared session to LLM utilities and camera discovery
- update API utils tests to exercise session handling

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561a9758bc8333b7146ea3b8b17815