### PR TITLE
Fix build imports

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -18,7 +18,7 @@ import psutil
 from app.utils.api_utils import request_with_retry
 
 from .oui_map import OUI_MAP as BUILTIN_OUI_MAP
-from .screenshots import is_port_open
+from .chrome_utils import is_port_open
 
 # Minimal OUI mapping for MAC manufacturer lookup.  The bulk of prefixes lives
 # in ``app.utils.oui_map`` which avoids pulling in external dependencies.

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -117,6 +117,12 @@ from .screenshots import (
     remove_background,
     throttle_cache,
 )
+from .system_metrics import (
+    get_system_metrics,
+    start_log_caching,
+    start_metrics_collection,
+    stop_event,
+)
 from .sms_alerts import sms_alert
 from .template_manager import (
     get_llm_cost_estimate,

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1727,6 +1727,7 @@ from .chrome_utils import (
     get_chrome_path,
     get_chrome_version,
     is_chrome_debug_port_open,
+    is_port_open,
 )
 
 


### PR DESCRIPTION
## Summary
- fix imports for camera discovery and scheduling modules
- include chrome port check helper in screenshots

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*
- `pytest -q` *(fails: multiple import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68604614ee9883338e3b03630939739e