### PR TITLE
docs: clarify GPU defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,8 @@ EMAIL_PASSWORD=
 # External binaries
 FFMPEG_PATH=ffmpeg
 FFPROBE_PATH=ffprobe
-FFMPEG_HWACCEL=False
+# Enable GPU acceleration when available. Set to "false" to force CPU mode.
+FFMPEG_HWACCEL=auto
 
 # LLM configuration
 LLM_MODEL_VERSION=gpt-4.1-mini

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -184,7 +184,7 @@ Additional variables control AI behaviour and external tools:
 - `FFMPEG_HWACCEL` – hardware acceleration mode for ffmpeg (default `auto`).
   When set to `auto` Glimpser inspects available encoders and enables the first
   supported GPU method (`cuda`, `vaapi`, `qsv`, `v4l2m2m`) or falls back to
-  software when none are detected.
+  software when none are detected. Set to `false` to force CPU mode.
 - When hardware acceleration is enabled and Chrome supports OpenGL, Glimpser
   automatically launches Chrome with `--use-gl=egl` for improved GPU use.
 - `FFMPEG_THREADS` – number of threads ffmpeg uses when encoding (default half the CPU cores)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,6 +76,9 @@ cp .env.example .env
 # edit .env as needed
 ```
 
+The sample file now sets `FFMPEG_HWACCEL=auto` so GPU acceleration works
+out of the box when supported. Change it to `false` to disable.
+
 ### 7. Set Up the Database
 
 Initialize the local SQLite database:


### PR DESCRIPTION
## Summary
- clarify default GPU behavior in environment example
- document FFMPEG_HWACCEL auto detection and disable option
- note GPU setting in installation guide

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --files .env.example docs/configuration_guide.md docs/installation.md` *(fails: Failed to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68600ec98dc48333b617cc7222b2b032