### PR TITLE
Use uv lock in CI

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,6 +22,8 @@ jobs:
             ${{ runner.os }}-uv-
       - name: Install uv
         run: python -m pip install --upgrade uv
+      - name: Sync dependencies from uv.lock
+        run: uv pip install --system -r uv.lock
       - name: Install mkdocs with uv
         run: uv pip install --system mkdocs
       - name: Build docs

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade uv
       - name: Sync dependencies from uv.lock
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install mkdocs with uv
         run: uv pip install --system mkdocs
       - name: Build docs

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,6 +23,8 @@ jobs:
             ${{ runner.os }}-uv-
       - name: Install uv
         run: python -m pip install --upgrade uv
+      - name: Sync dependencies from uv.lock
+        run: uv pip install --system -r uv.lock
       - name: Install pylint with uv
         run: uv pip install --system pylint
       - name: Analysing the code with pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade uv
       - name: Sync dependencies from uv.lock
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install pylint with uv
         run: uv pip install --system pylint
       - name: Analysing the code with pylint

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m pip install --upgrade uv
       # Use locked versions for reproducible builds
       - name: Sync dependencies from uv.lock
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install project with uv
         run: uv pip install --system --editable . --group dev
       - name: Set up Node.js

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,9 +36,11 @@ jobs:
             ${{ runner.os }}-uv-
       - name: Install uv
         run: python -m pip install --upgrade uv
-      - name: Install dependencies with uv
-        run: |
-          uv pip install --system --editable . --group dev
+      # Use locked versions for reproducible builds
+      - name: Sync dependencies from uv.lock
+        run: uv pip install --system -r uv.lock
+      - name: Install project with uv
+        run: uv pip install --system --editable . --group dev
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -29,6 +29,8 @@ jobs:
             ${{ runner.os }}-uv-
       - name: Install uv
         run: python -m pip install --upgrade uv
+      - name: Sync dependencies from uv.lock
+        run: uv pip install --system -r uv.lock
       - name: Install dependencies with uv
         run: uv pip install --system --editable . --group dev
       - name: Lint with flake8
@@ -86,6 +88,9 @@ jobs:
       - name: Install uv
         shell: bash
         run: python -m pip install --upgrade uv
+      - name: Sync dependencies from uv.lock
+        shell: bash
+        run: uv pip install --system -r uv.lock
       - name: Install PyInstaller
         shell: bash
         run: uv pip install --system pyinstaller
@@ -121,6 +126,8 @@ jobs:
             ${{ runner.os }}-uv-
       - name: Install uv
         run: python -m pip install --upgrade uv
+      - name: Sync dependencies from uv.lock
+        run: uv pip install --system -r uv.lock
       - name: Install PyInstaller
         run: uv pip install --system pyinstaller
       - name: Install project requirements

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade uv
       - name: Sync dependencies from uv.lock
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install dependencies with uv
         run: uv pip install --system --editable . --group dev
       - name: Lint with flake8
@@ -90,7 +90,7 @@ jobs:
         run: python -m pip install --upgrade uv
       - name: Sync dependencies from uv.lock
         shell: bash
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install PyInstaller
         shell: bash
         run: uv pip install --system pyinstaller
@@ -127,7 +127,7 @@ jobs:
       - name: Install uv
         run: python -m pip install --upgrade uv
       - name: Sync dependencies from uv.lock
-        run: uv pip install --system -r uv.lock
+        run: uv pip sync --system uv.lock
       - name: Install PyInstaller
         run: uv pip install --system pyinstaller
       - name: Install project requirements

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -13,6 +13,7 @@ following tasks:
 - Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
 - Scans dependencies using `npm audit`.
 - Caches Python and Node dependencies to speed up builds.
+- Installs Python dependencies from `uv.lock` with `uv` for reproducible environments.
 
 Running `pre-commit run --all-files` locally will execute the same Black,
 isort, Flake8, and mypy checks before they fail in CI. These checks help catch

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -13,7 +13,7 @@ following tasks:
 - Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
 - Scans dependencies using `npm audit`.
 - Caches Python and Node dependencies to speed up builds.
-- Installs Python dependencies from `uv.lock` with `uv` for reproducible environments.
+- Installs Python dependencies from `uv.lock` using `uv pip sync` for reproducible environments.
 
 Running `pre-commit run --all-files` locally will execute the same Black,
 isort, Flake8, and mypy checks before they fail in CI. These checks help catch

--- a/tests/test_scheduler_simple_job.py
+++ b/tests/test_scheduler_simple_job.py
@@ -43,7 +43,8 @@ def test_scheduler_executes_job(tmp_path):
             run_date=datetime.now(),
             id="test_job",
         )
-        for _ in range(10):
+        # CI runners may take longer to execute the scheduled job, so wait a bit more
+        for _ in range(25):
             if flag_file.exists():
                 break
             time.sleep(0.02)


### PR DESCRIPTION
## Summary
- sync dependencies from `uv.lock` in CI workflows
- document uv install step in docs
- increase wait in scheduler test for slower runners

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f6720ac08333bbbbd5e22e828203