### PR TITLE
Add headers and JSDoc for JS modules

### DIFF
--- a/app/static/js/camera_utils.js
+++ b/app/static/js/camera_utils.js
@@ -1,3 +1,13 @@
+/**
+ * Utility functions for camera-related lookups.
+ */
+
+/**
+ * Extract camera names from the details object.
+ *
+ * @param {Object} details Mapping of camera info keyed by name.
+ * @returns {string[]} Array of camera names.
+ */
 export function getCameraNames(details) {
   return Object.keys(details).filter(
     (key) => key !== "All" && !key.startsWith("group-"),

--- a/app/static/js/group_utils.js
+++ b/app/static/js/group_utils.js
@@ -1,3 +1,12 @@
+/**
+ * Helpers for loading and selecting camera groups.
+ */
+
+/**
+ * Fetch available groups and populate dropdowns.
+ *
+ * @returns {Promise<void>} Promise resolving when groups are loaded.
+ */
 export async function loadGroups() {
   const groupDropdown =
     document.getElementById("group-dropdown") ||
@@ -50,6 +59,11 @@ export async function loadGroups() {
   }
 }
 
+/**
+ * Determine the currently selected camera group.
+ *
+ * @returns {string} Selected group name or "all".
+ */
 export function getSelectedGroup() {
   const dropdown = document.getElementById("group-dropdown");
   if (dropdown && dropdown.value) return dropdown.value;

--- a/app/static/js/video.js
+++ b/app/static/js/video.js
@@ -1,3 +1,7 @@
+/**
+ * Video playback controls and clip prefetch logic.
+ */
+
 import { setCaptionsVisibility } from "./templates.js";
 
 let scrubTooltip;
@@ -70,6 +74,11 @@ function showErrorIndicator(video) {
   }, 2000);
 }
 
+/**
+ * Set delay between clip prefetch attempts.
+ *
+ * @param {number} ms Delay in milliseconds.
+ */
 export function setQueueDelay(ms) {
   queueDelay = ms;
 }
@@ -84,6 +93,11 @@ function adjustDelay(success) {
   }
 }
 
+/**
+ * Queue a video element for HD clip prefetching.
+ *
+ * @param {HTMLVideoElement} video Video element to preload.
+ */
 export function enqueueClip(video) {
   if (!video.dataset.hdSrc || video.dataset.hdLoaded === "true") return;
   if (prefetchQueue.includes(video)) return;
@@ -92,6 +106,9 @@ export function enqueueClip(video) {
   if (!processing) processQueue();
 }
 
+/**
+ * Stop any pending prefetch operations.
+ */
 export function clearPrefetchQueue() {
   prefetchQueue = [];
   processing = false;
@@ -143,6 +160,9 @@ function safePlay(el) {
   }
 }
 
+/**
+ * Initialize video behavior on discovery pages.
+ */
 export function initVideoControls() {
   document.addEventListener("DOMContentLoaded", () => {
     setupStatusPageVideoHover();
@@ -228,6 +248,9 @@ export function initVideoControls() {
   };
 }
 
+/**
+ * Refresh clip and poster URLs to avoid caching.
+ */
 export function updateVideoSources() {
   const videos = document.querySelectorAll(".templateDiv video");
   videos.forEach((video) => {
@@ -238,6 +261,9 @@ export function updateVideoSources() {
   });
 }
 
+/**
+ * Pause videos when the page becomes hidden.
+ */
 export function initVisibilityHandler() {
   document.addEventListener("visibilitychange", () => {
     if (document.hidden) {
@@ -247,6 +273,9 @@ export function initVisibilityHandler() {
   });
 }
 
+/**
+ * Set up live video control elements.
+ */
 export function setupVideoControls() {
   const video = document.getElementById("live-video");
   if (!video) return;
@@ -391,6 +420,9 @@ export function setupVideoControls() {
   }
 }
 
+/**
+ * Lazy-load and scrub preview clips on the status page.
+ */
 export function setupStatusPageVideoHover() {
   const thumbnailVideoCells = document.querySelectorAll(".thumbnail-video");
   const observer = new IntersectionObserver(
@@ -475,6 +507,9 @@ export function setupStatusPageVideoHover() {
   });
 }
 
+/**
+ * Enable hover scrubbing on the captions page.
+ */
 export function setupCaptionsPageVideoHover() {
   const containers = document.querySelectorAll(
     ".captions-page .video-container",
@@ -544,6 +579,9 @@ export function setupCaptionsPageVideoHover() {
   });
 }
 
+/**
+ * Initialize Google Cast API with default options.
+ */
 export function initializeCastApi() {
   cast.framework.CastContext.getInstance().setOptions({
     receiverApplicationId: chrome.cast.media.DEFAULT_MEDIA_RECEIVER_APP_ID,
@@ -551,6 +589,9 @@ export function initializeCastApi() {
   });
 }
 
+/**
+ * Start casting the live video to a receiver.
+ */
 export function startCasting() {
   const castSession =
     cast.framework.CastContext.getInstance().getCurrentSession();


### PR DESCRIPTION
## Summary
- document camera utilities
- add docs for group utilities
- clarify video module functions

## Testing
- `flake8`
- `pytest -q`
- `npm test`
- `pre-commit run --all-files` *(fails: Failed to download `multidict==6.4.4`)*

------
https://chatgpt.com/codex/tasks/task_e_68608f4dc6e483339c7274b6d78c3c66