### PR TITLE
Fix scheduling exports for tests

### DIFF
--- a/app/utils/camera_discovery.py
+++ b/app/utils/camera_discovery.py
@@ -18,7 +18,7 @@ import psutil
 from app.utils.api_utils import request_with_retry
 
 from .oui_map import OUI_MAP as BUILTIN_OUI_MAP
-from .screenshots import is_port_open
+from .chrome_utils import is_port_open
 
 # Minimal OUI mapping for MAC manufacturer lookup.  The bulk of prefixes lives
 # in ``app.utils.oui_map`` which avoids pulling in external dependencies.

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -43,6 +43,8 @@ from dateutil import parser
 from flask_apscheduler import APScheduler
 from PIL import Image
 
+from . import system_metrics as _system_metrics
+
 
 class CLIPProcessor:
     """Lightweight CLIP preprocessor used with ONNX models.
@@ -92,6 +94,7 @@ from app.config import (
     VIDEO_DIRECTORY,
     WATCHDOG_CPU_THRESHOLD,
     WATCHDOG_MEMORY_THRESHOLD,
+    DEBUG,
     get_setting,
 )
 from app.models import LogSummary, OfflineJob, Summary
@@ -1086,6 +1089,17 @@ def schedule_crawlers():
 
 
 from .system_metrics import log_cache, log_cache_lock
+
+# Re-export select attributes for backwards compatibility with older tests
+LOGGING_PATH = _system_metrics.LOGGING_PATH
+cache_logs = _system_metrics.cache_logs
+start_log_caching = _system_metrics.start_log_caching
+stop_background_tasks = _system_metrics.stop_background_tasks
+system_metrics = _system_metrics.system_metrics
+start_metrics_collection = _system_metrics.start_metrics_collection
+stop_event = _system_metrics.stop_event
+get_system_metrics = _system_metrics.get_system_metrics
+DEBUG = DEBUG
 
 
 def get_feed_status():

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -1727,6 +1727,7 @@ from .chrome_utils import (
     get_chrome_path,
     get_chrome_version,
     is_chrome_debug_port_open,
+    is_port_open,
 )
 
 

--- a/scripts/auto_tag_release.py
+++ b/scripts/auto_tag_release.py
@@ -18,7 +18,14 @@ def get_version() -> str:
 
 def tag_exists(tag):
     result = subprocess.run(
-        ["git", "tag", "-l", tag], capture_output=True, text=True, check=False
+        [
+            "git",
+            "tag",
+            "-l",
+            tag,
+        ],
+        capture_output=True,
+        text=True,
     )
     return tag in result.stdout.split()
 


### PR DESCRIPTION
## Summary
- fix import for `is_port_open`
- re-export background helpers in `scheduling`
- expose port check via `screenshots`
- call `subprocess.run` without `check=False`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860488ce33083339459f2aa085ec4ba