### PR TITLE
Add HTTP callback flow diagram

### DIFF
--- a/docs/http_callbacks.md
+++ b/docs/http_callbacks.md
@@ -55,6 +55,10 @@ send_http_callback(
 )
 ```
 
+The diagram below illustrates the callback flow including optional retries:
+
+![HTTP Callback Flow](images/http_callback_flow.svg)
+
 ## Configuring a Callback URL
 
 1. Open the Glimpser web interface and edit a template.

--- a/docs/images/http_callback_flow.svg
+++ b/docs/images/http_callback_flow.svg
@@ -1,0 +1,20 @@
+<svg width="220" height="220" viewBox="0 0 220 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Event</text>
+  <line x1="110" y1="40" x2="110" y2="80" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="80" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="100" font-size="12" text-anchor="middle" fill="#333">POST Callback</text>
+  <line x1="110" y1="110" x2="110" y2="150" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="150" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="170" font-size="12" text-anchor="middle" fill="#333">Response</text>
+  <path d="M110 180 L150 180 L150 95 L120 95" stroke="#333" stroke-dasharray="4 2" fill="none" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- create `http_callback_flow.svg` illustrating callbacks
- embed the diagram in `http_callbacks.md`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856bea818e48333ad7736ec4fd1217e