### PR TITLE
Fix run_with_timeout deadlock

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -335,8 +335,9 @@ def run_with_timeout(func, args=(), timeout=300):
         if success:
             job_failures.pop(key, None)
             job_backoff_until.pop(key, None)
-        else:
-            register_job_failure(key)
+
+    if not success:
+        register_job_failure(key)
 
 
 MAX_IMAGE_TIME_DIFF = datetime.timedelta(minutes=5)

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -31,26 +31,24 @@ class TestRunWithTimeout(unittest.TestCase):
 
     @patch("app.utils.scheduling.is_system_online", return_value=True)
     def test_run_completes_before_timeout(self, _online):
-        with multiprocessing.Manager() as manager:
-            d = manager.dict()
+        flag = multiprocessing.Value("b", False)
 
-            def quick(val):
-                val["done"] = True
+        def quick(val):
+            val.value = True
 
-            run_with_timeout(quick, args=(d,), timeout=2)
-            self.assertTrue(d.get("done"))
+        run_with_timeout(quick, args=(flag,), timeout=2)
+        self.assertTrue(flag.value)
 
     @patch("app.utils.scheduling.is_system_online", return_value=True)
     def test_run_terminated_on_timeout(self, _online):
-        with multiprocessing.Manager() as manager:
-            d = manager.dict()
+        flag = multiprocessing.Value("b", False)
 
-            def slow(val):
-                time.sleep(1)
-                val["done"] = True
+        def slow(val):
+            time.sleep(1)
+            val.value = True
 
-            run_with_timeout(slow, args=(d,), timeout=0.2)
-            self.assertIsNone(d.get("done"))
+        run_with_timeout(slow, args=(flag,), timeout=0.2)
+        self.assertFalse(flag.value)
 
     @patch("app.utils.scheduling.psutil.cpu_percent", return_value=10)
     @patch("app.utils.scheduling.is_system_online", return_value=True)


### PR DESCRIPTION
## Summary
- avoid nested lock calls in scheduling by moving register_job_failure
- use `multiprocessing.Value` in tests to bypass `pytest-socket`

## Testing
- `pre-commit run --all-files`
- `pytest -k scheduling -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cb4731e0833394950644bf92357a