### PR TITLE
Add inline error display to camera form

### DIFF
--- a/app/static/js/form.js
+++ b/app/static/js/form.js
@@ -1,5 +1,10 @@
 export function initFormValidation() {
   window.validateForm = function validateForm() {
+    const err = document.getElementById("template-error");
+    if (err) {
+      err.textContent = "";
+      err.classList.add("hidden");
+    }
     const name = document.getElementById("name").value.trim();
     const url = document.getElementById("url").value.trim();
     const frequency = parseInt(document.getElementById("frequency").value);
@@ -13,18 +18,27 @@ export function initFormValidation() {
       .getElementById("dedicated_xpath")
       .value.trim();
 
+    const showError = (msg) => {
+      if (err) {
+        err.textContent = msg;
+        err.classList.remove("hidden");
+      } else {
+        alert(msg);
+      }
+    };
+
     if (name === "" || url === "") {
-      alert("Template Name and URL are required fields.");
+      showError("Template Name and URL are required fields.");
       return false;
     }
 
     if (!/^https?:\/\//.test(url)) {
-      alert("URL must start with http:// or https://");
+      showError("URL must start with http:// or https://");
       return false;
     }
 
     if (frequency < 0 || frequency > 43200) {
-      alert("Frequency must be between 0 and 43200 minutes (30 days).");
+      showError("Frequency must be between 0 and 43200 minutes (30 days).");
       return false;
     }
 
@@ -39,17 +53,17 @@ export function initFormValidation() {
     }
 
     if (timeout < 3 || timeout > 59) {
-      alert("Timeout must be between 3 and 59 seconds.");
+      showError("Timeout must be between 3 and 59 seconds.");
       return false;
     }
 
     if (frequency > 0 && timeout >= frequency * 60) {
-      alert("Timeout must be less than the frequency.");
+      showError("Timeout must be less than the frequency.");
       return false;
     }
 
     if (objectFilter !== "" && (objectConfidence < 0 || objectConfidence > 1)) {
-      alert(
+      showError(
         "Object Confidence must be between 0 and 1 when Object Filter is specified.",
       );
       return false;
@@ -59,7 +73,7 @@ export function initFormValidation() {
       (popupXpath !== "" && !popupXpath.startsWith("//")) ||
       (dedicatedXpath !== "" && !dedicatedXpath.startsWith("//"))
     ) {
-      alert("XPath expressions must start with '//'.");
+      showError("XPath expressions must start with '//'.");
       return false;
     }
 

--- a/app/templates/components.html
+++ b/app/templates/components.html
@@ -129,6 +129,12 @@ object_tokens=None, clip_model=None, clip_gpu=False, default_url=None) -%}
     onsubmit="window.sendTelemetry && sendTelemetry('template_submit'); return validateForm()"
     title="Enter template details"
   >
+    <div
+      id="template-error"
+      class="form-error hidden"
+      role="alert"
+      aria-live="assertive"
+    ></div>
     {% if include_name %}
     <div class="form-row">
       <label for="name" title="Name of the template">Name:</label>

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,7 +51,8 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 4. Configure the source settings (URL, refresh rate, etc.). As you leave the URL
    field, Glimpser checks the address and shows a green check mark when it
-   responds. Expand **Advanced Options** to enter XPaths, callbacks or login
+   responds. Any problems appear below the form fields so you can correct them
+   right away. Expand **Advanced Options** to enter XPaths, callbacks or login
    credentials if needed.
 
 5. Save the source configuration.

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -144,6 +144,11 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('min="0"', components)
         self.assertIn('datalist id="object-filter-options"', components)
 
+    def test_template_form_error_container(self):
+        components = Path("app/templates/components.html").read_text(encoding="utf-8")
+        self.assertIn('id="template-error"', components)
+        self.assertIn('role="alert"', components)
+
     def test_groups_field_has_datalist(self):
         components = Path("app/templates/components.html").read_text(encoding="utf-8")
         self.assertIn('id="groups"', components)


### PR DESCRIPTION
## Summary
- display template form errors inline below the preview
- show errors in the form without alerts
- mention inline errors in the getting started guide
- test for the error container element

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d6b9ee58083338e1fc865656560fa