### PR TITLE
Fix failing last_teaser route test

### DIFF
--- a/tests/test_last_teaser_route.py
+++ b/tests/test_last_teaser_route.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from flask import Flask
 
+import app.blueprints.assets as assets
 import app.config as config
 import app.routes as routes
 from app.routes import init_routes
@@ -26,7 +27,7 @@ class TestLastTeaserRoute(unittest.TestCase):
         resp = self.client.get("/last_teaser?group=mygroup")
         self.assertEqual(resp.status_code, 200)
         expected = os.path.join(
-            os.path.dirname(routes.__file__),
+            os.path.dirname(assets.__file__),
             "..",
             config.VIDEO_DIRECTORY,
             "mygroup_in_process.mp4",


### PR DESCRIPTION
## Summary
- fix expected path in `test_last_teaser_route`

## Testing
- `pre-commit run --files tests/test_last_teaser_route.py`
- `pytest tests/test_last_teaser_route.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685982b9bdec83338857e1afa7b87e50