### PR TITLE
Add tests for GPU check and redirect helper

### DIFF
--- a/tests/test_clip_gpu_available.py
+++ b/tests/test_clip_gpu_available.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import app.routes as routes
+
+
+class TestClipGpuAvailable(unittest.TestCase):
+    def setUp(self):
+        routes.clip_gpu_available.cache_clear()
+
+    def test_returns_false_when_ort_missing(self):
+        with patch.object(routes, "ort", None):
+            routes.clip_gpu_available.cache_clear()
+            self.assertFalse(routes.clip_gpu_available())
+
+    def test_provider_check_and_cache(self):
+        class MockOrt:
+            def __init__(self, providers):
+                self._providers = providers
+
+            def get_available_providers(self):
+                return self._providers
+
+        with patch.object(routes, "ort", MockOrt(["CUDAExecutionProvider"])):
+            routes.clip_gpu_available.cache_clear()
+            self.assertTrue(routes.clip_gpu_available())
+            # Change providers but expect cached value
+            with patch.object(routes, "ort", MockOrt([])):
+                self.assertTrue(routes.clip_gpu_available())
+            routes.clip_gpu_available.cache_clear()
+            with patch.object(routes, "ort", MockOrt([])):
+                self.assertFalse(routes.clip_gpu_available())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_safe_redirect_url.py
+++ b/tests/test_safe_redirect_url.py
@@ -1,0 +1,20 @@
+import unittest
+
+from app.routes import is_safe_redirect_url
+
+
+class TestIsSafeRedirectUrl(unittest.TestCase):
+    def test_valid_relative_urls(self):
+        self.assertTrue(is_safe_redirect_url("/login"))
+        self.assertTrue(is_safe_redirect_url("settings"))
+
+    def test_invalid_urls(self):
+        self.assertFalse(is_safe_redirect_url("http://example.com"))
+        self.assertFalse(is_safe_redirect_url("https://site/path"))
+        self.assertFalse(is_safe_redirect_url("/evil\n"))
+        self.assertFalse(is_safe_redirect_url(None))
+        self.assertFalse(is_safe_redirect_url("//host"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- cover `clip_gpu_available` caching behavior
- test `is_safe_redirect_url` validation

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a95a71dd8833392183fb88dec347d