### PR TITLE
Document service_worker cache policy

### DIFF
--- a/app/blueprints/assets.py
+++ b/app/blueprints/assets.py
@@ -256,8 +256,12 @@ def create_blueprint() -> Blueprint:
         return resp
 
     @bp.route("/sw.js")
-    def service_worker():
-        response = routes.make_response(routes.current_app.send_static_file("sw.js"))
+    def service_worker() -> Response:
+        """Return the service-worker script with ``Cache-Control: no-cache``."""
+
+        response = routes.make_response(
+            routes.current_app.send_static_file("sw.js")
+        )
         response.headers["Cache-Control"] = "no-cache"
         return response
 


### PR DESCRIPTION
## Summary
- document assets blueprint's service_worker route

## Testing
- `pre-commit run --all-files` *(fails: Failed to download packages)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608f32a9d0833383c3df75267eb1b1