### PR TITLE
Fix SQLite commit locking

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,6 +1,7 @@
 """Database utilities for initializing the SQLite engine and schema."""
 
 import os
+import time
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import OperationalError
@@ -53,3 +54,18 @@ def ensure_column(
                     f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type} DEFAULT {default}"
                 )
             )
+
+
+def commit_with_retry(session, attempts: int = 3, delay: float = 0.1) -> None:
+    """Commit a session with retries on SQLite locking errors."""
+
+    for attempt in range(attempts):
+        try:
+            session.commit()
+            return
+        except OperationalError as exc:
+            if "database is locked" in str(exc) and attempt < attempts - 1:
+                session.rollback()
+                time.sleep(delay)
+                continue
+            raise

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -14,6 +14,7 @@ from werkzeug.utils import secure_filename
 
 import app.utils.db as db
 from app.config import SCREENSHOT_DIRECTORY, VIDEO_DIRECTORY
+from app.utils.db import commit_with_retry
 
 from .validators import validate_template_name
 from .video_details import get_latest_screenshot_date, get_latest_video_date
@@ -922,7 +923,7 @@ def update_last_screenshot_time(name: str) -> None:
             )
             template.offline_since = ""
             template.capture_failed = False
-            session.commit()
+            commit_with_retry(session)
     finally:
         session.close()
 


### PR DESCRIPTION
## Summary
- add `commit_with_retry` helper for SQLite writes
- use commit retries in `update_last_screenshot_time`

## Testing
- `pre-commit run --files app/utils/db.py app/utils/template_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d53c1db548333bc0bc97101910375