### PR TITLE
Add notifications flow doc

### DIFF
--- a/docs/images/notifications_sequence.svg
+++ b/docs/images/notifications_sequence.svg
@@ -1,0 +1,21 @@
+<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="black" />
+    </marker>
+    <linearGradient id="stage" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#dcdcdc" />
+    </linearGradient>
+  </defs>
+  <rect x="90" y="10" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="150" y="30" font-size="12" text-anchor="middle" fill="#333">Browser registers sw.js</text>
+  <line x1="150" y1="40" x2="150" y2="70" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="90" y="70" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="150" y="90" font-size="12" text-anchor="middle" fill="#333">POST /register_push</text>
+  <line x1="150" y1="100" x2="150" y2="130" stroke="#333" marker-end="url(#arrow)" />
+  <rect x="90" y="130" width="120" height="30" fill="url(#stage)" stroke="#333" />
+  <text x="150" y="150" font-size="12" text-anchor="middle" fill="#333">POST /send_notification</text>
+  <line x1="150" y1="160" x2="150" y2="190" stroke="#333" marker-end="url(#arrow)" />
+  <text x="150" y="198" font-size="12" text-anchor="middle" fill="#333">Push or SSE /stream_notifications</text>
+</svg>

--- a/docs/notifications_flow.md
+++ b/docs/notifications_flow.md
@@ -1,0 +1,9 @@
+# Notifications Flow
+
+Glimpser uses a Service Worker to deliver push notifications when possible. When users first open the site the browser registers `sw.js`. The script subscribes to push messages and sends the resulting subscription object to `/register_push`.
+
+Later any component can queue a message by POSTing to `/send_notification` with `title` and `body` fields. The server delivers the notification to all stored subscriptions.
+
+Browsers that do not support push still poll `/stream_notifications` with Server‑Sent Events (SSE). The main interface opens an `EventSource` that displays incoming notifications using the Notification API.
+
+![Notification Sequence](images/notifications_sequence.svg)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Offline Preview: offline_preview.md
       - Pylint Checks: pylint_checks.md
       - Web Notifications: web_notifications.md
+      - Notifications Flow: notifications_flow.md
       - Search Autocomplete: search_autocomplete.md
       - Recommendations: recommendations.md
       - Release Workflow: release_workflow.md


### PR DESCRIPTION
## Summary
- document service worker registration and push routes
- include sequence diagram
- link guide in mkdocs navigation

## Testing
- `pre-commit run --files docs/notifications_flow.md docs/images/notifications_sequence.svg mkdocs.yml`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856bf075d008333a6b9712eb818c168