### PR TITLE
Fix player on invalid URL test

### DIFF
--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -45,6 +45,8 @@ export function initUrlTester() {
       const defaultSrc = preview
         ? preview.dataset.placeholder || preview.src
         : "";
+      const player = document.getElementById("live-video");
+      const playerSource = player ? player.querySelector("source") : null;
       const defaultUrl = input.dataset.defaultUrl;
       const setStatus = (cls, title = "") => {
         status.textContent = "";
@@ -89,6 +91,16 @@ export function initUrlTester() {
           } else {
             setStatus("bad", title);
             if (preview) preview.src = defaultSrc;
+            if (player) {
+              player.pause();
+              if (playerSource) {
+                playerSource.removeAttribute("src");
+              } else {
+                player.removeAttribute("src");
+              }
+              player.poster = defaultSrc;
+              player.load();
+            }
             if (submit) submit.disabled = true;
           }
           sendTelemetry("url_test", { url, ok: data.ok });
@@ -96,6 +108,16 @@ export function initUrlTester() {
           if (controller.signal.aborted) return;
           setStatus("bad", "Unreachable");
           if (preview) preview.src = defaultSrc;
+          if (player) {
+            player.pause();
+            if (playerSource) {
+              playerSource.removeAttribute("src");
+            } else {
+              player.removeAttribute("src");
+            }
+            player.poster = defaultSrc;
+            player.load();
+          }
           if (submit) submit.disabled = true;
           sendTelemetry("url_test", { url, ok: false });
         }

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -120,6 +120,32 @@ describe("url_test", () => {
     expect(preview.src).toContain("blank.jpg");
   });
 
+  test("stops player on url error", async () => {
+    const html = `
+      <form><input id="url"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><input type="submit"></form>
+      <video id="live-video"><source src="old.mp4"></video>`;
+    document.body.innerHTML = html;
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: false, status: 404 }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.clearAllTimers();
+    const input = document.getElementById("url");
+    const video = document.getElementById("live-video");
+    input.value = "http://bad";
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+    const source = video.querySelector("source");
+    expect(source.hasAttribute("src")).toBe(false);
+    expect(video.paused).toBe(true);
+  });
+
   test("initializes multiple forms", async () => {
     const multiHtml = `
       <div class="edit-template-container">


### PR DESCRIPTION
## Summary
- halt the player when the URL tester fails
- add test to verify video player stops on URL errors

## Testing
- `pre-commit run --all-files` *(fails: Could not find stylelint-config-standard)*
- `pytest -q`
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_685ceb79ec248333b91e71f68730d31c