### PR TITLE
Add offline job flow guide

### DIFF
--- a/docs/images/offline_job_flow.svg
+++ b/docs/images/offline_job_flow.svg
@@ -1,0 +1,22 @@
+<svg width="220" height="260" viewBox="0 0 220 260" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Job Created</text>
+  <line x1="110" y1="40" x2="110" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="90" font-size="12" text-anchor="middle" fill="#333">Queued Offline</text>
+  <line x1="110" y1="100" x2="110" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="150" font-size="12" text-anchor="middle" fill="#333">Periodic Retry</text>
+  <line x1="110" y1="160" x2="110" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="210" font-size="12" text-anchor="middle" fill="#333">Job Executed</text>
+</svg>

--- a/docs/offline_job_flow.md
+++ b/docs/offline_job_flow.md
@@ -1,0 +1,9 @@
+# Offline Job Flow
+
+When Glimpser cannot reach external services, some scheduled tasks are deferred instead of failing. Each skipped job is stored in the `offline_jobs` table with the function name, arguments, timeout and a timestamp.
+
+A background scheduler calls `process_offline_jobs` every 30 seconds. If connectivity has been restored, each stored job is imported and executed with `run_with_timeout`. Successful runs remove the entry from the table so it will not be retried again. Failures leave the job in the queue for the next attempt.
+
+The diagram below summarizes this process:
+
+![Offline Job Flow](images/offline_job_flow.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Nginx HTTP/2 Push: nginx_http2_push.md
       - Offline Fonts: offline_fonts.md
       - Offline Preview: offline_preview.md
+      - Offline Job Flow: offline_job_flow.md
       - Pylint Checks: pylint_checks.md
       - Web Notifications: web_notifications.md
       - Search Autocomplete: search_autocomplete.md


### PR DESCRIPTION
## Summary
- document how offline jobs are queued and retried
- show offline job processing diagram
- link the new guide in the docs navigation

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856bea844808333b6d80d49ea739590