### PR TITLE
Update pre-commit handling in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -66,7 +66,15 @@ jobs:
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pre-commit-
+      - name: Get changed files
+        if: github.event_name == 'pull_request'
+        id: changed
+        uses: tj-actions/changed-files@v44
+      - name: Run pre-commit on changed files
+        if: github.event_name == 'pull_request'
+        run: pre-commit run --files ${{ steps.changed.outputs.all_changed_files }}
       - name: Run pre-commit
+        if: github.event_name != 'pull_request'
         run: pre-commit run --all-files
       - name: Run JavaScript tests with coverage
         run: npm test -- --coverage

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -18,3 +18,5 @@ following tasks:
 Running `pre-commit run --all-files` locally will execute the same Black,
 isort, Flake8, and mypy checks before they fail in CI. These checks help catch
 regressions and security issues before code is merged.
+On pull requests the workflow lints only the files that changed, while pushes
+to `staging` or `main` run the linter across the entire repository.


### PR DESCRIPTION
## Summary
- lint only changed files on pull requests
- document new selective linting behaviour

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*
- `pytest -q` *(fails: multiple assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685fa38025e4833390063f753548ab18