### PR TITLE
Add GPU build variants

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,13 @@ jobs:
   build:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gpu: [false, true]
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker image
-        run: docker build -t glimpser .
+        run: |
+          docker build \
+            --build-arg GLIMPSER_AUTO_BUILD_FFMPEG=${{ matrix.gpu && '1' || '0' }} \
+            -t glimpser:${{ matrix.gpu && 'gpu' || 'light' }} .

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -10,10 +10,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_debian:
+  build_light:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GLIMPSER_AUTO_BUILD_FFMPEG: "0"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -65,11 +67,54 @@ jobs:
           files: debian/glimpser.deb
           body_path: release-badges.md
 
-  build_windows:
-    runs-on: windows-latest
-    needs: build_debian
+  build_debian_gpu:
+    needs: build_light
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GLIMPSER_AUTO_BUILD_FFMPEG: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+      - name: Install dependencies with uv
+        run: uv pip install --system --editable . --group dev
+      - name: Build Debian package
+        run: |
+          ./build_packages.sh
+      - name: Build Python distributions
+        run: |
+          uv pip install --system build
+          python -m build
+      - name: Upload Debian GPU package
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: debian/glimpser.deb
+
+  build_windows:
+    runs-on: windows-latest
+    needs: build_light
+    strategy:
+      matrix:
+        gpu: [false, true]
+    permissions:
+      contents: write
+    env:
+      GLIMPSER_AUTO_BUILD_FFMPEG: ${{ matrix.gpu && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -103,9 +148,14 @@ jobs:
 
   build_macos:
     runs-on: macos-latest
-    needs: build_debian
+    needs: build_light
+    strategy:
+      matrix:
+        gpu: [false, true]
     permissions:
       contents: write
+    env:
+      GLIMPSER_AUTO_BUILD_FFMPEG: ${{ matrix.gpu && '1' || '0' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use an official Python runtime as a parent image
 FROM python:3.12-slim
 
+ARG GLIMPSER_AUTO_BUILD_FFMPEG=0
+ENV GLIMPSER_AUTO_BUILD_FFMPEG=$GLIMPSER_AUTO_BUILD_FFMPEG
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 libsqlite3-0 curl iputils-ping net-tools netcat-traditional \

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -31,7 +31,13 @@ EOF
 )
 mkdir -p debian/glimpser/opt/glimpser || { echo "Failed to create directory"; exit 1; }
 rsync -a app/ debian/glimpser/opt/glimpser/app/ || { echo "Failed to sync app directory"; exit 1; }
-rsync -a data/ debian/glimpser/opt/glimpser/data/ || { echo "Failed to sync data directory"; exit 1; }
+if [ -d data ]; then
+    rsync -a data/ debian/glimpser/opt/glimpser/data/ || {
+        echo "Failed to sync data directory"; exit 1;
+    }
+else
+    echo "Skipping data directory; none present"
+fi
 mkdir -p debian/glimpser/etc/systemd/system || { echo "Failed to create systemd directory"; exit 1; }
 cat > debian/glimpser/etc/systemd/system/glimpser.service << EOL || { echo "Failed to create service file"; exit 1; }
 [Unit]

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -1,7 +1,13 @@
 # Release Workflow
 
 Glimpser packages are generated automatically when a version tag is pushed to the repository.
-The process is split across multiple runners:
+The process is split across multiple runners. Each job first builds a **light**
+package without GPU support. Tests run against this CPU‑only version to catch
+issues quickly. Once the light build succeeds, a second pass builds packages
+with `GLIMPSER_AUTO_BUILD_FFMPEG=1` so FFmpeg includes GPU acceleration. This
+approach avoids lengthy GPU builds when tests fail.
+
+The runners are structured as follows:
 
 - **Ubuntu** builds the Debian package and runs the test suite. The packaging
   script now uses `rsync` to copy directories so unchanged files are skipped,


### PR DESCRIPTION
## Summary
- support GPU build arg in Dockerfile
- build light version first in CI
- build heavy (GPU) packages once tests pass
- build Docker images for both light and GPU variants

## Testing
- `pre-commit run --all-files` *(failed: Failed to fetch packages)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686016f74c48833386d57b5cf0eb2565