### PR TITLE
Improve ffmpeg timeout handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -423,6 +423,10 @@ def _concat_copy(out: Path, parts: list[Path], clip_len: int = 120) -> bool:
         subprocess.run(cmd, input=concat_payload, timeout=30, check=True)
         out_tmp.rename(out)
         return True
+    except subprocess.TimeoutExpired:
+        logging.error("FFmpeg concat timed out after 30s")
+        out_tmp.unlink(missing_ok=True)
+        return False
     except subprocess.SubprocessError as exc:
         logging.error("FFmpeg concat failed: %s", exc, exc_info=True)
         out_tmp.unlink(missing_ok=True)

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -117,6 +118,21 @@ class TestConcatCopy(unittest.TestCase):
             )
             self.assertIsNotNone(overlay_cmd)
             self.assertIn("r=1.0", " ".join(map(str, overlay_cmd)))
+
+    def test_concat_timeout_returns_false(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "clip.mp4"
+            part = Path(tmpdir) / "final_0.mp4"
+            part.touch()
+
+            with (
+                patch.object(routes, "_duration", return_value=1),
+                patch(
+                    "subprocess.run",
+                    side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=30),
+                ),
+            ):
+                self.assertFalse(routes._concat_copy(out, [part], clip_len=1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- log a clear message when ffmpeg concat times out
- test timeout behaviour for `_concat_copy`

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_6856903008ec8333bdfe1e5132ea61fd