### PR TITLE
Handle screenshot failures

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -190,6 +190,10 @@ class GracefulAPScheduler(APScheduler):
 scheduler = GracefulAPScheduler()
 
 
+class CaptureFailed(RuntimeError):
+    """Raised when screenshot capture fails."""
+
+
 def _run_target(func, args):
     """Wrapper to set process title before executing ``func``."""
     if setproctitle:
@@ -199,6 +203,9 @@ def _run_target(func, args):
         setproctitle(f"glimpser {title}")
     try:
         func(*args)
+    except CaptureFailed as exc:
+        logging.error(str(exc))
+        raise
     except Exception:
         logging.exception("Unhandled exception in %s", getattr(func, "__name__", "job"))
         raise
@@ -497,7 +504,7 @@ def update_camera(name, template, image_file=None, motion=False):
         clean_url = sanitize_url(url)
         logging.error("Capture failed for %s (%s)", name, clean_url)
         # Raise an exception so ``run_with_timeout`` can apply backoff logic
-        raise RuntimeError(f"capture failed for {name}: {clean_url}")
+        raise CaptureFailed(f"capture failed for {name}: {clean_url}")
 
     if lsuc is True:
         directory = os.path.join(SCREENSHOT_DIRECTORY, name)


### PR DESCRIPTION
## Summary
- avoid huge tracebacks for known screenshot failures
- raise `CaptureFailed` to still trigger backoff logic

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580fe7010883339e9f4cc738e2c6da