### PR TITLE
Fix last teaser test path

### DIFF
--- a/tests/test_last_teaser_route.py
+++ b/tests/test_last_teaser_route.py
@@ -27,7 +27,7 @@ class TestLastTeaserRoute(unittest.TestCase):
         resp = self.client.get("/last_teaser?group=mygroup")
         self.assertEqual(resp.status_code, 200)
         expected = os.path.join(
-            os.path.dirname(assets.__file__),
+            os.path.dirname(routes.__file__),
             "..",
             config.VIDEO_DIRECTORY,
             "mygroup_in_process.mp4",


### PR DESCRIPTION
## Summary
- fix expected path in last teaser route test

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails to exit cleanly but logs show all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6859c50956c88333bad5ffe3f1f2ae9c