### PR TITLE
Handle truncated screenshots gracefully

### DIFF
--- a/app/utils/image_processing.py
+++ b/app/utils/image_processing.py
@@ -8,7 +8,11 @@ import os
 import re
 from typing import List, Optional
 
-from PIL import Image
+from PIL import Image, ImageFile
+
+# Allow reading truncated images so processing does not fail when a screenshot
+# is incomplete.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 from app.config import CHATGPT_KEY, LLM_CAPTION_PROMPT, LLM_MODEL_VERSION
 from app.utils import llm_cache

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -1339,9 +1339,11 @@ def cache_logs():
     try:
         with open(log_file_path, "r") as file:
             file.seek(0, os.SEEK_END)  # Start at end of file
-            while not stop_event.is_set():
+            while True:
                 new_log = file.readline()
                 if not new_log:
+                    if stop_event.is_set():
+                        break
                     # Avoid busy looping when no new log lines are written.
                     time.sleep(1)
                     # The file may have been truncated. Seek to end and retry.

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -42,9 +42,15 @@ from pdf2image import convert_from_bytes
 from PIL import (
     Image,
     ImageDraw,
+    ImageFile,
     ImageFont,
     ImageOps,
 )
+
+# PIL may raise 'image file is truncated' if a screenshot is incomplete.
+# Allow truncated images to load so we can still overlay timestamps and
+# handle files gracefully.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.chrome.options import Options
@@ -2688,10 +2694,15 @@ def _finalize_screenshot(tmp_path, final_path, name, invert, dark):
                 img.save(tmp_path, "PNG")
                 success = True
 
-        # Now add a timestamp overlay
+        # Now add a timestamp overlay. If this fails the file may be removed.
         add_timestamp(tmp_path, name=name, invert=invert)
 
-        # Finally rename
+        # Finally rename if the temp file still exists. Timestamp overlay may
+        # delete corrupt images, so verify before moving.
+        if not os.path.exists(tmp_path):
+            logging.error("Temporary screenshot missing after timestamp overlay")
+            return False
+
         os.makedirs(os.path.dirname(final_path), exist_ok=True)
         os.rename(tmp_path, final_path)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -43,6 +43,29 @@ class TestImageProcessing(unittest.TestCase):
         finally:
             os.remove(image_path)
 
+    def test_add_timestamp_truncated_image(self):
+        """Ensure add_timestamp handles truncated PNG files gracefully."""
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as temp_file:
+            image_path = temp_file.name
+            # Save a valid PNG then truncate to simulate an incomplete file
+            with Image.new("RGB", (10, 10), color="white") as img:
+                img.save(temp_file, "PNG")
+            # Remove the last chunk to corrupt the file but leave the header intact
+            with open(image_path, "rb") as f:
+                data = f.read()
+            with open(image_path, "wb") as f:
+                f.write(data[:-10])
+
+        try:
+            add_timestamp(image_path, name="Broken", invert=False)
+            # The function should not raise and should still create an output file
+            self.assertTrue(os.path.exists(image_path))
+        finally:
+            for suffix in ["", ".broken"]:
+                path = image_path.replace(".png", f"{suffix}")
+                if os.path.exists(path):
+                    os.remove(path)
+
     def test_remove_background(self):
         with Image.new("RGBA", (100, 100), color=(14, 14, 14, 255)) as img:
             for x in range(20, 80):


### PR DESCRIPTION
## Summary
- handle truncated images by enabling PIL's truncated image loading
- skip renaming when timestamping removes broken screenshots
- keep reading logs even if stop event triggers early
- test `add_timestamp` with truncated PNG input

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ef5ce474833380eaafbaaf1f96ce