### PR TITLE
Add LAN-only recovery note logic

### DIFF
--- a/app/blueprints/assets.py
+++ b/app/blueprints/assets.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 import logging
 import os
 import re
 import time
+from pathlib import Path
 
 from flask import Blueprint, Response
 

--- a/app/blueprints/authentication.py
+++ b/app/blueprints/authentication.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta
+from ipaddress import ip_address as ip_address_module
 
 from flask import Blueprint, current_app, request, session, url_for
 
@@ -18,6 +19,13 @@ def create_blueprint() -> Blueprint:
     def login():
         next_url = request.args.get("next")
         ip_address = request.remote_addr
+        show_recovery = False
+        if ip_address:
+            try:
+                addr = ip_address_module(ip_address)
+                show_recovery = addr.is_private or addr.is_loopback
+            except ValueError:
+                pass
         now = datetime.now()
 
         if (
@@ -26,7 +34,12 @@ def create_blueprint() -> Blueprint:
         ):
             routes.flash("Too many failed attempts. Please try again later.", "error")
             logging.warning("Locked login attempt from %s", ip_address)
-            return routes.render_template("login.html", page_title="Login"), 429
+            return (
+                routes.render_template(
+                    "login.html", page_title="Login", show_recovery_note=show_recovery
+                ),
+                429,
+            )
 
         if request.method == "POST":
             username = (request.form.get("username") or "").strip()
@@ -35,7 +48,14 @@ def create_blueprint() -> Blueprint:
             if not username or not password:
                 logging.debug("Login failed: missing credentials from %s", ip_address)
                 routes.flash("Username and password are required", "error")
-                return routes.render_template("login.html", page_title="Login"), 400
+                return (
+                    routes.render_template(
+                        "login.html",
+                        page_title="Login",
+                        show_recovery_note=show_recovery,
+                    ),
+                    400,
+                )
 
             db_session = routes.SessionLocal()
             try:
@@ -104,7 +124,9 @@ def create_blueprint() -> Blueprint:
                     ip_address,
                 )
                 routes.flash("Invalid username or password", "error")
-        return routes.render_template("login.html", page_title="Login")
+        return routes.render_template(
+            "login.html", page_title="Login", show_recovery_note=show_recovery
+        )
 
     @bp.route("/sso", methods=["GET"], endpoint="sso_login")
     def sso_login():

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -77,11 +77,12 @@ content %}
     {% endif %} {% endwith %}
     <input type="submit" value="Login" title="Click to log in" />
   </form>
+  {% if show_recovery_note %}
   <p id="recovery-note" class="recovery-note">
     Forgot your password? Stop Glimpser and run
     <code>generate_credentials.py --update-password</code>.
   </p>
-  {% endcall %}
+  {% endif %} {% endcall %}
 </div>
 <script
   type="module"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -194,7 +194,9 @@ class TestRoutes(unittest.TestCase):
             },
         )
         self.assertEqual(response.status_code, 200)
-        mock_render_template.assert_called_with("login.html", page_title="Login")
+        mock_render_template.assert_called_with(
+            "login.html", page_title="Login", show_recovery_note=True
+        )
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.login_attempts", {})
@@ -202,7 +204,9 @@ class TestRoutes(unittest.TestCase):
     def test_login_missing_fields(self, mock_render_template, mock_session_local):
         response = self.client.post("/login", data={"username": "", "password": ""})
         self.assertEqual(response.status_code, 400)
-        mock_render_template.assert_called_with("login.html", page_title="Login")
+        mock_render_template.assert_called_with(
+            "login.html", page_title="Login", show_recovery_note=True
+        )
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})


### PR DESCRIPTION
## Summary
- restrict password recovery hint on login to local addresses
- sort imports in `assets.py`
- update HTML template for conditional recovery note
- adapt route tests for new argument

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_routes.py::TestRoutes::test_login_missing_fields -q`
- `pytest tests/test_routes.py::TestRoutes::test_login_failure -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6858bd126d208333a2d6dbbfa5e82ac2