### PR TITLE
Fix HTTP requests ignoring proxies

### DIFF
--- a/app/utils/api_utils.py
+++ b/app/utils/api_utils.py
@@ -17,6 +17,11 @@ def request_with_retry(
     """Send an HTTP request with retries and exponential backoff."""
 
     attempt = 0
+    # Disable proxy use by default to avoid environment interference. Requests
+    # will respect proxies passed explicitly via ``kwargs``.
+    if "proxies" not in kwargs:
+        kwargs["proxies"] = {"http": None, "https": None}
+
     while True:
         try:
             return requests.request(method, url, timeout=timeout, **kwargs)

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 from unittest.mock import MagicMock, patch
 
 from app.utils.api_utils import request_with_retry
@@ -12,7 +13,9 @@ class TestRequestWithRetry(unittest.TestCase):
         ) as mock_req:
             result = request_with_retry("get", "http://ex")
             self.assertIs(result, resp)
-            mock_req.assert_called_once_with("get", "http://ex", timeout=30)
+            mock_req.assert_called_once_with(
+                "get", "http://ex", timeout=30, proxies={"http": None, "https": None}
+            )
 
     def test_retry_then_success(self):
         resp = MagicMock()
@@ -26,6 +29,21 @@ class TestRequestWithRetry(unittest.TestCase):
             result = request_with_retry("get", "http://ex", retries=1, backoff_factor=0)
             self.assertIs(result, resp)
             self.assertEqual(mock_req.call_count, 2)
+            calls = [
+                unittest.mock.call(
+                    "get",
+                    "http://ex",
+                    timeout=30,
+                    proxies={"http": None, "https": None},
+                ),
+                unittest.mock.call(
+                    "get",
+                    "http://ex",
+                    timeout=30,
+                    proxies={"http": None, "https": None},
+                ),
+            ]
+            mock_req.assert_has_calls(calls)
             mock_sleep.assert_called_once()
 
     def test_retry_exhausted_raises(self):


### PR DESCRIPTION
## Summary
- disable environment proxies in request_with_retry
- update tests for new behavior

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856881487648333b212e592603c45f3