### PR TITLE
Fix version tag workflow

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -2,7 +2,7 @@ name: Tag Release
 
 on:
   push:
-    branches: ["main", "staging"]
+    branches: ["main"]
 
 jobs:
   tag_release:


### PR DESCRIPTION
## Summary
- limit the tag-on-version-bump workflow to run only on the `main` branch

## Testing
- `pre-commit run --all-files` *(fails: could not download dependencies)*
- `pytest -q` *(fails: ImportError: cannot import name 'is_port_open')*

------
https://chatgpt.com/codex/tasks/task_e_686047c63a3083338799451ac8009169