### PR TITLE
Handle offline job deletion

### DIFF
--- a/app/blueprints/discovery.py
+++ b/app/blueprints/discovery.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import csv
 import io
 import json
+import queue
 from ipaddress import ip_network
 from threading import Thread
-import queue
+
 from flask import (
     Blueprint,
     Response,
     jsonify,
-    request,
     render_template,
+    request,
     stream_with_context,
 )
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -82,6 +82,8 @@ class CLIPProcessor:
         }
 
 
+from sqlalchemy.orm.exc import ObjectDeletedError
+
 from app.config import (
     AUTO_UPDATE_BRANCH,
     CLIP_MODEL_NAME,
@@ -1728,7 +1730,12 @@ def process_offline_jobs() -> None:
     try:
         jobs = session.query(OfflineJob).order_by(OfflineJob.id).all()
         for job in jobs:
-            job_id = job.id
+            try:
+                job_id = job.id
+            except ObjectDeletedError:
+                # Job removed after query; skip it gracefully
+                session.rollback()
+                continue
             try:
                 module_name, func_name = job.function.rsplit(".", 1)
                 mod = importlib.import_module(module_name)
@@ -1738,6 +1745,9 @@ def process_offline_jobs() -> None:
                 )
                 session.delete(job)
                 session.commit()
+            except ObjectDeletedError:
+                session.rollback()
+                continue
             except Exception as exc:
                 session.rollback()
                 logging.error("Failed to run offline job %s: %s", job_id, exc)


### PR DESCRIPTION
## Summary
- handle ObjectDeletedError during offline job processing
- format imports in discovery blueprint

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fe8bab08833386620bdedb98633f