### PR TITLE
Add site folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ package-lock.json
 
 # Packaging artifacts
 debian/glimpser/
+
+# Documentation build output
+site/


### PR DESCRIPTION
## Summary
- ignore MkDocs build output in git

## Testing
- `pre-commit run --all-files` *(fails: Failed to fetch Flask-APScheduler)*
- `flake8`
- `pytest -q` *(fails: several tests in test_routes)*

------
https://chatgpt.com/codex/tasks/task_e_6860441339fc8333928363654f4471e7