### PR TITLE
fix: prevent scheduler deadlock

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -152,7 +152,9 @@ clip_processor, clip_session = None, None
 
 # Track currently running jobs to avoid launching duplicates.
 active_jobs: dict[str, multiprocessing.Process] = {}
-active_jobs_lock = threading.Lock()
+# Use an RLock to prevent deadlocks when register_job_failure is invoked
+# while the lock is already held in run_with_timeout.
+active_jobs_lock = threading.RLock()
 # Track failures and backoff time to slow down flapping jobs.
 job_failures: dict[str, int] = {}
 job_backoff_until: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- avoid deadlock by switching scheduler lock to `RLock`

## Testing
- `pre-commit run --all-files`
- `pytest -ra` *(463 passed, 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6859d032b6a08333bf58dd203b09fe91