### PR TITLE
Fix teaser path and sort test imports

### DIFF
--- a/app/blueprints/assets.py
+++ b/app/blueprints/assets.py
@@ -27,7 +27,7 @@ def create_blueprint() -> Blueprint:
 
         lgroup = routes.secure_filename(group) if group else "all"
         base_path = os.path.join(
-            os.path.dirname(os.path.join(routes.__file__)), "..", routes.VIDEO_DIRECTORY
+            os.path.dirname(routes.__file__), "..", routes.VIDEO_DIRECTORY
         )
         if not os.path.exists(base_path):
             routes.abort(404)

--- a/tests/test_e2e_offline_login.py
+++ b/tests/test_e2e_offline_login.py
@@ -3,8 +3,9 @@ import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import app
 import pytest
+
+import app
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- correct teaser video path calculation in assets blueprint
- sort imports in offline login test

## Testing
- `pre-commit run --files app/blueprints/assets.py tests/test_e2e_offline_login.py`
- `pytest tests/test_last_teaser_route.py::TestLastTeaserRoute::test_last_teaser_group -q`

------
https://chatgpt.com/codex/tasks/task_e_685983ece30083339f81bf39fc0a682e