### PR TITLE
Improve Debian package build

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -21,6 +21,14 @@ fi
 
 # Build Debian package
 echo "Building Debian package..."
+# Read version from pyproject so the package version matches the Python
+# distribution. tomllib is available from Python 3.11.
+VERSION=$(python3 - <<'EOF'
+import tomllib, pathlib
+data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+print(data["project"]["version"])
+EOF
+)
 mkdir -p debian/glimpser/opt/glimpser || { echo "Failed to create directory"; exit 1; }
 rsync -a app/ debian/glimpser/opt/glimpser/app/ || { echo "Failed to sync app directory"; exit 1; }
 rsync -a data/ debian/glimpser/opt/glimpser/data/ || { echo "Failed to sync data directory"; exit 1; }
@@ -44,7 +52,7 @@ EOL
 mkdir -p debian/glimpser/DEBIAN || { echo "Failed to create DEBIAN directory"; exit 1; }
 cat > debian/glimpser/DEBIAN/control <<EOF
 Package: glimpser
-Version: 1.0.0
+Version: ${VERSION}
 Section: utils
 Priority: optional
 Architecture: all
@@ -60,7 +68,7 @@ if [ -f debian/postinst ]; then
     chmod 755 debian/glimpser/DEBIAN/postinst
 fi
 
-dpkg-deb --build debian/glimpser
+dpkg-deb --build --root-owner-group debian/glimpser
 
 echo "Debian package built successfully."
 

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -5,7 +5,8 @@ The process is split across multiple runners:
 
 - **Ubuntu** builds the Debian package and runs the test suite. The packaging
   script now uses `rsync` to copy directories so unchanged files are skipped,
-  speeding up repeated builds.
+  speeding up repeated builds. It also reads the version from `pyproject.toml`
+  to populate the Debian control file so releases stay in sync.
 - **Windows** builds the standalone executable using `build_windows.py`.
 - The build sets `GLIMPSER_SKIP_DB_INIT=1` to prevent database access during analysis.
 - **macOS** builds a self-contained application with `build_macos.py`.


### PR DESCRIPTION
## Summary
- use `pyproject.toml` version in build script
- note new behaviour in release workflow docs

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d9b9fc088333b1fcf56941eeb982