### PR TITLE
Fix shellcheck warnings in setup-dev script

### DIFF
--- a/.github/scripts/setup-dev.sh
+++ b/.github/scripts/setup-dev.sh
@@ -1,23 +1,28 @@
+#!/usr/bin/env bash
+
 # 1 – Runtime / production
-uv pip install --system alembic==1.16.1 apscheduler==3.11.0 fake-useragent==2.2.0 \
-  flask==3.1.1 flask-apscheduler==1.13.1 flask-login==0.6.3 jinja2==3.1.6 \
-  "numpy>=1.26,<2.0" pdf2image==1.17.0 pillow==11.2.1 "psutil~=7.0.0" \
-  pynput==1.8.1 "python-dateutil>=2.9.0.post0" "python-dotenv>=1.1.0" \
-  pyvirtualdisplay==3.0 pywebpush==2.0.3 selenium==4.33.0 sqlalchemy==2.0.41 \
-  undetected-chromedriver==3.5.5 webdriver-manager==4.0.2 werkzeug==3.1.3 \
-  yt-dlp==2025.5.22 "onnxruntime-gpu~=1.18; sys_platform!='darwin'" \
-  "onnxruntime~=1.18; sys_platform=='darwin'" setproctitle==1.3.3 \
+uv pip install --system \
+  "alembic==1.16.1" "apscheduler==3.11.0" "fake-useragent==2.2.0" \
+  "flask==3.1.1" "flask-apscheduler==1.13.1" "flask-login==0.6.3" "jinja2==3.1.6" \
+  "numpy>=1.26,<2.0" "pdf2image==1.17.0" "pillow==11.2.1" "psutil~=7.0.0" \
+  "pynput==1.8.1" "python-dateutil>=2.9.0.post0" "python-dotenv>=1.1.0" \
+  "pyvirtualdisplay==3.0" "pywebpush==2.0.3" "selenium==4.33.0" "sqlalchemy==2.0.41" \
+  "undetected-chromedriver==3.5.5" "webdriver-manager==4.0.2" "werkzeug==3.1.3" \
+  "yt-dlp==2025.5.22" "onnxruntime-gpu~=1.18; sys_platform!='darwin'" \
+  "onnxruntime~=1.18; sys_platform=='darwin'" "setproctitle==1.3.3" \
   "filelock>=3.12" "PyYAML>=6.0" "uv>=0.6"
 
 # 2 – Dev toolchain
-uv pip install --system "black>=25.1" coverage>=7.9 flake8>=7.2 isort>=6.0 \
-  mkdocs>=1.6 mypy>=1.16 pre-commit>=4.2 "pytest>=8.3,<8.5" "uv>=0.6" \
-  pyinstaller>=6.14.1 pylint>=3.3.7 prettier pytest-socket pytest-xdist ruff>=0.4.4 \
-  pytest-cov>=6.1 hypothesis>=6.135 nox>=2025.2 bandit>=1.7 py-spy>=0.4 \
-  commitizen>=3.12
+uv pip install --system \
+  "black>=25.1" "coverage>=7.9" "flake8>=7.2" "isort>=6.0" \
+  "mkdocs>=1.6" "mypy>=1.16" "pre-commit>=4.2" "pytest>=8.3,<8.5" "uv>=0.6" \
+  "pyinstaller>=6.14.1" "pylint>=3.3.7" prettier pytest-socket pytest-xdist "ruff>=0.4.4" \
+  "pytest-cov>=6.1" "hypothesis>=6.135" "nox>=2025.2" "bandit>=1.7" "py-spy>=0.4" \
+  "commitizen>=3.12"
 
 # 3 – Ancillary “agents”
-uv pip install --system pytest-benchmark interrogate yamllint \
+uv pip install --system \
+  pytest-benchmark interrogate yamllint \
   pre-commit-docker gitlint vulture pytest-socket
 
 npm i -D jest stylelint eslint


### PR DESCRIPTION
## Summary
- add a bash shebang
- quote package specs in `setup-dev.sh`

## Testing
- `pre-commit run --files .github/scripts/setup-dev.sh`
- `pytest -q` *(fails: TestRunWithTimeout::test_run_completes_before_timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685a23975c38833388f300eea95af476