### PR TITLE
Add advanced template tooltip details

### DIFF
--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -280,13 +280,18 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
         {% endfor %}
       </datalist>
       <div class="form-row double-row">
-        <label for="popup_xpath">Popup XPath:</label>
+        <label
+          for="popup_xpath"
+          title="Only for web pages. XPath of a button or dialog to dismiss before capturing; ignored for video streams"
+          >Popup XPath:</label
+        >
         <div class="xpath-input-container">
           <input
             type="text"
             id="popup_xpath"
             name="popup_xpath"
             value="{{ template.popup_xpath if template else '' }}"
+            title="XPath to close pop-ups; requires Browser mode"
           />
           <button
             type="button"
@@ -296,13 +301,18 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             Structured
           </button>
         </div>
-        <label for="dedicated_xpath">Dedicated XPath:</label>
+        <label
+          for="dedicated_xpath"
+          title="Only for web pages. XPath of the main image or graph element; ignored when capturing video"
+          >Dedicated XPath:</label
+        >
         <div class="xpath-input-container">
           <input
             type="text"
             id="dedicated_xpath"
             name="dedicated_xpath"
             value="{{ template.dedicated_xpath if template else '' }}"
+            title="Element containing the main content; requires Browser mode"
           />
           <button
             type="button"
@@ -379,7 +389,10 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
         />
       </div>
       <div class="checkbox-row">
-        <label for="invert" title="Invert image colors">
+        <label
+          for="invert"
+          title="Flip colors of the captured frame. Useful for infrared feeds or high-contrast pages"
+        >
           <input
             type="checkbox"
             id="invert"
@@ -392,11 +405,14 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             %}checked{%
             endif
             %}
-            title="Invert colors of the captured image"
+            title="Flip colors of the captured frame"
           />
           Invert
         </label>
-        <label for="dark" title="Use dark mode">
+        <label
+          for="dark"
+          title="Force dark color scheme in the browser when available; ignored for raw video feeds"
+        >
           <input
             type="checkbox"
             id="dark"
@@ -410,11 +426,14 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             %}checked{%
             endif
             %}
-            title="Enable dark mode for the captured page"
+            title="Force dark color scheme when browser mode is enabled"
           />
           Dark Mode
         </label>
-        <label for="browser" title="Capture using full browser">
+        <label
+          for="browser"
+          title="Launch a full browser for pages that require JavaScript or login. Needed when using XPath fields. Leave off for direct video streams"
+        >
           <input
             type="checkbox"
             id="browser"
@@ -427,11 +446,14 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             %}checked{%
             endif
             %}
-            title="Capture page using a full browser"
+            title="Use a full browser for dynamic pages or when XPaths are set"
           />
           Browser
         </label>
-        <label for="headless" title="Run in headless mode">
+        <label
+          for="headless"
+          title="Hide the browser window. Disable to watch the page during debugging"
+        >
           <input
             type="checkbox"
             id="headless"
@@ -445,11 +467,14 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             %}checked{%
             endif
             %}
-            title="Run browser in headless mode"
+            title="Hide the browser window during capture"
           />
           Headless
         </label>
-        <label for="stealth" title="Use stealth mode">
+        <label
+          for="stealth"
+          title="Mask automation to bypass site bot checks. Increases startup time"
+        >
           <input
             type="checkbox"
             id="stealth"
@@ -462,7 +487,7 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
             %}checked{%
             endif
             %}
-            title="Use stealth mode to avoid detection"
+            title="Mask automation to avoid detection"
           />
           Stealth
         </label>

--- a/docs/edit_template_preview.md
+++ b/docs/edit_template_preview.md
@@ -2,5 +2,16 @@
 
 The edit template dialog now shows a mini live view of the camera in the top-right corner. This MJPEG stream lets you verify the feed while tweaking settings. The same preview appears on the **Settings → Discover** tab when adding a new camera so you can confirm the URL before saving.
 
-Advanced options include a **Browser** checkbox to capture pages using a full
-browser. When enabled, additional headless and stealth toggles become active.
+Advanced options include several checkboxes with expanded tooltips:
+
+- **Browser** – launch a full browser for dynamic pages or when you need to
+  supply popup or dedicated XPaths. Leave this disabled for raw video streams;
+  XPath fields are ignored when the source is a video.
+- **Headless** – hide the browser window during capture. Turn it off when
+  debugging a login flow so you can watch the page load.
+- **Stealth** – mask automation to bypass simple bot checks. It increases start
+  up time but helps on sites that block headless browsers.
+- **Dark Mode** – force a dark theme when the browser supports it. This has no
+  effect on direct video feeds.
+- **Invert** – flip the colors of the captured frame. Useful for infrared or
+  high‑contrast scenes.

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -47,6 +47,7 @@ Interactive forms now include additional tooltips:
 - **Info icon** – toggles camera metadata on the live page.
 - **Feed status indicators** – on the Status page, red or yellow dots display a tooltip with offline time and the latest log message.
 - **Camera type icons** – small symbols next to each feed name show whether the capture runs in a full browser, headless mode, or uses stealth.
+- **Camera advanced checkboxes** – Browser, Headless, Stealth, Dark Mode and Invert explain when each option applies. XPath fields work only with HTML pages, so disable Browser and clear the XPaths when monitoring video streams.
 - **Chat modal controls** – the close icon and submit button now describe their actions.
 - **Help page tabs** – each tab button explains what information the section contains.
 - **Settings tabs** – hovering shows which category will open.


### PR DESCRIPTION
## Summary
- expand tooltip titles for popup and dedicated XPath fields
- clarify advanced checkboxes under camera templates
- document when each advanced option applies

## Testing
- `pre-commit run --files app/templates/components.html docs/edit_template_preview.md docs/tooltips.md`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6ca602d8833387a97df7579aabcc