### PR TITLE
Fix mkdocs link warning

### DIFF
--- a/docs/pylint_checks.md
+++ b/docs/pylint_checks.md
@@ -1,6 +1,6 @@
 # Pylint Checks
 
-The workflow `.github/workflows/pylint.yml` runs Pylint on each push. It sets up a matrix of Python versions `3.8` through `3.13`. For every version it:
+The workflow [`pylint.yml`](https://github.com/KristopherKubicki/glimpser/blob/main/.github/workflows/pylint.yml) runs Pylint on each push. It sets up a matrix of Python versions `3.8` through `3.13`. For every version it:
 
 1. Checks out the repository.
 2. Installs Pylint using `pip`.


### PR DESCRIPTION
## Summary
- fix link to workflow in `pylint_checks` docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `mkdocs build --strict --site-dir site`

------
https://chatgpt.com/codex/tasks/task_e_6859d72b2a748333a436e4c9f884fe68