### PR TITLE
Show spinner when switching to live video

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -804,6 +804,7 @@ function handleVideoEnded() {
 
 function playLive() {
   resetVideo();
+  showLoadingIndicator();
   video.style.display = "block";
   // Live video cannot be scrubbed
   const seekBar = document.getElementById("seek-bar");

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -15,6 +15,16 @@
     <source type="video/mp4" />
     Your browser does not support the video tag.
   </video>
+  <div id="video-overlay" class="video-overlay"></div>
+  <div id="loading-indicator" class="loading-spinner"></div>
+  <div id="play-pause-indicator" class="video-icon"></div>
+  <div id="offline-indicator" class="offline-indicator"></div>
+  <div id="offline-message" role="status" aria-live="polite"></div>
+  <div id="capture-error-indicator" class="error-indicator"></div>
+  <div id="capture-error-message"></div>
+  <div id="stream-error-indicator" class="error-indicator"></div>
+  <div id="stream-error-message"></div>
+  <div id="error-message" role="status" aria-live="polite"></div>
   <div id="controls-wrapper" class="fade-out">
     <div id="speed-container">
       <label for="speed-slider" class="sr-only">Speed</label>

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -206,6 +206,11 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('role="timer"', html)
         self.assertIn('aria-live="polite"', html)
 
+    def test_live_page_has_overlay(self):
+        html = Path("app/templates/live.html").read_text(encoding="utf-8")
+        self.assertIn('id="video-overlay"', html)
+        self.assertIn('id="loading-indicator"', html)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add video overlay elements to the live template
- display a loading spinner when switching to the live feed
- check for overlay elements in template tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`
- `npm run size-audit`


------
https://chatgpt.com/codex/tasks/task_e_6857568e0e2c833380dc91f96b751428