### PR TITLE
Enable offline e2e testing

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -9,7 +9,17 @@ def _get_test_hosts():
 
 
 def is_system_online(timeout: int = 3) -> bool:
-    """Return ``True`` if a network connection can be opened to any test host."""
+    """Return ``True`` if a network connection can be opened to any test host.
+
+    When the ``NO_NETWORK`` environment variable is set to ``"1"`` the
+    function immediately returns ``False`` without attempting any socket
+    connections. This speeds up tests in offline environments by avoiding
+    lengthy connection timeouts.
+    """
+
+    if os.getenv("NO_NETWORK") == "1":
+        logging.info("offline mode enabled via NO_NETWORK")
+        return False
     for host in _get_test_hosts():
         host = host.strip()
         if not host:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,6 +50,10 @@ python -m coverage run -m pytest
 python -m coverage html
 ```
 
+If your machine lacks internet access you can also set `NO_NETWORK=1` to
+avoid lengthy connection attempts during startup. The test server will skip
+network probes and the scenarios run entirely offline.
+
 ## JavaScript Unit Tests
 
 Front‑end utilities under `app/static/js` are tested with **Jest**. The tests

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -1,5 +1,4 @@
 import os
-import socket
 import sys
 from threading import Thread
 from types import SimpleNamespace
@@ -10,17 +9,8 @@ import requests
 from werkzeug.serving import make_server
 
 
-def _has_network() -> bool:
-    """Check if outbound network access is available."""
-    try:
-        socket.create_connection(("1.1.1.1", 53), timeout=1).close()
-        return True
-    except OSError:
-        return False
-
-
-if os.environ.get("SKIP_E2E") == "1" or not _has_network():
-    pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
+if os.environ.get("SKIP_E2E") == "1":
+    pytest.skip("E2E tests disabled", allow_module_level=True)
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -13,8 +13,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 import pytest
 
-if os.environ.get("NO_NETWORK") == "1" or os.environ.get("SKIP_E2E") == "1":
-    pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
+if os.environ.get("SKIP_E2E") == "1":
+    pytest.skip("E2E tests disabled", allow_module_level=True)
 
 import app
 


### PR DESCRIPTION
## Summary
- allow skipping network probes when `NO_NETWORK=1`
- run e2e tests even if offline
- document `NO_NETWORK` flag for test execution

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodriver')*

------
https://chatgpt.com/codex/tasks/task_e_6859edc1d9fc833387297347ab2eb41f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for disabling network connectivity checks by setting the NO_NETWORK environment variable, allowing the app to operate in offline mode.

- **Documentation**
  - Updated testing documentation to describe the new NO_NETWORK environment variable for running tests offline.

- **Tests**
  - Simplified test skipping logic in end-to-end tests to rely solely on the SKIP_E2E environment variable, removing previous network availability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->