### PR TITLE
Add configurable Chrome debug port

### DIFF
--- a/app/blueprints/status.py
+++ b/app/blueprints/status.py
@@ -99,7 +99,9 @@ def create_blueprint() -> Blueprint:
     @routes.login_required
     @routes.profile_route("/danger_status")
     def danger_status():
-        port_open = routes.is_chrome_debug_port_open("127.0.0.1", 9222)
+        port_open = routes.is_chrome_debug_port_open(
+            "127.0.0.1", routes.config.DANGER_PORT
+        )
         idle = not routes.check_user_activity(timeout=1)
         enabled = routes.config.get_setting("DANGER_MODE", "True") == "True"
         browser_path = routes.get_chrome_path()
@@ -107,6 +109,7 @@ def create_blueprint() -> Blueprint:
         return jsonify(
             {
                 "port_open": port_open,
+                "port": routes.config.DANGER_PORT,
                 "idle": idle,
                 "enabled": enabled,
                 "ready": port_open and idle and enabled,

--- a/app/config.py
+++ b/app/config.py
@@ -266,6 +266,7 @@ NAME = get_setting("NAME", "glimpser")
 NAV_ICON = get_setting("NAV_ICON", "img/glimpser_small.png")
 HOST = get_setting("HOST", "0.0.0.0")
 PORT = int(get_setting("PORT", 8082))
+DANGER_PORT = int(get_setting("DANGER_PORT", 9222))
 ENFORCE_DOMAIN_IN_HOST = get_setting("ENFORCE_DOMAIN_IN_HOST", "False") == "True"
 DEBUG = get_setting("DEBUG", "False") == "True"
 # Provide a separate attribute for runtime checks

--- a/app/routes.py
+++ b/app/routes.py
@@ -1708,7 +1708,8 @@ def init_routes(app: Flask) -> None:
             "version": (get_chrome_version(chrome_path) if chrome_path else "N/A"),
             "shortcut": str(first_shortcut_path() or "N/A"),
             "patched": not shortcuts_need_patch(),
-            "running": is_chrome_debug_port_open("127.0.0.1", 9222),
+            "running": is_chrome_debug_port_open("127.0.0.1", config.DANGER_PORT),
+            "port": config.DANGER_PORT,
         }
 
         return render_template(
@@ -3565,7 +3566,8 @@ def init_routes(app: Flask) -> None:
             "version": (get_chrome_version(chrome_path) if chrome_path else "N/A"),
             "shortcut": str(first_shortcut_path() or "N/A"),
             "patched": not shortcuts_need_patch(),
-            "running": is_chrome_debug_port_open("127.0.0.1", 9222),
+            "running": is_chrome_debug_port_open("127.0.0.1", config.DANGER_PORT),
+            "port": config.DANGER_PORT,
         }
 
         last_backup = None

--- a/app/templates/danger.html
+++ b/app/templates/danger.html
@@ -21,7 +21,7 @@
     <p>
       Danger Mode reuses your running Chrome instance so Glimpser can capture
       pages that rely on your logged-in session. Chrome must be started with the
-      <code>--remote-debugging-port=9222</code> flag.
+      <code>--remote-debugging-port={{ danger_info.port }}</code> flag.
     </p>
   </section>
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -170,6 +170,7 @@ template_form, settings_row with context %} {% block content %}
         <li>Browser: {{ danger_info.browser }}</li>
         <li>Path: {{ danger_info.path }}</li>
         <li>Version: {{ danger_info.version }}</li>
+        <li>Port: {{ danger_info.port }}</li>
         <li>Shortcut: {{ danger_info.shortcut }}</li>
         <li>
           Shortcut Patched:

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -84,6 +84,7 @@ class CLIPProcessor:
 
 from sqlalchemy.orm.exc import ObjectDeletedError
 
+import app.config as config
 from app.config import (
     AUTO_UPDATE_BRANCH,
     CLIP_MODEL_NAME,

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -2090,10 +2090,10 @@ def is_port_open(host, port, timeout=5):
         return False
 
 
-def is_chrome_debug_port_open(host="127.0.0.1", port=9222, timeout=1):
-    """
-    Check if an existing Chrome with --remote-debugging-port=9222 is open.
-    """
+def is_chrome_debug_port_open(host="127.0.0.1", port=None, timeout=1):
+    """Return True if Chrome's remote debugging port is reachable."""
+    if port is None:
+        port = config.DANGER_PORT
     try:
         sock = socket.create_connection((host, port), timeout=timeout)
         sock.close()
@@ -2405,7 +2405,8 @@ def capture_screenshot_and_har(
     Captures a screenshot of `url` and saves to `output_path`.
 
     1) Danger Mode (danger=True):
-       - Attaches to an existing Chrome with --remote-debugging-port=9222.
+       - Attaches to an existing Chrome with the configured remote-debugging
+         port.
        - Opens a new tab, loads page, screenshots, closes tab.
        - Skips if the user is active (check_user_activity).
        - Not headless (relies on the user’s Chrome).
@@ -2450,11 +2451,11 @@ def capture_screenshot_and_har(
     # Danger Mode
     ############
     if danger and config.get_setting("DANGER_MODE", "True") == "True":
-        # If we rely on the user's local Chrome with remote-debugging-port=9222,
-        # let's confirm it's actually open.
-        if not is_chrome_debug_port_open("127.0.0.1", 9222):
+        # If we rely on the user's local Chrome with the debugging port open,
+        # confirm it is actually reachable.
+        if not is_chrome_debug_port_open("127.0.0.1", config.DANGER_PORT):
             logging.warning(
-                "[capture_screenshot_and_har] Danger mode requested, but no Chrome on port 9222."
+                "[capture_screenshot_and_har] Danger mode requested, but no Chrome on configured port."
             )
             return False
 
@@ -2727,7 +2728,8 @@ def _capture_danger_mode(
     dark,
 ) -> bool:
     """
-    Attach to an existing local Chrome with remote-debugging-port=9222,
+    Attach to an existing local Chrome with remote-debugging-port configured by
+    ``DANGER_PORT``,
     open a new tab, capture a screenshot, close the tab, and yield the result.
 
     Because we are hooking into a real user’s Chrome, you must be aware that
@@ -2742,7 +2744,7 @@ def _capture_danger_mode(
 
     # This part uses normal Selenium for the attach:
     danger_options = webdriver.ChromeOptions()
-    danger_options.debugger_address = "127.0.0.1:9222"
+    danger_options.debugger_address = f"127.0.0.1:{config.DANGER_PORT}"
 
     driver = None
     original_window = None

--- a/app/utils/settings_tooltips.py
+++ b/app/utils/settings_tooltips.py
@@ -27,6 +27,11 @@ SETTINGS_TOOLTIPS = {
         "TCP port used by the built-in web server. The default is 8082 but any "
         "available port may be chosen."
     ),
+    "DANGER_PORT": (
+        "Port used by Chrome for remote debugging when Danger mode is enabled. "
+        "Change this if you launch Chrome with --remote-debugging-port on a "
+        "different value."
+    ),
     "USER_NAME": (
         "Default username for logging into the interface. Combine with the "
         "password hash for authentication."
@@ -328,6 +333,7 @@ SETTINGS_GROUPS = {
         "TZ",
         "HOST",
         "PORT",
+        "DANGER_PORT",
         "DEBUG",
         "DEBUG_MODE",
         "MAX_WORKERS",
@@ -410,6 +416,7 @@ NUMERIC_FIELDS = {
     "LIVE_FALLBACK_FPS",
     "LIVE_MAX_FAILURES",
     "CHYRON_SPEED",
+    "DANGER_PORT",
     "WATCHDOG_FAILURE_THRESHOLD",
     "WATCHDOG_RESTART_COOLDOWN",
     "WATCHDOG_MAX_FILE_HANDLES",

--- a/docs/danger_mode.md
+++ b/docs/danger_mode.md
@@ -1,13 +1,13 @@
 # Danger Mode Setup and Usage
 
-Danger mode allows Glimpser to leverage your existing Chrome session for capturing dynamic sites. When active, Glimpser attaches to a local Chrome instance running with the `--remote-debugging-port=9222` flag. This is useful for pages that require an authenticated session or user context.
+Danger mode allows Glimpser to leverage your existing Chrome session for capturing dynamic sites. When active, Glimpser attaches to a local Chrome instance running with the `--remote-debugging-port=<PORT>` flag where `<PORT>` is the value of the `DANGER_PORT` setting. This is useful for pages that require an authenticated session or user context.
 
 ## Enabling Remote Debugging
 
 1. **Launch Chrome with the debugging port open.** The exact command varies by platform:
-   - **Linux**: `google-chrome --remote-debugging-port=9222`
-   - **macOS**: `open /Applications/Google\ Chrome.app --args --remote-debugging-port=9222`
-   - **Windows**: modify your Chrome shortcut to append `--remote-debugging-port=9222` to the _Target_ field.
+   - **Linux**: `google-chrome --remote-debugging-port=$DANGER_PORT`
+   - **macOS**: `open /Applications/Google\ Chrome.app --args --remote-debugging-port=$DANGER_PORT`
+   - **Windows**: modify your Chrome shortcut to append `--remote-debugging-port=%DANGER_PORT%` to the _Target_ field.
 2. Leave this Chrome window running. Glimpser will connect to the existing instance when the port is detected.
 
 If Chrome is not started with this flag, Danger mode will be unavailable.
@@ -61,13 +61,14 @@ review or disable the setting.
 Enabling the debugging port exposes your active Chrome session to other
 programs on the same machine. Keep your system on a trusted network and close
 Chrome when you are finished capturing. Avoid running Danger mode if untrusted
-software could access `http://localhost:9222`.
+software could access `http://localhost:<PORT>` where `<PORT>` matches
+`DANGER_PORT`.
 
 ## Connection Troubleshooting
 
 If Glimpser does not detect your Chrome instance:
 
-1. Visit `http://localhost:9222` in a browser. A JSON page should appear if the
+1. Visit `http://localhost:$DANGER_PORT` in a browser. A JSON page should appear if the
    port is open.
 2. Confirm Chrome was started with the flag and that no firewall is blocking the
    connection.
@@ -75,10 +76,9 @@ If Glimpser does not detect your Chrome instance:
 
 ## Customizing the Debugging Port
 
-If port `9222` is already in use, you may launch Chrome with a different port
-such as `--remote-debugging-port=9333`. Update any scripts that add the flag so
-they use the same value. Glimpser currently expects `9222`, so you must adjust
-the source code if you change it.
+If the default port is already in use, launch Chrome with a different value such
+as `--remote-debugging-port=9333`. Set `DANGER_PORT` to the same number so
+Glimpser knows where to connect.
 
 ## Temporary Enablement
 

--- a/docs/settings_page.md
+++ b/docs/settings_page.md
@@ -8,7 +8,7 @@ The **Settings** interface lets you manage configuration values stored in the da
 - **Current Settings** – edit existing values. Delete actions appear when advanced options are enabled using the toggle under the **Management** tab. Tabs switch between setting groups and the Management tab holds backup and offline options.
 - **Configuration Management** – backup, download, and upload the JSON configuration file.
 - **Admin** – buttons are organized into cards for a cleaner layout.
-- **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
+- **Danger Mode** – shows the detected browser path, Chrome version, and the first shortcut found. Green and red dots indicate if shortcuts are patched and if the debugging port is open. The current `DANGER_PORT` value is displayed. A link beside the heading opens the [Danger Mode documentation](danger_mode.md). You can also update Chrome shortcuts from here.
 - **Offline Preview** – cached snapshots are automatically enabled.
 - **Column Search** – click a header to filter rows by that column.
 - **Tab headers removed** – the active tab is highlighted, freeing space.

--- a/scripts/check_danger_mode.py
+++ b/scripts/check_danger_mode.py
@@ -1,9 +1,10 @@
+import app.config as config
 from app.utils.screenshots import is_chrome_debug_port_open
 from scripts.update_chrome_shortcut import shortcuts_need_patch
 
 
 def main() -> int:
-    ready = is_chrome_debug_port_open("127.0.0.1", 9222)
+    ready = is_chrome_debug_port_open("127.0.0.1", config.DANGER_PORT)
     if ready:
         print("Danger mode detected.")
     else:

--- a/scripts/update_chrome_shortcut.py
+++ b/scripts/update_chrome_shortcut.py
@@ -7,8 +7,10 @@ try:
 except ImportError:  # pragma: no cover - platform specific
     win32com = None
 
+import app.config as config
 
-FLAG = "--remote-debugging-port=9222"
+FLAG = f"--remote-debugging-port={config.DANGER_PORT}"
+
 
 LINUX_PATHS = [
     Path.home() / ".local/share/applications/google-chrome.desktop",

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -33,6 +33,7 @@ class TestDangerStatusEndpoint(unittest.TestCase):
             resp.get_json(),
             {
                 "port_open": True,
+                "port": 9222,
                 "idle": True,
                 "enabled": True,
                 "ready": True,
@@ -60,6 +61,7 @@ class TestDangerStatusEndpoint(unittest.TestCase):
             resp.get_json(),
             {
                 "port_open": False,
+                "port": 9222,
                 "idle": True,
                 "enabled": True,
                 "ready": False,
@@ -87,6 +89,7 @@ class TestDangerStatusEndpoint(unittest.TestCase):
             resp.get_json(),
             {
                 "port_open": True,
+                "port": 9222,
                 "idle": False,
                 "enabled": True,
                 "ready": False,


### PR DESCRIPTION
## Summary
- add `DANGER_PORT` setting
- use `DANGER_PORT` in danger mode helpers and status endpoint
- show the port on the Danger page and settings page
- document port option
- update danger_status tests

## Testing
- `pre-commit run --files app/config.py app/utils/settings_tooltips.py scripts/update_chrome_shortcut.py scripts/check_danger_mode.py app/utils/screenshots.py app/blueprints/status.py app/routes.py app/utils/scheduling.py app/templates/danger.html app/templates/settings.html docs/danger_mode.md docs/settings_page.md tests/test_danger_status_endpoint.py`
- `flake8`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685803dd348c83338b4ecdb78ab1759d