### PR TITLE
Improve CI caching

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: ["main", "staging"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -43,15 +47,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Cache npm
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
         # Jest and Prettier are devDependencies installed here
       - name: Run pre-commit
         run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- speed up JS dependency install using `setup-node` cache
- ensure redundant runs are cancelled automatically

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q` *(fails to access network for some tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a113973fc8333a244341354d14e87