### PR TITLE
Add capture summary sequence docs

### DIFF
--- a/docs/capture_summary_sequence.md
+++ b/docs/capture_summary_sequence.md
@@ -1,0 +1,12 @@
+# Capture Summary Sequence
+
+This page explains how a scheduled capture produces a text summary and triggers alerts. The sequence diagram shows the key steps.
+
+![Capture Summary Sequence](images/capture_summary_sequence.svg)
+
+## Flow Overview
+
+1. **Scheduler Job** – `schedule_crawlers` sets up periodic capture jobs for each camera template.
+2. **Screenshot Capture** – `update_camera` calls `capture_or_download` to grab the latest frame and save it to `data/screenshots/`.
+3. **Summary Update** – `update_summary` collects recent captions and requests the language model to generate a summary. The result is stored in the database as a `Summary` record.
+4. **Alerts** – When a new summary is saved, `email_alert` and `sms_alert` send notifications with the generated text.

--- a/docs/images/capture_summary_sequence.svg
+++ b/docs/images/capture_summary_sequence.svg
@@ -1,0 +1,111 @@
+<svg
+  width="240"
+  height="220"
+  viewBox="0 0 240 220"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker
+      id="arrow"
+      markerWidth="10"
+      markerHeight="10"
+      refX="5"
+      refY="5"
+      orient="auto"
+      markerUnits="strokeWidth"
+    >
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect
+    x="50"
+    y="10"
+    width="140"
+    height="30"
+    fill="url(#stage)"
+    stroke="#333"
+  />
+  <text x="120" y="30" font-size="12" text-anchor="middle" fill="#333">
+    Scheduler
+  </text>
+  <line
+    x1="120"
+    y1="40"
+    x2="120"
+    y2="70"
+    stroke="#333"
+    marker-end="url(#arrow)"
+  />
+  <rect
+    x="50"
+    y="70"
+    width="140"
+    height="30"
+    fill="url(#stage)"
+    stroke="#333"
+  />
+  <text x="120" y="90" font-size="12" text-anchor="middle" fill="#333">
+    Capture Job
+  </text>
+  <line
+    x1="120"
+    y1="100"
+    x2="120"
+    y2="130"
+    stroke="#333"
+    marker-end="url(#arrow)"
+  />
+  <rect
+    x="50"
+    y="130"
+    width="140"
+    height="30"
+    fill="url(#stage)"
+    stroke="#333"
+  />
+  <text x="120" y="150" font-size="12" text-anchor="middle" fill="#333">
+    Summary Update
+  </text>
+  <line
+    x1="120"
+    y1="160"
+    x2="70"
+    y2="190"
+    stroke="#333"
+    marker-end="url(#arrow)"
+  />
+  <line
+    x1="120"
+    y1="160"
+    x2="170"
+    y2="190"
+    stroke="#333"
+    marker-end="url(#arrow)"
+  />
+  <rect
+    x="20"
+    y="190"
+    width="100"
+    height="30"
+    fill="url(#stage)"
+    stroke="#333"
+  />
+  <text x="70" y="210" font-size="12" text-anchor="middle" fill="#333">
+    email_alert
+  </text>
+  <rect
+    x="140"
+    y="190"
+    width="100"
+    height="30"
+    fill="url(#stage)"
+    stroke="#333"
+  />
+  <text x="190" y="210" font-size="12" text-anchor="middle" fill="#333">
+    sms_alert
+  </text>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - Camera Discovery: camera_discovery.md
       - Camera Fix: camera_fix.md
       - Capture Process: capture_process.md
+      - Capture Summary Sequence: capture_summary_sequence.md
       - Browser Driver Management: driver_pool.md
       - Captions Live Update: captions_live_update.md
       - Floating Navigation Bar: floating_nav.md


### PR DESCRIPTION
## Summary
- document the scheduled capture flow
- include a sequence diagram for the summary flow
- link the guide in `mkdocs.yml`

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bea017e883338799f4c6215e0f43