### PR TITLE
Improve capture error handling

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -389,7 +389,10 @@ def update_camera(name, template, image_file=None, motion=False):
             mark_offline(name)
         set_capture_failed(name, True)
         clean_url = sanitize_url(url)
-        logging.error("Capture failed for %s (%s)", name, clean_url)
+        if entry and entry.get("errors", 0) > 2:
+            logging.debug("Capture failed for %s (%s)", name, clean_url)
+        else:
+            logging.error("Capture failed for %s (%s)", name, clean_url)
         register_job_failure(name)
         return None
 

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -641,9 +641,11 @@ def download_image(
             logging.warning(
                 f"Error downloading image: HTTP status code {status} {clean_url}"
             )
+            cas_error(url)
     except Exception as e:
-        logging.error(f"Error downloading image: {e} {clean_url} {timeout}")
+        logging.warning(f"Error downloading image: {e} {clean_url} {timeout}")
         set_cached_status_code(url, 0)
+        cas_error(url)
     finally:
         if response is not None:
             response.close()  # Ensure the connection is closed
@@ -713,7 +715,8 @@ def download_pdf(
         set_cached_status_code(url, response.status_code)
 
         if response.status_code != 200:
-            logging.error(f"Error downloading PDF: HTTP {response.status_code}")
+            logging.warning(f"Error downloading PDF: HTTP {response.status_code}")
+            cas_error(url)
             return False
 
         # Convert the first page to an image directly from the response bytes
@@ -742,8 +745,9 @@ def download_pdf(
         return lsuccess
 
     except Exception as e:
-        logging.error(f"Error downloading PDF: {e}")
+        logging.warning(f"Error downloading PDF: {e}")
         set_cached_status_code(url, 0)
+        cas_error(url)
         return False
 
 


### PR DESCRIPTION
## Summary
- soften logging for failed downloads
- avoid spamming capture failures after repeated errors

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d65d28ff0833385319c2703cd5266