### PR TITLE
Fix DB init race condition

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -3,6 +3,7 @@
 import os
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from app.config import DATABASE_PATH
@@ -28,7 +29,14 @@ def init_db():
     # load time.
     import app.models  # noqa: F401
 
-    Base.metadata.create_all(bind=engine)
+    try:
+        Base.metadata.create_all(bind=engine)
+    except OperationalError as exc:
+        # When multiple workers initialize the database concurrently the
+        # CREATE TABLE commands can race. Ignore "already exists" errors so
+        # repeated calls remain idempotent.
+        if "already exists" not in str(exc):
+            raise
 
 
 def ensure_column(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -24,6 +24,7 @@ class TestInitDb(unittest.TestCase):
         importlib.reload(models.user)
         importlib.reload(models.summary)
         importlib.reload(models.log_summary)
+        importlib.reload(models.offline_job)
         self.db = db
 
     def tearDown(self):
@@ -38,6 +39,7 @@ class TestInitDb(unittest.TestCase):
         importlib.reload(models.user)
         importlib.reload(models.summary)
         importlib.reload(models.log_summary)
+        importlib.reload(models.offline_job)
         self.temp_dir.cleanup()
 
     def test_init_db_creates_users_table(self):
@@ -49,6 +51,16 @@ class TestInitDb(unittest.TestCase):
         self.assertIn("users", tables)
         self.assertIn("summaries", tables)
         self.assertIn("log_summaries", tables)
+
+    def test_init_db_is_idempotent(self):
+        """Calling init_db multiple times should not raise errors."""
+        self.db.init_db()
+        self.db.init_db()
+        from sqlalchemy import inspect
+
+        inspector = inspect(self.db.engine)
+        tables = inspector.get_table_names()
+        self.assertIn("offline_jobs", tables)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- guard table creation against race conditions when multiple workers run
- reload offline_job model in DB tests
- add idempotency test for init_db

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -n 4`

------
https://chatgpt.com/codex/tasks/task_e_685aae028f1c8333b8f280bd705a593c