### PR TITLE
Add node_modules cache

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,8 +50,16 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+      - name: Cache Node modules
+        # Reuse installed packages between runs
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
         # Jest and Prettier are devDependencies installed here
       - name: Run pre-commit
         run: pre-commit run --all-files


### PR DESCRIPTION
## Summary
- cache `node_modules` in Python workflow for faster installs

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685be416d4608333bb72f2465073d23d