### PR TITLE
Add blueprint for network status

### DIFF
--- a/app/blueprints/network.py
+++ b/app/blueprints/network.py
@@ -1,0 +1,20 @@
+from flask import Blueprint, jsonify
+
+from app.utils.network import is_system_online
+
+
+def create_blueprint() -> Blueprint:
+    """Create and return the network status blueprint."""
+
+    from app.routes import login_required
+
+    bp = Blueprint("network", __name__)
+
+    @bp.route("/network_status")
+    @login_required
+    def network_status():
+        """Return current network connectivity status."""
+
+        return jsonify({"online": is_system_online()})
+
+    return bp

--- a/app/routes.py
+++ b/app/routes.py
@@ -95,7 +95,6 @@ from app.utils import (
     video_archiver,
 )
 from app.utils.llm import ask_question
-from app.utils.network import is_system_online
 from app.utils.screenshots import (
     capture_frame_from_stream,
     check_user_activity,
@@ -1509,6 +1508,12 @@ def allowed_filename(filename: str) -> bool:
 
 def init_routes(app: Flask) -> None:
     """Register all route handlers on the given ``app``."""
+    from app.blueprints.network import create_blueprint
+
+    if not getattr(app, "_network_bp_registered", False):
+        app.register_blueprint(create_blueprint())
+        app._network_bp_registered = True
+
     # get_active_groups()
 
     @app.after_request
@@ -1737,12 +1742,6 @@ def init_routes(app: Flask) -> None:
     def discovery_status():
         """Return cached background discovery status."""
         return jsonify(scheduling.get_discovery_status())
-
-    @app.route("/network_status")
-    @login_required
-    def network_status():
-        """Return current network connectivity status."""
-        return jsonify({"online": is_system_online()})
 
     @app.route("/discover/subnets")
     @login_required

--- a/tests/test_network_status_endpoint.py
+++ b/tests/test_network_status_endpoint.py
@@ -18,13 +18,13 @@ class TestNetworkStatusEndpoint(unittest.TestCase):
     def tearDown(self):
         self.login_patch.stop()
 
-    @patch("app.routes.is_system_online", return_value=True)
+    @patch("app.blueprints.network.is_system_online", return_value=True)
     def test_online(self, mock_online):
         resp = self.client.get("/network_status")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.get_json(), {"online": True})
 
-    @patch("app.routes.is_system_online", return_value=False)
+    @patch("app.blueprints.network.is_system_online", return_value=False)
     def test_offline(self, mock_online):
         resp = self.client.get("/network_status")
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary
- refactor network status route into a blueprint
- register the blueprint in `init_routes`
- adjust tests to use new import path

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68568d906fdc83339317499f9569e31d