### PR TITLE
Synchronize isort settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dev = [
   "black>=25.1",
   "coverage>=7.9",
   "flake8>=7.2",
-  "isort>=6.0",
+  "isort==6.0.1",
   "mkdocs>=1.6",
   "mypy>=1.16",
   "pre-commit>=4.2",
@@ -127,6 +127,9 @@ line-length       = 88
 target-version    = ["py311"]
 required-version  = "25.1.0"
 
+[tool.isort]
+profile = "black"
+
 # Ruff replaces most flake8 / isort / pylint rules, but you can keep the
 # originals for now; just run Ruff first so they have little to flag.
 [tool.ruff]
@@ -169,7 +172,7 @@ dev = [
   "black>=25.1",
   "coverage>=7.9",      # keep for standalone HTML reports
   "flake8>=7.2",
-  "isort>=6.0",         # now mirrors runtime pin
+  "isort==6.0.1",       # now mirrors runtime pin
   "mkdocs>=1.6",
   "mypy>=1.16",
   "pre-commit>=4.2",


### PR DESCRIPTION
## Summary
- pin isort version
- set profile for isort in pyproject

## Testing
- `flake8`
- `pytest -q` *(fails: sqlite3.OperationalError unable to open database)*
- `pre-commit run --all-files` *(fails: KeyboardInterrupt due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68605a35b3dc83339ed52ec31c2dd553