### PR TITLE
Fix URL tester in camera templates view

### DIFF
--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -2,112 +2,121 @@ import { sendTelemetry } from "./telemetry.js";
 
 export function initUrlTester() {
   document.addEventListener("DOMContentLoaded", () => {
-    const input = document.getElementById("url");
-    const status = document.getElementById("url-status");
-    const preview = document.getElementById("url-preview");
-    if (!input || !status) return;
+    const inputs = document.querySelectorAll("#url");
+    if (!inputs.length) return;
 
-    const form = input.closest("form");
-    const controlled = [];
-    let submit;
-    if (form) {
-      form.querySelectorAll("input, select, textarea").forEach((el) => {
-        if (el === input || el.id === "name") return;
-        if (!submit && el.type === "submit") submit = el;
-        controlled.push([el, el.disabled]);
-      });
-    }
+    inputs.forEach((input) => {
+      const container = input.closest(".edit-template-container");
+      const status = container
+        ? container.querySelector("#url-status")
+        : document.getElementById("url-status");
+      const preview = container
+        ? container.querySelector("img")
+        : document.getElementById("url-preview");
+      if (!status) return;
 
-    const toggleDisabled = () => {
-      const disable = input.value.trim() === "";
-      controlled.forEach(([el, orig]) => {
-        el.disabled = disable || orig;
-      });
-      if (submit) submit.disabled = disable;
-    };
-
-    let controller;
-    const debounce = (fn, delay) => {
-      let timer;
-      return (...args) => {
-        clearTimeout(timer);
-        timer = setTimeout(() => fn(...args), delay);
-      };
-    };
-    const defaultSrc = preview
-      ? preview.dataset.placeholder || preview.src
-      : "";
-    const defaultUrl = input.dataset.defaultUrl;
-    const setStatus = (cls, title = "") => {
-      status.textContent = "";
-      status.className = "url-status" + (cls ? ` ${cls}` : "");
-      status.title = title || "URL test result";
-    };
-
-    const check = async () => {
-      const url = input.value.trim();
-      setStatus("");
-      if (preview) preview.src = url || defaultSrc;
-      if (submit) submit.disabled = true;
-      if (!url) return;
-      controller?.abort();
-      controller = new AbortController();
-      setStatus("pending", "Testing...");
-      try {
-        const res = await fetch(
-          `/templates/test_url?url=${encodeURIComponent(url)}`,
-          {
-            signal: controller.signal,
-          },
-        );
-        const data = await res.json();
-        if (res.ok && data.ok) {
-          setStatus("ok", "URL reachable");
-          if (submit) submit.disabled = false;
-        } else {
-          const msg = data.status
-            ? `HTTP ${data.status}`
-            : data.error || "Unreachable";
-          setStatus("bad", msg);
-          if (submit) submit.disabled = true;
-        }
-        sendTelemetry("url_test", { url, ok: data.ok });
-      } catch {
-        if (controller.signal.aborted) return;
-        setStatus("bad", "Unreachable");
-        if (submit) submit.disabled = true;
-        sendTelemetry("url_test", { url, ok: false });
+      const form = input.closest("form");
+      const controlled = [];
+      let submit;
+      if (form) {
+        form.querySelectorAll("input, select, textarea").forEach((el) => {
+          if (el === input || el.id === "name") return;
+          if (!submit && el.type === "submit") submit = el;
+          controlled.push([el, el.disabled]);
+        });
       }
-    };
 
-    const checkDebounced = debounce(check, 500);
+      const toggleDisabled = () => {
+        const disable = input.value.trim() === "";
+        controlled.forEach(([el, orig]) => {
+          el.disabled = disable || orig;
+        });
+        if (submit) submit.disabled = disable;
+      };
 
-    toggleDisabled();
+      let controller;
+      const debounce = (fn, delay) => {
+        let timer;
+        return (...args) => {
+          clearTimeout(timer);
+          timer = setTimeout(() => fn(...args), delay);
+        };
+      };
+      const defaultSrc = preview
+        ? preview.dataset.placeholder || preview.src
+        : "";
+      const defaultUrl = input.dataset.defaultUrl;
+      const setStatus = (cls, title = "") => {
+        status.textContent = "";
+        status.className = "url-status" + (cls ? ` ${cls}` : "");
+        status.title = title || "URL test result";
+      };
 
-    if (!input.value && defaultUrl) {
-      input.value = defaultUrl;
-      toggleDisabled();
-      setTimeout(() => {
-        check();
-      }, 1000);
-    }
-
-    input.addEventListener("input", () => {
-      toggleDisabled();
-      const hasValue = input.value.trim() !== "";
-      setStatus(hasValue ? "pending" : "", hasValue ? "Testing..." : "");
-      if (submit) submit.disabled = true;
-      if (hasValue) checkDebounced();
-    });
-    input.addEventListener("paste", () => {
-      setTimeout(() => {
+      const check = async () => {
+        const url = input.value.trim();
+        setStatus("");
+        if (preview) preview.src = url || defaultSrc;
+        if (submit) submit.disabled = true;
+        if (!url) return;
+        controller?.abort();
+        controller = new AbortController();
         setStatus("pending", "Testing...");
-        checkDebounced();
-      }, 0);
-    });
-    input.addEventListener("blur", check);
-    input.addEventListener("change", () => {
-      check();
+        try {
+          const res = await fetch(
+            `/templates/test_url?url=${encodeURIComponent(url)}`,
+            {
+              signal: controller.signal,
+            },
+          );
+          const data = await res.json();
+          if (res.ok && data.ok) {
+            setStatus("ok", "URL reachable");
+            if (submit) submit.disabled = false;
+          } else {
+            const msg = data.status
+              ? `HTTP ${data.status}`
+              : data.error || "Unreachable";
+            setStatus("bad", msg);
+            if (submit) submit.disabled = true;
+          }
+          sendTelemetry("url_test", { url, ok: data.ok });
+        } catch {
+          if (controller.signal.aborted) return;
+          setStatus("bad", "Unreachable");
+          if (submit) submit.disabled = true;
+          sendTelemetry("url_test", { url, ok: false });
+        }
+      };
+
+      const checkDebounced = debounce(check, 500);
+
+      toggleDisabled();
+
+      if (!input.value && defaultUrl) {
+        input.value = defaultUrl;
+        toggleDisabled();
+        setTimeout(() => {
+          check();
+        }, 1000);
+      }
+
+      input.addEventListener("input", () => {
+        toggleDisabled();
+        const hasValue = input.value.trim() !== "";
+        setStatus(hasValue ? "pending" : "", hasValue ? "Testing..." : "");
+        if (submit) submit.disabled = true;
+        if (hasValue) checkDebounced();
+      });
+      input.addEventListener("paste", () => {
+        setTimeout(() => {
+          setStatus("pending", "Testing...");
+          checkDebounced();
+        }, 0);
+      });
+      input.addEventListener("blur", check);
+      input.addEventListener("change", () => {
+        check();
+      });
     });
   });
 }

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -112,7 +112,7 @@ template_form %} {% block content %}
     <h3>Edit Template Details</h3>
     {{ template_form( 'edit-template-form', '/update_template/' ~ template_name,
     template=template_details, preview_src='/stream.mjpg?camera=' ~
-    template_name, preview_id='mini-live-preview', include_name=False,
+    template_name, preview_id='url-preview', include_name=False,
     submit_label='Update Template', object_tokens=object_tokens,
     clip_model=clip_model, clip_gpu=clip_gpu ) }}
   </div>
@@ -558,9 +558,9 @@ template_form %} {% block content %}
       title="Close dialog"
       >&times;</span
     >
-    {{ template_form( 'edit-template-form', '/update_template/' ~ template_name,
-    template=template_details, preview_src='/stream.mjpg?camera=' ~
-    template_name, preview_id='mini-live-preview', include_name=False,
+    {{ template_form( 'edit-template-form-modal', '/update_template/' ~
+    template_name, template=template_details, preview_src='/stream.mjpg?camera='
+    ~ template_name, preview_id='url-preview', include_name=False,
     submit_label='Save', object_tokens=object_tokens, clip_model=clip_model,
     clip_gpu=clip_gpu ) }}
   </div>
@@ -572,5 +572,9 @@ template_form %} {% block content %}
 <script
   type="module"
   src="{{ url_for('static', filename='js/recent_videos.js') }}"
+></script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/url_test.js') }}"
 ></script>
 {% endblock %}

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -101,4 +101,38 @@ describe("url_test", () => {
     expect(status.classList.contains("bad")).toBe(true);
     expect(status.title).toBe("HTTP 404");
   });
+
+  test("initializes multiple forms", async () => {
+    const multiHtml = `
+      <div class="edit-template-container">
+        <img id="p1">
+        <form><input id="url" data-default-url="http://a"><span id="url-status"></span><input type="submit"></form>
+      </div>
+      <div class="edit-template-container">
+        <img id="p2">
+        <form><input id="url" data-default-url="http://b"><span id="url-status"></span><input type="submit"></form>
+      </div>`;
+    document.body.innerHTML = multiHtml;
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const previews = document.querySelectorAll("img");
+    previews[1]
+      .closest(".edit-template-container")
+      .querySelector("#url").value = "http://cam";
+    previews[1]
+      .closest(".edit-template-container")
+      .querySelector("#url")
+      .dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    expect(previews[1].src).toContain("http://cam");
+  });
 });


### PR DESCRIPTION
## Summary
- enable URL tester across all template edit forms
- load `url_test.js` for camera template details
- test multiple URL tester forms

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68573a4abb3c8333b2523216747a39b4