### PR TITLE
Speed up PyInstaller builds

### DIFF
--- a/build_macos.py
+++ b/build_macos.py
@@ -25,6 +25,7 @@ ARGS = [
     "--hidden-import=yt_dlp",
     "--hidden-import=pdf2image",
     "--hidden-import=pyvirtualdisplay",
+    "--exclude-module=onnxruntime",  # Skip optional onnxruntime to speed up build
     "--icon=app/static/favicon.ico",
 ]
 

--- a/build_windows.py
+++ b/build_windows.py
@@ -25,6 +25,7 @@ ARGS = [
     "--hidden-import=yt_dlp",  # Include hidden import yt_dlp
     "--hidden-import=pdf2image",  # Include hidden import pdf2image
     "--hidden-import=pyvirtualdisplay",  # Include hidden import pyvirtualdisplay
+    "--exclude-module=onnxruntime",  # Skip optional onnxruntime to speed up build
     "--exclude-module=urllib3.contrib.emscripten",  # Skip optional module
     "--exclude-module=curl_cffi",  # Skip optional module
     "--icon=app/static/favicon.ico",  # Path to the icon file

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -8,6 +8,7 @@ The process is split across multiple runners:
   speeding up repeated builds.
 - **Windows** builds the standalone executable using `build_windows.py`.
 - The build sets `GLIMPSER_SKIP_DB_INIT=1` to prevent database access during analysis.
+- It also skips the optional `onnxruntime` package to avoid lengthy dependency scanning.
 - **macOS** builds a self-contained application with `build_macos.py`.
 
 The Ubuntu job also generates a small `release-badges.md` file that lists

--- a/tests/test_build_scripts.py
+++ b/tests/test_build_scripts.py
@@ -14,6 +14,7 @@ class TestBuildMacOS(TestCase):
         mock_run.assert_called_once()
         args = mock_run.call_args.args[0]
         self.assertIn("--name=Glimpser", args)
+        self.assertIn("--exclude-module=onnxruntime", args)
 
 
 class TestBuildWindows(TestCase):
@@ -23,6 +24,7 @@ class TestBuildWindows(TestCase):
         mock_run.assert_called_once()
         args = mock_run.call_args.args[0]
         self.assertIn("--name=Glimpser", args)
+        self.assertIn("--exclude-module=onnxruntime", args)
 
 
 def test_build_packages_missing_deps(tmp_path):


### PR DESCRIPTION
## Summary
- skip optional `onnxruntime` dependency in build scripts
- mention the optimization in the release documentation
- test that build scripts include the new flag

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d7d2779c8333a8be94a5616a84d3