### PR TITLE
Delay live view switch on template page

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -1,5 +1,10 @@
 import { showSpinner, hideSpinner, showErrorIndicator } from "./video.js";
 
+function safePlay(el) {
+  const p = el.play?.();
+  if (p && typeof p.catch === "function") p.catch(() => {});
+}
+
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
@@ -66,6 +71,14 @@ export function initTilePlayer() {
   }
 
   const LIVE_CLASS = "live-mode";
+  const IDLE_DELAY = 30000;
+
+  function showClip() {
+    image.style.display = "none";
+    video.style.display = "block";
+    container?.classList.remove(LIVE_CLASS);
+    safePlay(video);
+  }
 
   function playMjpg(target, isCamera = false) {
     if (!target) return;
@@ -79,23 +92,9 @@ export function initTilePlayer() {
     if (container) container.classList.add(LIVE_CLASS);
   }
 
-  function scheduleLive(group) {
+  function scheduleLive(name) {
     clearTimeout(liveTimer);
-    const onInteract = () => {
-      clearTimeout(liveTimer);
-      container.removeEventListener("mousemove", onInteract);
-      container.removeEventListener("mousedown", onInteract);
-      container.removeEventListener("touchstart", onInteract);
-    };
-    container.addEventListener("mousemove", onInteract);
-    container.addEventListener("mousedown", onInteract);
-    container.addEventListener("touchstart", onInteract);
-    liveTimer = setTimeout(() => {
-      container.removeEventListener("mousemove", onInteract);
-      container.removeEventListener("mousedown", onInteract);
-      container.removeEventListener("touchstart", onInteract);
-      playMjpg(group);
-    }, 2000);
+    liveTimer = setTimeout(() => play(name), IDLE_DELAY);
   }
 
   async function loadHdClip() {
@@ -154,19 +153,27 @@ export function initTilePlayer() {
   }
 
   if (camSelect) {
-    camSelect.addEventListener("change", () => play(camSelect.value));
+    camSelect.addEventListener("change", () => {
+      current = camSelect.value;
+      showClip();
+      scheduleLive(current);
+    });
   }
 
-  play(current);
-
-  if (container) {
-    const reset = () => {
-      if (container.classList.contains(LIVE_CLASS)) {
-        play(current);
+  if (source && source.src) {
+    const onInteract = () => {
+      clearTimeout(liveTimer);
+      if (container?.classList.contains(LIVE_CLASS)) {
+        showClip();
       }
+      scheduleLive(current);
     };
-    container.addEventListener("mousedown", reset);
-    container.addEventListener("touchstart", reset);
+    container?.addEventListener("mousemove", onInteract);
+    container?.addEventListener("mousedown", onInteract);
+    container?.addEventListener("touchstart", onInteract);
+    scheduleLive(current);
+  } else {
+    play(current);
   }
 }
 

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -28,6 +28,7 @@ test("no clip fetch occurs", async () => {
 });
 
 test("group change updates image src", () => {
+  jest.useFakeTimers();
   document.body.innerHTML = `
     <video id="live-video"><source></source></video>
     <select id="camera-selector"></select>
@@ -41,10 +42,13 @@ test("group change updates image src", () => {
   init();
   changeGroup("kitchen");
   const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
+  jest.advanceTimersByTime(30000);
   expect(img.src).toMatch(/\/stream\.mjpg\?group=kitchen&time=\d+$/);
 });
 
 test("fallback to nav camera dropdown", () => {
+  jest.useFakeTimers();
   document.body.innerHTML = `
     <video id="live-video"><source></source></video>
     <select id="nav-camera-dropdown"></select>
@@ -58,10 +62,13 @@ test("fallback to nav camera dropdown", () => {
   init();
   changeGroup("foo");
   const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
+  jest.advanceTimersByTime(30000);
   expect(img.src).toMatch(/\/stream\.mjpg\?group=foo&time=\d+$/);
 });
 
 test("all group uses group mjpeg", () => {
+  jest.useFakeTimers();
   document.body.innerHTML = `
     <video id="live-video"><source></source></video>
     <select id="camera-selector"><option>All</option></select>
@@ -87,4 +94,19 @@ test("context menu is suppressed", () => {
   const event = new Event("contextmenu", { bubbles: true, cancelable: true });
   video.dispatchEvent(event);
   expect(event.defaultPrevented).toBe(true);
+});
+
+test("clip waits 30s before live", () => {
+  jest.useFakeTimers();
+  document.body.innerHTML = `
+    <video id="live-video"><source src="/last_video/cam1"></source></video>
+  `;
+  window.templateDetails = { cam1: {} };
+  init();
+  const img = document.getElementById("live-image");
+  expect(img.src).toBe("");
+  jest.advanceTimersByTime(29999);
+  expect(img.src).toBe("");
+  jest.advanceTimersByTime(1);
+  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
 });


### PR DESCRIPTION
## Summary
- start video gallery on template page and swap to live view after 30s idle
- switch back to gallery when the mouse moves
- update tests for delayed live behavior

## Testing
- `pre-commit run --files app/static/js/tile_player.js tests/js/tile_player.test.js`
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857394b1cb083338f2686897be1e5e4