### PR TITLE
Improve template URL tester

### DIFF
--- a/app/blueprints/discovery.py
+++ b/app/blueprints/discovery.py
@@ -183,21 +183,41 @@ def create_blueprint() -> Blueprint:
     @bp.route("/templates/test_url")
     @routes.login_required
     def test_template_url() -> Response:
-        """Return JSON indicating whether the given URL is reachable."""
+        """Probe the given URL and return HTTP status and content type."""
 
         url = request.args.get("url") or ""
         url = routes.validators.validate_url(url)
         if not url:
             return jsonify({"ok": False, "error": "invalid"}), 400
 
-        try:
-            resp = routes.requests.head(url, timeout=5)
-            ok = resp.status_code < 400
-        except Exception as exc:  # pragma: no cover - network
-            routes.logging.warning("url check failed: %s", exc)
-            return jsonify({"ok": False, "error": "unreachable"}), 400
+        def attempt(method: str) -> tuple[bool, dict]:
+            """Try a request and return success with info."""
+            try:
+                headers = {"Range": "bytes=0-512"} if method == "GET" else {}
+                resp = routes.requests.request(
+                    method,
+                    url,
+                    timeout=3,
+                    allow_redirects=True,
+                    headers=headers,
+                )
+                return True, {
+                    "status": resp.status_code,
+                    "content_type": resp.headers.get("Content-Type", ""),
+                    "url": resp.url,
+                }
+            except Exception as exc:  # pragma: no cover - network
+                routes.logging.debug("%s probe failed for %s: %s", method, url, exc)
+                return False, {}
 
-        return jsonify({"ok": ok, "status": resp.status_code})
+        ok, info = attempt("HEAD")
+        if not ok or info["status"] >= 400 or info["status"] in {403, 405}:
+            ok, info = attempt("GET")
+            if not ok:
+                return jsonify({"ok": False, "error": "unreachable"}), 400
+
+        info["ok"] = info.get("status", 500) < 400
+        return jsonify(info)
 
     @bp.route("/discover/export", methods=["POST"])
     @routes.login_required

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -52,6 +52,19 @@ export function initUrlTester() {
         status.title = title || "URL test result";
       };
 
+      const formatTitle = (data) => {
+        if (!data.ok) {
+          return (
+            data.error || (data.status ? `HTTP ${data.status}` : "Unreachable")
+          );
+        }
+        let t = data.status ? `HTTP ${data.status}` : "OK";
+        if (data.content_type) {
+          t += ` \u00b7 ${data.content_type}`;
+        }
+        return t;
+      };
+
       const check = async () => {
         const url = input.value.trim();
         setStatus("");
@@ -69,20 +82,20 @@ export function initUrlTester() {
             },
           );
           const data = await res.json();
+          const title = formatTitle(data);
           if (res.ok && data.ok) {
-            setStatus("ok", "URL reachable");
+            setStatus("ok", title);
             if (submit) submit.disabled = false;
           } else {
-            const msg = data.status
-              ? `HTTP ${data.status}`
-              : data.error || "Unreachable";
-            setStatus("bad", msg);
+            setStatus("bad", title);
+            if (preview) preview.src = defaultSrc;
             if (submit) submit.disabled = true;
           }
           sendTelemetry("url_test", { url, ok: data.ok });
         } catch {
           if (controller.signal.aborted) return;
           setStatus("bad", "Unreachable");
+          if (preview) preview.src = defaultSrc;
           if (submit) submit.disabled = true;
           sendTelemetry("url_test", { url, ok: false });
         }

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -37,7 +37,7 @@ These tooltips aim to make the interface self‑explanatory and easier to naviga
 Interactive forms now include additional tooltips:
 
 - **Add Camera** – describes each field on the Discover tab and the "Structured" XPath buttons. A short helper paragraph guides you to test the URL and open the Advanced Options section.
-- **URL tester** – a tooltip shows "checking" then "valid" or "invalid" next to the URL field.
+- **URL tester** – now displays detailed feedback like HTTP status and content type. The live preview falls back to a placeholder image when the check fails.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
 - **Template toolbar** – quick actions appear at the bottom-left of the details page and fade out when idle.
 - **Captions** – upload and filter controls have descriptive titles. The metric dropdown filters feeds by count or storage and updates the list immediately.

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 
 const formHtml =
-  '<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview"><input type="submit"></form>';
+  '<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><input type="submit"></form>';
 
 beforeEach(() => {
   document.body.innerHTML = formHtml;
@@ -98,18 +98,36 @@ describe("url_test", () => {
     jest.runAllTimers();
     await Promise.resolve();
     await Promise.resolve();
+    const preview = document.getElementById("url-preview");
     expect(status.classList.contains("bad")).toBe(true);
     expect(status.title).toBe("HTTP 404");
+    expect(preview.src).toContain("blank.jpg");
+  });
+
+  test("uses placeholder when fetch fails", async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error("fail")));
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.clearAllTimers();
+    const input = document.getElementById("url");
+    const preview = document.getElementById("url-preview");
+    input.value = "http://bad";
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(preview.src).toContain("blank.jpg");
   });
 
   test("initializes multiple forms", async () => {
     const multiHtml = `
       <div class="edit-template-container">
-        <img id="p1">
+        <img id="p1" data-placeholder="blank.jpg">
         <form><input id="url" data-default-url="http://a"><span id="url-status"></span><input type="submit"></form>
       </div>
       <div class="edit-template-container">
-        <img id="p2">
+        <img id="p2" data-placeholder="blank.jpg">
         <form><input id="url" data-default-url="http://b"><span id="url-status"></span><input type="submit"></form>
       </div>`;
     document.body.innerHTML = multiHtml;


### PR DESCRIPTION
## Summary
- make `/templates/test_url` endpoint try HEAD then GET and return more information
- show content-type and HTTP status in tooltip and reset preview on failure
- test placeholder behavior in JS
- document the new tooltip details

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_url_test_route.py` *(fails: SocketBlockedError)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68580ce5f27c8333898483a44a9a6736