### PR TITLE
Add LAN login bypass

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ import shutil
 import sqlite3
 import subprocess
 from importlib.metadata import PackageNotFoundError, version
+from ipaddress import ip_network
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
@@ -290,6 +291,14 @@ SESSION_COOKIE_SECURE = get_setting("SESSION_COOKIE_SECURE", "True") == "True"
 SESSION_COOKIE_HTTPONLY = get_setting("SESSION_COOKIE_HTTPONLY", "True") == "True"
 SESSION_TIMEOUT_MINUTES = int(get_setting("SESSION_TIMEOUT_MINUTES", 30))
 AUTO_LOGIN_DAYS = int(get_setting("AUTO_LOGIN_DAYS", 30))
+# Skip login for these networks when not accessing admin pages
+_login_subnets_raw = get_setting("SKIP_LOGIN_SUBNETS", "")
+SKIP_LOGIN_SUBNETS = []
+for _sub in [s.strip() for s in _login_subnets_raw.split(",") if s.strip()]:
+    try:
+        SKIP_LOGIN_SUBNETS.append(ip_network(_sub))
+    except ValueError:
+        logging.warning("Invalid subnet in SKIP_LOGIN_SUBNETS: %s", _sub)
 
 # Clock configuration
 CLOCK_OVERLAY = get_setting("CLOCK_OVERLAY", "False") == "True"

--- a/app/routes.py
+++ b/app/routes.py
@@ -27,7 +27,7 @@ from collections import deque
 from datetime import datetime, timedelta
 from fractions import Fraction
 from functools import lru_cache, wraps
-from ipaddress import ip_network
+from ipaddress import ip_address, ip_network
 from pathlib import Path
 from threading import Lock, Thread
 from urllib.parse import urlparse
@@ -553,6 +553,18 @@ def login_required(f: Callable) -> Callable:
 
     @wraps(f)
     def decorated_function(*args, **kwargs):
+        # Allow LAN access without login when configured
+        ip = request.remote_addr
+        try:
+            ip_obj = ip_address(ip) if ip else None
+        except ValueError:
+            ip_obj = None
+        if (
+            ip_obj
+            and any(ip_obj in net for net in config.SKIP_LOGIN_SUBNETS)
+            and not request.path.startswith("/settings")
+        ):
+            return f(*args, **kwargs)
         # Check for API key in headers, GET parameters, or POST form data
         api_key = (
             request.headers.get("X-API-Key")

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -165,6 +165,10 @@ SETTINGS_TOOLTIPS = {
         "Remember the user for this many days when the 'stay logged in' option "
         "is selected."
     ),
+    "SKIP_LOGIN_SUBNETS": (
+        "Comma-separated CIDR blocks that can access non-admin pages without "
+        "logging in."
+    ),
     "ALLOW_BOTS": (
         "Allow search engines to index the site. Disable for private " "installations."
     ),
@@ -344,6 +348,7 @@ SETTINGS_GROUPS = {
         "SESSION_COOKIE_SECURE",
         "SESSION_COOKIE_HTTPONLY",
         "SESSION_TIMEOUT_MINUTES",
+        "SKIP_LOGIN_SUBNETS",
     ],
     "Capture": [
         "DATABASE_PATH",

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -64,6 +64,8 @@ updated with `generate_credentials.py` or through the web interface.
   inactivity (default `30`)
 - `AUTO_LOGIN_DAYS` – days the session persists when "Remember me" is checked
   (default `30`)
+- `SKIP_LOGIN_SUBNETS` – comma-separated list of IPv4 or IPv6 subnets allowed
+  to browse non-admin pages without logging in (empty by default)
 
 User accounts are stored in the `users` table. Each record contains the
 `username`, `password_hash`, and an optional `role` that can be used for future

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,6 +4,7 @@ import datetime
 import os
 import time
 import unittest
+from ipaddress import ip_network
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -548,6 +549,30 @@ class TestAuthentication(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.mimetype, "text/event-stream")
         self.assertIn(b'{"error": "unauthorized"}', response.data)
+
+    def test_skip_login_for_allowed_subnet(self):
+        login_attempts = {}
+        with patch(
+            "app.routes.config.SKIP_LOGIN_SUBNETS",
+            [ip_network("127.0.0.0/8")],
+        ):
+            response = self.client.get(
+                "/protected", environ_base={"REMOTE_ADDR": "127.0.0.1"}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b"Protected Content", response.data)
+
+    def test_admin_requires_login_even_from_allowed_subnet(self):
+        login_attempts = {}
+        with patch(
+            "app.routes.config.SKIP_LOGIN_SUBNETS",
+            [ip_network("127.0.0.0/8")],
+        ):
+            response = self.client.get(
+                "/settings", environ_base={"REMOTE_ADDR": "127.0.0.1"}
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/login", response.headers["Location"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow skipping login for non-admin pages when client IP falls within `SKIP_LOGIN_SUBNETS`
- document new `SKIP_LOGIN_SUBNETS` setting
- expose tooltip text and admin grouping for the setting
- test LAN bypass behaviour

## Testing
- `pre-commit run --files app/config.py app/routes.py docs/configuration_guide.md app/utils/settings_tooltips.py tests/test_authentication.py`
- `pytest tests/test_authentication.py::TestAuthentication::test_skip_login_for_allowed_subnet tests/test_authentication.py::TestAuthentication::test_admin_requires_login_even_from_allowed_subnet -q`

------
https://chatgpt.com/codex/tasks/task_e_68568d8350648333b6f2caae1e9b1822