### PR TITLE
Add staged GitHub flow documentation and branch protection

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,31 @@
+name: Branch Protection Enforcement
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  enforce_protection:
+    name: Enforce Branch Protection
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect staging merge
+        id: staging
+        run: |
+          if git log -1 --pretty=%B | grep -qi "merge.*staging"; then
+            echo "staging_merge=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "staging_merge=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Block direct pushes to main
+        if: steps.staging.outputs.staging_merge == 'false'
+        run: |
+          echo "❌ Direct pushes to main branch are not allowed!"
+          echo "Please create a pull request instead."
+          echo "Use: git checkout -b feature-branch && git push origin feature-branch"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,11 +12,15 @@ We love your input! We want to make contributing to this project as easy and tra
 
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+## We Use a Staged GitHub Flow
+
+All code changes are proposed through pull requests. Feature branches merge into
+`staging`, and the CD pipeline promotes those commits to `main`.
 
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from `main`.
+1. Fork the repo and create your feature branch from `main`.
+   When the change is ready, open a pull request targeting the `staging` branch.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,13 @@ Contributions are always welcome. If you have an idea to improve Glimpser, feel 
    ```
 5. Open a pull request.
 
+### Branching Workflow
+
+All changes start in a feature branch and merge into `staging` first. The `main`
+branch is always deployable and receives commits only from the CD pipeline.
+Direct pushes to `main` are blocked by a branch protection workflow. See
+[Staged GitHub Flow](docs/staged_github_flow.md) for a detailed diagram.
+
 ## Recommendations
 
 For detailed suggestions on how to use Glimpser effectively, please check out our [Recommendations](docs/recommendations.md) guide.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -61,12 +61,13 @@ Running the full test suite helps ensure that your changes do not introduce regr
 
 ## Contribution Workflow
 
-We follow a standard GitHub Flow:
+We follow a staged GitHub Flow:
 
 1. Fork the repository and create a feature branch from `main`.
+   Open a pull request targeting the `staging` branch once the feature is ready.
 2. Make your changes and commit them with clear messages.
 3. Ensure all tests pass and linting succeeds.
-4. Open a pull request describing your changes.
+4. Open a pull request describing your changes and merge it into `staging` after review.
 
 For more details, see [CONTRIBUTING.md](https://github.com/KristopherKubicki/glimpser/blob/main/CONTRIBUTING.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ Glimpser monitors cameras and video streams, applying AI to summarize important 
 - [Pylint Checks](pylint_checks.md)
 - [Dependency Review](dependency_review.md)
 - [Continuous Integration Checks](ci_checks.md)
+- [Staged GitHub Flow](staged_github_flow.md)
 - [CodeQL Security Scanning](codeql.md)
 - [OpenSSF Scorecard](scorecard.md)
 

--- a/docs/staged_github_flow.md
+++ b/docs/staged_github_flow.md
@@ -1,0 +1,27 @@
+# Staged GitHub Flow
+
+Our development workflow promotes changes in three lanes:
+
+feature/topic branches – work in progress with draft pull requests
+staging – the dress‑rehearsal branch
+main – always deployable
+
+```
+                     ┌──────────────────────┐
+feature/topic ──┬──▶ │      STAGING         │ ──┐
+branches        │    └──────────────────────┘   │
+(feature-x) ────┤                                │
+(feature-y) ────┤                                ▼
+(feature-z) ────┘                         ┌──────────────────────┐
+                                          │        MAIN          │──▶ ● v0.3.6
+                                          └──────────────────────┘
+```
+
+Developers can branch off anything and push freely. When a change is ready, retarget the pull request to **staging**. The PR must merge cleanly and pass all CI checks. Our CD pipeline deploys that exact commit to the staging environment. Once smoke tests remain green, the pipeline fast‑forwards the same artefact to **main**.
+
+Direct commits to **main** are blocked to keep history linear and ensure the environment stays deployable. Tags are cut automatically whenever a commit reaches **main**. Hot-fixes follow the same path: branch off `main`, open a PR into `staging`, and let CI/CD promote the commit back to `main`.
+
+The `.github/workflows/branch-protection.yml` workflow enforces this rule by
+rejecting any push to `main` that does not originate from a merge of `staging`.
+
+This unified flow simplifies rollbacks and removes manual steps from production pushes. For edge cases or questions, ping `@DevOps` in Slack.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Caption Prefix Issue: caption_prefix.md
       - Captions Chatbot: chatbot.md
       - Continuous Integration Checks: ci_checks.md
+      - Staged GitHub Flow: staged_github_flow.md
       - Jog-Shuttle Control: jog_shuttle.md
       - Live All Playback: live_all.md
       - Live View Scrubbing: live_scrub.md


### PR DESCRIPTION
## Summary
- outline the new staged GitHub flow
- update contribution docs to target `staging`
- document branching workflow in the README
- include staged flow in `mkdocs.yml` and docs index
- add a workflow to block direct pushes to `main`

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d5324208c83338fed00c719c4edde