### PR TITLE
Fix tile player duplicate live-image bug

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -54,10 +54,13 @@ export function initTilePlayer() {
   if (speedSlider) speedSlider.addEventListener("input", updateSpeedLabel);
   updateSpeedLabel();
 
-  const image = document.createElement("img");
-  image.id = "live-image";
-  image.style.display = "none";
-  if (container) container.appendChild(image);
+  let image = document.getElementById("live-image");
+  if (!image) {
+    image = document.createElement("img");
+    image.id = "live-image";
+    image.style.display = "none";
+    if (container) container.appendChild(image);
+  }
 
   function showBounce() {
     if (!spinner) return;

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -110,3 +110,14 @@ test("clip waits 30s before live", () => {
   jest.advanceTimersByTime(1);
   expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
 });
+
+test("init does not duplicate live-image", () => {
+  document.body.innerHTML = `
+    <video id="live-video"><source></source></video>
+  `;
+  window.templateDetails = { cam1: {} };
+  init();
+  expect(document.querySelectorAll("#live-image").length).toBe(1);
+  init();
+  expect(document.querySelectorAll("#live-image").length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- prevent duplicate `#live-image` element in `tile_player`
- test that `initTilePlayer` only inserts one image

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`
- `npm test --silent`
- `npm run size-audit`


------
https://chatgpt.com/codex/tasks/task_e_6857427be9548333a0a433458b57e51d