### PR TITLE
Fix callback host resolution

### DIFF
--- a/app/utils/http_callbacks.py
+++ b/app/utils/http_callbacks.py
@@ -1,5 +1,7 @@
 import logging
+import socket
 import time
+from urllib.parse import urlparse
 
 import requests
 
@@ -36,6 +38,17 @@ def send_http_callback(
     hammering the remote service.
     """
     if not url:
+        return
+
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if not host:
+        logging.warning("Invalid callback URL: %s", sanitize_url(url))
+        return
+    try:
+        socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        logging.warning("Callback host does not resolve: %s", host)
         return
 
     data = {"event": event_type, "payload": payload}

--- a/tests/test_http_callbacks.py
+++ b/tests/test_http_callbacks.py
@@ -1,3 +1,4 @@
+import socket
 import unittest
 from unittest.mock import patch
 
@@ -42,6 +43,14 @@ class TestHttpCallbacks(unittest.TestCase):
         with patch("requests.post", side_effect=[Exception("fail"), None]) as mock_post:
             send_http_callback("http://example.com", "event", {"a": 1}, retries=1)
             self.assertEqual(mock_post.call_count, 2)
+
+    def test_send_http_callback_bad_host(self):
+        with (
+            patch("socket.getaddrinfo", side_effect=socket.gaierror()),
+            patch("requests.post") as mock_post,
+        ):
+            send_http_callback("http://badhost", "event", {})
+            mock_post.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate callback host resolves before POSTing
- test skip on unreachable host

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858013230a0833397f2ea6cdb161a3d