### PR TITLE
Fix SSRF and symlink paths

### DIFF
--- a/app/utils/http_callbacks.py
+++ b/app/utils/http_callbacks.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import requests
 
 from .logging_utils import sanitize_url
+from .validators import is_public_url
 
 
 def send_http_callback(
@@ -18,6 +19,9 @@ def send_http_callback(
     retries=0,
 ):
     """Send an HTTP POST callback if a URL is provided.
+
+    Only public URLs are allowed to prevent SSRF attacks. The call is
+    skipped when *url* points to a private address.
 
     Parameters
     ----------
@@ -38,6 +42,10 @@ def send_http_callback(
     hammering the remote service.
     """
     if not url:
+        return
+
+    if not is_public_url(url):
+        logging.warning("Callback URL not public: %s", sanitize_url(url))
         return
 
     parsed = urlparse(url)

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -335,14 +335,28 @@ def run_with_timeout(func, args=(), timeout=300):
 
 
 from .image_utils import add_motion_and_caption, find_closest_image
+from app.config import SCREENSHOT_DIRECTORY
 
 
 def safe_symlink(src: str, dst: str) -> None:
-    """Create ``dst`` pointing to ``src`` replacing any existing link."""
+    """Create ``dst`` pointing to ``src`` replacing any existing link.
+
+    Both paths must reside under ``SCREENSHOT_DIRECTORY`` to avoid
+    creating links outside the managed tree.
+    """
+
     src_path = os.path.abspath(src)
     dst_path = os.path.abspath(dst)
+
+    base = os.path.abspath(SCREENSHOT_DIRECTORY)
+    # Reject paths outside the screenshot directory to mitigate
+    # symlink attacks on arbitrary locations.
+    if not src_path.startswith(base) or not dst_path.startswith(base):
+        raise ValueError("symlink paths must stay within screenshot directory")
+
     if os.path.lexists(dst_path):
         os.remove(dst_path)
+    os.makedirs(os.path.dirname(dst_path), exist_ok=True)
     os.symlink(src_path, dst_path)
 
 
@@ -416,7 +430,7 @@ def update_camera(name, template, image_file=None, motion=False):
             if os.path.lexists(lpath + ".tmp"):
                 os.unlink(os.path.abspath(lpath + ".tmp"))
             safe_symlink(
-                os.path.abspath(os.path.join("data/screenshots", name, png_files[-1])),
+                os.path.abspath(os.path.join(SCREENSHOT_DIRECTORY, name, png_files[-1])),
                 os.path.abspath(lpath + ".tmp"),
             )
             os.rename(os.path.abspath(lpath + ".tmp"), os.path.abspath(lpath))
@@ -425,7 +439,7 @@ def update_camera(name, template, image_file=None, motion=False):
             if os.path.lexists(lpath + ".tmp"):
                 os.unlink(os.path.abspath(lpath + ".tmp"))
             safe_symlink(
-                os.path.abspath(os.path.join("data/screenshots", name, png_files[-1])),
+                os.path.abspath(os.path.join(SCREENSHOT_DIRECTORY, name, png_files[-1])),
                 os.path.abspath(lpath + ".tmp"),
             )
             os.rename(os.path.abspath(lpath + ".tmp"), os.path.abspath(lpath))
@@ -442,7 +456,7 @@ def update_camera(name, template, image_file=None, motion=False):
                         os.unlink(os.path.abspath(group_lpath + ".tmp"))
                     safe_symlink(
                         os.path.abspath(
-                            os.path.join("data/screenshots", name, png_files[-1])
+                            os.path.join(SCREENSHOT_DIRECTORY, name, png_files[-1])
                         ),
                         os.path.abspath(group_lpath + ".tmp"),
                     )
@@ -725,7 +739,7 @@ def update_camera(name, template, image_file=None, motion=False):
                 ):
                     os.remove(os.path.join(directory, "last_motion_caption.png.tmp"))
                 safe_symlink(
-                    png_files[-1],
+                    os.path.join(directory, png_files[-1]),
                     os.path.join(directory, "last_motion_caption.png.tmp"),
                 )
                 os.rename(
@@ -737,7 +751,8 @@ def update_camera(name, template, image_file=None, motion=False):
                 if os.path.lexists(os.path.join(directory, "last_caption.png.tmp")):
                     os.remove(os.path.join(directory, "last_caption.png.tmp"))
                 safe_symlink(
-                    png_files[-1], os.path.join(directory, "last_caption.png.tmp")
+                    os.path.join(directory, png_files[-1]),
+                    os.path.join(directory, "last_caption.png.tmp"),
                 )
                 os.rename(
                     os.path.join(directory, "last_caption.png.tmp"),
@@ -749,7 +764,8 @@ def update_camera(name, template, image_file=None, motion=False):
                 if os.path.lexists(os.path.join(directory, "prev_motion.png.tmp")):
                     os.remove(os.path.join(directory, "prev_motion.png.tmp"))
                 safe_symlink(
-                    destination, os.path.join(directory, "prev_motion.png.tmp")
+                    destination,
+                    os.path.join(directory, "prev_motion.png.tmp"),
                 )
                 os.rename(
                     os.path.join(directory, "prev_motion.png.tmp"),
@@ -758,7 +774,10 @@ def update_camera(name, template, image_file=None, motion=False):
                 image_paths.append(os.path.join(directory, "prev_motion.png"))
             if os.path.lexists(os.path.join(directory, "last_motion.png.tmp")):
                 os.remove(os.path.join(directory, "last_motion.png.tmp"))
-            safe_symlink(png_files[-1], os.path.join(directory, "last_motion.png.tmp"))
+            safe_symlink(
+                os.path.join(directory, png_files[-1]),
+                os.path.join(directory, "last_motion.png.tmp"),
+            )
             os.rename(
                 os.path.join(directory, "last_motion.png.tmp"),
                 os.path.join(directory, "last_motion.png"),
@@ -789,7 +808,8 @@ def update_camera(name, template, image_file=None, motion=False):
                 if os.path.lexists(os.path.join(directory, "prev_motion.png.tmp")):
                     os.remove(os.path.join(directory, "prev_motion.png.tmp"))
                 safe_symlink(
-                    destination, os.path.join(directory, "prev_motion.png.tmp")
+                    destination,
+                    os.path.join(directory, "prev_motion.png.tmp"),
                 )
                 os.rename(
                     os.path.join(directory, "prev_motion.png.tmp"),
@@ -797,7 +817,10 @@ def update_camera(name, template, image_file=None, motion=False):
                 )
             if os.path.lexists(os.path.join(directory, "last_motion.png.tmp")):
                 os.remove(os.path.join(directory, "last_motion.png.tmp"))
-            safe_symlink(png_files[-1], os.path.join(directory, "last_motion.png.tmp"))
+            safe_symlink(
+                os.path.join(directory, png_files[-1]),
+                os.path.join(directory, "last_motion.png.tmp"),
+            )
             os.rename(
                 os.path.join(directory, "last_motion.png.tmp"),
                 os.path.join(directory, "last_motion.png"),

--- a/tests/test_http_callbacks.py
+++ b/tests/test_http_callbacks.py
@@ -52,6 +52,11 @@ class TestHttpCallbacks(unittest.TestCase):
             send_http_callback("http://badhost", "event", {})
             mock_post.assert_not_called()
 
+    def test_send_http_callback_private_host(self):
+        with patch("requests.post") as mock_post:
+            send_http_callback("http://localhost", "event", {})
+            mock_post.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_safe_symlink.py
+++ b/tests/test_safe_symlink.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 import unittest
 
+from unittest.mock import patch
+
 from app.utils.scheduling import safe_symlink
 
 
@@ -15,7 +17,8 @@ class TestSafeSymlink(unittest.TestCase):
             open(src2, "w").close()
             os.symlink(src1, dst)
 
-            safe_symlink(src2, dst)
+            with patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp):
+                safe_symlink(src2, dst)
 
             self.assertEqual(os.readlink(dst), src2)
 
@@ -27,11 +30,23 @@ class TestSafeSymlink(unittest.TestCase):
             cwd = os.getcwd()
             os.chdir(tmp)
             try:
-                safe_symlink(src, dst)
+                with patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp):
+                    safe_symlink(src, dst)
             finally:
                 os.chdir(cwd)
 
             self.assertEqual(os.readlink(dst), os.path.abspath(os.path.join(tmp, src)))
+
+    def test_rejects_outside_base(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "shots")
+            os.makedirs(base)
+            src = os.path.join(tmp, "f")
+            dst = os.path.join(tmp, "link")
+            open(src, "w").close()
+            with patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", base):
+                with self.assertRaises(ValueError):
+                    safe_symlink(src, dst)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce public URL check in `send_http_callback`
- restrict `safe_symlink` to screenshot directory
- use screenshot directory for symlink sources
- adjust tests for new validations
- add regression tests

## Testing
- `flake8`
- `pre-commit` *(fails: failed to download dependencies)*
- `pytest tests/test_http_callbacks.py tests/test_safe_symlink.py tests/test_clip_config.py::TestClipModelSetting::test_custom_onnx_clip_model_used tests/test_clip_config.py::TestClipModelSetting::test_skips_when_onnx_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_6860712599d88333a74d85a8669f78a7