### PR TITLE
Update Windows build to include ONNX binaries

### DIFF
--- a/build_windows.py
+++ b/build_windows.py
@@ -25,6 +25,7 @@ ARGS = [
     "--hidden-import=yt_dlp",  # Include hidden import yt_dlp
     "--hidden-import=pdf2image",  # Include hidden import pdf2image
     "--hidden-import=pyvirtualdisplay",  # Include hidden import pyvirtualdisplay
+    "--collect-binaries=onnxruntime",  # Bundle ONNX Runtime DLLs
     "--exclude-module=urllib3.contrib.emscripten",  # Skip optional module
     "--exclude-module=curl_cffi",  # Skip optional module
     "--icon=app/static/favicon.ico",  # Path to the icon file

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -7,6 +7,8 @@ The process is split across multiple runners:
   script now uses `rsync` to copy directories so unchanged files are skipped,
   speeding up repeated builds.
 - **Windows** builds the standalone executable using `build_windows.py`.
+  The script bundles ONNX Runtime binaries with `--collect-binaries=onnxruntime`
+  so CUDA libraries are included when available.
 - The build sets `GLIMPSER_SKIP_DB_INIT=1` to prevent database access during analysis.
 - **macOS** builds a self-contained application with `build_macos.py`.
 

--- a/tests/test_build_scripts.py
+++ b/tests/test_build_scripts.py
@@ -23,6 +23,7 @@ class TestBuildWindows(TestCase):
         mock_run.assert_called_once()
         args = mock_run.call_args.args[0]
         self.assertIn("--name=Glimpser", args)
+        self.assertIn("--collect-binaries=onnxruntime", args)
 
 
 def test_build_packages_missing_deps(tmp_path):


### PR DESCRIPTION
## Summary
- bundle ONNX Runtime binaries when building the Windows executable
- verify new PyInstaller argument in tests
- note the change in release workflow docs

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859da419d5883339743526b4cbf2938