### PR TITLE
Add capture flow diagram

### DIFF
--- a/docs/capture_process.md
+++ b/docs/capture_process.md
@@ -39,6 +39,8 @@ The general flow of the capture process is as follows:
 9. **Post-Processing**: Apply any necessary post-processing steps, such as adding timestamps or applying dark mode.
 10. **Result Handling**: Return the success status of the capture process.
 
+![Capture Flow Diagram](diagrams/capture_flow.svg)
+
 ## Content-Specific Capture Methods
 
 Glimpser uses different methods to capture various types of content:
@@ -56,6 +58,7 @@ For web pages, Glimpser uses two main approaches:
 2. **Full Browser Capture**: Uses Selenium with Chrome/Chromium for more complex web pages, supporting JavaScript execution, popup handling, and custom selectors.
 
 The choice between these methods depends on factors such as:
+
 - Presence of popups that need to be handled
 - Need for JavaScript execution
 - Requirement for stealth mode
@@ -81,6 +84,7 @@ After capturing the content, Glimpser applies several post-processing steps:
 
    is wrapped and rendered with the same improved font styling to avoid
    overlapping the content.
+
 5. **Micro Barcode Overlay**: A small 1D barcode containing the camera name is placed in the lower-right corner so screenshots can be tracked within the system.
 6. **Image Optimization**: Ensure the captured image is in the correct format and optimized for storage.
 7. **PNG Validation**: Verify the temporary screenshot file before renaming it to avoid leaving corrupt images.

--- a/docs/diagrams/capture_flow.svg
+++ b/docs/diagrams/capture_flow.svg
@@ -1,0 +1,81 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="900"
+  height="200"
+  font-family="Arial, sans-serif"
+  font-size="14"
+>
+  <defs>
+    <marker
+      id="arrow"
+      markerWidth="10"
+      markerHeight="10"
+      refX="10"
+      refY="3"
+      orient="auto"
+      markerUnits="strokeWidth"
+    >
+      <path d="M0,0 L0,6 L9,3 z" fill="#333" />
+    </marker>
+    <style>
+      .box {
+        fill: #fff;
+        stroke: #333;
+        stroke-width: 1.5;
+        rx: 4;
+      }
+      .arrow {
+        stroke: #333;
+        stroke-width: 1.5;
+        fill: none;
+        marker-end: url(#arrow);
+      }
+      text {
+        dominant-baseline: middle;
+        text-anchor: middle;
+      }
+    </style>
+  </defs>
+  <!-- Row 1 -->
+  <rect class="box" x="10" y="20" width="100" height="30" />
+  <text x="60" y="35">APScheduler</text>
+
+  <rect class="box" x="130" y="20" width="120" height="30" />
+  <text x="190" y="35">update_camera</text>
+
+  <rect class="box" x="270" y="20" width="160" height="30" />
+  <text x="350" y="35">capture_or_download</text>
+
+  <rect class="box" x="450" y="20" width="220" height="40" />
+  <text x="560" y="40">Post-processing</text>
+  <text x="560" y="55">(video_archiver, overlays)</text>
+
+  <rect class="box" x="690" y="20" width="140" height="30" />
+  <text x="760" y="35">update_summary</text>
+
+  <!-- Row 2 -->
+  <rect class="box" x="350" y="120" width="100" height="30" />
+  <text x="400" y="135">database</text>
+
+  <rect class="box" x="480" y="120" width="170" height="30" />
+  <text x="565" y="135">send_http_callback</text>
+
+  <rect class="box" x="10" y="120" width="110" height="30" />
+  <text x="65" y="135">Flask routes</text>
+
+  <rect class="box" x="150" y="120" width="120" height="30" />
+  <text x="210" y="135">Frontend</text>
+
+  <!-- Arrows row 1 -->
+  <path class="arrow" d="M110,35 H130" />
+  <path class="arrow" d="M250,35 H270" />
+  <path class="arrow" d="M430,35 H450" />
+  <path class="arrow" d="M670,35 H690" />
+  <path class="arrow" d="M760,50 V120 H400" />
+
+  <!-- Arrows row 2 -->
+  <path class="arrow" d="M410,120 V100" />
+  <path class="arrow" d="M450,135 H480" />
+  <path class="arrow" d="M70,120 V70 H190" />
+  <path class="arrow" d="M120,135 H150" />
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ Glimpser is a monitoring platform that captures images and video streams, using 
 
 - [API Documentation](api_documentation.md)
 - [Capture Process](capture_process.md)
+- [Capture Flow Diagram](diagrams/capture_flow.svg)
 - [Configuration Guide](configuration_guide.md)
 - [Command Line Reference](command_line.md)
 - [Video Archiver](video_archiver.md)


### PR DESCRIPTION
## Summary
- create `docs/diagrams` and add `capture_flow.svg`
- embed diagram in `docs/capture_process.md`
- link diagram from documentation index

## Testing
- `npx prettier --parser html -w docs/diagrams/capture_flow.svg`
- `npx prettier -w docs/capture_process.md docs/index.md`
- `flake8`
- `pytest -q` *(fails: 70 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68568ed34d5c8333bcbffd2da3be3efb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and readability in the capture process documentation.
	- Added a visual capture flow diagram to illustrate the process.
	- Updated the documentation index to include a link to the new capture flow diagram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->