### PR TITLE
Add template tester feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 - **SMS Alerts**: Configure Twilio credentials to receive important notifications by text message.
 - **Camera Discovery**: Open **Settings** and switch to the **Discover** tab to automatically scan the local network for ONVIF, RTSP, RTMP, HTTP/MJPEG, HLS, and SSDP devices. The table now displays each camera's MAC address plus manufacturer and model information when available. Glimpser checks common system OUI databases, an online lookup service, and the ONVIF device service to gather these details.
 - **Camera Fix Suggestions**: Validate a template and discover alternative URLs with `/suggest_fix/<template>`. See [Camera Fix Suggestions](docs/camera_fix.md).
+- **Template Tester**: Use `/test_template/<template>` to detect content type and receive checkbox suggestions. See [Template Tester](docs/template_tester.md).
 - **Local Cameras**: The Discover tab also lists any available `/dev/video*` devices for easy webcam integration.
 
 - **Web Interface**: A user-friendly web interface allows for easy monitoring and configuration. Users can view live feeds, summaries, and configure settings without delving into the code.

--- a/app/routes.py
+++ b/app/routes.py
@@ -76,6 +76,7 @@ from app.utils import (
     camera_discovery,
     prompt_optimizer,
     camera_fix,
+    template_tester,
 )
 
 from app.utils.llm import ask_question
@@ -2533,6 +2534,47 @@ def init_routes(app: Flask) -> None:
         url = details.get("url", "")
         xpaths = [details.get("popup_xpath", ""), details.get("dedicated_xpath", "")]
         info = camera_fix.check_camera_template(url, xpaths)
+        return jsonify(info)
+
+    @app.route("/test_template/<string:template_name>", methods=["POST"])
+    @login_required
+    def test_template_route(template_name: TemplateName):
+        """Return capture strategy suggestions for ``template_name``."""
+
+        template_name = validate_template_name(template_name)
+        if template_name is None:
+            abort(404)
+
+        details = template_manager.get_template(template_name)
+        if not details:
+            abort(404)
+
+        form = request.get_json() if request.is_json else request.form.to_dict()
+
+        url = form.get("url") or details.get("url", "")
+        popup_xpath = form.get("popup_xpath") or details.get("popup_xpath", "")
+        dedicated_xpath = form.get("dedicated_xpath") or details.get(
+            "dedicated_xpath", ""
+        )
+
+        flags = {
+            "browser": form.get("browser", "false").lower()
+            in ["true", "1", "t", "y", "yes", "on"],
+            "headless": form.get("headless", "false").lower()
+            in ["true", "1", "t", "y", "yes", "on"],
+            "stealth": form.get("stealth", "false").lower()
+            in ["true", "1", "t", "y", "yes", "on"],
+            "danger": form.get("danger", "false").lower()
+            in ["true", "1", "t", "y", "yes", "on"],
+        }
+
+        info = template_tester.test_template_settings(
+            url,
+            popup_xpath=popup_xpath,
+            dedicated_xpath=dedicated_xpath,
+            **flags,
+        )
+
         return jsonify(info)
 
     @app.route("/screenshots/<string:name>/<string:filename>")

--- a/app/templates/template_details.html
+++ b/app/templates/template_details.html
@@ -181,6 +181,7 @@ function updateVideo(templateName) {
             </div>
             <button type="button" onclick="suggestPrompt('{{ template_name }}')" title="Generate a prompt">Suggest Prompt</button>
             <button type="button" onclick="suggestFix('{{ template_name }}')" title="Suggest troubleshooting tips">Suggest Fix</button>
+            <button type="button" onclick="testTemplate('{{ template_name }}')" title="Test this template and suggest settings">Test Template</button>
 
             <div class="form-row">
                 <label for="object_filter" title="Filter for specific objects">Object Filter:</label>
@@ -438,6 +439,24 @@ function suggestFix(name) {
         .then(data => {
             alert(JSON.stringify(data, null, 2));
         });
+}
+
+function testTemplate(name) {
+    const form = document.getElementById('edit-template-form');
+    const data = new URLSearchParams(new FormData(form));
+    fetch(`/test_template/${name}`, {
+        method: 'POST',
+        body: data
+    })
+    .then(resp => resp.json())
+    .then(info => {
+        alert(`Collector: ${info.collector}\nType: ${info.content_type}`);
+        if (info.checkboxes) {
+            document.getElementById('browser').checked = info.checkboxes.browser;
+            document.getElementById('headless').checked = info.checkboxes.headless;
+            document.getElementById('stealth').checked = info.checkboxes.stealth;
+        }
+    });
 }
 
 function closePromptModal() {

--- a/app/utils/template_tester.py
+++ b/app/utils/template_tester.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict
+
+from .screenshots import (
+    get_content_type,
+    is_image_url,
+    is_pdf_url,
+    is_video_stream_url,
+    should_use_lightweight_browser,
+    should_use_phantom_browser,
+    is_enhanced,
+)
+
+
+def test_template_settings(
+    url: str,
+    *,
+    popup_xpath: str = "",
+    dedicated_xpath: str = "",
+    browser: bool = False,
+    headless: bool = False,
+    stealth: bool = False,
+    danger: bool = False,
+) -> Dict[str, Any]:
+    """Return capture suggestions for ``url``."""
+
+    content_type, _ = get_content_type(url, danger, stealth=stealth)
+
+    if is_image_url(url, content_type):
+        collector = "image"
+    elif is_pdf_url(url, content_type):
+        collector = "pdf"
+    elif is_video_stream_url(url, content_type):
+        collector = "stream"
+    elif is_enhanced(url):
+        collector = "ytdlp"
+    elif should_use_lightweight_browser(
+        url, dedicated_xpath, popup_xpath, headless, stealth, browser, danger
+    ):
+        collector = "lightweight"
+    elif should_use_phantom_browser(
+        url, dedicated_xpath, popup_xpath, headless, stealth, browser, danger
+    ):
+        collector = "phantom"
+    else:
+        collector = "browser"
+
+    checkboxes = {"browser": False, "headless": False, "stealth": False}
+    if collector not in {"image", "pdf", "stream"}:
+        checkboxes["headless"] = True
+        if collector in {"browser", "phantom"}:
+            checkboxes["browser"] = True
+        if collector == "browser":
+            checkboxes["stealth"] = True
+
+    return {
+        "content_type": content_type,
+        "collector": collector,
+        "checkboxes": checkboxes,
+    }

--- a/docs/template_tester.md
+++ b/docs/template_tester.md
@@ -1,0 +1,7 @@
+# Template Tester
+
+Use `/test_template/<template>` to analyze a template before saving. The route
+returns the detected content type, the collector that will handle the capture,
+and suggested checkbox settings. On the template details page, click **Test
+Template** to run this check. The browser, headless, and stealth checkboxes are
+updated automatically.

--- a/tests/test_template_test_route.py
+++ b/tests/test_template_test_route.py
@@ -1,0 +1,53 @@
+import sys
+import types
+import unittest
+from flask import Flask
+from unittest.mock import patch
+
+dummy_tf = types.ModuleType("transformers")
+dummy_tf.CLIPProcessor = object
+dummy_tf.CLIPModel = object
+sys.modules.setdefault("transformers", dummy_tf)
+skimage_mod = types.ModuleType("skimage")
+metrics_mod = types.ModuleType("skimage.metrics")
+metrics_mod.structural_similarity = lambda *a, **k: 0
+skimage_mod.metrics = metrics_mod
+sys.modules.setdefault("skimage", skimage_mod)
+sys.modules.setdefault("skimage.metrics", metrics_mod)
+sys.modules.setdefault("nodriver", types.ModuleType("nodriver"))
+
+from app.routes import init_routes
+
+
+class TestTemplateTestRoute(unittest.TestCase):
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.login_patch = patch("app.routes.login_required", lambda x: x)
+        self.login_patch.start()
+        init_routes(self.app)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        self.login_patch.stop()
+
+    @patch("app.routes.template_manager.get_template")
+    @patch("app.routes.template_tester.test_template_settings")
+    def test_test_template_success(self, mock_test, mock_get):
+        mock_get.return_value = {
+            "url": "http://x",
+            "popup_xpath": "",
+            "dedicated_xpath": "",
+        }
+        mock_test.return_value = {"collector": "image"}
+        resp = self.client.post("/test_template/cam1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"collector": "image"})
+
+    @patch("app.routes.template_manager.get_template", return_value={})
+    def test_test_template_not_found(self, mock_get):
+        resp = self.client.post("/test_template/missing")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve the template details page with a **Test Template** button
- implement `/test_template/<name>` endpoint that reports collector suggestions
- add helper module `template_tester` to infer content type
- document the new feature
- add unit tests for the new route

## Testing
- `flake8 app/routes.py app/utils/template_tester.py tests/test_template_test_route.py`
- `PYTHONPATH=. pytest -q tests/test_template_test_route.py tests/test_suggest_fix_route.py`

------
https://chatgpt.com/codex/tasks/task_e_685d7ab45bc48333b95aad74b1439c29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Test Template" feature, allowing users to analyze templates and receive suggestions for browser, headless, and stealth settings directly from the template details page.
  * Added a new endpoint to test templates and return content type, collector type, and recommended settings.

* **Documentation**
  * Added a new documentation page describing how to use the Template Tester feature and endpoint.

* **Bug Fixes**
  * None.

* **Tests**
  * Added tests to verify the new template testing endpoint and its responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->