### PR TITLE
chore(test): report slowest tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ check_untyped_defs     = true
 
 # pytest defaults (feel free to tweak)
 [tool.pytest.ini_options]
-addopts = "-ra -q"
+addopts = "-ra -q --durations=10"
 testpaths = ["tests"]
 
 # bandit – basic security scan config


### PR DESCRIPTION
## Summary
- enable pytest timing output

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dc3349748333ae9a0f05dc05423f