### PR TITLE
Add hold-to-reveal password toggle

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1640,6 +1640,25 @@ footer.fade-out {
   display: block;
   margin-bottom: 0.25rem;
 }
+.password-input {
+  position: relative;
+}
+
+.password-input input {
+  padding-right: 2.5rem;
+}
+
+.password-input .toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 0.5rem;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
 .login-icon {
   text-align: center;
   color: var(--primary-color);

--- a/app/static/js/password_toggle.js
+++ b/app/static/js/password_toggle.js
@@ -5,13 +5,24 @@ export function initPasswordToggle() {
     if (!toggle || !input) return;
     const useEl = toggle.querySelector("use");
     const sprite = useEl ? useEl.getAttribute("href").split("#")[0] : "";
-    toggle.addEventListener("click", () => {
-      const showing = input.type === "text";
-      input.type = showing ? "password" : "text";
+    const show = () => {
+      input.type = "text";
       if (useEl) {
-        useEl.setAttribute("href", `${sprite}#${showing ? "eye" : "eye-off"}`);
+        useEl.setAttribute("href", `${sprite}#eye-off`);
       }
-    });
+    };
+    const hide = () => {
+      input.type = "password";
+      if (useEl) {
+        useEl.setAttribute("href", `${sprite}#eye`);
+      }
+    };
+    toggle.addEventListener("mousedown", show);
+    toggle.addEventListener("touchstart", show);
+    toggle.addEventListener("mouseup", hide);
+    toggle.addEventListener("mouseleave", hide);
+    toggle.addEventListener("touchend", hide);
+    toggle.addEventListener("touchcancel", hide);
   };
 
   if (document.readyState === "loading") {

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -30,7 +30,7 @@ content %}
         autofocus
       />
     </div>
-    <div class="form-field">
+    <div class="form-field password-input">
       <label for="password" class="sr-only">Password</label>
       <input
         id="password"

--- a/tests/js/password_toggle.test.js
+++ b/tests/js/password_toggle.test.js
@@ -7,7 +7,7 @@ beforeAll(async () => {
   initPasswordToggle = mod.initPasswordToggle;
 });
 
-test("click toggles password visibility", () => {
+test("password visible while button held", () => {
   document.body.innerHTML = `
     <input id="password" type="password" />
     <button id="password-toggle" aria-label="Show password">
@@ -19,10 +19,10 @@ test("click toggles password visibility", () => {
   const input = document.getElementById("password");
   const btn = document.getElementById("password-toggle");
   const useEl = btn.querySelector("use");
-  btn.click();
+  btn.dispatchEvent(new Event("mousedown"));
   expect(input.type).toBe("text");
   expect(useEl.getAttribute("href")).toBe("icons.svg#eye-off");
-  btn.click();
+  btn.dispatchEvent(new Event("mouseup"));
   expect(input.type).toBe("password");
   expect(useEl.getAttribute("href")).toBe("icons.svg#eye");
 });


### PR DESCRIPTION
## Summary
- show login password only while holding the toggle
- position toggle icon inside the password field
- update CSS for the embedded icon
- adjust unit test for the new behavior

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569f1e85dc8333bfa735401def0dc8