### PR TITLE
Refactor live JS utilities

### DIFF
--- a/app/static/js/camera_utils.js
+++ b/app/static/js/camera_utils.js
@@ -1,0 +1,5 @@
+export function getCameraNames(details) {
+  return Object.keys(details).filter(
+    (key) => key !== "All" && !key.startsWith("group-"),
+  );
+}

--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1,35 +1,15 @@
-import { timeAgo, formatExactTime } from "./templates.js";
 import { attemptAutoLogin } from "./login.js";
+import { safePlay, setClipSrc as setClipSrcVideo } from "./video_utils.js";
+import { getCameraNames as getCameraNamesUtil } from "./camera_utils.js";
+import {
+  updateFrameTimestamp as updateFrameTimestampUtil,
+  setTimestampVisibility as setTimestampVisibilityUtil,
+} from "./timestamp_utils.js";
 
 const video = document.getElementById("live-video");
 
-const CLIP_THROTTLE_MS = 30000;
-let lastClipTime = 0;
-
-function safePlay(el) {
-  const promise = el.play();
-  if (promise && typeof promise.catch === "function") {
-    promise.catch((err) => {
-      // Browsers may reject play() when switching clips or before
-      // the user interacts with the page. Ignore these common cases
-      // so console logs stay readable.
-      if (err.name !== "AbortError" && err.name !== "NotAllowedError") {
-        console.error("Error playing video:", err);
-      }
-    });
-  }
-}
-
 function setClipSrc(cameraName) {
-  const now = Date.now();
-  if (now - lastClipTime >= CLIP_THROTTLE_MS) {
-    video.src = `/clip/${cameraName}`;
-    lastClipTime = now;
-  } else {
-    video.src = `/stream.mp4?camera=${encodeURIComponent(cameraName)}`;
-  }
-  video.load();
-  safePlay(video);
+  setClipSrcVideo(video, cameraName);
 }
 const image = document.getElementById("live-image");
 const templateDetailsContainer = document.getElementById("template-details");
@@ -54,9 +34,7 @@ if (!templateDetails["All"]) {
 }
 
 function getCameraNames() {
-  return Object.keys(templateDetails).filter(
-    (key) => key !== "All" && !key.startsWith("group-"),
-  );
+  return getCameraNamesUtil(templateDetails);
 }
 
 // Allow embedding the live view for a specific camera by reading the
@@ -700,35 +678,11 @@ function playLoop() {
 }
 
 function updateFrameTimestamp() {
-  const container = document.querySelector(".video-container");
-  if (!container) return;
-  const details = templateDetails[currentCamera];
-  if (!details || !details.last_screenshot_time) {
-    container.removeAttribute("data-timestamp");
-    container.removeAttribute("title");
-    return;
-  }
-  container.dataset.originalTimestamp = details.last_screenshot_time;
-  container.setAttribute(
-    "data-timestamp",
-    timeAgo(details.last_screenshot_time),
-  );
-  container.setAttribute(
-    "title",
-    details.last_caption
-      ? `${formatExactTime(details.last_screenshot_time)} - ${details.last_caption}`
-      : formatExactTime(details.last_screenshot_time),
-  );
+  updateFrameTimestampUtil(templateDetails, currentCamera);
 }
 
 function setTimestampVisibility(show) {
-  const container = document.querySelector(".video-container");
-  if (!container) return;
-  if (show) {
-    updateFrameTimestamp();
-  } else {
-    container.removeAttribute("data-timestamp");
-  }
+  setTimestampVisibilityUtil(templateDetails, currentCamera, show);
 }
 
 function refreshPNG() {

--- a/app/static/js/timestamp_utils.js
+++ b/app/static/js/timestamp_utils.js
@@ -1,0 +1,30 @@
+import { timeAgo, formatExactTime } from "./templates.js";
+
+export function updateFrameTimestamp(details, camera) {
+  const container = document.querySelector(".video-container");
+  if (!container) return;
+  const info = details[camera];
+  if (!info || !info.last_screenshot_time) {
+    container.removeAttribute("data-timestamp");
+    container.removeAttribute("title");
+    return;
+  }
+  container.dataset.originalTimestamp = info.last_screenshot_time;
+  container.setAttribute("data-timestamp", timeAgo(info.last_screenshot_time));
+  container.setAttribute(
+    "title",
+    info.last_caption
+      ? `${formatExactTime(info.last_screenshot_time)} - ${info.last_caption}`
+      : formatExactTime(info.last_screenshot_time),
+  );
+}
+
+export function setTimestampVisibility(details, camera, show) {
+  const container = document.querySelector(".video-container");
+  if (!container) return;
+  if (show) {
+    updateFrameTimestamp(details, camera);
+  } else {
+    container.removeAttribute("data-timestamp");
+  }
+}

--- a/app/static/js/video_utils.js
+++ b/app/static/js/video_utils.js
@@ -1,0 +1,25 @@
+export const CLIP_THROTTLE_MS = 30000;
+let lastClipTime = 0;
+
+export function safePlay(el) {
+  const promise = el.play();
+  if (promise && typeof promise.catch === "function") {
+    promise.catch((err) => {
+      if (err.name !== "AbortError" && err.name !== "NotAllowedError") {
+        console.error("Error playing video:", err);
+      }
+    });
+  }
+}
+
+export function setClipSrc(videoEl, cameraName) {
+  const now = Date.now();
+  if (now - lastClipTime >= CLIP_THROTTLE_MS) {
+    videoEl.src = `/clip/${cameraName}`;
+    lastClipTime = now;
+  } else {
+    videoEl.src = `/stream.mp4?camera=${encodeURIComponent(cameraName)}`;
+  }
+  videoEl.load();
+  safePlay(videoEl);
+}

--- a/tests/js/camera_utils.test.js
+++ b/tests/js/camera_utils.test.js
@@ -1,0 +1,13 @@
+import { getCameraNames } from "../../app/static/js/camera_utils.js";
+
+describe("getCameraNames util", () => {
+  test("returns camera names without groups", () => {
+    const details = {
+      cam1: {},
+      cam2: {},
+      "group-test": {},
+      All: {},
+    };
+    expect(getCameraNames(details)).toEqual(["cam1", "cam2"]);
+  });
+});


### PR DESCRIPTION
## Summary
- extract reusable helpers from live.js
- create camera, video, and timestamp utility modules
- add unit test for `getCameraNames`

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a533a27848333a31b3dc8704b129d