### PR TITLE
feat(player): fade fullscreen button

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -239,6 +239,12 @@ video::-moz-volume-control {
   font-size: 1.25rem;
   border-radius: 4px;
   cursor: pointer;
+  transition: opacity 0.3s;
+}
+
+#fullscreen-toggle.fade-out {
+  opacity: 0;
+  pointer-events: none;
 }
 
 #fullscreen-toggle:focus {

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -362,17 +362,20 @@ export function setupVideoControls() {
   const container = video.closest(".video-container");
   const controls = container?.querySelector(".video-controls");
   const navButtons = container?.querySelectorAll(".clip-nav");
+  const fsButton = container?.querySelector("#fullscreen-toggle");
   let fadeTimeout;
   let autoplayTimeout;
 
   const showControls = () => {
     if (controls) controls.classList.remove("fade-out");
     navButtons?.forEach((btn) => btn.classList.remove("fade-out"));
+    fsButton?.classList.remove("fade-out");
     clearTimeout(fadeTimeout);
     clearTimeout(autoplayTimeout);
     fadeTimeout = setTimeout(() => {
       if (controls) controls.classList.add("fade-out");
       navButtons?.forEach((btn) => btn.classList.add("fade-out"));
+      fsButton?.classList.add("fade-out");
     }, 3000);
     autoplayTimeout = setTimeout(() => {
       video.playbackRate = 0.5;

--- a/docs/help_page.md
+++ b/docs/help_page.md
@@ -29,7 +29,7 @@ Key topics covered include:
 
 On the **Live** page, pick a camera from the drop-down menu. The **Video Source** now defaults to **MJPG** so you immediately see a lightweight stream of the latest frames. Select **Live Video** for a direct real-time feed or **MP4** to scrub through archived footage. Glimpser remembers your last camera, video source, and playback speed to streamline future visits.
 
-Click **Live All** to switch every tile to a real-time feed and **Play All** to toggle between playing or pausing archived clips. When watching a single stream you can drag the jog‑shuttle or time slider to scrub forward or backward. A fullscreen button in the lower-right corner lets you maximize the video.
+Click **Live All** to switch every tile to a real-time feed and **Play All** to toggle between playing or pausing archived clips. When watching a single stream you can drag the jog‑shuttle or time slider to scrub forward or backward. A fullscreen button in the lower-right corner lets you maximize the video. This expand control fades away after a few seconds of inactivity along with the rest of the player tools.
 
 Keyboard shortcuts help you navigate quickly: press `Ctrl+F` or `⌘+F` to jump to the page search box, `Space` or `k` toggles play or pause, `f` enters fullscreen, `[` and `]` change playback speed, and the arrow keys cycle cameras or media types. On phones and tablets, swipe left or right on the video to switch cameras or swipe up or down to change the media type. A vertical speed slider also appears when you hover over the player so you can fine‑tune playback without extra clutter.
 Press `?` at any time to see a quick overlay of these shortcuts and `Esc` to dismiss it.

--- a/tests/js/fullscreen_fade.test.js
+++ b/tests/js/fullscreen_fade.test.js
@@ -1,0 +1,36 @@
+import { jest } from "@jest/globals";
+
+document.body.innerHTML = `
+  <div class="video-container">
+    <video id="live-video"></video>
+    <div class="video-controls"></div>
+    <button id="fullscreen-toggle"></button>
+  </div>
+  <button id="play-pause"></button>
+  <input id="seek-bar" />
+`;
+
+Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+  configurable: true,
+  value: jest.fn(() => Promise.resolve()),
+});
+
+let setup;
+
+beforeAll(async () => {
+  const mod = await import("../../app/static/js/video.js");
+  setup = mod.setupVideoControls;
+});
+
+jest.useFakeTimers();
+
+test("fullscreen button fades after idle", () => {
+  setup();
+  jest.advanceTimersByTime(3000);
+  const btn = document.getElementById("fullscreen-toggle");
+  expect(btn.classList.contains("fade-out")).toBe(true);
+  btn.classList.remove("fade-out");
+  const container = document.querySelector(".video-container");
+  container.dispatchEvent(new Event("mousemove"));
+  expect(btn.classList.contains("fade-out")).toBe(false);
+});


### PR DESCRIPTION
## Summary
- fade fullscreen button with other controls
- document fade behaviour
- test that fullscreen toggle fades

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f44f850008333a141133a070bfa70