### PR TITLE
Add sequence diagrams

### DIFF
--- a/docs/diagrams/capture_flow.svg
+++ b/docs/diagrams/capture_flow.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300">
+  <style>
+    .actor { fill: none; stroke: #000; }
+    .text { font-family: sans-serif; font-size: 12px; }
+    .arrow { marker-end: url(#arrow); }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <!-- Actors -->
+  <line class="actor" x1="80" y1="40" x2="80" y2="260" />
+  <line class="actor" x1="240" y1="40" x2="240" y2="260" />
+  <line class="actor" x1="400" y1="40" x2="400" y2="260" />
+  <line class="actor" x1="560" y1="40" x2="560" y2="260" />
+  <text class="text" x="55" y="30">Scheduler</text>
+  <text class="text" x="210" y="30">Screenshots</text>
+  <text class="text" x="365" y="30">Database</text>
+  <text class="text" x="530" y="30">Summarizer</text>
+
+  <!-- Messages -->
+  <line class="arrow" x1="80" y1="60" x2="240" y2="60" />
+  <text class="text" x="100" y="55">capture job</text>
+
+  <line class="arrow" x1="240" y1="80" x2="240" y2="120" />
+  <text class="text" x="250" y="100">capture_or_download</text>
+
+  <line class="arrow" x1="240" y1="140" x2="400" y2="140" />
+  <text class="text" x="260" y="135">store file path</text>
+
+  <line class="arrow" x1="400" y1="160" x2="560" y2="160" />
+  <text class="text" x="420" y="155">update_summary</text>
+
+  <line class="arrow" x1="560" y1="180" x2="400" y2="180" />
+  <text class="text" x="460" y="175">save text</text>
+
+  <line class="arrow" x1="400" y1="200" x2="80" y2="200" />
+  <text class="text" x="200" y="195">next capture time</text>
+</svg>

--- a/docs/diagrams/login_flow.svg
+++ b/docs/diagrams/login_flow.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="300" viewBox="0 0 700 300">
+  <style>
+    .actor { fill: none; stroke: #000; }
+    .text { font-family: sans-serif; font-size: 12px; }
+    .arrow { marker-end: url(#arrow); }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <!-- Actors -->
+  <line class="actor" x1="120" y1="40" x2="120" y2="260" />
+  <line class="actor" x1="320" y1="40" x2="320" y2="260" />
+  <line class="actor" x1="520" y1="40" x2="520" y2="260" />
+  <text class="text" x="100" y="30">User</text>
+  <text class="text" x="285" y="30">Flask App</text>
+  <text class="text" x="480" y="30">Database</text>
+
+  <!-- Messages -->
+  <line class="arrow" x1="120" y1="60" x2="320" y2="60" />
+  <text class="text" x="150" y="55">/login credentials</text>
+
+  <line class="arrow" x1="320" y1="80" x2="520" y2="80" />
+  <text class="text" x="340" y="75">lookup user</text>
+
+  <line class="arrow" x1="520" y1="100" x2="320" y2="100" />
+  <text class="text" x="410" y="95">user data</text>
+
+  <line class="arrow" x1="320" y1="120" x2="320" y2="160" />
+  <text class="text" x="330" y="140">verify password</text>
+
+  <line class="arrow" x1="320" y1="180" x2="120" y2="180" />
+  <text class="text" x="170" y="175">set session</text>
+
+  <line class="arrow" x1="120" y1="200" x2="320" y2="200" />
+  <text class="text" x="150" y="195">next page</text>
+</svg>

--- a/docs/diagrams/startup_sequence.svg
+++ b/docs/diagrams/startup_sequence.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <style>
+    .actor { fill: none; stroke: #000; }
+    .text { font-family: sans-serif; font-size: 12px; }
+    .arrow { marker-end: url(#arrow); }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#000" />
+    </marker>
+  </defs>
+  <!-- Actors -->
+  <line class="actor" x1="100" y1="40" x2="100" y2="260" />
+  <line class="actor" x1="250" y1="40" x2="250" y2="260" />
+  <line class="actor" x1="400" y1="40" x2="400" y2="260" />
+  <text class="text" x="80" y="30">User</text>
+  <text class="text" x="215" y="30">Flask App</text>
+  <text class="text" x="360" y="30">Scheduler</text>
+
+  <!-- Messages -->
+  <line class="arrow" x1="100" y1="60" x2="250" y2="60" />
+  <text class="text" x="120" y="55">run main.py</text>
+
+  <line class="arrow" x1="250" y1="80" x2="250" y2="120" />
+  <text class="text" x="260" y="100">create_app</text>
+
+  <line class="arrow" x1="250" y1="140" x2="400" y2="140" />
+  <text class="text" x="270" y="135">start scheduler</text>
+
+  <line class="arrow" x1="400" y1="160" x2="250" y2="160" />
+  <text class="text" x="305" y="155">jobs scheduled</text>
+
+  <line class="arrow" x1="250" y1="180" x2="250" y2="220" />
+  <text class="text" x="260" y="200">watchdog thread</text>
+
+  <line class="arrow" x1="250" y1="240" x2="100" y2="240" />
+  <text class="text" x="150" y="235">ready</text>
+</svg>

--- a/docs/sequence_diagrams.md
+++ b/docs/sequence_diagrams.md
@@ -1,0 +1,26 @@
+# Sequence Diagrams
+
+This page illustrates a few key flows within Glimpser. Each diagram is provided
+as an SVG so it renders cleanly at any size.
+
+## Application Startup
+
+![Startup Sequence](diagrams/startup_sequence.svg)
+
+The diagram shows how the Flask application initializes, starts the scheduler,
+and launches the watchdog thread before returning control to the caller.
+
+## Capture Flow
+
+![Capture Flow](diagrams/capture_flow.svg)
+
+Scheduler jobs trigger `capture_or_download`, which writes screenshots to disk
+and stores references in the database. The summarizer updates the text summary
+for each template.
+
+## Login Flow
+
+![Login Flow](diagrams/login_flow.svg)
+
+A standard login request verifies the credentials against the database and, on
+success, stores the user ID in the session before redirecting to the dashboard.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
       - API Documentation: api_documentation.md
       - API Resilience: api_resilience.md
       - Architecture Overview: architecture_overview.md
+      - Sequence Diagrams: sequence_diagrams.md
       - Camera Discovery: camera_discovery.md
       - Camera Fix: camera_fix.md
       - Capture Process: capture_process.md


### PR DESCRIPTION
## Summary
- document application flows with SVG sequence diagrams
- include diagrams in documentation navigation

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68568caff94c83339884db4d29f46c22