### PR TITLE
Add speed slider to live player

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -867,9 +867,9 @@ function playLive() {
     };
 
     const slider = document.getElementById("speed-slider");
-    const speed = Math.pow(2, slider.value);
+    const secs = Math.max(1, parseInt(slider.value, 10) || 1);
     liveSwitchFunction();
-    liveSwitchInterval = setInterval(liveSwitchFunction, 10000 / speed);
+    liveSwitchInterval = setInterval(liveSwitchFunction, secs * 1000);
   } else {
     video.src = "/live_video?camera=" + encodeURIComponent(currentCamera);
     video.load();
@@ -889,7 +889,7 @@ function playPNG() {
   video.style.display = "none";
   image.style.display = "block";
   const slider = document.getElementById("speed-slider");
-  const speed = Math.pow(2, slider.value);
+  const secs = Math.max(1, parseInt(slider.value, 10) || 1);
   const seekBar = document.getElementById("seek-bar");
   if (seekBar) {
     seekBar.style.display = "none";
@@ -901,7 +901,7 @@ function playPNG() {
     JSON.stringify({
       ts: Date.now(),
       ctx: "discover",
-      msg: `seekBar:${seekBar},speed:${speed}`,
+      msg: `seekBar:${seekBar},secs:${secs}`,
     }),
   );
   if (currentCamera.startsWith("group-")) {
@@ -919,7 +919,7 @@ function playPNG() {
     };
     refreshGroupPNG();
     clearInterval(pngInterval);
-    pngInterval = setInterval(refreshGroupPNG, 10000 / speed);
+    pngInterval = setInterval(refreshGroupPNG, secs * 1000);
   } else if (currentCamera === "All") {
     // Special handling for the "All" option
     let cameraIndex = 0;
@@ -935,12 +935,12 @@ function playPNG() {
     };
     refreshAllPNG();
     clearInterval(pngInterval);
-    pngInterval = setInterval(refreshAllPNG, 10000 / speed);
+    pngInterval = setInterval(refreshAllPNG, secs * 1000);
   } else {
     // Original behavior for individual cameras
     refreshPNG();
     clearInterval(pngInterval);
-    pngInterval = setInterval(refreshPNG, 10000 / speed);
+    pngInterval = setInterval(refreshPNG, secs * 1000);
   }
 }
 
@@ -1020,21 +1020,22 @@ function changeVideoSource() {
 function updatePlaybackSpeed() {
   const slider = document.getElementById("speed-slider");
   const speedDisplay = document.getElementById("speed-value");
-  const speed = Math.pow(2, slider.value);
+  const secs = Math.max(1, parseInt(slider.value, 10) || 1);
   localStorage.setItem("playbackSpeed", slider.value);
-  video.playbackRate = parseFloat(speed.toFixed(2)); // Ensure the speed is a float with two decimal places
-  speedDisplay.textContent = speed.toFixed(2) + "x"; // Update the text to show two decimal places
+  const fps = 1 / secs;
+  video.playbackRate = fps;
+  speedDisplay.textContent = secs === 60 ? "1fpm" : `${fps.toFixed(2)}fps`;
 
   // Adjust the refresh rate for the PNG stream based on the playback speed
   if (pngInterval) {
     clearInterval(pngInterval);
-    pngInterval = setInterval(refreshPNG, 10000 / speed);
+    pngInterval = setInterval(refreshPNG, secs * 1000);
   }
 
   // Adjust the live group switch interval if active
   if (liveSwitchInterval && liveSwitchFunction) {
     clearInterval(liveSwitchInterval);
-    liveSwitchInterval = setInterval(liveSwitchFunction, 10000 / speed);
+    liveSwitchInterval = setInterval(liveSwitchFunction, secs * 1000);
   }
 
   speedDisplay.classList.add("highlight-speed");

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -31,6 +31,24 @@ export function initTilePlayer() {
     container.appendChild(spinner);
   }
 
+  const speedSlider = document.getElementById("speed-slider");
+  const speedValue = document.getElementById("speed-value");
+  let refreshSeconds = speedSlider
+    ? Math.max(1, parseInt(speedSlider.value, 10) || 1)
+    : 1;
+
+  function updateSpeedLabel() {
+    if (!speedValue || !speedSlider) return;
+    const secs = Math.max(1, parseInt(speedSlider.value, 10) || 1);
+    refreshSeconds = secs;
+    speedValue.textContent =
+      secs === 60 ? "1fpm" : `${(1 / secs).toFixed(2)}fps`;
+    video.playbackRate = 1 / secs;
+  }
+
+  if (speedSlider) speedSlider.addEventListener("input", updateSpeedLabel);
+  updateSpeedLabel();
+
   const image = document.createElement("img");
   image.id = "live-image";
   image.style.display = "none";

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -15,6 +15,21 @@
     <source type="video/mp4" />
     Your browser does not support the video tag.
   </video>
+  <div id="controls-wrapper" class="fade-out">
+    <div id="speed-container">
+      <label for="speed-slider" class="sr-only">Speed</label>
+      <input
+        type="range"
+        id="speed-slider"
+        min="1"
+        max="60"
+        value="1"
+        step="1"
+        aria-label="Playback speed"
+      />
+      <span id="speed-value">1fps</span>
+    </div>
+  </div>
 </div>
 <script>
   window.templateDetails = {{ template_details|tojson }};

--- a/docs/speed_slider.md
+++ b/docs/speed_slider.md
@@ -2,5 +2,5 @@
 
 The live player includes a vertical slider to adjust playback rate.
 Drag upward to speed up or downward to slow the clip.
-Speeds range from 0.25&times; to 4&times;.
+Speeds range from 1&nbsp;frame per second to 1&nbsp;frame per minute.
 The slider hides until you hover over the player so the layout stays clean.


### PR DESCRIPTION
## Summary
- add vertical speed slider control on `/live` view
- allow live tiles to update playback speed
- unify speed control logic across players
- document new speed range

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68571704a17883338c936ae289e91e8b