### PR TITLE
Add welcome modal tests

### DIFF
--- a/tests/js/welcome.test.js
+++ b/tests/js/welcome.test.js
@@ -1,0 +1,60 @@
+import { jest } from "@jest/globals";
+
+let initWelcome;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/welcome.js");
+  initWelcome = mod.initWelcome;
+});
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="welcome-modal" style="display:none">
+      <span id="welcome-close"></span>
+      <button id="welcome-ok"></button>
+    </div>
+  `;
+  localStorage.clear();
+});
+
+test("shows modal when no templates loaded and not seen", () => {
+  initWelcome();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  window.dispatchEvent(
+    new CustomEvent("templatesLoaded", { detail: { count: 0 } }),
+  );
+  const modal = document.getElementById("welcome-modal");
+  expect(modal.style.display).toBe("block");
+});
+
+test("does not show modal when templates exist or welcome seen", () => {
+  initWelcome();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  window.dispatchEvent(
+    new CustomEvent("templatesLoaded", { detail: { count: 2 } }),
+  );
+  const modal = document.getElementById("welcome-modal");
+  expect(modal.style.display).toBe("none");
+  localStorage.setItem("welcomeSeen", "true");
+  window.dispatchEvent(
+    new CustomEvent("templatesLoaded", { detail: { count: 0 } }),
+  );
+  expect(modal.style.display).toBe("none");
+});
+
+test("dismiss buttons hide modal and store preference", () => {
+  initWelcome();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  window.dispatchEvent(
+    new CustomEvent("templatesLoaded", { detail: { count: 0 } }),
+  );
+  document.getElementById("welcome-close").dispatchEvent(new Event("click"));
+  const modal = document.getElementById("welcome-modal");
+  expect(modal.style.display).toBe("none");
+  expect(localStorage.getItem("welcomeSeen")).toBe("true");
+  modal.style.display = "block";
+  localStorage.clear();
+  document.getElementById("welcome-ok").dispatchEvent(new Event("click"));
+  expect(modal.style.display).toBe("none");
+  expect(localStorage.getItem("welcomeSeen")).toBe("true");
+});


### PR DESCRIPTION
## Summary
- add JS tests for the welcome modal

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562ccab57083339760320c78eb9128