### PR TITLE
Fix login asset loading

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -42,9 +42,11 @@
     <script>
       window.IS_LOGGED_IN = {{ 'true' if session.get('user_id') else 'false' }};
     </script>
+    {% if session.get('user_id') %}
     <script
       type="module"
       src="{{ url_for('static', filename='js/script.js') }}"
     ></script>
+    {% endif %}
   </head>
 </html>


### PR DESCRIPTION
## Summary
- avoid loading script.js before authentication

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569616f378833393e50e81449a395e