### PR TITLE
Add macOS danger mode shortcut patching

### DIFF
--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -20,7 +20,7 @@ After Chrome updates, shortcuts may revert to their original command line. Two a
 - **Helper script**: Run `python scripts/update_chrome_shortcut.py` to rewrite the shortcut with the required flag. This can also be triggered from the _Update Chrome Shortcut_ button on the Settings page or the _Patch Chrome Shortcuts_ button on the Danger page. The page now shows which shortcuts were updated after the patch completes.
 - **Dropdown selector**: The Danger page lets you choose a detected shortcut from a dropdown or enter a custom path before patching.
 - **Check script**: Run `python scripts/check_danger_mode.py` to print whether the debug port is detected and if your shortcuts still require patching.
-- **Default shortcut locations**: `%USERPROFILE%\Desktop`, `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs`. On Linux, try `/usr/share/applications/google-chrome.desktop` or `~/.local/share/applications/google-chrome.desktop`. The Settings page lists any writable shortcuts it discovers.
+- **Default shortcut locations**: `%USERPROFILE%\Desktop`, `%APPDATA%\Microsoft\Windows\Start Menu\Programs`, and `%ProgramData%\Microsoft\Windows\Start Menu\Programs`. On Linux, try `/usr/share/applications/google-chrome.desktop` or `~/.local/share/applications/google-chrome.desktop`. On macOS, pass the path to your `.app` or AppleScript file to `python scripts/update_chrome_shortcut.py`. The Settings page lists any writable shortcuts it discovers.
 
 After patching your shortcuts, restart Chrome and open it using the profile you intend to use with Danger mode.
 

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -18,6 +18,8 @@ LINUX_PATHS = [
     Path("/usr/share/applications/chromium.desktop"),
 ]
 
+MAC_DIRS = [Path("/Applications"), Path.home() / "Applications"]
+
 
 def _update_shortcut(shortcut: Path, shell) -> bool:
     sc = shell.CreateShortcut(str(shortcut))
@@ -44,6 +46,34 @@ def _update_desktop_file(desktop: Path) -> bool:
     if updated:
         desktop.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return updated
+
+
+def _update_macos_script(script: Path) -> bool:
+    """Add the debug flag to a macOS script-based shortcut."""
+    if not script.exists() or not os.access(script, os.W_OK):
+        return False
+    try:
+        text = script.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False
+    if FLAG in text:
+        return False
+    script.write_text(text.rstrip() + f" {FLAG}\n", encoding="utf-8")
+    return True
+
+
+def _mac_shortcut_paths() -> list[Path]:
+    paths: list[Path] = []
+    for base in MAC_DIRS:
+        if base.exists():
+            for item in base.iterdir():
+                if item.suffix.lower() in {".command", ".applescript", ".sh"}:
+                    paths.append(item)
+                elif item.suffix == ".app":
+                    target = item / "Contents" / "MacOS" / item.stem
+                    if target.exists():
+                        paths.append(target)
+    return paths
 
 
 def update_chrome_shortcuts() -> list[Path]:
@@ -73,6 +103,14 @@ def update_chrome_shortcuts() -> list[Path]:
                             updated.append(shortcut)
         return updated
 
+    if sys.platform == "darwin":
+        updated: list[Path] = []
+        for script in _mac_shortcut_paths():
+            if "chrome" in script.name.lower():
+                if _update_macos_script(script):
+                    updated.append(script)
+        return updated
+
     updated = []
     for path in LINUX_PATHS:
         if _update_desktop_file(path):
@@ -83,7 +121,10 @@ def update_chrome_shortcuts() -> list[Path]:
 def update_chrome_shortcuts_info(path: Path | None = None) -> tuple[list[Path], str]:
     """Return updated paths and a message describing the result."""
     if path is not None:
-        paths = [path] if _update_desktop_file(path) else []
+        if sys.platform == "darwin":
+            paths = [path] if _update_macos_script(path) else []
+        else:
+            paths = [path] if _update_desktop_file(path) else []
     else:
         paths = update_chrome_shortcuts()
 
@@ -127,6 +168,18 @@ def shortcuts_need_patch(path: Path | None = None) -> bool:
                             return True
         return False
 
+    if sys.platform == "darwin":
+        paths = [path] if path else _mac_shortcut_paths()
+        for script in paths:
+            if script.exists():
+                try:
+                    text = script.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    continue
+                if FLAG not in text:
+                    return True
+        return False
+
     paths = [path] if path else LINUX_PATHS
     for desktop in paths:
         if desktop.exists():
@@ -160,6 +213,12 @@ def first_shortcut_path() -> Path | None:
                     if "chrome" in shortcut.name.lower():
                         shell.CreateShortcut(str(shortcut))
                         return shortcut
+        return None
+
+    if sys.platform == "darwin":
+        for script in _mac_shortcut_paths():
+            if script.exists():
+                return script
         return None
 
     for path in LINUX_PATHS:

--- a/tests/test_shortcuts_need_patch.py
+++ b/tests/test_shortcuts_need_patch.py
@@ -29,6 +29,14 @@ class TestShortcutsNeedPatch(unittest.TestCase):
         fake_os = SimpleNamespace(name="nt", environ=os.environ)
         return patch.object(update_chrome_shortcut, "os", fake_os)
 
+    def _patch_macos(self):
+        fake_os = SimpleNamespace(name="posix", environ=os.environ, access=os.access)
+        return patch.object(update_chrome_shortcut, "os", fake_os)
+
+    def _patch_sys_darwin(self):
+        fake_sys = SimpleNamespace(platform="darwin")
+        return patch.object(update_chrome_shortcut, "sys", fake_sys)
+
     def test_needs_patch(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             desktop = self._setup_env(tmpdir)
@@ -48,6 +56,34 @@ class TestShortcutsNeedPatch(unittest.TestCase):
             with (
                 self._patch_os(),
                 patch.object(update_chrome_shortcut, "win32com", stub),
+            ):
+                self.assertFalse(update_chrome_shortcut.shortcuts_need_patch())
+
+    def test_macos_needs_patch(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app_dir = Path(tmpdir) / "Chrome.app" / "Contents" / "MacOS"
+            app_dir.mkdir(parents=True)
+            script = app_dir / "Chrome"
+            script.write_text("open /Applications/Google Chrome.app")
+            with (
+                self._patch_macos(),
+                self._patch_sys_darwin(),
+                patch.object(update_chrome_shortcut, "MAC_DIRS", [Path(tmpdir)]),
+            ):
+                self.assertTrue(update_chrome_shortcut.shortcuts_need_patch())
+
+    def test_macos_no_patch_needed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app_dir = Path(tmpdir) / "Chrome.app" / "Contents" / "MacOS"
+            app_dir.mkdir(parents=True)
+            script = app_dir / "Chrome"
+            script.write_text(
+                f"open /Applications/Google Chrome.app --args {update_chrome_shortcut.FLAG}"
+            )
+            with (
+                self._patch_macos(),
+                self._patch_sys_darwin(),
+                patch.object(update_chrome_shortcut, "MAC_DIRS", [Path(tmpdir)]),
             ):
                 self.assertFalse(update_chrome_shortcut.shortcuts_need_patch())
 


### PR DESCRIPTION
## Summary
- support patching macOS shortcuts
- document macOS helper usage
- test macOS shortcut detection

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580401d3448333bfe173f10dca6ca7