### PR TITLE
Precompile allowed filename regex

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -152,6 +152,11 @@ FFMPEG = config.FFMPEG_PATH  # shortcut
 # Limit configuration uploads to 5 MB to avoid excessive memory usage
 MAX_UPLOAD_SIZE = 5 * 1024 * 1024
 
+# Precompiled regular expression for validating filenames. Only letters,
+# numbers, periods, hyphens and underscores are allowed. Using a compiled
+# regex avoids recompiling the pattern on every call to ``allowed_filename``.
+ALLOWED_FILENAME_RE = re.compile(r"^[a-zA-Z0-9\.\-_]+?$")
+
 
 # ---------- tiny helpers ----------------------------------------------------
 @lru_cache(maxsize=256)
@@ -1496,8 +1501,7 @@ def allowed_filename(filename: str) -> bool:
     if ".." in filename:
         return False
 
-    if re.findall(r"^[a-zA-Z0-9\.\-_]+?$", filename):
-
+    if ALLOWED_FILENAME_RE.fullmatch(filename):
         return True
 
     return False

--- a/tests/test_allowed_filename.py
+++ b/tests/test_allowed_filename.py
@@ -5,13 +5,21 @@ from app.routes import allowed_filename
 
 class TestAllowedFilename(unittest.TestCase):
     def test_valid(self):
-        valid = ["image.png", "file-1.txt", "archive.tar.gz", "simple"]
+        valid = ["image.png", "file-1.txt", "archive.tar.gz", "simple", "foo_bar-123"]
         for name in valid:
             with self.subTest(name=name):
                 self.assertTrue(allowed_filename(name))
 
     def test_invalid(self):
-        invalid = ["../secret", "bad/name", "name space", "weird\x00char", ""]
+        invalid = [
+            "../secret",
+            "bad/name",
+            "name space",
+            "weird\x00char",
+            "",
+            "file..txt",
+            "umlautä.txt",
+        ]
         for name in invalid:
             with self.subTest(name=name):
                 self.assertFalse(allowed_filename(name))


### PR DESCRIPTION
## Summary
- precompile regex for `allowed_filename`
- use `fullmatch` instead of `findall`
- extend tests for additional edge cases

## Testing
- `pre-commit run --files app/routes.py tests/test_allowed_filename.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685629fe80ac8333b2e3c363132f4768