### PR TITLE
Improve test speed

### DIFF
--- a/tests/test_capture_danger_mode.py
+++ b/tests/test_capture_danger_mode.py
@@ -42,8 +42,10 @@ class TestDangerModeCapture(unittest.TestCase):
     @patch("app.utils.screenshots.webdriver.Chrome")
     @patch("app.utils.screenshots.check_user_activity", return_value=False)
     @patch("app.utils.screenshots.is_chrome_debug_port_open", return_value=True)
+    @patch("app.utils.screenshots.time.sleep", return_value=None)
     def test_success(
         self,
+        _sleep,
         mock_port,
         mock_user_idle,
         mock_webdriver,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -344,8 +344,9 @@ class TestRoutes(unittest.TestCase):
 
     @patch("app.routes.SessionLocal")
     @patch("app.routes.session", {"user_id": 1})
+    @patch("app.routes.camera_discovery.autodetect_onvif_endpoints", return_value={})
     @patch("app.routes.template_manager.save_template")
-    def test_save_template(self, mock_save_template, mock_session_local):
+    def test_save_template(self, mock_save_template, _auto, mock_session_local):
         dummy_user = SimpleNamespace(id=1)
 
         class DummyQuery:


### PR DESCRIPTION
## Summary
- patch webdriver screenshot tests to skip sleep
- avoid autodetect in template route tests

## Testing
- `pytest tests/test_capture_danger_mode.py::TestDangerModeCapture::test_success tests/test_routes.py::TestRoutes::test_save_template -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cb4731e0833394950644bf92357a