### PR TITLE
Fix handling of corrupt screenshots

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1280,6 +1280,14 @@ def generate(
                             last_shot = None
                     except Exception as e:
                         logging.error("Failed to open last shot %s: %s", last_shot, e)
+                        try:
+                            os.remove(last_shot)
+                        except OSError as exc:
+                            logging.warning(
+                                "Failed to remove bad shot %s: %s",
+                                last_shot,
+                                exc,
+                            )
                         last_shot = None
 
                 if frame is None:
@@ -1395,6 +1403,14 @@ def generate(
                                 exc,
                                 exc_info=True,
                             )
+                            try:
+                                os.remove(most_recent_file)
+                            except OSError as remove_exc:
+                                logging.warning(
+                                    "Failed to remove invalid screenshot %s: %s",
+                                    most_recent_file,
+                                    remove_exc,
+                                )
 
         if not frame:
             frame = _placeholder_frame()

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -259,10 +259,12 @@ def http_session():
     return _session
 
 
-def _is_valid_png(path):
+def _is_valid_png(path: str) -> bool:
+    """Return ``True`` if ``path`` points to a valid, readable PNG."""
+
     try:
         with Image.open(path) as im:
-            im.verify()  # raises if corrupt/zero-byte
+            im.load()  # fully read file to detect truncation
         return True
     except Exception:
         return False

--- a/tests/test_png_validation.py
+++ b/tests/test_png_validation.py
@@ -31,6 +31,20 @@ class TestPNGValidation(unittest.TestCase):
         finally:
             os.remove(path)
 
+    def test_truncated_png(self):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+            path = tmp.name
+        try:
+            with Image.new("RGB", (10, 10), color="blue") as img:
+                img.save(path)
+            with open(path, "rb+") as f:
+                data = f.read()
+                f.seek(len(data) // 2)
+                f.truncate()
+            self.assertFalse(_is_valid_png(path))
+        finally:
+            os.remove(path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- detect truncated PNGs in `_is_valid_png`
- delete invalid screenshot files when image loading fails
- cover truncated file handling in tests

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68575c54dd808333b60fb00cebba6d02