### PR TITLE
Add docs navigation hook

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -24,5 +24,7 @@ jobs:
         run: python -m pip install --upgrade uv
       - name: Install mkdocs with uv
         run: uv pip install --system mkdocs
+      - name: Check docs navigation
+        run: python scripts/check_docs_nav.py
       - name: Build docs
         run: mkdocs build --strict --site-dir site

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,6 +80,13 @@ repos:
         entry: python scripts/check_exclude_docs.py
         language: system
         pass_filenames: false
+  - repo: local
+    hooks:
+      - id: check-docs-nav
+        name: docs navigation complete
+        entry: python scripts/check_docs_nav.py
+        language: system
+        pass_filenames: false
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- run `scripts/check_docs_nav.py` during pre-commit
- verify docs navigation during documentation build

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: KeyboardInterrupt due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685a13a765688333ba1409454ee6c6ca