### PR TITLE
Fix Codecov coverage

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -67,8 +67,7 @@ jobs:
         run: mypy .
       - name: Test with coverage
         run: |
-          python -m coverage run -m pytest --color=yes
-          python -m coverage xml
+          pytest --cov=app --cov-report=xml --color=yes
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/tests/test_clip_gpu_available.py
+++ b/tests/test_clip_gpu_available.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import app.routes as routes
 

--- a/tests/test_template_validators.py
+++ b/tests/test_template_validators.py
@@ -41,4 +41,3 @@ def test_validate_object_confidence():
         t.validate_object_confidence("object_confidence", 1.5)
     t_no_filter = Template(object_filter="")
     assert t_no_filter.validate_object_confidence("object_confidence", 1.5) == 1.5
-


### PR DESCRIPTION
## Summary
- use `pytest-cov` in workflow so coverage works with xdist
- fix import ordering for test case
- drop trailing blank line in validator tests

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `pytest --cov=app --cov-report=term -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab183d26c833389e341c8b64b9b96