### PR TITLE
Add docstrings to dummy session methods

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -121,13 +121,14 @@ def _get_session():
 
         class _DummySession:
             def execute(self, *args, **kwargs):
+                """Return a dummy result."""
                 return _DummyResult()
 
             def commit(self):
-                pass
+                """Pretend to commit."""
 
             def close(self):
-                pass
+                """Do nothing."""
 
         return _DummySession()
 


### PR DESCRIPTION
## Summary
- add docstrings for methods of `_DummySession` in `config.py`

## Testing
- `flake8 app/config.py`
- `pytest`
- `pre-commit run --files app/config.py` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68608f36ef688333a48cd83f2dcc8eb4