### PR TITLE
Fix relative symlink handling in update_camera

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -769,6 +769,12 @@ def update_camera(name, template, image_file=None, motion=False):
 
             if os.path.lexists(prev_motion):
                 destination = os.readlink(prev_motion)
+                if not os.path.isabs(destination):
+                    # ``os.readlink`` may return a relative path when the
+                    # symlink was created with one. Convert it to an absolute
+                    # path relative to the camera directory so ``safe_symlink``
+                    # does not reject it as escaping ``SCREENSHOT_DIRECTORY``.
+                    destination = os.path.abspath(os.path.join(directory, destination))
                 if os.path.lexists(os.path.join(directory, "prev_motion.png.tmp")):
                     os.remove(os.path.join(directory, "prev_motion.png.tmp"))
                 safe_symlink(
@@ -813,6 +819,9 @@ def update_camera(name, template, image_file=None, motion=False):
 
             if os.path.lexists(prev_motion):
                 destination = os.readlink(prev_motion)
+                if not os.path.isabs(destination):
+                    # Normalize relative symlink targets to absolute paths.
+                    destination = os.path.abspath(os.path.join(directory, destination))
                 if os.path.lexists(os.path.join(directory, "prev_motion.png.tmp")):
                     os.remove(os.path.join(directory, "prev_motion.png.tmp"))
                 safe_symlink(

--- a/tests/test_update_camera_symlink.py
+++ b/tests/test_update_camera_symlink.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+from PIL import Image
+
+import app.utils.scheduling as scheduling
+
+
+class TestUpdateCameraSymlink(unittest.TestCase):
+    def test_handles_relative_prev_motion_symlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cam_dir = os.path.join(tmp, "cam1")
+            os.makedirs(cam_dir)
+            img1 = os.path.join(cam_dir, "img1.png")
+            img2 = os.path.join(cam_dir, "img2.png")
+            Image.new("RGB", (10, 10)).save(img1)
+            Image.new("RGB", (10, 10)).save(img2)
+
+            os.symlink("img1.png", os.path.join(cam_dir, "last_motion.png"))
+
+            template = {"name": "cam1", "motion": 0, "last_caption": "", "url": ""}
+
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("app.utils.scheduling.capture_or_download", return_value=True),
+                patch("app.utils.scheduling.add_timestamp"),
+                patch("app.utils.scheduling.remove_background"),
+                patch("app.utils.scheduling.add_motion_and_caption"),
+                patch("app.utils.scheduling.save_template"),
+                patch("app.utils.scheduling.send_http_callback"),
+                patch("app.utils.scheduling.chatgpt_compare", return_value="cap"),
+                patch("app.utils.scheduling.is_mostly_blank", return_value=False),
+                patch("app.utils.scheduling.get_template", return_value=template),
+            ):
+                scheduling.update_camera("cam1", template)
+
+            self.assertTrue(os.path.islink(os.path.join(cam_dir, "prev_motion.png")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid ValueError in update_camera when existing prev_motion symlink uses relative paths
- add regression test for relative prev_motion symlink

## Testing
- `flake8`
- `pre-commit run --all-files` *(failed: unsuccessful tunnel)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608daf82548333914d5a751fed7c23