### PR TITLE
Fix mobile scrolling on live views

### DIFF
--- a/app/static/css/player.css
+++ b/app/static/css/player.css
@@ -61,12 +61,18 @@
 
 .video-container.full-height {
   height: auto;
-  max-height: 92vh;
+  max-height: calc(
+    100dvh - var(--header-space, 0px) - var(--banner-space, 0px) -
+      var(--footer-space, 60px)
+  );
 }
 
 @media (min-width: 768px) {
   .video-container.full-height {
-    height: 92vh;
+    height: calc(
+      100dvh - var(--header-space, 0px) - var(--banner-space, 0px) -
+        var(--footer-space, 60px)
+    );
   }
 }
 #live-video,

--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -5,6 +5,36 @@ function safePlay(el) {
   if (p && typeof p.catch === "function") p.catch(() => {});
 }
 
+export function adjustFullHeight() {
+  const container = document.querySelector(".video-container.full-height");
+  if (!container) return;
+  const header = document.querySelector("header");
+  const banner = document.getElementById("network-banner");
+  const footerSpace = parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue(
+      "--footer-space",
+    ) || "0",
+  );
+  const headerHeight = header ? header.offsetHeight : 0;
+  const bannerHeight = banner ? banner.offsetHeight : 0;
+  document.documentElement.style.setProperty(
+    "--header-space",
+    `${headerHeight}px`,
+  );
+  document.documentElement.style.setProperty(
+    "--banner-space",
+    `${bannerHeight}px`,
+  );
+  const available =
+    window.innerHeight - headerHeight - bannerHeight - footerSpace;
+  container.style.maxHeight = `${available}px`;
+  if (window.innerWidth >= 768) {
+    container.style.height = `${available}px`;
+  } else {
+    container.style.height = "auto";
+  }
+}
+
 export function initTilePlayer() {
   const video = document.getElementById("live-video");
   if (!video) return;
@@ -192,7 +222,11 @@ export function initTilePlayer() {
   }
 }
 
-document.addEventListener("DOMContentLoaded", initTilePlayer);
+document.addEventListener("DOMContentLoaded", () => {
+  adjustFullHeight();
+  initTilePlayer();
+});
+window.addEventListener("resize", adjustFullHeight);
 
 export function updateCameraOptions(group) {
   const camSelect =


### PR DESCRIPTION
## Summary
- compute available viewport space dynamically for the video container
- apply max-height adjustment for live and template views

## Testing
- `pre-commit run --files app/static/js/tile_player.js app/static/css/player.css`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685f44dcb47c83339441b773f3902083