### PR TITLE
Format clock route test

### DIFF
--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -6,9 +6,7 @@ import tempfile
 import sys
 from unittest.mock import patch
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import app
 import app.config as config


### PR DESCRIPTION
## Summary
- run `black` on `tests/test_clock_route.py`

## Testing
- `black --check .`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers', 'nodriver', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685627a3f94c83338387eb6f4aa50690