### PR TITLE
Add browser checkbox to template form

### DIFF
--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -413,6 +413,23 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
           />
           Dark Mode
         </label>
+        <label for="browser" title="Capture using full browser">
+          <input
+            type="checkbox"
+            id="browser"
+            name="browser"
+            {%
+            if
+            template
+            and
+            template.browser
+            %}checked{%
+            endif
+            %}
+            title="Capture page using a full browser"
+          />
+          Browser
+        </label>
         <label for="headless" title="Run in headless mode">
           <input
             type="checkbox"

--- a/docs/edit_template_preview.md
+++ b/docs/edit_template_preview.md
@@ -1,3 +1,6 @@
 # Edit Template Preview
 
 The edit template dialog now shows a mini live view of the camera in the top-right corner. This MJPEG stream lets you verify the feed while tweaking settings. The same preview appears on the **Settings → Discover** tab when adding a new camera so you can confirm the URL before saving.
+
+Advanced options include a **Browser** checkbox to capture pages using a full
+browser. When enabled, additional headless and stealth toggles become active.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -153,6 +153,10 @@ class TestHtmlTemplates(unittest.TestCase):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn("object-gpu-status", components)
 
+    def test_browser_checkbox_present(self):
+        components = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn('id="browser"', components)
+
     def test_status_tab_has_sparklines(self):
         html = Path("app/templates/_status_tab.html").read_text(encoding="utf-8")
         self.assertIn('id="memory-sparkline"', html)


### PR DESCRIPTION
## Summary
- add a Browser checkbox in the template form for full browser captures
- document the new option
- test that the checkbox is present

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685803849c5483338bbec52c237c9528