### PR TITLE
Fix console dashboard timeout handling

### DIFF
--- a/app/utils/console_dashboard.py
+++ b/app/utils/console_dashboard.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import curses
-import time
 from typing import Any
 
 from .scheduling import get_feed_status
@@ -19,6 +18,8 @@ def _render(screen: curses.window) -> None:
     curses.init_pair(1, curses.COLOR_GREEN, -1)
     curses.init_pair(2, curses.COLOR_YELLOW, -1)
     curses.init_pair(3, curses.COLOR_RED, -1)
+
+    screen.timeout(REFRESH_INTERVAL * 1000)
 
     while True:
         feeds = get_feed_status()
@@ -44,11 +45,9 @@ def _render(screen: curses.window) -> None:
             screen.addstr(idx, 0, row[: width - 1], color)
 
         screen.refresh()
-        for _ in range(REFRESH_INTERVAL * 10):
-            time.sleep(0.1)
-            ch = screen.getch()
-            if ch in (ord("q"), ord("Q")):
-                return
+        ch = screen.getch()
+        if ch in (ord("q"), ord("Q")):
+            return
 
 
 def main() -> None:

--- a/tests/test_console_dashboard.py
+++ b/tests/test_console_dashboard.py
@@ -10,6 +10,59 @@ class TestConsoleDashboard(unittest.TestCase):
         console_dashboard.main()
         mock_wrapper.assert_called_once_with(console_dashboard._render)
 
+    @patch("app.utils.console_dashboard.get_feed_status")
+    @patch("app.utils.console_dashboard.curses")
+    def test_render_quits_on_q(self, mock_curses, mock_get_status):
+        screen = MagicMock()
+        screen.getmaxyx.return_value = (10, 40)
+        screen.getch.side_effect = [ord("q")]
+        mock_get_status.return_value = [
+            {
+                "name": "cam1",
+                "status": "ok",
+                "last_screenshot_display": "",
+                "last_caption_display": "",
+            }
+        ]
+
+        console_dashboard._render(screen)
+
+        screen.timeout.assert_called_once_with(
+            console_dashboard.REFRESH_INTERVAL * 1000
+        )
+        screen.refresh.assert_called()
+        self.assertEqual(screen.getch.call_count, 1)
+
+    @patch("app.utils.console_dashboard.get_feed_status")
+    @patch("app.utils.console_dashboard.curses")
+    def test_render_refreshes_after_timeout(self, mock_curses, mock_get_status):
+        screen = MagicMock()
+        screen.getmaxyx.return_value = (10, 40)
+        screen.getch.side_effect = [-1, ord("q")]
+        mock_get_status.side_effect = [
+            [
+                {
+                    "name": "cam1",
+                    "status": "ok",
+                    "last_screenshot_display": "",
+                    "last_caption_display": "",
+                }
+            ],
+            [
+                {
+                    "name": "cam1",
+                    "status": "ok",
+                    "last_screenshot_display": "",
+                    "last_caption_display": "",
+                }
+            ],
+        ]
+
+        console_dashboard._render(screen)
+
+        self.assertEqual(mock_get_status.call_count, 2)
+        self.assertEqual(screen.refresh.call_count, 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- use `screen.timeout` for curses dashboard updates
- refresh dashboard once per timeout
- exit with `q` from the dashboard
- test updated dashboard behaviour

## Testing
- `pre-commit run --all-files`
- `pytest -q -n 0`

------
https://chatgpt.com/codex/tasks/task_e_685f4a4227888333ad6f7927b58449ee