### PR TITLE
Add ARIA live regions

### DIFF
--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -18,7 +18,13 @@
   role="region"
   aria-label="Templates"
 ></div>
-<div id="index-time" class="corner-time" title=""></div>
+<div
+  id="index-time"
+  class="corner-time"
+  title=""
+  role="timer"
+  aria-live="polite"
+></div>
 <script type="module">
   import { loadTemplates } from '{{ url_for('static', filename='js/templates.js') }}';
   window.currentGroup = '{{ group_name }}';

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -26,7 +26,13 @@
   </div>
 </section>
 
-<div id="index-time" class="corner-time" title=""></div>
+<div
+  id="index-time"
+  class="corner-time"
+  title=""
+  role="timer"
+  aria-live="polite"
+></div>
 
 <div id="welcome-modal" class="modal">
   <div class="modal-content">

--- a/app/templates/logs.html
+++ b/app/templates/logs.html
@@ -1,35 +1,52 @@
-
 <h1>Logs</h1>
 
-    <form id="log-filter-form">
-        <input type="text" id="search-input" name="search" placeholder="Search logs..." title="Search log messages">
-        <select id="level-select" name="level" title="Filter logs by level">
-            <option value="">All Levels</option>
-            <option value="DEBUG">DEBUG</option>
-            <option value="INFO">INFO</option>
-            <option value="WARNING">WARNING</option>
-            <option value="ERROR">ERROR</option>
-            <option value="CRITICAL">CRITICAL</option>
-        </select>
-        <input type="text" name="source" placeholder="Source" title="Filter logs by source">
-        <input type="date" name="start_date" title="Start date filter">
-        <input type="date" name="end_date" title="End date filter">
-        <button type="submit" title="Apply filters">Apply Filters</button>
-    </form>
+<form id="log-filter-form">
+  <input
+    type="text"
+    id="search-input"
+    name="search"
+    placeholder="Search logs..."
+    title="Search log messages"
+  />
+  <select id="level-select" name="level" title="Filter logs by level">
+    <option value="">All Levels</option>
+    <option value="DEBUG">DEBUG</option>
+    <option value="INFO">INFO</option>
+    <option value="WARNING">WARNING</option>
+    <option value="ERROR">ERROR</option>
+    <option value="CRITICAL">CRITICAL</option>
+  </select>
+  <input
+    type="text"
+    name="source"
+    placeholder="Source"
+    title="Filter logs by source"
+  />
+  <input type="date" name="start_date" title="Start date filter" />
+  <input type="date" name="end_date" title="End date filter" />
+  <button type="submit" title="Apply filters">Apply Filters</button>
+</form>
 
-    <table id="log-table">
-        <thead>
-            <tr>
-                <th>Timestamp</th>
-                <th>Level</th>
-                <th>Source</th>
-                <th>Message</th>
-            </tr>
-        </thead>
-        <tbody>
-        </tbody>
-    </table>
+<table id="log-table">
+  <thead>
+    <tr>
+      <th>Timestamp</th>
+      <th>Level</th>
+      <th>Source</th>
+      <th>Message</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
 
-    <div id="log-connection-status" class="hidden"></div>
+<div
+  id="log-connection-status"
+  class="hidden"
+  role="status"
+  aria-live="polite"
+></div>
 
-    <script type="module" src="{{ url_for('static', filename='js/logs.js') }}"></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/logs.js') }}"
+></script>

--- a/app/templates/player.html
+++ b/app/templates/player.html
@@ -1,28 +1,32 @@
-{% extends 'base.html' %}
-{% block content %}
-    <h2>Live Camera Feed</h2>
-    <h2>Live Feed
-    </h2>
+{% extends 'base.html' %} {% block content %}
+<h2>Live Camera Feed</h2>
+<h2>Live Feed</h2>
 
-    <div class="video-container" title="Looping video feed from all cameras">
-            <div id="camera-name" class="camera-name" title="Currently playing camera"></div>
-        <video id="live-video" controls autoplay muted title="Video player"></video>
-    </div>
+<div class="video-container" title="Looping video feed from all cameras">
+  <div
+    id="camera-name"
+    class="camera-name"
+    title="Currently playing camera"
+    role="status"
+    aria-live="polite"
+  ></div>
+  <video id="live-video" controls autoplay muted title="Video player"></video>
+</div>
 
-    <script>
+<script>
         const cameras = {{ cameras|tojson }};
         let currentCameraIndex = 0;
 
         function playNextCamera() {
             const videoElement = document.getElementById('live-video');
-		const cameraNameElement = document.getElementById('camera-name');
+  const cameraNameElement = document.getElementById('camera-name');
             if (cameras.length > 0) {
                 const currentCamera = cameras[currentCameraIndex];
                 videoElement.src = `/clip/${currentCamera}`;
                 videoElement.load();
                 videoElement.playbackRate = 0.25;
                 videoElement.play();
-		    cameraNameElement.textContent = currentCamera;  
+      cameraNameElement.textContent = currentCamera;
                 currentCameraIndex = (currentCameraIndex + 1) % cameras.length;
             }
         }
@@ -38,6 +42,5 @@
 
         // Start playing the first camera
         playNextCamera();
-    </script>
+</script>
 {% endblock %}
-

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -15,6 +15,8 @@ The user interface now includes additional tooltips and descriptive alt text to 
 - A "skip to main content" link enables quick keyboard navigation.
 - The base template uses a `<main>` element for semantic structure.
 - Live video overlays use ARIA roles so screen readers announce status changes.
+- Dynamic regions like the log connection status, player camera name, and
+  dashboard clock now use `aria-live="polite"` so updates are announced.
 - Offline and error indicators now include `title` attributes so assistive
   technology can describe the icon meaning.
 - Focus outlines appear when navigating via keyboard.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -183,6 +183,24 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('name="TEST_BOOL"', html)
         self.assertIn('type="checkbox"', html)
 
+    def test_player_camera_name_has_live_status(self):
+        html = Path("app/templates/player.html").read_text(encoding="utf-8")
+        self.assertIn('id="camera-name"', html)
+        self.assertIn('role="status"', html)
+        self.assertIn('aria-live="polite"', html)
+
+    def test_logs_status_has_live_region(self):
+        html = Path("app/templates/logs.html").read_text(encoding="utf-8")
+        self.assertIn('id="log-connection-status"', html)
+        self.assertIn('role="status"', html)
+        self.assertIn('aria-live="polite"', html)
+
+    def test_index_time_live_region(self):
+        html = Path("app/templates/index.html").read_text(encoding="utf-8")
+        self.assertIn('id="index-time"', html)
+        self.assertIn('role="timer"', html)
+        self.assertIn('aria-live="polite"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- mark clock widget as a timer with an aria-live region
- expose logs connection status with aria-live
- announce camera name changes on the player page
- document new live regions in accessibility guide
- verify templates via new tests

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562d2518908333947e163ccf8c0f2a