### PR TITLE
Safely parse frame rate

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -25,6 +25,7 @@ import typing
 import uuid
 from collections import deque
 from datetime import datetime, timedelta
+from fractions import Fraction
 from functools import lru_cache, wraps
 from ipaddress import ip_network
 from pathlib import Path
@@ -269,7 +270,12 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
         ref = fixed[-1]  # last clip for geometry/fps
         first_clip = fixed[0]
         w, h = _probe(ref, "width"), _probe(ref, "height")
-        fps = eval(_probe(ref, "r_frame_rate"))
+        fps_str = _probe(ref, "r_frame_rate")
+        try:
+            fps = float(Fraction(fps_str))
+        except (ValueError, ZeroDivisionError):
+            logging.warning("Invalid r_frame_rate %s, defaulting to 1", fps_str)
+            fps = 1.0
         pad = ramroot / "pad_black.mp4"
 
         # extract first frame from earliest clip for overlay

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -79,6 +79,46 @@ class TestConcatCopy(unittest.TestCase):
             self.assertLess(ss_idx, t_idx)
             self.assertEqual(concat_cmd[ss_idx + 1], "1.000")
 
+    def test_malformed_frame_rate_defaults_to_one(self):
+        """Pad generation uses fps=1.0 when r_frame_rate is invalid."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "clip.mp4"
+            part = Path(tmpdir) / "final_0.mp4"
+            part.touch()
+            parts = [part]
+
+            calls = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(cmd)
+                if cmd:
+                    last = cmd[-1]
+                    if isinstance(last, (str, Path)) and str(last).endswith(".mp4"):
+                        Path(str(last)).touch()
+                return None
+
+            with (
+                patch.object(routes, "_duration", return_value=1),
+                patch.object(
+                    routes,
+                    "_probe",
+                    side_effect=lambda p, k: {
+                        "width": "640",
+                        "height": "360",
+                        "r_frame_rate": "bad",
+                    }[k],
+                ),
+                patch("subprocess.run", side_effect=fake_run),
+            ):
+                self.assertTrue(routes._concat_copy(out, parts, clip_len=2))
+
+            overlay_cmd = next(
+                (c for c in calls if "color=c=black@0.9" in " ".join(map(str, c))),
+                None,
+            )
+            self.assertIsNotNone(overlay_cmd)
+            self.assertIn("r=1.0", " ".join(map(str, overlay_cmd)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid `eval` for frame rate parsing
- test fallback behaviour with invalid frame-rate strings

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561a8403588333899e9ab62c16486d