### PR TITLE
Fix live view default

### DIFF
--- a/app/static/js/tile_player.js
+++ b/app/static/js/tile_player.js
@@ -52,7 +52,18 @@ export function initTilePlayer() {
     };
   }
 
+  const params = new URLSearchParams(window.location.search);
+  const requested = params.get("camera");
+
   let current = camSelect && camSelect.value ? camSelect.value : "All";
+  if (!camSelect) {
+    const cams = Object.keys(window.templateDetails).filter((c) => c !== "All");
+    if (requested && window.templateDetails[requested]) {
+      current = requested;
+    } else if (cams.length === 1) {
+      current = cams[0];
+    }
+  }
 
   let abortCtl;
   let liveTimer;

--- a/tests/js/tile_player.test.js
+++ b/tests/js/tile_player.test.js
@@ -20,6 +20,14 @@ test("defaults to all cameras", () => {
   expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
 });
 
+test("single camera defaults to that camera", () => {
+  document.body.innerHTML = `<video id="live-video"><source></source></video>`;
+  window.templateDetails = { SoloCam: {} };
+  init();
+  const img = document.getElementById("live-image");
+  expect(img.src).toMatch(/\/fast_stream\.mjpg\?camera=SoloCam&time=\d+$/);
+});
+
 test("no clip fetch occurs", async () => {
   global.fetch = jest.fn();
   init();
@@ -108,7 +116,7 @@ test("clip waits 30s before live", () => {
   jest.advanceTimersByTime(29999);
   expect(img.src).toBe("");
   jest.advanceTimersByTime(1);
-  expect(img.src).toMatch(/\/stream\.mjpg\?group=all&time=\d+$/);
+  expect(img.src).toMatch(/\/fast_stream\.mjpg\?camera=cam1&time=\d+$/);
 });
 
 test("init does not duplicate live-image", () => {


### PR DESCRIPTION
## Summary
- prefer requested camera when no selector is present
- test single-camera live view defaults
- update expected MJPEG path in existing test

## Testing
- `pre-commit run --all-files` *(fails: Failed to fetch packages)*
- `pytest -q` *(fails: initialization error & route assertions)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f964de91083338fba01ea0c0eff8e