### PR TITLE
Speed up Debian package build

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,6 +20,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- cache Python dependencies in release workflow

## Testing
- `pre-commit run --files .github/workflows/release-packages.yml`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859eea07d2c8333a4307ca644b6d05c