### PR TITLE
Add login flow guide

### DIFF
--- a/docs/images/login_flow.svg
+++ b/docs/images/login_flow.svg
@@ -1,0 +1,25 @@
+<svg width="220" height="260" viewBox="0 0 220 260" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Browser</text>
+  <line x1="110" y1="40" x2="110" y2="80" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="80" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="100" font-size="12" text-anchor="middle" fill="#333">/login</text>
+  <line x1="110" y1="110" x2="110" y2="150" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="150" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="170" font-size="12" text-anchor="middle" fill="#333">Database Check</text>
+  <line x1="110" y1="180" x2="60" y2="220" stroke="#333" marker-end="url(#arrow)" />
+  <line x1="110" y1="180" x2="160" y2="220" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="20" y="220" width="80" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="60" y="240" font-size="12" text-anchor="middle" fill="#333">Session</text>
+  <rect x="120" y="220" width="80" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="160" y="240" font-size="12" text-anchor="middle" fill="#333">Lockout</text>
+</svg>

--- a/docs/login_flow.md
+++ b/docs/login_flow.md
@@ -1,0 +1,9 @@
+# Login Flow
+
+The `/login` route handles both GET and POST requests. When a user submits credentials the server first checks the `login_attempts` table to see if the client's IP address is temporarily locked out. Failed attempts trigger short rate limits after every second failure and a 24‑hour lockout after five failures.
+
+If the request proceeds, the username and password are validated against the `User` table. On success the session stores `user_id`, an expiry timestamp and the optional `remember` flag. The lifetime defaults to `SESSION_TIMEOUT_MINUTES` and extends to `AUTO_LOGIN_DAYS` when "Remember me" is checked. The lockout counter resets after a successful login.
+
+Invalid credentials increment the attempt count and may eventually lock out the IP. The server returns the login page with an error message or status `429` when locked out.
+
+![Login Flow](images/login_flow.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,3 +88,4 @@ nav:
       - Speed Slider: speed_slider.md
       - Size Audit: size_audit.md
       - Template Edit Preview: edit_template_preview.md
+      - Login Flow: login_flow.md


### PR DESCRIPTION
## Summary
- document the login request/response cycle
- include SVG diagram for the process
- link new guide from the MkDocs navigation

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856be9e3c5c83339ae0e7ca5c180a58