### PR TITLE
Fix auto login handling

### DIFF
--- a/app/static/js/login.js
+++ b/app/static/js/login.js
@@ -57,13 +57,16 @@ export async function attemptAutoLogin() {
         remember: "on",
       }),
     });
-    if (resp.redirected || resp.url.endsWith("/")) {
+    if (resp.ok && (resp.redirected || resp.url.endsWith("/"))) {
       window.IS_LOGGED_IN = true;
       if (window.location.pathname === "/login") {
         window.location.href = "/";
       }
       return true;
     }
+    // Login failed; clear stored credentials so we don't keep retrying.
+    localStorage.removeItem("autoLogin");
+    return false;
   } catch (err) {
     console.error("Auto login failed", err);
   }

--- a/tests/js/login.test.js
+++ b/tests/js/login.test.js
@@ -21,6 +21,7 @@ beforeAll(async () => {
 beforeEach(() => {
   localStorage.clear();
   jest.clearAllMocks();
+  window.IS_LOGGED_IN = false;
 });
 
 test("shows error when fields empty", () => {
@@ -76,7 +77,9 @@ test("attemptAutoLogin posts credentials and redirects", async () => {
     configurable: true,
     value: { pathname: "/login", href: "/login" },
   });
-  global.fetch = jest.fn(() => Promise.resolve({ redirected: true, url: "/" }));
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ redirected: true, url: "/", ok: true }),
+  );
   const result = await attemptAutoLogin();
   expect(fetch).toHaveBeenCalledWith(
     "/login",
@@ -85,4 +88,22 @@ test("attemptAutoLogin posts credentials and redirects", async () => {
   expect(result).toBe(true);
   expect(window.location.href).toBe("/");
   expect(window.IS_LOGGED_IN).toBe(true);
+});
+
+test("failed auto login clears stored credentials", async () => {
+  localStorage.setItem(
+    "autoLogin",
+    JSON.stringify({ username: "carol", password: "pw" }),
+  );
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      redirected: false,
+      url: "/login",
+      ok: false,
+      status: 401,
+    }),
+  );
+  const result = await attemptAutoLogin();
+  expect(result).toBe(false);
+  expect(localStorage.getItem("autoLogin")).toBeNull();
 });


### PR DESCRIPTION
## Summary
- clear saved credentials on failed auto login attempts
- test that failed logins clean up localStorage

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6856be8608fc833391042c11f10576d0