### PR TITLE
Add fullscreen toggle for live view

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -227,3 +227,21 @@ video::-moz-volume-control {
 #mute {
   display: none;
 }
+
+#fullscreen-toggle {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  padding: 0.25rem;
+  font-size: 1.25rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#fullscreen-toggle:focus {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -62,6 +62,18 @@ export function initTilePlayer() {
     if (container) container.appendChild(image);
   }
 
+  const fsButton = document.getElementById("fullscreen-toggle");
+  if (fsButton) {
+    fsButton.addEventListener("click", () => {
+      const target = container || video;
+      if (!document.fullscreenElement) {
+        target?.requestFullscreen?.();
+      } else {
+        document.exitFullscreen?.();
+      }
+    });
+  }
+
   function showBounce() {
     if (!spinner) return;
     spinner.textContent = "\u25CF";

--- a/app/templates/live.html
+++ b/app/templates/live.html
@@ -40,6 +40,14 @@
       <span id="speed-value">1fps</span>
     </div>
   </div>
+  <button
+    id="fullscreen-toggle"
+    class="fullscreen-toggle"
+    aria-label="Toggle fullscreen"
+    title="Toggle fullscreen"
+  >
+    ⛶
+  </button>
 </div>
 <script>
   window.templateDetails = {{ template_details|tojson }};

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -29,7 +29,7 @@ Key topics covered include:
 
 On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** for a direct real-time feed or **MP4** to scrub through archived footage. Glimpser remembers your last camera, video source, and playback speed to streamline future visits.
 
-Click **Live All** to switch every tile to a real-time feed and **Play All** to toggle between playing or pausing archived clips. When watching a single stream you can drag the jog‑shuttle or time slider to scrub forward or backward.
+Click **Live All** to switch every tile to a real-time feed and **Play All** to toggle between playing or pausing archived clips. When watching a single stream you can drag the jog‑shuttle or time slider to scrub forward or backward. A fullscreen button in the lower-right corner lets you maximize the video.
 
 Keyboard shortcuts help you navigate quickly: press `Ctrl+F` or `⌘+F` to jump to the page search box, `Space` or `k` toggles play or pause, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type. A vertical speed slider also appears when you hover over the player so you can fine‑tune playback without extra clutter.
 Press `?` at any time to see a quick overlay of these shortcuts and `Esc` to dismiss it.

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -121,3 +121,18 @@ test("init does not duplicate live-image", () => {
   init();
   expect(document.querySelectorAll("#live-image").length).toBe(1);
 });
+
+test("fullscreen button requests fullscreen", () => {
+  document.body.innerHTML = `
+    <div id="container">
+      <video id="live-video"><source></source></video>
+      <button id="fullscreen-toggle"></button>
+    </div>
+  `;
+  const container = document.getElementById("container");
+  container.requestFullscreen = jest.fn();
+  window.templateDetails = { cam1: {} };
+  init();
+  document.getElementById("fullscreen-toggle").click();
+  expect(container.requestFullscreen).toHaveBeenCalled();
+});

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -220,6 +220,10 @@ class TestHtmlTemplates(unittest.TestCase):
         self.assertIn('id="video-overlay"', html)
         self.assertIn('id="loading-indicator"', html)
 
+    def test_live_page_has_fullscreen_button(self):
+        html = Path("app/templates/live.html").read_text(encoding="utf-8")
+        self.assertIn('id="fullscreen-toggle"', html)
+
     def test_timeline_has_nav_buttons(self):
         html = Path("app/templates/timeline.html").read_text(encoding="utf-8")
         self.assertIn('id="timeline-prev"', html)


### PR DESCRIPTION
## Summary
- support fullscreen mode with a new control
- document the fullscreen button
- test presence of new control in templates
- test fullscreen activation

## Testing
- `pytest -n 0`
- `npm test`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_685dc6a6a9008333bc46e6ed1362900e