### PR TITLE
Enhance Add Camera URL validation

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1701,6 +1701,10 @@ input[type="submit"] {
   cursor: pointer;
 }
 
+input[type="submit"].confirm-submit {
+  background-color: #d9534f;
+}
+
 input[type="submit"]:hover {
   background-color: #45a049;
 }

--- a/app/static/js/form.js
+++ b/app/static/js/form.js
@@ -23,6 +23,15 @@ export function initFormValidation() {
       return false;
     }
 
+    const submitBtn = document.querySelector(
+      "input[type='submit'][data-url-ok]",
+    );
+    if (submitBtn && submitBtn.dataset.urlOk === "false") {
+      if (!confirm("URL check failed. Add anyway?")) {
+        return false;
+      }
+    }
+
     if (frequency < 0 || frequency > 43200) {
       alert("Frequency must be between 0 and 43200 minutes (30 days).");
       return false;

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -21,6 +21,7 @@ export function initUrlTester() {
       const form = input.closest("form");
       const controlled = [];
       let submit;
+      let urlOk = false;
       if (form) {
         form.querySelectorAll("input, select, textarea").forEach((el) => {
           if (el === input || el.id === "name") return;
@@ -34,7 +35,13 @@ export function initUrlTester() {
         controlled.forEach(([el, orig]) => {
           el.disabled = disable || orig;
         });
-        if (submit) submit.disabled = disable;
+        if (submit) {
+          submit.disabled = disable;
+          if (disable) {
+            submit.classList.remove("confirm-submit");
+            delete submit.dataset.urlOk;
+          }
+        }
       };
 
       let controller;
@@ -97,10 +104,16 @@ export function initUrlTester() {
           const data = await res.json();
           const title = formatTitle(data);
           if (res.ok && data.ok) {
+            urlOk = true;
             setStatus("ok", title);
             showOverlay("");
-            if (submit) submit.disabled = false;
+            if (submit) {
+              submit.disabled = false;
+              submit.classList.remove("confirm-submit");
+              submit.dataset.urlOk = "true";
+            }
           } else {
+            urlOk = false;
             setStatus("bad", title);
             showOverlay(title);
             if (preview) preview.src = defaultSrc;
@@ -114,11 +127,16 @@ export function initUrlTester() {
               player.poster = defaultSrc;
               player.load();
             }
-            if (submit) submit.disabled = true;
+            if (submit) {
+              submit.disabled = false;
+              submit.classList.add("confirm-submit");
+              submit.dataset.urlOk = "false";
+            }
           }
           sendTelemetry("url_test", { url, ok: data.ok });
         } catch {
           if (controller.signal.aborted) return;
+          urlOk = false;
           setStatus("bad", "Unreachable");
           showOverlay("Unreachable");
           if (preview) preview.src = defaultSrc;
@@ -132,7 +150,11 @@ export function initUrlTester() {
             player.poster = defaultSrc;
             player.load();
           }
-          if (submit) submit.disabled = true;
+          if (submit) {
+            submit.disabled = false;
+            submit.classList.add("confirm-submit");
+            submit.dataset.urlOk = "false";
+          }
           sendTelemetry("url_test", { url, ok: false });
         }
       };
@@ -154,13 +176,21 @@ export function initUrlTester() {
         const hasValue = input.value.trim() !== "";
         setStatus(hasValue ? "pending" : "", hasValue ? "Testing..." : "");
         showOverlay(hasValue ? "Testing..." : "");
-        if (submit) submit.disabled = true;
+        if (submit) {
+          submit.disabled = true;
+          submit.classList.remove("confirm-submit");
+          delete submit.dataset.urlOk;
+        }
         if (hasValue) checkDebounced();
       });
       input.addEventListener("paste", () => {
         setTimeout(() => {
           setStatus("pending", "Testing...");
           showOverlay("Testing...");
+          if (submit) {
+            submit.classList.remove("confirm-submit");
+            delete submit.dataset.urlOk;
+          }
           checkDebounced();
         }, 0);
       });

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -128,6 +128,27 @@ describe("url_test", () => {
     expect(overlay.style.display).toBe("flex");
   });
 
+  test("adds confirm class on url failure", async () => {
+    const res = Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ ok: false }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    jest.clearAllTimers();
+    const input = document.getElementById("url");
+    const submit = document.querySelector("input[type='submit']");
+    input.value = "http://bad";
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(submit.classList.contains("confirm-submit")).toBe(true);
+    expect(submit.disabled).toBe(false);
+  });
+
   test("stops player on url error", async () => {
     const html = `
       <form><input id="url"><span id="url-status"></span><img id="url-preview" data-placeholder="blank.jpg"><div class="preview-status"></div><input type="submit"></form>


### PR DESCRIPTION
## Summary
- highlight submit button when URL check fails
- allow submitting unreachable URLs only after confirmation
- mark button state in `url_test.js`
- verify confirmation flow in Jest tests

## Testing
- `pre-commit run --all-files`
- `pytest`
- `npm test`
- `npm run size-audit`


------
https://chatgpt.com/codex/tasks/task_e_685d6c61bea08333b030f8e9785468d3