### PR TITLE
Fix offline job processor logging

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1726,6 +1726,7 @@ def process_offline_jobs() -> None:
     try:
         jobs = session.query(OfflineJob).order_by(OfflineJob.id).all()
         for job in jobs:
+            job_id = job.id
             try:
                 module_name, func_name = job.function.rsplit(".", 1)
                 mod = importlib.import_module(module_name)
@@ -1737,7 +1738,7 @@ def process_offline_jobs() -> None:
                 session.commit()
             except Exception as exc:
                 session.rollback()
-                logging.error("Failed to run offline job %s: %s", job.id, exc)
+                logging.error("Failed to run offline job %s: %s", job_id, exc)
     finally:
         session.close()
 


### PR DESCRIPTION
## Summary
- avoid SQLAlchemy ObjectDeletedError when logging failed offline jobs

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857e0469af4833386a746fdbc49a3c9