### PR TITLE
Improve CI build times

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -6,8 +6,14 @@ name: Python application
 on:
   push:
     branches: ["main", "staging"]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
   pull_request:
     branches: ["main", "staging"]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
 
 permissions:
   contents: read
@@ -53,6 +59,13 @@ jobs:
       - name: Install Node dependencies
         run: npm install
         # Jest and Prettier are devDependencies installed here
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: Run JavaScript tests with coverage

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -12,7 +12,8 @@ following tasks:
 - Executes `pytest` and `jest` test suites and uploads coverage.
 - Coverage reports allow a small drop (up to 0.5%) before the Codecov check fails.
 - Scans dependencies using `npm audit`.
-- Caches Python and Node dependencies to speed up builds.
+- Caches Python, Node, and pre-commit dependencies to speed up builds.
+- Skips the workflow when only documentation files change.
 
 Running `pre-commit run --all-files` locally will execute the same Black,
 isort, Flake8, and mypy checks before they fail in CI. These checks help catch


### PR DESCRIPTION
## Summary
- cache the pre-commit environment
- skip Python CI when only documentation changes
- document new caching and doc-only skip behaviour

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be416d4608333bb72f2465073d23d