### PR TITLE
Add JSDoc comments for JS helpers

### DIFF
--- a/app/static/js/cli_help.js
+++ b/app/static/js/cli_help.js
@@ -1,3 +1,10 @@
+/**
+ * Load CLI help text into the page on demand.
+ *
+ * Requires a button with id `load-cli-help` and an output element
+ * with id `cli-help`. Fetches `/cli_help` when the button is clicked
+ * and reveals the result.
+ */
 export function initCliHelp() {
   document.addEventListener("DOMContentLoaded", () => {
     const button = document.getElementById("load-cli-help");

--- a/app/static/js/notifications.js
+++ b/app/static/js/notifications.js
@@ -1,3 +1,10 @@
+/**
+ * Initialize streaming notifications and push subscription.
+ *
+ * Opens an EventSource to `/stream_notifications` and displays
+ * browser notifications when permitted. Registers a push
+ * subscription via the active service worker if available.
+ */
 export function initNotifications() {
   if (!("Notification" in window)) return;
 


### PR DESCRIPTION
## Summary
- document exported functions in notifications.js and cli_help.js

## Testing
- `npm test --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608f3795fc8333b7dfe1dd31a24907