### PR TITLE
Fix Docker build order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,14 @@ WORKDIR /app
 
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
+
+# Copy package source early for installation
+COPY app scripts ./
+
+# Install Python dependencies once sources are present
 RUN pip install --no-cache-dir . gunicorn
 
-# Copy application code
+# Copy remaining application code
 COPY . .
 
 # Set environment variables


### PR DESCRIPTION
## Summary
- copy package sources before installation

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: network blocked)*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a138a06748333a42a78e283332084