### PR TITLE
Add docstrings for retention utilities

### DIFF
--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -17,6 +17,19 @@ from app.utils.screenshots import check_user_activity
 
 
 def get_files_sorted_by_creation_time(directory):
+    """Return files in *directory* sorted from oldest to newest.
+
+    Parameters
+    ----------
+    directory : str
+        Path to a directory containing files.
+
+    Returns
+    -------
+    list[str]
+        Ordered list of file paths or ``[]`` if ``directory`` is invalid.
+    """
+
     if not os.path.isdir(directory):
         return []
 
@@ -35,6 +48,24 @@ def get_files_sorted_by_creation_time(directory):
 
 
 def delete_old_files(file_list, max_age, max_size, minimum=10):
+    """Delete files older than ``max_age`` days or when ``max_size`` is exceeded.
+
+    Parameters
+    ----------
+    file_list : list[str]
+        Files sorted from oldest to newest.
+    max_age : int
+        Age in days beyond which a file is removed.
+    max_size : int
+        Maximum cumulative size before pruning begins.
+    minimum : int, optional
+        Number of newest files to preserve. Defaults to 10.
+
+    Returns
+    -------
+    None
+    """
+
     current_time = time.time()
     total_size = 0
 

--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -39,6 +39,8 @@ class ConcatStatus(Enum):
 
 
 def touch(fname, times=None):
+    """Create ``fname`` if missing and update its modification time."""
+
     with open(fname, "a"):
         os.utime(fname, times)
 


### PR DESCRIPTION
## Summary
- document helper functions in retention policy
- explain behavior of `touch` helper in video_archiver

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685629f06d78833387813ee0f19e440b