### PR TITLE
Fix screenshot deletion crash in video archiver

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -609,9 +609,13 @@ def _compile_to_video_inner(camera_path, video_path) -> bool:
         temp_file_path = None
         with tempfile.NamedTemporaryFile(mode="w+", delete=False) as temp_file:
             for file in new_files[-300:]:  # keep it short for now
-                if os.path.getsize(os.path.abspath(file)) > 10 and "_2" in file:
-                    temp_file.write(f"file '{os.path.abspath(file)}'\n")
-                    lcount += 1
+                try:
+                    if os.path.getsize(os.path.abspath(file)) > 10 and "_2" in file:
+                        temp_file.write(f"file '{os.path.abspath(file)}'\n")
+                        lcount += 1
+                except FileNotFoundError:
+                    # Screenshot was removed concurrently; ignore it
+                    continue
             temp_file_path = temp_file.name
         if lcount == 0:
             # nothing to do
@@ -791,9 +795,14 @@ def _old_compile_to_video_inner(camera_path, video_path) -> bool:
 
     if new_files:
         # keep the size/“_2” filter you already had
-        candidate = [
-            f for f in new_files[-300:] if os.path.getsize(f) > 10 and "_2" in f
-        ]
+        candidate = []
+        for f in new_files[-300:]:
+            try:
+                if os.path.getsize(f) > 10 and "_2" in f:
+                    candidate.append(f)
+            except FileNotFoundError:
+                # Screenshot was removed concurrently; ignore it
+                continue
 
         # drop corrupt or truncated PNGs
         frame_files = []

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -292,6 +292,34 @@ class TestVideoArchiver(unittest.TestCase):
         mock_open.assert_called_once_with("shot_2.png")
         # self.assertEqual(captured_lines, ["shot_2.png"])
 
+    @patch("app.utils.video_archiver.run_ffmpeg")
+    @patch("app.utils.video_archiver.Image.open")
+    @patch("glob.glob")
+    def test_compile_to_video_skips_missing_files(
+        self, mock_glob, mock_open, mock_run_ffmpeg
+    ):
+        mock_glob.return_value = ["frame1_2.png", "frame2_2.png"]
+
+        def size_side_effect(path):
+            if "frame1" in path:
+                raise FileNotFoundError
+            return 1000
+
+        with (
+            patch("os.path.exists", return_value=True),
+            patch("os.path.isfile", return_value=False),
+            patch("os.path.getmtime", return_value=1724516114),
+            patch("os.path.getctime", return_value=1724516115),
+            patch("os.path.getsize", side_effect=size_side_effect),
+            patch("os.rename"),
+        ):
+            mock_open.return_value.__enter__.return_value = MagicMock()
+            mock_open.return_value.__exit__.return_value = None
+            mock_run_ffmpeg.return_value.returncode = 0
+            compile_to_video(self.temp_dir, self.temp_dir)
+
+        self.assertTrue(mock_run_ffmpeg.called)
+
     @patch("app.utils.video_archiver.compile_to_video")
     def test_archive_screenshots(self, mock_compile_to_video):
         with (


### PR DESCRIPTION
## Summary
- avoid crashing when screenshots vanish while encoding
- cover missing screenshot case in video archiver tests

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: TestLastTeaserRoute::test_last_teaser_group)*

------
https://chatgpt.com/codex/tasks/task_e_6859620ae59c8333b28c187284135926