### PR TITLE
Improve job failure backoff

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -488,6 +488,8 @@ def update_camera(name, template, image_file=None, motion=False):
         ):
             mark_offline(name)
         set_capture_failed(name, True)
+        # Raise an exception so ``run_with_timeout`` can apply backoff logic
+        raise RuntimeError("capture failed")
 
     if lsuc is True:
         directory = os.path.join(SCREENSHOT_DIRECTORY, name)


### PR DESCRIPTION
## Summary
- raise an exception when screenshot capture fails so run_with_timeout can apply backoff

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580225b4048333862f9fd599ce2f7b