### PR TITLE
Improve RTSP HEAD 403 handling

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1437,6 +1437,10 @@ def get_content_type(
                 )
 
             if resp.status_code >= 400:
+                if verb == "HEAD" and resp.status_code == 403:
+                    # some cameras block HEAD; retry with GET before failing
+                    logging.debug("HEAD 403 for %s; retrying with GET", clean_url)
+                    continue
                 logging.info(f"HTTP error {resp.status_code} for {clean_url}")
                 set_cached_status_code(url, resp.status_code)
                 return "", False

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,6 +232,8 @@ snapshot image rather than a true video stream.
 - HTTP errors like `403 Forbidden` or repeated ffmpeg timeouts typically mean
   the stream is blocked. Verify the URL is accessible from the host running
   Glimpser and check for required credentials or firewall rules.
+- Cameras that reject the `HEAD` method with a 403 now trigger a `GET`
+  fallback so valid streams aren't marked offline.
 - When ffmpeg repeatedly fails, retries now back off exponentially up to
   `LIVE_MAX_RETRY_DELAY` seconds so the server isn't hammered.
 - Some cameras reject ffmpeg if it does not send browser-style headers. The

--- a/tests/test_capture_status_errors.py
+++ b/tests/test_capture_status_errors.py
@@ -49,6 +49,26 @@ class TestCaptureStatusErrors(unittest.TestCase):
         self.assertFalse(modified)
         self.assertEqual(ss.get_cached_status_code(url), 500)
 
+    @patch("app.utils.screenshots.http_session")
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
+    def test_get_content_type_head_403_fallback(
+        self, mock_online, mock_session_factory
+    ):
+        url = "http://example.com"
+        mock_session = MagicMock()
+        head_resp = MagicMock()
+        head_resp.status_code = 403
+        head_resp.headers = {}
+        get_resp = MagicMock()
+        get_resp.status_code = 200
+        get_resp.headers = {"Content-Type": "video/mp4"}
+        mock_session.request.side_effect = [head_resp, get_resp]
+        mock_session_factory.return_value = mock_session
+
+        ctype, modified = ss.get_content_type(url, False)
+        self.assertEqual(ctype, "video/mp4")
+        self.assertTrue(modified)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- retry with GET when a camera returns 403 to HEAD
- document that HEAD 403 responses now fallback to GET
- test the new fallback logic

## Testing
- `pre-commit run --files app/utils/screenshots.py docs/troubleshooting.md tests/test_capture_status_errors.py`
- `pytest -q tests/test_capture_status_errors.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858024a56ec83338dbc969d3c6ab47d