### PR TITLE
Improve logging for sanitize_url

### DIFF
--- a/app/utils/logging_utils.py
+++ b/app/utils/logging_utils.py
@@ -3,6 +3,8 @@ import time
 from typing import Dict
 from urllib.parse import urlparse
 
+logger = logging.getLogger(__name__)
+
 
 class ColorFormatter(logging.Formatter):
     """Add ANSI colors to log level names for console output."""
@@ -53,6 +55,6 @@ def sanitize_url(url: str) -> str:
                 netloc += f":{parts.port}"
             parts = parts._replace(netloc=netloc)
             return parts.geturl()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Failed to sanitize URL %s: %s", url, exc)
     return url

--- a/tests/test_sanitize_url.py
+++ b/tests/test_sanitize_url.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import patch
+
+from app.utils.logging_utils import sanitize_url
+
+
+class TestSanitizeUrl(unittest.TestCase):
+    def test_logs_on_parse_error(self):
+        with patch("app.utils.logging_utils.urlparse", side_effect=ValueError("boom")):
+            with self.assertLogs("app.utils.logging_utils", level="DEBUG") as logs:
+                result = sanitize_url("http://user:pass@example.com")
+        self.assertEqual(result, "http://user:pass@example.com")
+        joined = "\n".join(logs.output)
+        self.assertIn("boom", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- log parse issues in `sanitize_url`
- add unit test ensuring errors are logged

## Testing
- `pre-commit run --files app/utils/logging_utils.py tests/test_sanitize_url.py`
- `pytest tests/test_sanitize_url.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685622a4b4908333abef24ef223260a0