### PR TITLE
Fix offline content type check

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1385,6 +1385,14 @@ def get_content_type(
 
     content_type = ""
     clean_url = sanitize_url(url)
+
+    if not is_system_online():
+        logging.warning(
+            "System offline; skipping content type check for %s",
+            clean_url,
+        )
+        return "", False
+
     methods = [requests.head, requests.get]
 
     lua = UA

--- a/tests/test_capture_status_errors.py
+++ b/tests/test_capture_status_errors.py
@@ -34,7 +34,8 @@ class TestCaptureStatusErrors(unittest.TestCase):
         mock_reachable.assert_not_called()
 
     @patch("app.utils.screenshots.http_session")
-    def test_get_content_type_caches_error(self, mock_session_factory):
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
+    def test_get_content_type_caches_error(self, mock_online, mock_session_factory):
         url = "http://example.com"
         mock_session = MagicMock()
         resp = MagicMock()


### PR DESCRIPTION
## Summary
- skip content-type lookup when system is offline
- patch tests to mock network check

## Testing
- `pre-commit run --files app/utils/screenshots.py tests/test_capture_status_errors.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857e148586083339c6044acd33bd62e