### PR TITLE
Sanitize group names before creating symlinks

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -136,7 +136,7 @@ from .template_manager import (
     set_capture_failed,
     update_last_screenshot_time,
 )
-from .validators import validate_template_name
+from .validators import validate_group_name, validate_template_name
 
 logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
@@ -444,13 +444,16 @@ def update_camera(name, template, image_file=None, motion=False):
             )
             os.rename(os.path.abspath(lpath + ".tmp"), os.path.abspath(lpath))
 
-            # Create symlinks for each group
+            # Create symlinks for each valid group
             if "groups" in template:
                 groups = template["groups"].split(",")
                 for group in groups:
-                    trimmed_group_name = group.strip()
+                    valid_group = validate_group_name(group)
+                    if not valid_group:
+                        logging.warning("Ignoring invalid group name: %s", group)
+                        continue
                     group_lpath = os.path.join(
-                        SCREENSHOT_DIRECTORY, f"{trimmed_group_name}_latest_camera.png"
+                        SCREENSHOT_DIRECTORY, f"{valid_group}_latest_camera.png"
                     )
                     if os.path.lexists(group_lpath + ".tmp"):
                         os.unlink(os.path.abspath(group_lpath + ".tmp"))

--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -128,6 +128,32 @@ def validate_template_name(template_name: str):
     return sanitized_name
 
 
+def validate_group_name(group_name: str | None) -> str | None:
+    """Return sanitized group name if valid, otherwise ``None``."""
+
+    if group_name is None or not isinstance(group_name, str):
+        return None
+
+    sanitized = group_name.strip().replace(" ", "_").lower()
+    if not sanitized:
+        return None
+
+    allowed = set("abcdefghijklmnopqrstuvwxyz0123456789_-")
+    if not all(ch in allowed for ch in sanitized):
+        return None
+
+    if sanitized[0] in "-_" or sanitized[-1] in "-_":
+        return None
+    if ".." in sanitized or "--" in sanitized or "__" in sanitized:
+        return None
+
+    secure = secure_filename(sanitized)
+    if secure != sanitized or len(secure) > 32:
+        return None
+
+    return secure
+
+
 def validate_update_data(data: dict) -> dict:
     """Validate and normalize template update data.
 

--- a/tests/test_validate_group_name.py
+++ b/tests/test_validate_group_name.py
@@ -1,0 +1,18 @@
+import unittest
+
+from app.utils.validators import validate_group_name
+
+
+class TestValidateGroupName(unittest.TestCase):
+    def test_valid_names(self):
+        self.assertEqual(validate_group_name("Group One"), "group_one")
+        self.assertEqual(validate_group_name("group-1"), "group-1")
+
+    def test_invalid_names(self):
+        self.assertIsNone(validate_group_name("../evil"))
+        self.assertIsNone(validate_group_name("bad/name"))
+        self.assertIsNone(validate_group_name("bad..name"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid symlink errors by validating group names
- add validator helper and tests

## Testing
- `pre-commit run --files app/utils/validators.py app/utils/scheduling.py tests/test_validate_group_name.py` *(fails: failed to download pluggy)*
- `pytest --cov=. -q`

------
https://chatgpt.com/codex/tasks/task_e_6860877561e48333a9829edcf5e36b7f