### PR TITLE
Ignore packaging artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,9 @@ package-lock.json
 
 # Packaging artifacts
 debian/glimpser/
+*.deb
+*.exe
+release-badges.md
+
+# Documentation build output
+site/


### PR DESCRIPTION
## Summary
- ignore Debian and Windows build outputs in gitignore
- treat release-badges as generated output

## Testing
- `pre-commit run --all-files` *(fails: Failed to fetch dependencies)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860441339fc8333928363654f4471e7