### PR TITLE
Refactor routes to blueprints

### DIFF
--- a/app/blueprints/assets.py
+++ b/app/blueprints/assets.py
@@ -27,7 +27,7 @@ def create_blueprint() -> Blueprint:
 
         lgroup = routes.secure_filename(group) if group else "all"
         base_path = os.path.join(
-            os.path.dirname(os.path.join(__file__)), "..", routes.VIDEO_DIRECTORY
+            os.path.dirname(os.path.join(routes.__file__)), "..", routes.VIDEO_DIRECTORY
         )
         if not os.path.exists(base_path):
             routes.abort(404)
@@ -48,7 +48,7 @@ def create_blueprint() -> Blueprint:
             routes.abort(404)
 
         path = os.path.join(
-            os.path.dirname(os.path.join(__file__)),
+            os.path.dirname(os.path.join(routes.__file__)),
             "..",
             routes.VIDEO_DIRECTORY,
             str(template_name),
@@ -105,7 +105,7 @@ def create_blueprint() -> Blueprint:
             routes.abort(400, "Invalid duration")
 
         root = (
-            Path(__file__).resolve().parent
+            Path(routes.__file__).resolve().parent
             / ".."
             / routes.VIDEO_DIRECTORY
             / str(template_name)
@@ -205,7 +205,7 @@ def create_blueprint() -> Blueprint:
 
         for group_camera in re.findall(r"^group-(.+?)$", template_name):
             path = os.path.join(
-                os.path.dirname(os.path.join(__file__)),
+                os.path.dirname(os.path.join(routes.__file__)),
                 "..",
                 routes.SCREENSHOT_DIRECTORY,
                 f"{group_camera}_latest_camera.png",
@@ -222,7 +222,7 @@ def create_blueprint() -> Blueprint:
             return resp
 
         path = os.path.join(
-            os.path.dirname(os.path.join(__file__)),
+            os.path.dirname(os.path.join(routes.__file__)),
             "..",
             routes.SCREENSHOT_DIRECTORY,
             str(template_name),
@@ -254,5 +254,23 @@ def create_blueprint() -> Blueprint:
         )
         resp.status_code = 404
         return resp
+
+    @bp.route("/sw.js")
+    def service_worker():
+        response = routes.make_response(routes.current_app.send_static_file("sw.js"))
+        response.headers["Cache-Control"] = "no-cache"
+        return response
+
+    @bp.route("/robots.txt")
+    def robots_txt():
+        """Return ``robots.txt`` rules based on ``ALLOW_BOTS`` setting."""
+        rules = ["User-agent: *"]
+        if routes.config.ALLOW_BOTS:
+            rules.append("Allow: /")
+        else:
+            rules.append("Disallow: /")
+        response = routes.Response("\n".join(rules) + "\n", mimetype="text/plain")
+        response.headers["Cache-Control"] = "no-cache"
+        return response
 
     return bp

--- a/app/blueprints/system.py
+++ b/app/blueprints/system.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, redirect, url_for
+
+
+def create_blueprint() -> Blueprint:
+    """Create and return the system management blueprint."""
+
+    import app.routes as routes
+
+    bp = Blueprint("system", __name__)
+
+    @bp.route("/system_metrics")
+    def system_metrics():
+        return redirect(url_for("health_check"))
+
+    @bp.route("/toggle_scheduler", methods=["POST"])
+    @routes.login_required
+    @routes.profile_route("/toggle_scheduler")
+    def toggle_scheduler():
+        try:
+            if routes.scheduling.scheduler.running:
+                routes.scheduling.scheduler.shutdown(wait=True)
+                return jsonify({"status": "stopped"})
+            routes.scheduling.scheduler.start()
+            with routes.current_app.app_context():
+                routes.scheduling.scheduler.remove_all_jobs()
+                routes.scheduling.schedule_crawlers()
+                routes.scheduling.schedule_summarization()
+            return jsonify({"status": "running"})
+        except Exception as e:  # pragma: no cover - unexpected errors
+            return jsonify({"status": "error", "message": str(e)}), 500
+
+    @bp.route("/scheduler_status")
+    @routes.login_required
+    @routes.profile_route("/scheduler_status")
+    def scheduler_status():
+        return jsonify(
+            {
+                "status": (
+                    "running" if routes.scheduling.scheduler.running else "stopped"
+                )
+            }
+        )
+
+    @bp.route("/profiling")
+    @routes.login_required
+    def profiling_data():
+        return jsonify(routes.get_latency_stats())
+
+    return bp

--- a/app/routes.py
+++ b/app/routes.py
@@ -1568,6 +1568,7 @@ def init_routes(app: Flask) -> None:
     )
     from app.blueprints.status import create_blueprint as create_status_blueprint
     from app.blueprints.stream import create_blueprint as create_stream_blueprint
+    from app.blueprints.system import create_blueprint as create_system_blueprint
     from app.blueprints.views import create_blueprint as create_views_blueprint
 
     if not getattr(app, "_network_bp_registered", False):
@@ -1597,6 +1598,10 @@ def init_routes(app: Flask) -> None:
     if not getattr(app, "_assets_bp_registered", False):
         app.register_blueprint(create_assets_blueprint())
         app._assets_bp_registered = True
+
+    if not getattr(app, "_system_bp_registered", False):
+        app.register_blueprint(create_system_blueprint())
+        app._system_bp_registered = True
 
     if not getattr(app, "_api_bp_registered", False):
         app.register_blueprint(create_api_blueprint())
@@ -3535,11 +3540,6 @@ def init_routes(app: Flask) -> None:
             page_title="Settings",
         )
 
-    # Retained for backwards compatibility; redirect to the health endpoint.
-    @app.route("/system_metrics")
-    def system_metrics():
-        return redirect(url_for("health_check"))
-
     def allowed_file(filename):
         return "." in filename and filename.rsplit(".", 1)[1].lower() == "json"
 
@@ -3759,52 +3759,3 @@ def init_routes(app: Flask) -> None:
                 break
 
         return jsonify(suggestions)
-
-    @app.route("/sw.js")
-    def service_worker():
-        response = make_response(app.send_static_file("sw.js"))
-        response.headers["Cache-Control"] = "no-cache"
-        return response
-
-    @app.route("/robots.txt")
-    def robots_txt():
-        """Return ``robots.txt`` rules based on ``ALLOW_BOTS`` setting."""
-        rules = ["User-agent: *"]
-        if config.ALLOW_BOTS:
-            rules.append("Allow: /")
-        else:
-            rules.append("Disallow: /")
-        response = Response("\n".join(rules) + "\n", mimetype="text/plain")
-        response.headers["Cache-Control"] = "no-cache"
-        return response
-
-    @app.route("/toggle_scheduler", methods=["POST"])
-    @login_required
-    @profile_route("/toggle_scheduler")
-    def toggle_scheduler():
-        try:
-            if scheduling.scheduler.running:
-                scheduling.scheduler.shutdown(wait=True)
-                return jsonify({"status": "stopped"})
-            else:
-                scheduling.scheduler.start()
-                with app.app_context():
-                    scheduling.scheduler.remove_all_jobs()
-                    scheduling.schedule_crawlers()
-                    scheduling.schedule_summarization()
-                return jsonify({"status": "running"})
-        except Exception as e:
-            return jsonify({"status": "error", "message": str(e)}), 500
-
-    @app.route("/scheduler_status")
-    @login_required
-    @profile_route("/scheduler_status")
-    def get_scheduler_status():
-        return jsonify(
-            {"status": ("running" if scheduling.scheduler.running else "stopped")}
-        )
-
-    @app.route("/profiling")
-    @login_required
-    def profiling_data():
-        return jsonify(get_latency_stats())


### PR DESCRIPTION
## Summary
- move scheduler, profiling and metrics routes into new `system` blueprint
- serve `sw.js` and `robots.txt` from the assets blueprint
- register new blueprint in `init_routes`

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68597da1bcac833392b122ab5d7899ab