### PR TITLE
Fix isort grouping in commit retry test

### DIFF
--- a/tests/test_commit_with_retry.py
+++ b/tests/test_commit_with_retry.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
+
 from sqlalchemy.exc import OperationalError
 
 from app.utils.db import commit_with_retry


### PR DESCRIPTION
## Summary
- fix import grouping for `tests/test_commit_with_retry.py`

## Testing
- `pytest tests/test_commit_with_retry.py -q`
- `pre-commit run --files tests/test_commit_with_retry.py` *(fails: Could not download py-serializable due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68606921dd388333b8964d949ead3a4a