### PR TITLE
Update scheduler test

### DIFF
--- a/tests/test_scheduler_simple_job.py
+++ b/tests/test_scheduler_simple_job.py
@@ -25,6 +25,7 @@ def test_scheduler_executes_job(tmp_path):
         patch("app.start_log_caching"),
         patch("app.email_alert"),
         patch("app.sms_alert"),
+        patch("time.sleep", return_value=None),
     ):
         create_app(enable_watchdog=False, schedule=True)
         # Shut down any jobs created during app initialization. Using wait=True
@@ -39,10 +40,10 @@ def test_scheduler_executes_job(tmp_path):
             func=create_flag_file,
             args=(flag_file,),
             trigger="date",
-            run_date=datetime.now() + timedelta(milliseconds=100),
+            run_date=datetime.now(),
             id="test_job",
         )
-        for _ in range(50):
+        for _ in range(10):
             if flag_file.exists():
                 break
             time.sleep(0.02)


### PR DESCRIPTION
## Summary
- patch `time.sleep` in scheduler test to speed up
- limit scheduler polling loop to 10 iterations

## Testing
- `flake8`
- `pre-commit run --all-files`
- `pytest tests/test_scheduler_simple_job.py::test_scheduler_executes_job -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dc0779d483339f2a7150499f772d