### PR TITLE
Fix precommit exclude docs

### DIFF
--- a/scripts/check_exclude_docs.py
+++ b/scripts/check_exclude_docs.py
@@ -45,6 +45,8 @@ def main() -> int:
         print("exclude_docs mismatch", file=sys.stderr)
         print(f"mkdocs.yml: {mkdocs_list}", file=sys.stderr)
         print(f"docs/exclude_docs: {expected_list}", file=sys.stderr)
+        DOCS_LIST_FILE.write_text("\n".join(mkdocs_list) + "\n")
+        print("docs/exclude_docs updated", file=sys.stderr)
         return 1
     return 0
 


### PR DESCRIPTION
## Summary
- auto-sync `docs/exclude_docs` within `check_exclude_docs.py`

## Testing
- `flake8`
- `black scripts/check_exclude_docs.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686017a4179c833392db6b5fee207768