### PR TITLE
Cache ffmpeg hardware check

### DIFF
--- a/app/utils/system_metrics.py
+++ b/app/utils/system_metrics.py
@@ -12,7 +12,7 @@ import subprocess
 import threading
 import time
 from collections import deque
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import psutil
 
@@ -35,6 +35,8 @@ child_procs: List[psutil.Process] = []
 
 # Cache ffmpeg version after the first lookup to avoid repeated subprocess calls.
 FFMPEG_VERSION: str | None = None
+# Cache result of ffmpeg hwaccel capability detection
+FFMPEG_GPU_SUPPORT: Optional[bool] = None
 
 log_cache: deque = deque(maxlen=10000)
 log_cache_lock = threading.Lock()
@@ -67,14 +69,18 @@ def machine_supports_hwaccel() -> bool:
 def ffmpeg_supports_hwaccel() -> bool:
     """Return ``True`` if ``ffmpeg`` reports any hardware acceleration methods."""
 
+    global FFMPEG_GPU_SUPPORT
+    if FFMPEG_GPU_SUPPORT is not None:
+        return FFMPEG_GPU_SUPPORT
     try:
         output = subprocess.check_output(
             [FFMPEG_PATH, "-hwaccels"], stderr=subprocess.STDOUT, timeout=2
         ).decode()
         lines = [l.strip() for l in output.splitlines() if l.strip()]
-        return len(lines) > 1
+        FFMPEG_GPU_SUPPORT = len(lines) > 1
     except Exception:
-        return False
+        FFMPEG_GPU_SUPPORT = False
+    return FFMPEG_GPU_SUPPORT
 
 
 def collect_system_metrics() -> None:
@@ -145,7 +151,9 @@ def get_system_metrics() -> Dict[str, Any]:
         open_files = len(process.open_files())
     ffmpeg_path = shutil.which(FFMPEG_PATH) or FFMPEG_PATH
     ffmpeg_version_str = ffmpeg_version()
-    ffmpeg_gpu_support = ffmpeg_supports_hwaccel()
+    ffmpeg_gpu_support = (
+        ffmpeg_supports_hwaccel() if FFMPEG_GPU_SUPPORT is None else FFMPEG_GPU_SUPPORT
+    )
     return {
         "cpu_usage": round(system_metrics["cpu_usage"], 1),
         "memory_usage": round(system_metrics["memory_usage"], 1),

--- a/tests/test_system_metrics.py
+++ b/tests/test_system_metrics.py
@@ -1,0 +1,52 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.utils import system_metrics
+
+
+class TestFFmpegSupportCaching(unittest.TestCase):
+    def setUp(self):
+        system_metrics.FFMPEG_GPU_SUPPORT = None
+
+    def tearDown(self):
+        system_metrics.FFMPEG_GPU_SUPPORT = None
+
+    def test_ffmpeg_supports_hwaccel_caches_result(self):
+        output = b"Hardware acceleration methods:\nvaapi"
+        with patch(
+            "app.utils.system_metrics.subprocess.check_output", return_value=output
+        ) as mock_check:
+            self.assertTrue(system_metrics.ffmpeg_supports_hwaccel())
+            self.assertTrue(system_metrics.ffmpeg_supports_hwaccel())
+            self.assertEqual(mock_check.call_count, 1)
+
+    @patch("app.utils.system_metrics.FFMPEG_HWACCEL", "cuda")
+    @patch("app.utils.system_metrics.shutil.which", return_value="/usr/bin/ffmpeg")
+    @patch("app.utils.system_metrics.machine_supports_hwaccel", return_value=True)
+    @patch.object(system_metrics, "FFMPEG_VERSION", "6.0")
+    def test_get_system_metrics_uses_cached_value(self, *_):
+        with patch("app.utils.system_metrics.psutil") as mock_psutil:
+            mock_psutil.disk_usage.return_value = SimpleNamespace(percent=55.5)
+            process = mock_psutil.Process.return_value
+            if hasattr(process, "num_fds"):
+                process.num_fds.return_value = 3
+            else:
+                process.open_files.return_value = [1, 2, 3]
+
+            with patch(
+                "app.utils.system_metrics.subprocess.check_output",
+                return_value=b"Hardware acceleration methods:\nvaapi",
+            ) as mock_check:
+                system_metrics.FFMPEG_GPU_SUPPORT = None
+                metrics1 = system_metrics.get_system_metrics()
+                metrics2 = system_metrics.get_system_metrics()
+                call_count = mock_check.call_count
+
+        self.assertTrue(metrics1["ffmpeg_hwaccel"])
+        self.assertTrue(metrics2["ffmpeg_hwaccel"])
+        self.assertEqual(call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache ffmpeg GPU support detection result
- use cached value when collecting system metrics
- test the new caching behaviour

## Testing
- `pre-commit run --all-files`
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f4a280f748333ada2bcea0edb0b7b