### PR TITLE
Update CI to use secure changed-files action

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Get changed files
         if: github.event_name == 'pull_request'
         id: changed
-        uses: tj-actions/changed-files@v44
+        # v44 contained a vulnerability allowing secret leakage
+        # via logs. v45 or later resolves this issue.
+        uses: tj-actions/changed-files@v45
       - name: Run pre-commit on changed files
         if: github.event_name == 'pull_request'
         run: pre-commit run --files ${{ steps.changed.outputs.all_changed_files }}


### PR DESCRIPTION
## Summary
- use `tj-actions/changed-files@v45` in python workflow to avoid a vulnerability

## Testing
- `pre-commit run --all-files` *(fails: could not fetch dependencies)*
- `flake8`
- `pytest -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fa6f89c588333bcf66166bc9329ed