### PR TITLE
Improve camera URL tester

### DIFF
--- a/app/blueprints/discovery.py
+++ b/app/blueprints/discovery.py
@@ -16,6 +16,8 @@ from flask import (
     stream_with_context,
 )
 
+import app.utils.screenshots as screenshots
+
 
 def create_blueprint() -> Blueprint:
     """Create and return the camera discovery blueprint."""
@@ -217,6 +219,23 @@ def create_blueprint() -> Blueprint:
                 return jsonify({"ok": False, "error": "unreachable"}), 400
 
         info["ok"] = info.get("status", 500) < 400
+
+        content_type = info.get("content_type", "")
+        kind = "webpage"
+        if screenshots.is_image_url(url, content_type):
+            kind = "image"
+        elif screenshots.is_pdf_url(url, content_type):
+            kind = "pdf"
+        elif screenshots.is_video_stream_url(url, content_type):
+            kind = "video"
+
+        suggestions = {
+            "browser": kind in {"webpage", "pdf"},
+            "headless": kind in {"webpage", "pdf"},
+            "stealth": False,
+        }
+
+        info.update({"kind": kind, "suggestions": suggestions})
         return jsonify(info)
 
     @bp.route("/discover/export", methods=["POST"])

--- a/app/static/js/url_test.js
+++ b/app/static/js/url_test.js
@@ -103,6 +103,13 @@ export function initUrlTester() {
           );
           const data = await res.json();
           const title = formatTitle(data);
+          const sugg = data.suggestions || {};
+          const setCheck = (id, val) => {
+            const el = container
+              ? container.querySelector(`#${id}`)
+              : document.getElementById(id);
+            if (el && typeof val === "boolean") el.checked = val;
+          };
           if (res.ok && data.ok) {
             urlOk = true;
             setStatus("ok", title);
@@ -133,6 +140,9 @@ export function initUrlTester() {
               submit.dataset.urlOk = "false";
             }
           }
+          setCheck("browser", sugg.browser);
+          setCheck("headless", sugg.headless);
+          setCheck("stealth", sugg.stealth);
           sendTelemetry("url_test", { url, ok: data.ok });
         } catch {
           if (controller.signal.aborted) return;

--- a/docs/tooltips.md
+++ b/docs/tooltips.md
@@ -37,7 +37,7 @@ These tooltips aim to make the interface self‑explanatory and easier to naviga
 Interactive forms now include additional tooltips:
 
 - **Add Camera** – describes each field on the Discover tab and the "Structured" XPath buttons. A short helper paragraph guides you to test the URL and open the Advanced Options section.
-- **URL tester** – now displays detailed feedback like HTTP status and content type. The live preview falls back to a placeholder image when the check fails.
+- **URL tester** – now displays detailed feedback like HTTP status and content type. It also recommends Browser, Headless and Stealth settings based on the probe results. The live preview falls back to a placeholder image when the check fails.
 - **Template Details** – buttons like "Suggest Prompt" and "Suggest Fix" describe their actions.
 - **Template toolbar** – quick actions appear at the bottom-left of the details page and fade out when idle.
 - **Captions** – upload and filter controls have descriptive titles. The metric dropdown filters feeds by count or storage and updates the list immediately.

--- a/tests/js/url_test.test.js
+++ b/tests/js/url_test.test.js
@@ -177,6 +177,42 @@ describe("url_test", () => {
     expect(overlay.textContent).toBe("HTTP 404");
   });
 
+  test("applies checkbox suggestions", async () => {
+    document.body.innerHTML = `
+      <form>
+        <input id="url" />
+        <span id="url-status"></span>
+        <img id="url-preview" data-placeholder="blank.jpg">
+        <div class="preview-status"></div>
+        <input type="submit">
+      </form>
+      <input id="browser">
+      <input id="headless">
+      <input id="stealth">
+    `;
+    const res = Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ok: true,
+          suggestions: { browser: true, headless: true, stealth: false },
+        }),
+    });
+    global.fetch = jest.fn(() => res);
+    initUrlTester();
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+    const input = document.getElementById("url");
+    input.value = "http://ex";
+    input.dispatchEvent(new Event("input"));
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(document.getElementById("browser").checked).toBe(true);
+    expect(document.getElementById("headless").checked).toBe(true);
+    expect(document.getElementById("stealth").checked).toBe(false);
+  });
+
   test("initializes multiple forms", async () => {
     const multiHtml = `
       <div class="edit-template-container">

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -49,7 +49,10 @@ def test_url_test_endpoint(tmp_http_server):
                 f"http://127.0.0.1:{server.port}/templates/test_url",
                 params={"url": url},
             )
+            data = resp.json()
             assert resp.status_code == 200
-            assert resp.json()["ok"]
+            assert data["ok"]
+            assert data["kind"] == "webpage"
+            assert data["suggestions"]["browser"] is True
         finally:
             server.shutdown()


### PR DESCRIPTION
## Summary
- refine `/templates/test_url` to classify content and return suggestions
- auto-set advanced options in the URL tester UI
- document the new recommendations
- test new behavior in Python and JS

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d7e2ee05883338d7660af5eedf97f