### PR TITLE
Fix SSRF and symlink path issues

### DIFF
--- a/app/blueprints/discovery.py
+++ b/app/blueprints/discovery.py
@@ -182,7 +182,7 @@ def create_blueprint() -> Blueprint:
 
         url = request.args.get("url") or ""
         url = routes.validators.validate_url(url)
-        if not url:
+        if not url or not routes.validators.is_public_url(url):
             return jsonify({"ok": False, "error": "invalid"}), 400
 
         def attempt(method: str) -> tuple[bool, dict]:

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -339,11 +339,11 @@ from .image_utils import add_motion_and_caption, find_closest_image
 
 def safe_symlink(src: str, dst: str) -> None:
     """Create ``dst`` pointing to ``src`` replacing any existing link."""
-    try:
-        os.symlink(src, dst)
-    except FileExistsError:
-        os.remove(dst)
-        os.symlink(src, dst)
+    src_path = os.path.abspath(src)
+    dst_path = os.path.abspath(dst)
+    if os.path.lexists(dst_path):
+        os.remove(dst_path)
+    os.symlink(src_path, dst_path)
 
 
 def update_camera(name, template, image_file=None, motion=False):

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -167,9 +167,10 @@ class TestCameraDiscovery(unittest.TestCase):
         ]
         self.assertEqual(result, expected)
 
+    @patch("app.utils.camera_discovery._fetch_snmp_sysdescr", return_value="desc")
     @patch("app.utils.camera_discovery._fetch_snmp_sysname")
     @patch("app.utils.camera_discovery.is_port_open")
-    def test_scan_snmp_ports(self, mock_port_open, mock_fetch_name):
+    def test_scan_snmp_ports(self, mock_port_open, mock_fetch_name, mock_descr):
         mock_port_open.side_effect = self._port_open_side_effect
         mock_fetch_name.return_value = "cam1"
         subnets = [
@@ -182,7 +183,7 @@ class TestCameraDiscovery(unittest.TestCase):
                 "ip": "192.168.1.6",
                 "protocol": "snmp",
                 "port": 161,
-                "info": {"name": "cam1"},
+                "info": {"name": "cam1", "firmware": "desc"},
             },
         ]
         self.assertEqual(result, expected)

--- a/tests/test_safe_symlink.py
+++ b/tests/test_safe_symlink.py
@@ -19,6 +19,20 @@ class TestSafeSymlink(unittest.TestCase):
 
             self.assertEqual(os.readlink(dst), src2)
 
+    def test_uses_absolute_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = "f"
+            dst = os.path.join(tmp, "link")
+            open(os.path.join(tmp, src), "w").close()
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            try:
+                safe_symlink(src, dst)
+            finally:
+                os.chdir(cwd)
+
+            self.assertEqual(os.readlink(dst), os.path.abspath(os.path.join(tmp, src)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -39,7 +39,10 @@ def tmp_http_server(tmp_path):
 
 
 def test_url_test_endpoint(tmp_http_server):
-    with patch("app.routes.login_required", lambda x: x):
+    with (
+        patch("app.routes.login_required", lambda x: x),
+        patch("app.routes.validators.is_public_url", return_value=True),
+    ):
         app = create_app(enable_watchdog=False, schedule=False, log_cache=False)
         server = ServerThread(app)
         server.start()


### PR DESCRIPTION
## Summary
- validate URLs against local addresses before testing
- sanitize symlink paths
- update URL test to patch public-url check
- extend symlink tests for absolute targets
- mock SNMP sysdescr fetch in camera discovery test

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --all-files` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68606df637ec83338f0ca24d7950e584