### PR TITLE
Add status overlay in template preview

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2158,6 +2158,7 @@ details > summary {
 }
 
 .edit-template-preview {
+  position: relative;
   float: right;
   width: 240px;
   height: 180px;
@@ -2170,6 +2171,23 @@ details > summary {
   object-fit: contain;
   border-radius: 4px;
   border: 1px solid var(--accent-color);
+}
+
+.preview-status {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 0.25rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
 }
 
 .thumbnail-preview {

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -13,6 +13,9 @@ export function initUrlTester() {
       const preview = container
         ? container.querySelector("img")
         : document.getElementById("url-preview");
+      const overlay = container
+        ? container.querySelector(".preview-status")
+        : document.querySelector(".preview-status");
       if (!status) return;
 
       const form = input.closest("form");
@@ -54,6 +57,12 @@ export function initUrlTester() {
         status.title = title || "URL test result";
       };
 
+      const showOverlay = (msg) => {
+        if (!overlay) return;
+        overlay.textContent = msg;
+        overlay.style.display = msg ? "flex" : "none";
+      };
+
       const formatTitle = (data) => {
         if (!data.ok) {
           return (
@@ -70,12 +79,14 @@ export function initUrlTester() {
       const check = async () => {
         const url = input.value.trim();
         setStatus("");
+        showOverlay("");
         if (preview) preview.src = url || defaultSrc;
         if (submit) submit.disabled = true;
         if (!url) return;
         controller?.abort();
         controller = new AbortController();
         setStatus("pending", "Testing...");
+        showOverlay("Testing...");
         try {
           const res = await fetch(
             `/templates/test_url?url=${encodeURIComponent(url)}`,
@@ -87,9 +98,11 @@ export function initUrlTester() {
           const title = formatTitle(data);
           if (res.ok && data.ok) {
             setStatus("ok", title);
+            showOverlay("");
             if (submit) submit.disabled = false;
           } else {
             setStatus("bad", title);
+            showOverlay(title);
             if (preview) preview.src = defaultSrc;
             if (player) {
               player.pause();
@@ -107,6 +120,7 @@ export function initUrlTester() {
         } catch {
           if (controller.signal.aborted) return;
           setStatus("bad", "Unreachable");
+          showOverlay("Unreachable");
           if (preview) preview.src = defaultSrc;
           if (player) {
             player.pause();
@@ -139,12 +153,14 @@ export function initUrlTester() {
         toggleDisabled();
         const hasValue = input.value.trim() !== "";
         setStatus(hasValue ? "pending" : "", hasValue ? "Testing..." : "");
+        showOverlay(hasValue ? "Testing..." : "");
         if (submit) submit.disabled = true;
         if (hasValue) checkDebounced();
       });
       input.addEventListener("paste", () => {
         setTimeout(() => {
           setStatus("pending", "Testing...");
+          showOverlay("Testing...");
           checkDebounced();
         }, 0);
       });

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -119,6 +119,7 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
       %}
       alt="Live preview"
     />
+    <div class="preview-status" role="status" aria-live="polite"></div>
   </div>
   {% endif %}
   <form

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 
 const formHtml =
-  '<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><input type="submit"></form>';
+  '<form><input id="url" data-default-url="http://example.com/test"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><div class="preview-status"></div><input type="submit"></form>';
 
 beforeEach(() => {
   document.body.innerHTML = formHtml;
@@ -43,6 +43,8 @@ describe("url_test", () => {
     expect(status.classList.contains("ok")).toBe(true);
     const preview = document.getElementById("url-preview");
     expect(preview.src).toContain("http://example.com");
+    const overlay = document.querySelector(".preview-status");
+    expect(overlay.style.display).toBe("none");
   });
 
   test("paste triggers check and enables submit", async () => {
@@ -102,6 +104,9 @@ describe("url_test", () => {
     expect(status.classList.contains("bad")).toBe(true);
     expect(status.title).toBe("HTTP 404");
     expect(preview.src).toContain("blank.jpg");
+    const overlay = document.querySelector(".preview-status");
+    expect(overlay.textContent).toBe("HTTP 404");
+    expect(overlay.style.display).toBe("flex");
   });
 
   test("uses placeholder when fetch fails", async () => {
@@ -118,11 +123,14 @@ describe("url_test", () => {
     jest.runAllTimers();
     await Promise.resolve();
     expect(preview.src).toContain("blank.jpg");
+    const overlay = document.querySelector(".preview-status");
+    expect(overlay.textContent).toBe("Unreachable");
+    expect(overlay.style.display).toBe("flex");
   });
 
   test("stops player on url error", async () => {
     const html = `
-      <form><input id="url"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><input type="submit"></form>
+      <form><input id="url"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><div class="preview-status"></div><input type="submit"></form>
       <video id="live-video"><source src="old.mp4"></video>`;
     document.body.innerHTML = html;
     const res = Promise.resolve({
@@ -144,16 +152,20 @@ describe("url_test", () => {
     const source = video.querySelector("source");
     expect(source.hasAttribute("src")).toBe(false);
     expect(video.paused).toBe(true);
+    const overlay = document.querySelector(".preview-status");
+    expect(overlay.textContent).toBe("HTTP 404");
   });
 
   test("initializes multiple forms", async () => {
     const multiHtml = `
       <div class="edit-template-container">
         <img id="p1" data-placeholder="blank.jpg">
+        <div class="preview-status"></div>
         <form><input id="url" data-default-url="http://a"><span id="url-status"></span><input type="submit"></form>
       </div>
       <div class="edit-template-container">
         <img id="p2" data-placeholder="blank.jpg">
+        <div class="preview-status"></div>
         <form><input id="url" data-default-url="http://b"><span id="url-status"></span><input type="submit"></form>
       </div>`;
     document.body.innerHTML = multiHtml;
@@ -178,5 +190,9 @@ describe("url_test", () => {
     jest.advanceTimersByTime(500);
     await Promise.resolve();
     expect(previews[1].src).toContain("http://cam");
+    const overlay = previews[1]
+      .closest(".edit-template-container")
+      .querySelector(".preview-status");
+    expect(overlay.style.display).toBe("none");
   });
 });


### PR DESCRIPTION
## Summary
- show preview status overlay in camera template form
- style preview status overlay
- update JS URL tester to display overlay messages
- test overlay behavior in URL tester

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d644531f483338e1bafc6ff9e7f9f