### PR TITLE
Add CLI version flag

### DIFF
--- a/app/utils/cli.py
+++ b/app/utils/cli.py
@@ -8,7 +8,11 @@ import app.config as config
 
 
 def build_argument_parser() -> argparse.ArgumentParser:
-    """Return the ``argparse`` parser used for the ``glimpser`` CLI."""
+    """Return the ``argparse`` parser used for the ``glimpser`` CLI.
+
+    The parser includes a ``--version`` flag that prints ``config.VERSION`` and
+    exits.
+    """
     parser = argparse.ArgumentParser(description=f"Glimpser {config.VERSION}")
     parser.add_argument(
         "--db-path",
@@ -84,6 +88,12 @@ def build_argument_parser() -> argparse.ArgumentParser:
         "--summaries-dir",
         default=config.SUMMARIES_DIRECTORY,
         help="Directory for storing summaries",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=config.VERSION,
+        help="Show the application version and exit",
     )
     return parser
 

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -22,6 +22,7 @@ The primary application script accepts the following options:
 | `--screenshot-dir` | Directory for storing screenshots.                               |
 | `--video-dir`      | Directory for storing video files.                               |
 | `--summaries-dir`  | **Deprecated:** summaries are now stored in the database.        |
+| `--version`        | Show the current Glimpser version and exit. |
 The background scheduler orchestrates all recurring jobs. It creates teaser clips, archives screenshots, refreshes clip previews, cleans up old files, processes queued offline jobs, collects system metrics and checks for application updates. Use `--no-scheduler` to disable every scheduled task or `--no-crawlers` when only camera captures should be skipped.
 
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,11 @@ def parse_arguments(arg_list=None):
 
 
 def get_cli_help() -> str:
-    """Return the formatted ``--help`` text."""
+    """Return the formatted CLI help text.
+
+    The output reflects all supported options, including the ``--version``
+    flag added to :func:`app.utils.cli.build_argument_parser`.
+    """
     return cli_help_text()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 import tempfile
@@ -270,6 +271,13 @@ class TestMain(unittest.TestCase):
     def test_cli_help_text(self):
         text = main.get_cli_help()
         self.assertIn("--db-path", text)
+
+    def test_cli_version_argument(self):
+        parser = main.build_argument_parser()
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            with self.assertRaises(SystemExit):
+                parser.parse_args(["--version"])
+        self.assertIn(config.VERSION, mock_stdout.getvalue())
 
     @patch("main.create_app")
     @patch("main.ensure_directories")


### PR DESCRIPTION
## Summary
- expose `--version` in CLI parser
- mention new option in CLI help docstring and docs
- test `--version` output

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562ad3f050833386e580b125b928e1