### PR TITLE
Add shellcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,14 @@ repos:
 
   - repo: local
     hooks:
+      - id: shellcheck
+        name: shellcheck
+        entry: shellcheck
+        language: system
+        files: '\.sh$'
+
+  - repo: local
+    hooks:
       - id: check-yaml-format
         name: prettier yaml
         entry: npx prettier --check '*.yml'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
   "uv>=0.6",
   "pyinstaller>=6.14.1",
   "pylint>=3.3.7",
+  "shellcheck-py>=0.9",
   "prettier",
   "pytest-socket", # for offline test passing
   "pytest-xdist",


### PR DESCRIPTION
## Summary
- add shellcheck-py to dev extras
- enforce shellcheck on shell scripts via pre-commit

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Executable `shellcheck` not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a139ed458833398520dc670f56867