### PR TITLE
Add camera diagnostics

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -14,6 +14,7 @@ import queue
 import random
 import re
 import shutil
+import socket
 import sqlite3
 import struct
 import subprocess
@@ -3672,6 +3673,58 @@ def init_routes(app: Flask) -> None:
         ]
         info = camera_fix.check_camera_template(url, xpaths)
         return jsonify(info)
+
+    @app.route("/camera_diagnostics/<string:template_name>")
+    @login_required
+    def camera_diagnostics(template_name: TemplateName) -> Response:
+        """Return live diagnostics for ``template_name``.
+
+        The diagnostics include ping latency, open ports, HTTP banner
+        information and a simple device type label when available.
+        """
+
+        template_name = validate_template_name(str(template_name))
+        if template_name is None:
+            abort(404)
+
+        details = template_manager.get_template(template_name)
+        if not details:
+            abort(404)
+
+        url = details.get("url", "")
+        host = urlparse(url).hostname or url
+        try:
+            ip = socket.gethostbyname(host)
+        except Exception:
+            ip = host
+
+        data: dict[str, typing.Any] = {"ip": ip}
+
+        latency = camera_discovery._ping_latency(ip)
+        if latency is not None:
+            data["ping_ms"] = latency
+
+        ports = camera_discovery._detect_open_ports(ip, camera_discovery.COMMON_PORTS)
+        if ports:
+            data["open_ports"] = ports
+            for p in ports:
+                if p in (80, 8080, 443):
+                    banner = camera_discovery._fetch_http_banner(ip, p)
+                    for k, v in banner.items():
+                        data.setdefault(k, v)
+
+        dtype = camera_discovery._classify_device(
+            {
+                "ip": ip,
+                "protocol": details.get("protocol", urlparse(url).scheme or "http"),
+                "port": details.get("port", urlparse(url).port or 0),
+                "info": data,
+            }
+        )
+        if dtype:
+            data["device_type"] = dtype
+
+        return jsonify(data)
 
     @app.route("/screenshots/<string:name>/<string:filename>")
     @login_required

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -248,7 +248,7 @@ template_form %} {% block content %}
     }, 10000);
   }
 
-  function showCameraDetails(templateName) {
+  async function showCameraDetails(templateName) {
     const baseUrl = window.location.origin;
     const endpoints = {
       "Camera Name": templateName,
@@ -273,6 +273,19 @@ template_form %} {% block content %}
     }
     if (meta.capture_failed) {
       metadata["Capture Failed"] = true;
+    }
+
+    try {
+      const resp = await fetch(`/camera_diagnostics/${templateName}`);
+      if (resp.ok) {
+        const diag = await resp.json();
+        if (diag.device_type) metadata["Device Type"] = diag.device_type;
+        if (diag.ping_ms) metadata["Ping (ms)"] = diag.ping_ms;
+        if (diag.open_ports)
+          metadata["Open Ports"] = diag.open_ports.join(", ");
+      }
+    } catch (err) {
+      console.error("diagnostics error", err);
     }
 
     let detailsHtml = "<h3>Camera Endpoints</h3><pre>";

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -16,6 +16,7 @@ Key topics covered include:
 - Configuration file locations and environment overrides.
 - Dark mode toggle and mobile-friendly responsive layout.
 - Status metrics, feed dashboard, and live log viewer.
+- Camera diagnostics on the edit page show device type, open ports and ping latency.
 - Offline preview of recent snapshots and locally hosted fonts.
 - "Remember me" option on the login page for automatic sign in.
 - Logging out now clears any saved credentials so shared devices stay secure.

--- a/tests/test_camera_diagnostics_route.py
+++ b/tests/test_camera_diagnostics_route.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+from flask import Flask
+
+from app.routes import init_routes
+
+
+class TestCameraDiagnosticsRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.socket.gethostbyname", return_value="1.2.3.4")
+    @patch("app.routes.camera_discovery._classify_device", return_value="camera")
+    @patch(
+        "app.routes.camera_discovery._fetch_http_banner",
+        return_value={"server": "CamOS"},
+    )
+    @patch("app.routes.camera_discovery._detect_open_ports", return_value=[80])
+    @patch("app.routes.camera_discovery._ping_latency", return_value=5.0)
+    @patch("app.routes.template_manager.get_template")
+    def test_diagnostics_success(
+        self,
+        mock_get_template,
+        mock_ping,
+        mock_ports,
+        mock_banner,
+        mock_classify,
+        mock_gethost,
+    ):
+        mock_get_template.return_value = {"url": "http://cam"}
+        resp = self.client.get("/camera_diagnostics/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.get_json(),
+            {
+                "ip": "1.2.3.4",
+                "ping_ms": 5.0,
+                "open_ports": [80],
+                "server": "CamOS",
+                "device_type": "camera",
+            },
+        )
+
+    @patch("app.routes.template_manager.get_template", return_value=None)
+    def test_diagnostics_not_found(self, mock_get):
+        resp = self.client.get("/camera_diagnostics/missing")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `/camera_diagnostics/<template>` API endpoint
- show device type, ping and open ports in camera details modal
- document new diagnostics
- test the diagnostics route

## Testing
- `pre-commit run --files app/routes.py app/templates/template_details.html docs/help_page.md tests/test_camera_diagnostics_route.py`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68575cc7d664833380bbbd120f43a5a9