### PR TITLE
Use uv across CI workflows

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,7 +2,7 @@ name: Docs Build
 
 on:
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
   pull_request:
 
 jobs:
@@ -12,10 +12,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install mkdocs
+          python-version: "3.x"
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+      - name: Install mkdocs with uv
+        run: uv pip install --system mkdocs
       - name: Build docs
         run: mkdocs build --strict --site-dir site

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,15 +9,22 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
-    - name: Analysing the code with pylint
-      run: |
-        pylint $(git ls-files '*.py') --exit-zero
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+      - name: Install pylint with uv
+        run: uv pip install --system pylint
+      - name: Analysing the code with pylint
+        run: |
+          pylint $(git ls-files '*.py') --exit-zero

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,10 +20,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[dev]"
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+      - name: Install dependencies with uv
+        run: uv pip install --system --editable . --group dev
       - name: Lint with flake8
         run: |
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -38,7 +45,7 @@ jobs:
           ./build_packages.sh
       - name: Build Python distributions
         run: |
-          python -m pip install build
+          uv pip install --system build
           python -m build
       - name: Generate release badges
         run: |
@@ -69,16 +76,22 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        shell: bash
+        run: python -m pip install --upgrade uv
       - name: Install PyInstaller
         shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller
+        run: uv pip install --system pyinstaller
       - name: Install project requirements
         shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
+        run: uv pip install --system .
       - name: Build Windows executable
         run: python build_windows.py
       - name: Upload Windows executable
@@ -99,12 +112,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        run: python -m pip install --upgrade uv
       - name: Install PyInstaller
-        run: python -m pip install --upgrade pip && pip install pyinstaller
+        run: uv pip install --system pyinstaller
       - name: Install project requirements
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
+        run: uv pip install --system .
       - name: Build macOS executable
         run: python build_macos.py
       - name: Upload macOS archive


### PR DESCRIPTION
## Summary
- speed up CI installs by caching uv in docs, pylint and release workflows
- use `uv` to install Python dependencies across these workflows

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea46cba48333bc0c951cfa1cefd4