### PR TITLE
Move discovery scan script to module

### DIFF
--- a/app/static/js/discovery_scan.js
+++ b/app/static/js/discovery_scan.js
@@ -1,0 +1,202 @@
+export function initDiscoveryScan() {
+  document.addEventListener("DOMContentLoaded", () => {
+    const page = document.querySelector(".discovery-page");
+    if (!page) return;
+    const existingMap = JSON.parse(page.dataset.existingMap || "{}");
+    const iconUrl = page.dataset.iconUrl || "/static/icons/sprite.svg";
+    const button = document.getElementById("discover-btn");
+    const msg = document.getElementById("discover-message");
+    const progress = document.getElementById("discover-progress");
+    const body = document.getElementById("discover-body");
+    const exportJson = document.getElementById("export-json");
+    const exportCsv = document.getElementById("export-csv");
+
+    const renderInfo = (info) => {
+      if (!info) return "";
+      const pieces = [];
+      if (info.name) pieces.push(info.name);
+      if (info.xaddr) pieces.push(info.xaddr);
+      if (info.path) pieces.push(info.path);
+      if (info.sdp) pieces.push("SDP available");
+      Object.entries(info).forEach(([k, v]) => {
+        if (
+          !["name", "xaddr", "path", "sdp", "mac", "manufacturer"].includes(k)
+        ) {
+          pieces.push(`${k}: ${v}`);
+        }
+      });
+      return pieces.join(" ");
+    };
+
+    let results = [];
+    const updateExportState = () => {
+      if (exportJson) exportJson.disabled = results.length === 0;
+      if (exportCsv) exportCsv.disabled = results.length === 0;
+    };
+    updateExportState();
+
+    if (button) {
+      button.addEventListener("click", async () => {
+        msg.textContent = "Searching...";
+        try {
+          const res = await fetch("/discovery_status");
+          const data = await res.json();
+          if (data.status !== "running") {
+            await fetch("/toggle_discovery", { method: "POST" });
+          }
+        } catch (e) {
+          console.warn("Unable to start background discovery", e);
+        }
+        progress.style.display = "inline";
+        progress.value = 0;
+        body.innerHTML = "";
+        results = [];
+        updateExportState();
+        const cidr = document.getElementById("cidr-input").value.trim();
+        const url = cidr
+          ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}`
+          : "/discover/scan_stream";
+        const source = new EventSource(url);
+        const known = new Set();
+        const addRow = (cam) => {
+          const key = cam.ip
+            ? `${cam.ip}-${cam.protocol}-${cam.port}`
+            : cam.url;
+          if (known.has(key)) return;
+          known.add(key);
+          results.push(cam);
+          updateExportState();
+          const tr = document.createElement("tr");
+          let url = cam.url || `${cam.protocol}://${cam.ip}:${cam.port}`;
+          const existing = existingMap[url];
+          const action = existing
+            ? `<a href="/templates/${existing}" class="btn btn-primary" title="View this camera">View</a>`
+            : `<form action="/discover/add" method="post">
+                            ${
+                              cam.ip
+                                ? `<input type="hidden" name="ip" value="${cam.ip}">`
+                                : ""
+                            }
+                            ${
+                              cam.protocol
+                                ? `<input type="hidden" name="protocol" value="${cam.protocol}">`
+                                : ""
+                            }
+                            ${
+                              cam.port
+                                ? `<input type="hidden" name="port" value="${cam.port}">`
+                                : ""
+                            }
+                            ${
+                              cam.url
+                                ? `<input type="hidden" name="url" value="${cam.url}">`
+                                : ""
+                            }
+                            <input type="hidden" name="name" value="${cam.name || cam.ip}">
+                            <button type="submit" title="Add this camera">Add</button>
+                        </form>`;
+          let protocol = cam.protocol;
+          let port = cam.port;
+          if (!cam.ip && cam.url) {
+            try {
+              const p = new URL(cam.url);
+              protocol = protocol || p.protocol.replace(":", "");
+              port = port || p.port || (p.protocol === "https:" ? "443" : "80");
+            } catch {}
+          }
+          const info = renderInfo(
+            cam.info || {
+              name: cam.name,
+              category: cam.category,
+              notes: cam.notes,
+            },
+          );
+          tr.innerHTML = `
+                    <td>${cam.ip || ""}</td>
+                    <td>${protocol || ""}</td>
+                    <td>${port || ""}</td>
+                    <td>${(cam.info && cam.info.mac) || ""}</td>
+                    <td>${(cam.info && cam.info.manufacturer) || ""}</td>
+                    <td><svg class="camera-icon" width="12" height="12" aria-hidden="true"><use href="${iconUrl}#camera"></use></svg>
+                    ${info ? `<span class="info-icon" title="${info}">ℹ️</span>` : ""}</td>
+                    <td>${action}</td>`;
+          body.appendChild(tr);
+        };
+        let plan = [];
+        source.onmessage = (event) => {
+          const data = JSON.parse(event.data);
+          if (data.error) {
+            console.error("Discovery error", data.error);
+            msg.textContent = `Error discovering cameras: ${data.error}`;
+            progress.style.display = "none";
+            source.close();
+            return;
+          }
+          if (data.total) {
+            progress.max = 100;
+            progress.value = 0;
+            plan = data.stages || [];
+            if (data.subnets) {
+              msg.textContent = `Scanning networks: ${data.subnets.join(", ")}. Plan: ${plan.join(", ")}`;
+            }
+            return;
+          }
+          if (data.done) {
+            msg.textContent = `Found ${known.size} cameras.`;
+            progress.style.display = "none";
+            source.close();
+            return;
+          }
+          if (typeof data.progress === "number") {
+            progress.value = data.progress;
+          } else {
+            progress.value += 1;
+          }
+          if (plan.length && plan[0] === data.stage) {
+            plan.shift();
+          }
+          const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : "";
+          msg.textContent =
+            `Scanning ${data.stage} (${data.count} found)...` +
+            (plan.length ? ` Next: ${plan[0]}` : "") +
+            eta;
+          if (data.cameras) {
+            data.cameras.forEach(addRow);
+          }
+        };
+        source.onerror = (e) => {
+          console.error("Discovery error", e);
+          let text = "Error discovering cameras";
+          if (e && e.message) {
+            text += `: ${e.message}`;
+          }
+          msg.textContent = text;
+          progress.style.display = "none";
+          source.close();
+        };
+      });
+    }
+
+    const exportData = (fmt) => {
+      fetch(`/discover/export?format=${fmt}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(results),
+      })
+        .then((r) => r.blob())
+        .then((blob) => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement("a");
+          a.href = url;
+          a.download = fmt === "csv" ? "discovery.csv" : "discovery.json";
+          document.body.appendChild(a);
+          a.click();
+          a.remove();
+          URL.revokeObjectURL(url);
+        });
+    };
+    if (exportJson)
+      exportJson.addEventListener("click", () => exportData("json"));
+    if (exportCsv) exportCsv.addEventListener("click", () => exportData("csv"));
+  });
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -31,6 +31,7 @@ import { initUnsavedIndicator } from "./unsaved.js";
 import { initVideoZoom } from "./zoom.js";
 import { initSearchShortcut } from "./search_shortcut.js";
 import { initUrlTester } from "./url_test.js";
+import { initDiscoveryScan } from "./discovery_scan.js";
 
 initTemplates();
 initVideoControls();
@@ -39,6 +40,7 @@ initSchedulerToggle();
 initDiscoveryToggle();
 initSubnetInput();
 initDiscoveryTable();
+initDiscoveryScan();
 initNav();
 initFormValidation();
 initAddSettingValidation();

--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -10,6 +10,7 @@ const OFFLINE_URLS = [
   "/static/css/style.css",
   "/static/css/player.css",
   "/static/js/script.js",
+  "/static/js/discovery_scan.js",
 ];
 
 self.addEventListener("install", (event) => {

--- a/app/templates/_discover_tab.html
+++ b/app/templates/_discover_tab.html
@@ -1,4 +1,8 @@
-<div class="discovery-page">
+<div
+  class="discovery-page"
+  data-existing-map="{{ existing_urls | tojson | safe }}"
+  data-icon-url="{{ url_for('static', filename='icons/sprite.svg') }}"
+>
   {% call card('Background Discovery') %}
   <div class="discovery-controls" title="Manage background discovery">
     <button
@@ -137,182 +141,10 @@
   </div>
   {% endcall %}
 </div>
-<script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const existingMap = {{ existing_urls | tojson | safe }};
-    const iconUrl = "{{ url_for('static', filename='icons/sprite.svg') }}";
-    const button = document.getElementById("discover-btn");
-    const msg = document.getElementById("discover-message");
-    const progress = document.getElementById("discover-progress");
-    const body = document.getElementById("discover-body");
-    const exportJson = document.getElementById("export-json");
-    const exportCsv = document.getElementById("export-csv");
-
-    const renderInfo = (info) => {
-      if (!info) return "";
-      const pieces = [];
-      if (info.name) pieces.push(info.name);
-      if (info.xaddr) pieces.push(info.xaddr);
-      if (info.path) pieces.push(info.path);
-      if (info.sdp) pieces.push("SDP available");
-      Object.entries(info).forEach(([k, v]) => {
-        if (
-          !["name", "xaddr", "path", "sdp", "mac", "manufacturer"].includes(k)
-        ) {
-          pieces.push(`${k}: ${v}`);
-        }
-      });
-      return pieces.join(" ");
-    };
-
-    let results = [];
-    const updateExportState = () => {
-      if (exportJson) exportJson.disabled = results.length === 0;
-      if (exportCsv) exportCsv.disabled = results.length === 0;
-    };
-    updateExportState();
-
-    if (button) {
-      button.addEventListener("click", async () => {
-        msg.textContent = "Searching...";
-        try {
-          const res = await fetch("/discovery_status");
-          const data = await res.json();
-          if (data.status !== "running") {
-            await fetch("/toggle_discovery", { method: "POST" });
-          }
-        } catch (e) {
-          console.warn("Unable to start background discovery", e);
-        }
-        progress.style.display = "inline";
-        progress.value = 0;
-        body.innerHTML = "";
-        results = [];
-        updateExportState();
-        const cidr = document.getElementById("cidr-input").value.trim();
-        const url = cidr
-          ? `/discover/scan_stream?cidr=${encodeURIComponent(cidr)}`
-          : "/discover/scan_stream";
-        const source = new EventSource(url);
-        const known = new Set();
-        const addRow = (cam) => {
-          const key = cam.ip ? `${cam.ip}-${cam.protocol}-${cam.port}` : cam.url;
-          if (known.has(key)) return;
-          known.add(key);
-          results.push(cam);
-          updateExportState();
-          const tr = document.createElement("tr");
-          let url = cam.url || `${cam.protocol}://${cam.ip}:${cam.port}`;
-          const existing = existingMap[url];
-          const action = existing
-            ? `<a href="/templates/${existing}" class="btn btn-primary" title="View this camera">View</a>`
-            : `<form action="/discover/add" method="post">
-                            ${cam.ip ? `<input type="hidden" name="ip" value="${cam.ip}">` : ""}
-                            ${cam.protocol ? `<input type="hidden" name="protocol" value="${cam.protocol}">` : ""}
-                            ${cam.port ? `<input type="hidden" name="port" value="${cam.port}">` : ""}
-                            ${cam.url ? `<input type="hidden" name="url" value="${cam.url}">` : ""}
-                            <input type="hidden" name="name" value="${cam.name || cam.ip}">
-                            <button type="submit" title="Add this camera">Add</button>
-                        </form>`;
-          let protocol = cam.protocol;
-          let port = cam.port;
-          if (!cam.ip && cam.url) {
-            try {
-              const p = new URL(cam.url);
-              protocol = protocol || p.protocol.replace(":", "");
-              port = port || p.port || (p.protocol === "https:" ? "443" : "80");
-            } catch {}
-          }
-          const info = renderInfo(cam.info || { name: cam.name, category: cam.category, notes: cam.notes });
-          tr.innerHTML = `
-                    <td>${cam.ip || ""}</td>
-                    <td>${protocol || ""}</td>
-                    <td>${port || ""}</td>
-                    <td>${(cam.info && cam.info.mac) || ""}</td>
-                    <td>${(cam.info && cam.info.manufacturer) || ""}</td>
-                    <td><svg class="camera-icon" width="12" height="12" aria-hidden="true"><use href="${iconUrl}#camera"></use></svg>
-                    ${info ? `<span class="info-icon" title="${info}">ℹ️</span>` : ""}</td>
-                    <td>${action}</td>`;
-          body.appendChild(tr);
-        };
-        let plan = [];
-        source.onmessage = (event) => {
-          const data = JSON.parse(event.data);
-          if (data.error) {
-            console.error("Discovery error", data.error);
-            msg.textContent = `Error discovering cameras: ${data.error}`;
-            progress.style.display = "none";
-            source.close();
-            return;
-          }
-          if (data.total) {
-            progress.max = 100;
-            progress.value = 0;
-            plan = data.stages || [];
-            if (data.subnets) {
-              msg.textContent = `Scanning networks: ${data.subnets.join(", ")}. Plan: ${plan.join(", ")}`;
-            }
-            return;
-          }
-          if (data.done) {
-            msg.textContent = `Found ${known.size} cameras.`;
-            progress.style.display = "none";
-            source.close();
-            return;
-          }
-          if (typeof data.progress === "number") {
-            progress.value = data.progress;
-          } else {
-            progress.value += 1;
-          }
-          if (plan.length && plan[0] === data.stage) {
-            plan.shift();
-          }
-          const eta = data.eta ? ` ~${Math.round(data.eta)}s left` : "";
-          msg.textContent =
-            `Scanning ${data.stage} (${data.count} found)...` +
-            (plan.length ? ` Next: ${plan[0]}` : "") +
-            eta;
-          if (data.cameras) {
-            data.cameras.forEach(addRow);
-          }
-        };
-        source.onerror = (e) => {
-          console.error("Discovery error", e);
-          let text = "Error discovering cameras";
-          if (e && e.message) {
-            text += `: ${e.message}`;
-          }
-          msg.textContent = text;
-          progress.style.display = "none";
-          source.close();
-        };
-      });
-    }
-
-    const exportData = (fmt) => {
-      fetch(`/discover/export?format=${fmt}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(results),
-      })
-        .then((r) => r.blob())
-        .then((blob) => {
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = fmt === "csv" ? "discovery.csv" : "discovery.json";
-          document.body.appendChild(a);
-          a.click();
-          a.remove();
-          URL.revokeObjectURL(url);
-        });
-    };
-    if (exportJson)
-      exportJson.addEventListener("click", () => exportData("json"));
-    if (exportCsv) exportCsv.addEventListener("click", () => exportData("csv"));
-  });
-</script>
+<script
+  type="module"
+  src="{{ url_for('static', filename='js/discovery_scan.js') }}"
+></script>
 <script
   type="module"
   src="{{ url_for('static', filename='js/url_test.js') }}"

--- a/tests/js/discovery_scan.test.js
+++ b/tests/js/discovery_scan.test.js
@@ -1,0 +1,57 @@
+import { jest } from "@jest/globals";
+
+let initDiscoveryScan;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/discovery_scan.js");
+  initDiscoveryScan = mod.initDiscoveryScan;
+});
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div class="discovery-page" data-existing-map="{}" data-icon-url="/icons.svg">
+      <input id="cidr-input" />
+      <button id="discover-btn"></button>
+      <span id="discover-message"></span>
+      <progress id="discover-progress"></progress>
+      <table><tbody id="discover-body"></tbody></table>
+      <button id="export-json"></button>
+      <button id="export-csv"></button>
+    </div>`;
+  global.EventSource = jest.fn(() => ({
+    onmessage: null,
+    onerror: null,
+    close: jest.fn(),
+  }));
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ status: "ready" }) }),
+  );
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("starts scan on click", async () => {
+  initDiscoveryScan();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  document.getElementById("discover-btn").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(EventSource).toHaveBeenCalledWith("/discover/scan_stream");
+});
+
+test("enables export after results arrive", async () => {
+  initDiscoveryScan();
+  document.dispatchEvent(new Event("DOMContentLoaded"));
+  document.getElementById("discover-btn").click();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  const es = EventSource.mock.results[0].value;
+  es.onmessage({ data: JSON.stringify({ cameras: [{ ip: "1" }] }) });
+  const exportJson = document.getElementById("export-json");
+  expect(exportJson.disabled).toBe(false);
+});

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -96,9 +96,8 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn("template_form(", html)
 
     def test_discover_has_existing_map_variable(self):
-        with open("app/templates/_discover_tab.html", encoding="utf-8") as f:
-            html = f.read()
-        self.assertIn("existingMap", html)
+        html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")
+        self.assertIn("data-existing-map", html)
 
     def test_discover_table_sortable(self):
         html = Path("app/templates/_discover_tab.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- move the discovery page JS into its own module
- load the new module from the discovery tab template
- hook the new init into the main script
- cache the new file in the service worker
- add tests for the module and update template tests

## Testing
- `pre-commit run --all-files`
- `npm test`
- `pytest -q` *(fails: expected call not found, keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68597d8107b48333be4c64cc6011ec0d