### PR TITLE
Add LLM summarization documentation

### DIFF
--- a/docs/images/llm_summarization_flow.svg
+++ b/docs/images/llm_summarization_flow.svg
@@ -1,0 +1,25 @@
+<svg width="220" height="300" viewBox="0 0 220 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="5" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="50" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="30" font-size="12" text-anchor="middle" fill="#333">Capture Screenshot</text>
+  <line x1="110" y1="40" x2="110" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="90" font-size="12" text-anchor="middle" fill="#333">Generate Caption</text>
+  <line x1="110" y1="100" x2="110" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="150" font-size="12" text-anchor="middle" fill="#333">update_summary</text>
+  <line x1="110" y1="160" x2="110" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="190" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="210" font-size="12" text-anchor="middle" fill="#333">Store in DB</text>
+  <line x1="110" y1="220" x2="110" y2="250" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="50" y="250" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="110" y="270" font-size="12" text-anchor="middle" fill="#333">Display in UI</text>
+</svg>

--- a/docs/llm_summarization.md
+++ b/docs/llm_summarization.md
@@ -1,0 +1,17 @@
+# LLM Summarization Flow
+
+Glimpser turns captured screenshots into short textual summaries so you can grasp current system status at a glance.
+
+## Screenshot Capture
+When a template runs, `capture_or_download` in `app/utils/screenshots.py` saves an image and updates `last_screenshot_time` in the database.
+
+## Caption Generation
+`caption_image` from `app/utils/image_processing.py` sends the screenshot to the language model. The result becomes `last_caption` for that template.
+
+## `update_summary`
+The scheduled function `update_summary` in `app/utils/scheduling.py` collects recent captions and calls the language model using the prompt defined by `LLM_SUMMARY_PROMPT`. The response is stored in the `Summary` table with a timestamp.
+
+## Database and UI
+Summaries are retrieved through `get_last_summary_time()` and displayed on the Captions page. The latest entry also appears on the home screen.
+
+![LLM Summarization Flow](images/llm_summarization_flow.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Live View Scrubbing: live_scrub.md
       - Clip Navigation: clip_navigation.md
       - LLM Prompt Settings: llm_prompts.md
+      - LLM Summarization: llm_summarization.md
       - MCP Integration: mcp_integration.md
       - In-App Onboarding: onboarding.md
       - OpenSSF Scorecard: scorecard.md


### PR DESCRIPTION
## Summary
- document LLM summarization flow
- include sequence diagram
- update navigation

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest` *(fails: test_cache_logs_parses_lines)*

------
https://chatgpt.com/codex/tasks/task_e_6856beab68588333952de6386f1f674b