### PR TITLE
Add architecture diagram

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -3,6 +3,7 @@
 This guide provides a high-level look at Glimpser's core components and how they interact.
 
 ## Flask Application Initialization (`app/__init__.py`)
+
 - Creates the Flask application instance.
 - Loads configuration values and sets up logging.
 - Initializes routes from `app/routes.py`.
@@ -14,11 +15,13 @@ This guide provides a high-level look at Glimpser's core components and how they
   the check succeeds even when login is required.
 
 ## Configuration Handling (`app/config.py`)
+
 - Loads environment variables and values stored in the database.
 - Exposes settings such as `SECRET_KEY`, database location and retention policy limits.
 - Includes helper functions to back up and restore configuration state.
 
 ## Utility Modules (`app/utils/`)
+
 - Collection of helpers for image processing, database access, notifications and more.
 - Key modules include:
   - `db.py` – SQLAlchemy setup and database initialization.
@@ -28,6 +31,7 @@ This guide provides a high-level look at Glimpser's core components and how they
   - `email_alerts.py`, `sms_alerts.py` and `cap_alerts.py` – sending notifications.
 
 ## Scheduler Jobs (`app/utils/scheduling.py`)
+
 - Uses APScheduler to run periodic tasks.
 - Jobs include crawler scheduling, video archiving, discovery and summarization.
 - Tasks run asynchronously so functions like `schedule_discovery` and `schedule_summarization` never block the caller.
@@ -35,19 +39,15 @@ This guide provides a high-level look at Glimpser's core components and how they
 - Stale crawler jobs are removed when templates are updated.
 
 ## How Components Fit Together
-```
- Client Request ---> Routes (app/routes.py) ----> Models (app/models/) ----> Database
-                           |                           |
-                           v                           v
-                     Utility Functions ----> Scheduler Jobs / Background Tasks
-```
+
+<img src="diagrams/architecture_overview.svg" alt="Architecture overview diagram" width="600" />
 - Routes handle incoming API or web requests.
 - Models define the database schema.
 - Utility functions perform processing and are called by both routes and scheduled jobs.
 - Background tasks run outside request/response cycles to capture data and generate summaries.
 
-
 ## Data Flow from Camera to UI
+
 1. **Camera Source** – Each camera is defined in the database as a template specifying the capture URL and parameters.
 2. **Capture Job** – The scheduler runs `capture_template` jobs that use `screenshots.py` to grab frames or video from the source.
 3. **Database Update** – Captured metadata and any motion events are stored via `db.py` while images are written to `data/screenshots/`.

--- a/docs/diagrams/architecture_overview.svg
+++ b/docs/diagrams/architecture_overview.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="170">
+  <defs>
+    <marker
+      id="arrow"
+      markerWidth="10"
+      markerHeight="7"
+      refX="10"
+      refY="3.5"
+      orient="auto"
+    >
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333" />
+    </marker>
+    <style>
+      .box {
+        fill: #fff;
+        stroke: #333;
+        stroke-width: 1.5;
+      }
+      text {
+        font-family: sans-serif;
+        font-size: 14px;
+      }
+      .arrow {
+        stroke: #333;
+        stroke-width: 1.5;
+        fill: none;
+        marker-end: url(#arrow);
+      }
+    </style>
+  </defs>
+  <!-- Top row -->
+  <rect class="box" x="10" y="20" width="110" height="30" />
+  <text x="65" y="40" text-anchor="middle">User Request</text>
+
+  <rect class="box" x="150" y="20" width="110" height="30" />
+  <text x="205" y="40" text-anchor="middle">Flask Route</text>
+
+  <rect class="box" x="290" y="20" width="150" height="30" />
+  <text x="365" y="40" text-anchor="middle">Models / Database</text>
+
+  <rect class="box" x="470" y="20" width="110" height="30" />
+  <text x="525" y="40" text-anchor="middle">Frontend</text>
+
+  <!-- Arrows top row -->
+  <path class="arrow" d="M120 35 L150 35" />
+  <path class="arrow" d="M260 35 L290 35" />
+  <path class="arrow" d="M440 35 L470 35" />
+  <path class="arrow" d="M470 55 L365 55" />
+
+  <!-- Bottom row -->
+  <rect class="box" x="150" y="110" width="150" height="30" />
+  <text x="225" y="130" text-anchor="middle">Utility Modules</text>
+
+  <rect class="box" x="330" y="110" width="200" height="30" />
+  <text x="430" y="130" text-anchor="middle">Scheduler / Background Jobs</text>
+
+  <!-- Arrows bottom row -->
+  <path class="arrow" d="M300 125 L330 125" />
+  <path class="arrow" d="M430 110 L365 50" />
+</svg>


### PR DESCRIPTION
## Summary
- add high-level architecture diagram
- embed diagram in docs

## Testing
- `npx prettier -w docs/architecture_overview.md docs/index.md`
- `npx prettier -w --parser html docs/diagrams/architecture_overview.svg`
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68568ed8389c83338d5524e3d2f2726a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved readability and formatting in the architecture overview.
  - Replaced the ASCII diagram with an embedded SVG image for clearer visualization of component interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->