### PR TITLE
Fix reconnect after auth redirect

### DIFF
--- a/app/static/js/live.js
+++ b/app/static/js/live.js
@@ -1349,6 +1349,13 @@ let wasPlaying = false;
 async function attemptReconnect() {
   try {
     const res = await fetch("/network_status");
+    if (!res.ok || res.redirected) {
+      const ok = await attemptAutoLogin();
+      if (ok) {
+        return attemptReconnect();
+      }
+      return;
+    }
     const data = await res.json();
     if (data.error === "unauthorized") {
       const ok = await attemptAutoLogin();

--- a/tests/js/network_reconnect.test.js
+++ b/tests/js/network_reconnect.test.js
@@ -1,5 +1,9 @@
 import { jest } from "@jest/globals";
 
+jest.unstable_mockModule("../../app/static/js/login.js", () => ({
+  attemptAutoLogin: jest.fn(),
+}));
+
 document.body.innerHTML = `
   <div class="video-container"></div>
   <video id="live-video"></video>
@@ -36,15 +40,18 @@ Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
 
 let handleNetworkOffline;
 let handleNetworkOnline;
+let attemptAutoLogin;
 
 beforeAll(async () => {
   const mod = await import("../../app/static/js/live.js");
   handleNetworkOffline = mod.handleNetworkOffline;
   handleNetworkOnline = mod.handleNetworkOnline;
+  const loginMod = await import("../../app/static/js/login.js");
+  attemptAutoLogin = loginMod.attemptAutoLogin;
 });
 
 global.fetch = jest.fn(() =>
-  Promise.resolve({ json: () => Promise.resolve({ online: true }) }),
+  Promise.resolve({ ok: true, redirected: false, json: () => Promise.resolve({ online: true }) }),
 );
 
 beforeEach(() => {
@@ -65,6 +72,20 @@ test("shows offline overlay and resumes when back online", async () => {
   );
   await handleNetworkOnline();
   expect(fetch).toHaveBeenCalledWith("/network_status");
+  expect(document.getElementById("offline-indicator").style.display).toBe(
+    "none",
+  );
+});
+
+test("auto login attempts when network_status redirects", async () => {
+  attemptAutoLogin.mockResolvedValue(true);
+  global.fetch
+    .mockResolvedValueOnce({ ok: false, redirected: true, json: () => Promise.resolve({}) })
+    .mockResolvedValueOnce({ ok: true, redirected: false, json: () => Promise.resolve({ online: true }) });
+  handleNetworkOffline();
+  await handleNetworkOnline();
+  expect(attemptAutoLogin).toHaveBeenCalled();
+  expect(fetch).toHaveBeenCalledTimes(2);
   expect(document.getElementById("offline-indicator").style.display).toBe(
     "none",
   );


### PR DESCRIPTION
## Summary
- handle login redirects in reconnect logic
- mock auto-login in reconnect tests

## Testing
- `pre-commit run --all-files` *(fails: Failed to fetch dependencies)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68600613438c83339fe086323a78b117