### PR TITLE
Add user activity docstrings

### DIFF
--- a/app/utils/user_activity.py
+++ b/app/utils/user_activity.py
@@ -40,21 +40,52 @@ user_active = False
 
 # Callback functions to update activity state
 def on_move(x, y):
+    """Set ``user_active`` when the mouse moves.
+
+    Args:
+        x (int): The mouse X coordinate.
+        y (int): The mouse Y coordinate.
+    """
+
     global user_active
     user_active = True
 
 
 def on_click(x, y, button, pressed):
+    """Set ``user_active`` when a mouse button is clicked.
+
+    Args:
+        x (int): The mouse X coordinate.
+        y (int): The mouse Y coordinate.
+        button: The mouse button pressed.
+        pressed (bool): Whether the button is pressed.
+    """
+
     global user_active
     user_active = True
 
 
 def on_scroll(x, y, dx, dy):
+    """Set ``user_active`` when the mouse wheel scrolls.
+
+    Args:
+        x (int): The mouse X coordinate.
+        y (int): The mouse Y coordinate.
+        dx (int): Horizontal scroll delta.
+        dy (int): Vertical scroll delta.
+    """
+
     global user_active
     user_active = True
 
 
 def on_press(key):
+    """Set ``user_active`` when a key is pressed.
+
+    Args:
+        key: The pressed key.
+    """
+
     global user_active
     user_active = True
 
@@ -65,6 +96,8 @@ _xss = None
 
 
 class XScreenSaverInfo(ctypes.Structure):
+    """Structure for XScreenSaverInfo returned by libXss."""
+
     _fields_ = [
         ("window", ctypes.c_ulong),
         ("state", ctypes.c_int),
@@ -191,6 +224,15 @@ def idle_seconds_macos() -> int:
 
 
 def check_user_activity(timeout: int = 10) -> bool:
+    """Return True if recent user interaction is observed.
+
+    Args:
+        timeout (int): Seconds to wait for an input event.
+
+    Returns:
+        bool: ``True`` if the user appears active.
+    """
+
     _safe_import_pynput()
     global user_active
     user_active = False


### PR DESCRIPTION
## Summary
- document user activity callbacks
- explain XScreenSaverInfo purpose
- document check_user_activity

## Testing
- `flake8`
- `pre-commit run --all-files` *(failed: unable to download dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608f3f26948333b8e57f2832013c77