### PR TITLE
Add auth blueprint

### DIFF
--- a/app/blueprints/authentication.py
+++ b/app/blueprints/authentication.py
@@ -1,0 +1,149 @@
+"""Authentication related routes exposed via a blueprint."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from flask import Blueprint, current_app, flash, redirect, request, session, url_for
+
+
+def create_blueprint() -> Blueprint:
+    """Create and return the authentication blueprint."""
+
+    import app.routes as routes
+
+    bp = Blueprint("auth", __name__)
+
+    @bp.route("/login", methods=["GET", "POST"], endpoint="login")
+    def login():
+        next_url = request.args.get("next")
+        ip_address = request.remote_addr
+        now = datetime.now()
+
+        # Check if the IP address is locked out
+        if (
+            ip_address in routes.login_attempts
+            and routes.login_attempts[ip_address]["locked_until"] > now
+        ):
+            flash("Too many failed attempts. Please try again later.", "error")
+            logging.warning("Locked login attempt from %s", ip_address)
+            return routes.render_template("login.html", page_title="Login"), 429
+
+        if request.method == "POST":
+            username = (request.form.get("username") or "").strip()
+            password = (request.form.get("password") or "").strip()
+            remember = request.form.get("remember") == "on"
+            if not username or not password:
+                logging.debug("Login failed: missing credentials from %s", ip_address)
+                flash("Username and password are required", "error")
+                return routes.render_template("login.html", page_title="Login"), 400
+
+            db_session = routes.SessionLocal()
+            try:
+                user = (
+                    db_session.query(routes.User).filter_by(username=username).first()
+                )
+            finally:
+                db_session.close()
+
+            if user and routes.check_password_hash(user.password_hash, password):
+                session["user_id"] = user.id
+                if remember:
+                    current_app.permanent_session_lifetime = timedelta(
+                        days=routes.config.AUTO_LOGIN_DAYS
+                    )
+                    session["remember"] = True
+                    timeout = timedelta(days=routes.config.AUTO_LOGIN_DAYS)
+                else:
+                    current_app.permanent_session_lifetime = timedelta(
+                        minutes=routes.config.SESSION_TIMEOUT_MINUTES
+                    )
+                    session.pop("remember", None)
+                    timeout = timedelta(minutes=routes.config.SESSION_TIMEOUT_MINUTES)
+                session["expiry"] = (now + timeout).strftime("%Y-%m-%d %H:%M:%S")
+                session.permanent = True
+                routes.login_attempts.pop(ip_address, None)
+                logging.info("Successful login for %s from %s", username, ip_address)
+                target = (
+                    next_url
+                    if routes.is_safe_redirect_url(next_url)
+                    else url_for("index")
+                )
+                return redirect(target)
+
+            # Record the failed attempt
+            if ip_address not in routes.login_attempts:
+                routes.login_attempts[ip_address] = {"attempts": 1, "locked_until": now}
+            else:
+                routes.login_attempts[ip_address]["attempts"] += 1
+
+            if routes.login_attempts[ip_address]["attempts"] >= 5:
+                routes.login_attempts[ip_address]["locked_until"] = now + timedelta(
+                    hours=24
+                )
+
+            if routes.login_attempts[ip_address]["attempts"] % 2 == 0:
+                routes.login_attempts[ip_address]["locked_until"] = now + timedelta(
+                    minutes=1
+                )
+
+            if not user:
+                logging.warning(
+                    "Login failed: unknown username '%s' from %s", username, ip_address
+                )
+            else:
+                logging.warning(
+                    "Login failed: incorrect password for %s from %s",
+                    username,
+                    ip_address,
+                )
+            logging.debug(
+                "Failed login attempt count %s from %s",
+                routes.login_attempts[ip_address]["attempts"],
+                ip_address,
+            )
+            flash("Invalid username or password", "error")
+
+        return routes.render_template("login.html", page_title="Login")
+
+    @bp.route("/sso", methods=["GET"], endpoint="sso_login")
+    def sso_login():
+        token = request.args.get("token") or request.headers.get("X-SSO-Token")
+        if token != routes.config.SSO_TOKEN or not token:
+            flash("Invalid SSO token", "error")
+            logging.warning("Invalid SSO token from %s", request.remote_addr)
+            return redirect(url_for("login"))
+
+        db_session = routes.SessionLocal()
+        try:
+            user = (
+                db_session.query(routes.User)
+                .filter_by(username=routes.config.SSO_USERNAME)
+                .first()
+            )
+        finally:
+            db_session.close()
+
+        if not user:
+            flash("Configured SSO user not found", "error")
+            logging.error("SSO user %s not found", routes.config.SSO_USERNAME)
+            return redirect(url_for("login"))
+
+        session["user_id"] = user.id
+        session["expiry"] = (
+            datetime.now() + timedelta(minutes=routes.config.SESSION_TIMEOUT_MINUTES)
+        ).strftime("%Y-%m-%d %H:%M:%S")
+        session.permanent = True
+        flash("Logged in via SSO", "success")
+        logging.info("SSO login for %s from %s", user.username, request.remote_addr)
+        return redirect(url_for("index"))
+
+    @bp.route("/logout", endpoint="logout")
+    @routes.login_required
+    def logout():
+        session.pop("user_id", None)
+        flash("You have been logged out successfully.", "success")
+        return redirect(url_for("login", logout="1"))
+
+    return bp

--- a/app/routes.py
+++ b/app/routes.py
@@ -1556,6 +1556,7 @@ def allowed_filename(filename: str) -> bool:
 
 def init_routes(app: Flask) -> None:
     """Register all route handlers on the given ``app``."""
+    from app.blueprints.authentication import create_blueprint as create_auth_blueprint
     from app.blueprints.network import create_blueprint
     from app.blueprints.status import create_blueprint as create_status_blueprint
 
@@ -1566,6 +1567,10 @@ def init_routes(app: Flask) -> None:
     if not getattr(app, "_status_bp_registered", False):
         app.register_blueprint(create_status_blueprint())
         app._status_bp_registered = True
+
+    if not getattr(app, "_auth_bp_registered", False):
+        app.register_blueprint(create_auth_blueprint(), name="")
+        app._auth_bp_registered = True
 
     # get_active_groups()
 
@@ -1752,132 +1757,6 @@ def init_routes(app: Flask) -> None:
         result = mcp.call_tool_sync(name, params)
         return jsonify(result)
 
-    @app.route("/login", methods=["GET", "POST"])
-    def login():
-        next_url = request.args.get("next")
-        ip_address = request.remote_addr
-        now = datetime.now()
-
-        # Check if the IP address is locked out
-        if (
-            ip_address in login_attempts
-            and login_attempts[ip_address]["locked_until"] > now
-        ):
-            flash("Too many failed attempts. Please try again later.", "error")
-            logging.warning("Locked login attempt from %s", ip_address)
-            return render_template("login.html", page_title="Login"), 429
-
-        if request.method == "POST":
-            username = (request.form.get("username") or "").strip()
-            password = (request.form.get("password") or "").strip()
-            remember = request.form.get("remember") == "on"
-            if not username or not password:
-                logging.debug("Login failed: missing credentials from %s", ip_address)
-                flash("Username and password are required", "error")
-                return render_template("login.html", page_title="Login"), 400
-
-            db_session = SessionLocal()
-            try:
-                user = db_session.query(User).filter_by(username=username).first()
-            finally:
-                db_session.close()
-
-            if user and check_password_hash(user.password_hash, password):
-                session["user_id"] = user.id
-                if remember:
-                    current_app.permanent_session_lifetime = timedelta(
-                        days=config.AUTO_LOGIN_DAYS
-                    )
-                    session["remember"] = True
-                    timeout = timedelta(days=config.AUTO_LOGIN_DAYS)
-                else:
-                    current_app.permanent_session_lifetime = timedelta(
-                        minutes=config.SESSION_TIMEOUT_MINUTES
-                    )
-                    session.pop("remember", None)
-                    timeout = timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
-                session["expiry"] = (now + timeout).strftime("%Y-%m-%d %H:%M:%S")
-                session.permanent = True
-                login_attempts.pop(
-                    ip_address, None
-                )  # Reset attempts on successful login
-                logging.info("Successful login for %s from %s", username, ip_address)
-                target = (
-                    next_url if is_safe_redirect_url(next_url) else url_for("index")
-                )
-                return redirect(target)
-            else:
-                # Record the failed attempt
-                if ip_address not in login_attempts:
-                    login_attempts[ip_address] = {
-                        "attempts": 1,
-                        "locked_until": now,
-                    }
-                else:
-                    login_attempts[ip_address]["attempts"] += 1
-
-                # Lockout after 5 failed attempts
-                if login_attempts[ip_address]["attempts"] >= 5:
-                    login_attempts[ip_address]["locked_until"] = now + timedelta(
-                        hours=24
-                    )
-
-                # Rate limit after 2 attempts per minute
-                if login_attempts[ip_address]["attempts"] % 2 == 0:
-                    login_attempts[ip_address]["locked_until"] = now + timedelta(
-                        minutes=1
-                    )
-
-                if not user:
-                    logging.warning(
-                        "Login failed: unknown username '%s' from %s",
-                        username,
-                        ip_address,
-                    )
-                else:
-                    logging.warning(
-                        "Login failed: incorrect password for %s from %s",
-                        username,
-                        ip_address,
-                    )
-                logging.debug(
-                    "Failed login attempt count %s from %s",
-                    login_attempts[ip_address]["attempts"],
-                    ip_address,
-                )
-                flash("Invalid username or password", "error")
-        return render_template("login.html", page_title="Login")
-
-    @app.route("/sso", methods=["GET"])
-    def sso_login():
-        token = request.args.get("token") or request.headers.get("X-SSO-Token")
-        if token != config.SSO_TOKEN or not token:
-            flash("Invalid SSO token", "error")
-            logging.warning("Invalid SSO token from %s", request.remote_addr)
-            return redirect(url_for("login"))
-
-        db_session = SessionLocal()
-        try:
-            user = (
-                db_session.query(User).filter_by(username=config.SSO_USERNAME).first()
-            )
-        finally:
-            db_session.close()
-
-        if not user:
-            flash("Configured SSO user not found", "error")
-            logging.error("SSO user %s not found", config.SSO_USERNAME)
-            return redirect(url_for("login"))
-
-        session["user_id"] = user.id
-        session["expiry"] = (
-            datetime.now() + timedelta(minutes=config.SESSION_TIMEOUT_MINUTES)
-        ).strftime("%Y-%m-%d %H:%M:%S")
-        session.permanent = True
-        flash("Logged in via SSO", "success")
-        logging.info("SSO login for %s from %s", user.username, request.remote_addr)
-        return redirect(url_for("index"))
-
     @app.route("/help")
     @login_required
     def help_page():
@@ -1920,14 +1799,6 @@ def init_routes(app: Flask) -> None:
     def offline_page():
         """Render a fallback page when offline."""
         return render_template("offline.html", page_title="Offline")
-
-    @app.route("/logout")
-    @login_required
-    def logout():
-        session.pop("user_id", None)
-        flash("You have been logged out successfully.", "success")
-        # add query flag so client can clear persistent credentials
-        return redirect(url_for("login", logout="1"))
 
     @app.route("/")
     @login_required


### PR DESCRIPTION
## Summary
- create `authentication` blueprint
- register blueprint in `init_routes`
- route decorator uses blueprint endpoints
- adjust login redirects to blueprint

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685772fbdc6083338c8593bf047abf4b