### PR TITLE
Add offline job queue documentation

### DIFF
--- a/docs/images/offline_job_sequence.svg
+++ b/docs/images/offline_job_sequence.svg
@@ -1,0 +1,66 @@
+<svg
+  width="300"
+  height="220"
+  viewBox="0 0 300 220"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <defs>
+    <marker
+      id="arrow"
+      viewBox="0 0 10 10"
+      refX="5"
+      refY="5"
+      markerWidth="6"
+      markerHeight="6"
+      orient="auto-start-reverse"
+    >
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="black" />
+    </marker>
+    <style>
+      rect {
+        fill: #f2f2f2;
+        stroke: #333;
+        stroke-width: 1;
+      }
+      text {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+      }
+    </style>
+  </defs>
+  <rect x="90" y="10" width="120" height="30" />
+  <text x="150" y="30" text-anchor="middle">run_with_timeout</text>
+  <line
+    x1="150"
+    y1="40"
+    x2="150"
+    y2="70"
+    stroke="black"
+    marker-end="url(#arrow)"
+  />
+
+  <rect x="90" y="70" width="120" height="30" />
+  <text x="150" y="90" text-anchor="middle">System Offline?</text>
+  <line
+    x1="150"
+    y1="100"
+    x2="150"
+    y2="130"
+    stroke="black"
+    marker-end="url(#arrow)"
+  />
+
+  <rect x="60" y="130" width="180" height="30" />
+  <text x="150" y="150" text-anchor="middle">Insert into OfflineJob</text>
+  <line
+    x1="150"
+    y1="160"
+    x2="150"
+    y2="190"
+    stroke="black"
+    marker-end="url(#arrow)"
+  />
+
+  <rect x="70" y="190" width="160" height="30" />
+  <text x="150" y="210" text-anchor="middle">process_offline_jobs</text>
+</svg>

--- a/docs/offline_job_sequence.md
+++ b/docs/offline_job_sequence.md
@@ -1,0 +1,11 @@
+# Offline Job Queue When Glimpser detects that network connectivity is
+unavailable, scheduled tasks are not executed immediately. Instead
+`run_with_timeout` stores job details in the `OfflineJob` table so they can run
+later. The database model defined in `app/models/offline_job.py` captures: -
+`function` – full dotted path to the callable - `args` – JSON encoded arguments
+- `timeout` – maximum runtime in seconds - `timestamp` – when the job was queued
+`process_offline_jobs` runs every 30 seconds (via
+`schedule_offline_job_processor`). It loads the queued entries, imports the
+recorded function, and invokes `run_with_timeout` with the saved arguments.
+Successful jobs are removed from the table. ![Offline Job
+Sequence](images/offline_job_sequence.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Nginx HTTP/2 Push: nginx_http2_push.md
       - Offline Fonts: offline_fonts.md
       - Offline Preview: offline_preview.md
+      - Offline Job Queue: offline_job_sequence.md
       - Pylint Checks: pylint_checks.md
       - Web Notifications: web_notifications.md
       - Search Autocomplete: search_autocomplete.md


### PR DESCRIPTION
## Summary
- document how offline jobs are queued and processed
- add sequence diagram
- link new page in mkdocs

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bea18b9c83339230d4fb68f47377