### PR TITLE
Fix Chrome install step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome
-RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg 
+RUN wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing-keyring.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list 
     && apt-get update && apt-get install -y google-chrome-stable 
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- escape newline in Dockerfile to avoid parse errors

## Testing
- `pre-commit run --files Dockerfile`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859d7e88d0c8333aa83ce971945a734