### PR TITLE
Reduce Hypothesis example counts via env var

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,10 +10,15 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
+# Avoid expensive FFmpeg setup during imports
+os.environ.setdefault("FFMPEG_PATH", "ffmpeg")
+
 from app.utils.scheduling import scheduler
 
 # Skip end-to-end tests unless explicitly enabled
 os.environ.setdefault("SKIP_E2E", "1")
+# Limit Hypothesis examples to speed up tests unless overridden
+os.environ.setdefault("HYPOTHESIS_MAX_EXAMPLES", "10")
 
 # Block network access during tests to avoid accidental HTTP requests.
 pytest_socket.disable_socket()

--- a/tests/test_fuzz_update_summary.py
+++ b/tests/test_fuzz_update_summary.py
@@ -14,6 +14,7 @@ import app.utils.db as db
 import app.utils.scheduling as scheduling
 
 LETTERS = string.ascii_letters + string.digits + string.punctuation + " "
+MAX_EXAMPLES = int(os.getenv("HYPOTHESIS_MAX_EXAMPLES", "20"))
 
 
 @st.composite
@@ -80,7 +81,7 @@ summary_strategy = st.one_of(
     ),
     summary=summary_strategy,
 )
-@settings(max_examples=20)
+@settings(max_examples=MAX_EXAMPLES)
 def test_fuzz_update_summary(templates, summary):
     with tempfile.TemporaryDirectory() as tmp:
         db_path = os.path.join(tmp, "test.db")
@@ -114,7 +115,7 @@ def test_fuzz_update_summary(templates, summary):
     ),
     summary=summary_strategy,
 )
-@settings(max_examples=20)
+@settings(max_examples=MAX_EXAMPLES)
 def test_fuzz_update_summary_edge_cases(templates, summary):
     with tempfile.TemporaryDirectory() as tmp:
         db_path = os.path.join(tmp, "test.db")

--- a/tests/test_fuzz_validators.py
+++ b/tests/test_fuzz_validators.py
@@ -1,3 +1,4 @@
+import os
 import string
 
 from hypothesis import given, settings
@@ -10,6 +11,7 @@ from app.utils.validators import (
 )
 
 LETTERS = string.ascii_letters + string.digits + string.punctuation + " \n\r"
+MAX_EXAMPLES = int(os.getenv("HYPOTHESIS_MAX_EXAMPLES", "50"))
 
 
 @given(
@@ -18,7 +20,7 @@ LETTERS = string.ascii_letters + string.digits + string.punctuation + " \n\r"
     ),
     value=st.text(LETTERS, min_size=0, max_size=10),
 )
-@settings(max_examples=50)
+@settings(max_examples=MAX_EXAMPLES)
 def test_fuzz_validate_setting(name: str, value: str) -> None:
     validate_setting(name, value)
 
@@ -58,12 +60,12 @@ def update_data_strategy(draw):
 
 
 @given(data=update_data_strategy())
-@settings(max_examples=20)
+@settings(max_examples=MAX_EXAMPLES)
 def test_fuzz_validate_update_data(data: dict) -> None:
     validate_update_data(data)
 
 
 @given(name=st.text(LETTERS, min_size=0, max_size=40))
-@settings(max_examples=50)
+@settings(max_examples=MAX_EXAMPLES)
 def test_fuzz_validate_template_name(name: str) -> None:
     validate_template_name(name)


### PR DESCRIPTION
## Summary
- allow tests to limit Hypothesis runs via `HYPOTHESIS_MAX_EXAMPLES`
- stub FFmpeg path during tests to skip the build step

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1848ebf483339f763de8b29d1aa3