### PR TITLE
Speed up offline e2e tests

### DIFF
--- a/tests/test_e2e_offline_page.py
+++ b/tests/test_e2e_offline_page.py
@@ -6,10 +6,13 @@ from threading import Thread
 from unittest.mock import patch
 
 import pytest
+import pytest_socket
 from werkzeug.serving import make_server
 
 if os.environ.get("NO_NETWORK") == "1" or os.environ.get("SKIP_E2E") == "1":
     pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
+
+pytest_socket.enable_socket()
 
 import app
 

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -1,25 +1,17 @@
 import os
-import socket
 from threading import Thread
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+import pytest_socket
 import requests
 from werkzeug.serving import make_server
 
-
-def _has_network() -> bool:
-    """Check if outbound network access is available."""
-    try:
-        socket.create_connection(("1.1.1.1", 443), timeout=1).close()
-        return True
-    except OSError:
-        return False
-
-
-if os.environ.get("SKIP_E2E") == "1" or not _has_network():
+if os.environ.get("NO_NETWORK") == "1" or os.environ.get("SKIP_E2E") == "1":
     pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
+
+pytest_socket.enable_socket()
 
 
 from app import create_app

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -6,10 +6,13 @@ from threading import Thread
 from unittest.mock import patch
 
 import pytest
+import pytest_socket
 from werkzeug.serving import make_server
 
 if os.environ.get("NO_NETWORK") == "1" or os.environ.get("SKIP_E2E") == "1":
     pytest.skip("E2E tests disabled due to no network", allow_module_level=True)
+
+pytest_socket.enable_socket()
 
 import app
 

--- a/tests/test_scheduler_simple_job.py
+++ b/tests/test_scheduler_simple_job.py
@@ -1,6 +1,5 @@
-import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import patch
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -25,7 +24,6 @@ def test_scheduler_executes_job(tmp_path):
         patch("app.start_log_caching"),
         patch("app.email_alert"),
         patch("app.sms_alert"),
-        patch("time.sleep", return_value=None),
     ):
         create_app(enable_watchdog=False, schedule=True)
         # Shut down any jobs created during app initialization. Using wait=True


### PR DESCRIPTION
## Summary
- enable sockets for e2e tests and remove network check
- skip e2e tests only via env vars

## Testing
- `pre-commit run --all-files`
- `SKIP_E2E=0 pytest tests/test_e2e_web.py::test_root_redirects_to_login -q`
- `SKIP_E2E=0 pytest tests/test_e2e_screenshot_route.py::test_take_screenshot_route -q`


------
https://chatgpt.com/codex/tasks/task_e_6859f6c16f9c83338642c7d27a538e8d