### PR TITLE
Enable parallel pytest runs

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -54,7 +54,7 @@ The project uses `pytest` for testing and lints Python with `ruff` and `flake8`.
 ```sh
 ruff check --exit-zero .
 flake8
-pytest
+pytest  # runs in parallel via pytest-xdist
 ```
 
 Running the full test suite helps ensure that your changes do not introduce regressions.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@
 Glimpser includes a comprehensive suite of unit tests. Run them with coverage to ensure your changes do not introduce regressions:
 
 ```sh
-python -m coverage run -m pytest
+python -m coverage run -m pytest  # parallel via xdist
 python -m coverage html
 ```
 
@@ -60,7 +60,7 @@ Running the full suite with coverage, including the end-to-end tests, looks
 like:
 
 ```sh
-python -m coverage run -m pytest
+python -m coverage run -m pytest  # parallel via xdist
 python -m coverage html
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ check_untyped_defs     = true
 
 # pytest defaults (feel free to tweak)
 [tool.pytest.ini_options]
-addopts = "-ra -q --durations=10"
+addopts = "-ra -q --durations=10 -n auto"
 testpaths = ["tests"]
 
 # bandit – basic security scan config

--- a/tests/test_chrome_debug_port.py
+++ b/tests/test_chrome_debug_port.py
@@ -2,11 +2,14 @@ import os
 import socket
 import unittest
 
+import pytest_socket
+
 from app.utils.screenshots import is_chrome_debug_port_open
 
 
 class TestChromeDebugPort(unittest.TestCase):
     def test_detect_open_and_closed_port(self):
+        pytest_socket.enable_socket()
         server = socket.socket()
         server.bind(("127.0.0.1", 0))
         port = server.getsockname()[1]
@@ -15,6 +18,7 @@ class TestChromeDebugPort(unittest.TestCase):
             self.assertTrue(is_chrome_debug_port_open("127.0.0.1", port, timeout=1))
         finally:
             server.close()
+            pytest_socket.disable_socket()
         self.assertFalse(is_chrome_debug_port_open("127.0.0.1", port, timeout=1))
 
 

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -29,9 +29,31 @@ class TestRunWithTimeout(unittest.TestCase):
     def setUp(self):
         scheduling.active_jobs.clear()
 
+    @patch("app.utils.scheduling.multiprocessing.Process")
     @patch("app.utils.scheduling.is_system_online", return_value=True)
-    def test_run_completes_before_timeout(self, _online):
+    def test_run_completes_before_timeout(self, _online, mock_proc):
         flag = multiprocessing.Value("b", False)
+
+        class DummyProc:
+            def __init__(self, target=None, args=None, **_):
+                self.target = target
+                self.args = args or ()
+                self.exitcode = 0
+
+            def start(self):
+                if self.target:
+                    self.target(*self.args)
+
+            def join(self, timeout=None):
+                pass
+
+            def is_alive(self):
+                return False
+
+            def terminate(self):
+                pass
+
+        mock_proc.side_effect = DummyProc
 
         def quick(val):
             val.value = True

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -11,9 +12,9 @@ from app.routes import init_routes
 
 class TestStreamPngRoute(unittest.TestCase):
     def setUp(self):
-        self.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        self.sshot_dir = "test_stream_png"
-        os.makedirs(os.path.join(self.repo_root, self.sshot_dir, "cam1"), exist_ok=True)
+        self.repo_root = tempfile.mkdtemp(prefix="stream_png_")
+        self.sshot_dir = os.path.join(self.repo_root, "screenshots")
+        os.makedirs(os.path.join(self.sshot_dir, "cam1"), exist_ok=True)
         self.login_patch = patch("app.routes.login_required", lambda x: x)
         self.sc_patch = patch("app.routes.SCREENSHOT_DIRECTORY", self.sshot_dir)
         self.tpl_patch = patch("app.routes.template_manager.get_templates")
@@ -28,7 +29,7 @@ class TestStreamPngRoute(unittest.TestCase):
         self.login_patch.stop()
         self.sc_patch.stop()
         self.tpl_patch.stop()
-        shutil.rmtree(os.path.join(self.repo_root, self.sshot_dir), ignore_errors=True)
+        shutil.rmtree(self.repo_root, ignore_errors=True)
 
     def test_empty_directory_returns_404(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
@@ -37,14 +38,14 @@ class TestStreamPngRoute(unittest.TestCase):
 
     def test_returns_latest_image(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
-        img_path = os.path.join(self.repo_root, self.sshot_dir, "cam1", "cam1_1.png")
+        img_path = os.path.join(self.sshot_dir, "cam1", "cam1_1.png")
         Image.new("RGB", (1, 1)).save(img_path)
         resp = self.client.get("/stream.png")
         self.assertEqual(resp.status_code, 200)
 
     def test_ignores_missing_files(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
-        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        img_dir = os.path.join(self.sshot_dir, "cam1")
         valid = os.path.join(img_dir, "cam1_valid.png")
         missing = os.path.join(img_dir, "cam1_missing.png")
         Image.new("RGB", (1, 1)).save(valid)
@@ -71,12 +72,12 @@ class TestStreamPngRoute(unittest.TestCase):
             "cam1": {"name": "cam1", "groups": "g1"},
             "cam2": {"name": "cam2", "groups": "g2"},
         }
-        img_dir1 = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        img_dir1 = os.path.join(self.sshot_dir, "cam1")
         img1 = os.path.join(img_dir1, "shot.png")
         Image.new("RGB", (1, 1)).save(img1)
         os.symlink(img1, os.path.join(img_dir1, "latest_camera.png"))
 
-        img_dir2 = os.path.join(self.repo_root, self.sshot_dir, "cam2")
+        img_dir2 = os.path.join(self.sshot_dir, "cam2")
         os.makedirs(img_dir2, exist_ok=True)
         img2 = os.path.join(img_dir2, "shot.png")
         Image.new("RGB", (1, 1)).save(img2)
@@ -88,13 +89,11 @@ class TestStreamPngRoute(unittest.TestCase):
 
     def test_group_parameter(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1", "groups": "g1"}}
-        img_dir1 = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        img_dir1 = os.path.join(self.sshot_dir, "cam1")
         img1 = os.path.join(img_dir1, "shot.png")
         Image.new("RGB", (1, 1)).save(img1)
         os.symlink(img1, os.path.join(img_dir1, "latest_camera.png"))
-        group_link = os.path.join(
-            self.repo_root, self.sshot_dir, "g1_latest_camera.png"
-        )
+        group_link = os.path.join(self.sshot_dir, "g1_latest_camera.png")
         os.symlink(img1, group_link)
 
         resp = self.client.get("/stream.png?group=g1")
@@ -103,7 +102,7 @@ class TestStreamPngRoute(unittest.TestCase):
 
     def test_skips_invalid_png(self):
         self.mock_tpl.return_value = {"cam1": {"name": "cam1"}}
-        img_dir = os.path.join(self.repo_root, self.sshot_dir, "cam1")
+        img_dir = os.path.join(self.sshot_dir, "cam1")
         invalid = os.path.join(img_dir, "cam1_bad.png")
         with open(invalid, "wb") as fh:
             fh.write(b"not an image")


### PR DESCRIPTION
## Summary
- run pytest in parallel using pytest-xdist
- document parallel test runs in developer guide and testing docs
- allow network during chrome debug port test
- isolate screenshot route tests using temp directories
- avoid multiprocessing issues by mocking in scheduling tests

## Testing
- `pre-commit run --files tests/test_scheduling_more.py tests/test_stream_png_route.py tests/test_chrome_debug_port.py docs/developer_guide.md docs/testing.md pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a114ef94483338b1e2bcdbe88ff77