### PR TITLE
Speed up screenshot capture tests

### DIFF
--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -15,8 +15,12 @@ class TestScreenshotCapture(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.output_path = os.path.join(self.temp_dir, "test_screenshot.png")
+        # Speed up tests by skipping sleeps in the screenshot helper
+        self.sleep_patch = patch("app.utils.screenshots.time.sleep", return_value=None)
+        self.sleep_patch.start()
 
     def tearDown(self):
+        self.sleep_patch.stop()
         if os.path.exists(self.output_path):
             os.remove(self.output_path)
         orig = self.output_path + ".orig.png"


### PR DESCRIPTION
## Summary
- patch `time.sleep` in `TestScreenshotCapture` to skip real waits

## Testing
- `pre-commit run --all-files`
- `pytest tests/test_screenshot_capture.py::TestScreenshotCapture -vv -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d49d3018833396ccf6bd6d5cdc8b