### PR TITLE
Add daily log summary under metrics

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
+from .log_summary import LogSummary
 from .offline_job import OfflineJob
 from .push_subscription import PushSubscription
 from .summary import Summary
 from .user import User
 
-__all__ = ["User", "Summary", "OfflineJob", "PushSubscription"]
+__all__ = ["User", "Summary", "OfflineJob", "PushSubscription", "LogSummary"]

--- a/app/models/log_summary.py
+++ b/app/models/log_summary.py
@@ -1,0 +1,18 @@
+"""Database model for daily log summaries."""
+
+from sqlalchemy import Column, Integer, Text
+
+from app.utils.db import Base
+
+
+class LogSummary(Base):
+    """Summarized log entry for a given day."""
+
+    __tablename__ = "log_summaries"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(Integer, nullable=False)
+    content = Column(Text, nullable=False)
+
+    def __repr__(self) -> str:
+        return f"<LogSummary id={self.id} ts={self.timestamp}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -3885,6 +3885,7 @@ def init_routes(app: Flask) -> None:
         metrics = scheduling.get_system_metrics()
         feeds = scheduling.get_feed_status()
         last_summary = scheduling.get_last_summary_time()
+        log_summary = scheduling.get_or_generate_log_summary()
         danger_enabled = config.get_setting("DANGER_MODE", "True") == "True"
         cost_summary, total_tokens, total_cost, total_calls = (
             template_manager.get_llm_cost_summary()
@@ -3924,6 +3925,7 @@ def init_routes(app: Flask) -> None:
             metrics=metrics,
             feeds=feeds,
             last_summary=last_summary,
+            log_summary=log_summary,
             cost_summary=cost_summary,
             total_tokens=total_tokens,
             total_cost=total_cost,

--- a/app/templates/_status_tab.html
+++ b/app/templates/_status_tab.html
@@ -106,7 +106,11 @@
     </tbody>
   </table>
 </div>
-{% endcall %} {% call card('Feed Status') %}
+{% endcall %}
+{% if log_summary %}
+<p id="log-summary">{{ log_summary }}</p>
+{% endif %}
+{% call card('Feed Status') %}
 <div class="table-container">
   <table id="feed-status" class="feed-status">
     <thead>

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -99,7 +99,7 @@ from app.config import (
     WATCHDOG_CPU_THRESHOLD,
     get_setting,
 )
-from app.models import OfflineJob, Summary
+from app.models import LogSummary, OfflineJob, Summary
 from app.utils.auto_update import check_for_update
 from app.utils.db import SessionLocal
 
@@ -1578,6 +1578,50 @@ def get_last_summary_time() -> str | None:
     finally:
         session.close()
     return None
+
+
+def summarize_recent_logs(limit: int = 200) -> str | None:
+    """Summarize log entries from the last day using the LLM."""
+
+    cutoff = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+    with log_cache_lock:
+        lines = [
+            f"{e['level']} {e['message']}"
+            for e in list(log_cache)[-limit:]
+            if e.get("timestamp") and e["timestamp"] >= cutoff
+        ]
+
+    if not lines:
+        return None
+
+    text = "\n".join(lines)
+    result = summarize(text)
+    if result:
+        ts = int(datetime.datetime.utcnow().timestamp())
+        session = SessionLocal()
+        try:
+            session.add(LogSummary(timestamp=ts, content=result))
+            session.commit()
+        finally:
+            session.close()
+    return result
+
+
+def get_or_generate_log_summary() -> str | None:
+    """Return a recent log summary or generate one."""
+
+    cutoff = int(
+        (datetime.datetime.utcnow() - datetime.timedelta(hours=24)).timestamp()
+    )
+    session = SessionLocal()
+    try:
+        rec = session.query(LogSummary).order_by(LogSummary.timestamp.desc()).first()
+        if rec and rec.timestamp >= cutoff:
+            return rec.content
+    finally:
+        session.close()
+
+    return summarize_recent_logs()
 
 
 # Background discovery cache

--- a/docs/system_monitoring.md
+++ b/docs/system_monitoring.md
@@ -26,6 +26,9 @@ Below the system metrics the page lists each configured feed with a color-coded 
 The dashboard also shows when the most recent system summary was generated. The
 same table appears on the _Status_ tab under Settings so you can review
 usage metrics without leaving the configuration interface.
+Below the metrics graph a short daily log summary now appears. It condenses
+the last 24 hours of logs into a single paragraph using the configured
+language model.
 
 Additional KPI columns track the number of screenshots, videos, total storage
 used, LLM counts, and estimated LLM cost for each feed. Costs now display three decimal places.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -23,6 +23,7 @@ class TestInitDb(unittest.TestCase):
         importlib.reload(models)
         importlib.reload(models.user)
         importlib.reload(models.summary)
+        importlib.reload(models.log_summary)
         self.db = db
 
     def tearDown(self):
@@ -36,6 +37,7 @@ class TestInitDb(unittest.TestCase):
         importlib.reload(models)
         importlib.reload(models.user)
         importlib.reload(models.summary)
+        importlib.reload(models.log_summary)
         self.temp_dir.cleanup()
 
     def test_init_db_creates_users_table(self):
@@ -46,6 +48,7 @@ class TestInitDb(unittest.TestCase):
         tables = inspector.get_table_names()
         self.assertIn("users", tables)
         self.assertIn("summaries", tables)
+        self.assertIn("log_summaries", tables)
 
 
 if __name__ == "__main__":

--- a/tests/test_log_summary.py
+++ b/tests/test_log_summary.py
@@ -1,0 +1,50 @@
+import datetime
+import importlib
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import app.utils.scheduling as scheduling
+from app.models import LogSummary
+from app.utils import db
+
+
+class TestLogSummary(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmpdir.name, "test.db")
+        patch.dict(os.environ, {"GLIMPSER_DATABASE_PATH": self.db_path}).start()
+        import app.models as models
+
+        importlib.reload(db)
+        importlib.reload(models)
+        importlib.reload(models.log_summary)
+        importlib.reload(scheduling)
+        db.init_db()
+        scheduling.SessionLocal = db.SessionLocal
+
+    def tearDown(self):
+        patch.stopall()
+        self.tmpdir.cleanup()
+
+    @patch("app.utils.scheduling.summarize", return_value='{"1": "ok"}')
+    def test_summarize_recent_logs(self, mock_sum):
+        now = datetime.datetime.utcnow()
+        with scheduling.log_cache_lock:
+            scheduling.log_cache.clear()
+            scheduling.log_cache.append(
+                {
+                    "timestamp": now,
+                    "level": "INFO",
+                    "source": "system",
+                    "message": "test log",
+                }
+            )
+        scheduling.summarize_recent_logs()
+        session = db.SessionLocal()
+        try:
+            rows = session.query(LogSummary).all()
+            self.assertEqual(len(rows), 1)
+        finally:
+            session.close()


### PR DESCRIPTION
## Summary
- summarize last 24h of logs using LLM
- store summaries in new `log_summaries` table
- show latest summary on the status tab
- document log summary feature
- test new log summary logic

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685692d812e48333987f20e870c8c664