### PR TITLE
Add GPU-enabled FFmpeg build support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 # config.py
 
 import argparse
+import importlib.util
 import json
 import logging
 import os
@@ -13,6 +14,13 @@ from ipaddress import ip_network
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
+
+_ffmpeg_spec = importlib.util.spec_from_file_location(
+    "app.utils.ffmpeg_setup",
+    Path(__file__).resolve().parent / "utils" / "ffmpeg_setup.py",
+)
+ffmpeg_setup = importlib.util.module_from_spec(_ffmpeg_spec)
+_ffmpeg_spec.loader.exec_module(ffmpeg_setup)
 
 _SKIP_DB_INIT = os.getenv("GLIMPSER_SKIP_DB_INIT") == "1"
 
@@ -342,7 +350,8 @@ LLM_CAPTION_PROMPT = get_setting(
 )
 
 # FFMPEG/FFPROBE path settings
-FFMPEG_PATH = get_setting("FFMPEG_PATH", "ffmpeg")
+_ffmpeg_default = ffmpeg_setup.get_ffmpeg_path() or "ffmpeg"
+FFMPEG_PATH = get_setting("FFMPEG_PATH", _ffmpeg_default)
 FFPROBE_PATH = get_setting("FFPROBE_PATH", "ffprobe")
 
 

--- a/app/utils/ffmpeg_setup.py
+++ b/app/utils/ffmpeg_setup.py
@@ -1,0 +1,43 @@
+"""Utilities for building and validating an FFmpeg binary."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+
+def get_ffmpeg_path() -> str | None:
+    """Return the path to a GPU-enabled FFmpeg build.
+
+    If ``bin/ffmpeg`` does not exist, this function attempts to build it by
+    running ``scripts/build_gpu_ffmpeg.sh``. The resulting binary is validated
+    with ``-hwaccels``. When the build or validation fails ``None`` is returned.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    ffmpeg_bin = repo_root / "bin" / "ffmpeg"
+    build_script = repo_root / "scripts" / "build_gpu_ffmpeg.sh"
+
+    if not ffmpeg_bin.exists():
+        if not build_script.exists():
+            logging.error("Missing build script: %s", build_script)
+            return None
+        try:
+            subprocess.check_call(["bash", str(build_script)], timeout=1800)
+        except Exception as exc:  # pragma: no cover - build failures
+            logging.error("FFmpeg build failed: %s", exc)
+            return None
+
+    try:
+        subprocess.check_call(
+            [str(ffmpeg_bin), "-hwaccels"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except Exception as exc:
+        logging.error("FFmpeg validation failed: %s", exc)
+        return None
+
+    return str(ffmpeg_bin)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,16 @@ FFmpeg is used for video processing in Glimpser:
 sudo apt-get install -y ffmpeg
 ```
 
+For hardware-accelerated playback and encoding you may optionally build a custom
+version with GPU support:
+
+```sh
+./scripts/build_gpu_ffmpeg.sh
+```
+
+This requires development tools and matching NVIDIA or VA-API drivers
+installed on your system.
+
 ### 5. Install Python Dependencies
 
 Install the required Python packages:

--- a/main.py
+++ b/main.py
@@ -154,6 +154,11 @@ def create_application(args=None):
         setup_config()
         setup_logging()
 
+    # Ensure a GPU-enabled FFmpeg build exists before it's used
+    from app.utils import ffmpeg_setup
+
+    ffmpeg_setup.get_ffmpeg_path()
+
     if config.ENFORCE_DOMAIN_IN_HOST and "." not in config.HOST:
         raise ValueError(
             "HOST must include a domain when ENFORCE_DOMAIN_IN_HOST is enabled"

--- a/scripts/build_gpu_ffmpeg.sh
+++ b/scripts/build_gpu_ffmpeg.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/ffmpeg"
+BIN_DIR="$ROOT_DIR/bin"
+
+FFMPEG_VERSION="6.1"
+
+mkdir -p "$BUILD_DIR" "$BIN_DIR"
+cd "$BUILD_DIR"
+
+if [ ! -d "ffmpeg-$FFMPEG_VERSION" ]; then
+  curl -L -o ffmpeg.tar.gz "https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.gz"
+  tar xf ffmpeg.tar.gz
+fi
+cd "ffmpeg-$FFMPEG_VERSION"
+
+./configure \
+  --prefix="$BUILD_DIR/install" \
+  --enable-gpl --enable-nonfree \
+  --enable-nvenc --enable-cuda-nvcc --enable-libnpp \
+  --enable-vaapi --enable-libdrm
+
+make -j"$(nproc)"
+make install
+
+cp "$BUILD_DIR/install/bin/ffmpeg" "$BIN_DIR/ffmpeg"
+cp "$BUILD_DIR/install/bin/ffprobe" "$BIN_DIR/ffprobe"
+

--- a/tests/test_ffmpeg_setup.py
+++ b/tests/test_ffmpeg_setup.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+
+from app.utils import ffmpeg_setup
+
+
+class TestFFmpegSetup(unittest.TestCase):
+    @patch("app.utils.ffmpeg_setup.subprocess.check_call")
+    @patch("app.utils.ffmpeg_setup.Path.exists", return_value=True)
+    def test_existing_binary_validates(self, mock_exists, mock_call):
+        path = ffmpeg_setup.get_ffmpeg_path()
+        self.assertTrue(path.endswith("bin/ffmpeg"))
+        mock_call.assert_called_once()
+
+    @patch(
+        "app.utils.ffmpeg_setup.subprocess.check_call", side_effect=Exception("fail")
+    )
+    @patch("app.utils.ffmpeg_setup.Path.exists", return_value=False)
+    def test_build_failure_returns_none(self, mock_exists, mock_call):
+        res = ffmpeg_setup.get_ffmpeg_path()
+        self.assertIsNone(res)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add build script for a GPU-accelerated FFmpeg
- add helper to compile & validate FFmpeg
- prefer custom FFmpeg binary in configuration
- run setup during initialization
- document optional GPU build
- cover new helper with tests

## Testing
- `pre-commit run --files app/config.py app/utils/ffmpeg_setup.py main.py docs/installation.md tests/test_ffmpeg_setup.py scripts/build_gpu_ffmpeg.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dc59d148833387708ca326425c91