### PR TITLE
Add commit_with_retry tests

### DIFF
--- a/tests/test_commit_with_retry.py
+++ b/tests/test_commit_with_retry.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sqlalchemy.exc import OperationalError
+
+from app.utils.db import commit_with_retry
+
+
+class TestCommitWithRetry(unittest.TestCase):
+    def test_retries_on_locked_error(self):
+        session = MagicMock()
+        session.commit.side_effect = [
+            OperationalError("stmt", {}, Exception("database is locked")),
+            None,
+        ]
+        with patch("app.utils.db.time.sleep") as mock_sleep:
+            commit_with_retry(session, attempts=2, delay=0)
+        self.assertEqual(session.commit.call_count, 2)
+        session.rollback.assert_called_once()
+        mock_sleep.assert_called_once()
+
+    def test_raises_non_locked_error(self):
+        session = MagicMock()
+        session.commit.side_effect = OperationalError("stmt", {}, Exception("other"))
+        with self.assertRaises(OperationalError):
+            commit_with_retry(session, attempts=2, delay=0)
+        session.rollback.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for commit_with_retry

## Testing
- `flake8`
- `pre-commit run --all-files` *(failed: failed to download dependencies)*
- `pytest tests/test_commit_with_retry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686066dd03e88333815d125bda6ccfa7