### PR TITLE
Improve login page for mobile

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1619,19 +1619,22 @@ footer.fade-out {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: calc(100dvh - 120px); /* Reduce excess vertical scroll */
-  padding: 20px 0;
+  min-height: 100dvh;
+  padding: 0;
+}
+.login-page main {
+  padding: 0 1rem;
 }
 .login-container {
   background-color: var(--form-bg-color);
   color: var(--form-text-color);
-  padding: 20px;
-  border-radius: 5px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  padding: 1.5rem;
+  border-radius: 6px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.15);
   display: inline-block;
-  max-width: 340px;
-  width: 100%;
-  margin: 20px auto;
+  max-width: 380px;
+  width: 90%;
+  margin: 0 auto;
 }
 .login-form .form-field {
   margin-bottom: 1rem;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,12 +1,12 @@
 {% include 'header.html' %}
-<body>
+<body class="{{ body_class|default('') }}">
     <a href="#main-content" class="skip-link" title="Jump to main area">Skip to main content</a>
     <header>
         {% include 'nav.html' %}
     </header>
     <div id="network-banner" class="network-banner" role="alert" aria-live="polite"></div>
 
-    <main id="main-content" tabindex="-1">
+    <main id="main-content" tabindex="-1" class="{{ main_class|default('') }}">
         {% block content %}{% endblock %}
     </main>
     {% from 'components.html' import hotkeys_overlay %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,87 +1,89 @@
-{% extends 'base.html' %} {% from 'components.html' import card %} {% block
-content %}
+{% extends 'base.html' %} {% set body_class = 'login-page' %} {% from
+'components.html' import card %} {% block content %}
 <div class="login-wrapper">
-  {% call card('Secure Sign In') %}
-  <div class="login-icon" aria-hidden="true">
-    <svg width="32" height="32">
-      <use href="{{ url_for('static', filename='icons/sprite.svg') }}#lock" />
-    </svg>
+  <div class="login-container">
+    {% call card('Secure Sign In') %}
+    <div class="login-icon" aria-hidden="true">
+      <svg width="32" height="32">
+        <use href="{{ url_for('static', filename='icons/sprite.svg') }}#lock" />
+      </svg>
+    </div>
+    <p id="security-note" class="security-note"></p>
+    <form
+      id="login-form"
+      method="post"
+      class="login-form"
+      autocomplete="off"
+      title="Enter your credentials"
+    >
+      <div class="form-field">
+        <label for="username" class="sr-only">Username</label>
+        <input
+          id="username"
+          type="text"
+          name="username"
+          autofocus
+          placeholder="Username"
+          required
+          title="Enter your username"
+          aria-describedby="login-error"
+          autocomplete="username"
+          autofocus
+        />
+      </div>
+      <div class="form-field password-input">
+        <label for="password" class="sr-only">Password</label>
+        <input
+          id="password"
+          type="password"
+          name="password"
+          placeholder="Password"
+          required
+          title="Enter your password"
+          aria-describedby="login-error"
+          autocomplete="current-password"
+        />
+        <button
+          type="button"
+          id="password-toggle"
+          aria-label="Show password"
+          class="toggle-password"
+        >
+          <svg width="16" height="16">
+            <use
+              href="{{ url_for('static', filename='icons/sprite.svg') }}#eye"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        id="login-error"
+        class="form-error hidden"
+        role="alert"
+        aria-live="assertive"
+      ></div>
+
+      <div class="checkbox-row">
+        <input id="remember" type="checkbox" name="remember" />
+        <label for="remember">Remember me</label>
+      </div>
+
+      {% with messages = get_flashed_messages(with_categories=true) %} {% if
+      messages %}
+      <div class="flash-messages">
+        {% for category, message in messages %}
+        <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      </div>
+      {% endif %} {% endwith %}
+      <input type="submit" value="Login" title="Click to log in" />
+    </form>
+    <p id="recovery-note" class="recovery-note">
+      Forgot your password? Stop Glimpser and run
+      <code>generate_credentials.py --update-password</code>.
+    </p>
+    {% endcall %}
   </div>
-  <p id="security-note" class="security-note"></p>
-  <form
-    id="login-form"
-    method="post"
-    class="login-form"
-    autocomplete="off"
-    title="Enter your credentials"
-  >
-    <div class="form-field">
-      <label for="username" class="sr-only">Username</label>
-      <input
-        id="username"
-        type="text"
-        name="username"
-        autofocus
-        placeholder="Username"
-        required
-        title="Enter your username"
-        aria-describedby="login-error"
-        autocomplete="username"
-        autofocus
-      />
-    </div>
-    <div class="form-field password-input">
-      <label for="password" class="sr-only">Password</label>
-      <input
-        id="password"
-        type="password"
-        name="password"
-        placeholder="Password"
-        required
-        title="Enter your password"
-        aria-describedby="login-error"
-        autocomplete="current-password"
-      />
-      <button
-        type="button"
-        id="password-toggle"
-        aria-label="Show password"
-        class="toggle-password"
-      >
-        <svg width="16" height="16">
-          <use
-            href="{{ url_for('static', filename='icons/sprite.svg') }}#eye"
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      id="login-error"
-      class="form-error hidden"
-      role="alert"
-      aria-live="assertive"
-    ></div>
-
-    <div class="checkbox-row">
-      <input id="remember" type="checkbox" name="remember" />
-      <label for="remember">Remember me</label>
-    </div>
-
-    {% with messages = get_flashed_messages(with_categories=true) %} {% if
-    messages %}
-    <div class="flash-messages">
-      {% for category, message in messages %}
-      <div class="alert alert-{{ category }}">{{ message }}</div>
-      {% endfor %}
-    </div>
-    {% endif %} {% endwith %}
-    <input type="submit" value="Login" title="Click to log in" />
-  </form>
-  <p id="recovery-note" class="recovery-note">
-    Forgot your password? Stop Glimpser and run
-    <code>generate_credentials.py --update-password</code>.
-  </p>
-  {% endcall %}
 </div>
 <script
   type="module"


### PR DESCRIPTION
## Summary
- enhance login screen layout for small devices
- allow templates to specify body and main classes

## Testing
- `pre-commit run --files app/static/css/style.css app/templates/base.html app/templates/login.html`
- `pytest tests/test_html_templates.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bd7faba083339421e255da5794d0