### PR TITLE
Clarify password reset steps

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -77,6 +77,10 @@ content %}
     {% endif %} {% endwith %}
     <input type="submit" value="Login" title="Click to log in" />
   </form>
+  <p id="recovery-note" class="recovery-note">
+    Forgot your password? Stop Glimpser and run
+    <code>generate_credentials.py --update-password</code>.
+  </p>
   {% endcall %}
 </div>
 <script

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ The player now switches the `.video-container` to `overflow: auto` when the view
 
 ### I'm unable to log in
 
-Make sure you are using the correct credentials. If you forget your password, you can reset it through the recovery process on the login page.
+Make sure you are using the correct credentials. If you forget your password, you can reset it through the recovery process on the login page. If you have shell access to the server, stop Glimpser and run `generate_credentials.py --update-password` to set a new password from the command line.
 
 ### Where can I get more help?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -103,6 +103,7 @@ This guide addresses common issues that users might encounter while using Glimps
 - Ensure you're using the correct username and password
 - Verify that the account exists in the `users` table
 - Try resetting your password through the recovery process
+- If you have shell access, stop Glimpser and run `generate_credentials.py --update-password` to set a new password without using the web interface
 - Repeated failures trigger a 24-hour lockout and display a
   "Too many failed attempts" message
 - Invalid credentials now generate on-screen feedback and are logged

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -86,6 +86,11 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertEqual(username.get("aria-describedby"), "login-error")
         self.assertEqual(password.get("aria-describedby"), "login-error")
 
+    def test_login_has_recovery_note(self):
+        html = Path("app/templates/login.html").read_text(encoding="utf-8")
+        self.assertIn('id="recovery-note"', html)
+        self.assertIn("generate_credentials.py", html)
+
     def test_discover_add_camera_form_inputs(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
         self.assertIn("template_form(", html)


### PR DESCRIPTION
## Summary
- document how to reset password via `generate_credentials.py`
- show CLI password reset message on login page
- test login page recovery note

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685691102c1c8333bacd8a3a6a979a1e