### PR TITLE
Document JS helpers with JSDoc

### DIFF
--- a/app/static/js/camera_utils.js
+++ b/app/static/js/camera_utils.js
@@ -1,3 +1,10 @@
+// Extract camera names from server-provided details
+
+/**
+ * Return camera names excluding group keys.
+ * @param {Record<string, unknown>} details - Data keyed by camera.
+ * @returns {string[]} Array of camera names.
+ */
 export function getCameraNames(details) {
   return Object.keys(details).filter(
     (key) => key !== "All" && !key.startsWith("group-"),

--- a/app/static/js/fetch_utils.js
+++ b/app/static/js/fetch_utils.js
@@ -1,5 +1,12 @@
+// Lightweight fetch wrapper returning parsed JSON
+
+/**
+ * Fetch JSON from a URL with error handling.
+ * @param {string} url - Target endpoint.
+ * @param {RequestInit} [options] - Fetch options.
+ * @returns {Promise<unknown>} Parsed response body.
+ */
 export async function fetchJson(url, options = {}) {
-  // Wrapper to fetch JSON with basic error handling
   try {
     const res = await fetch(url, options);
     if (!res.ok) {

--- a/app/static/js/grid_utils.js
+++ b/app/static/js/grid_utils.js
@@ -1,9 +1,20 @@
+// Utilities for building and managing the camera grid layout
 import { timeAgo, NO_TIMESTAMP_PLACEHOLDER } from "./time_utils.js";
 
+/**
+ * Detect if the current viewport is considered mobile.
+ * @returns {boolean} True when running on a small screen.
+ */
 export function isMobile() {
   return window.matchMedia("(hover: none) and (max-width: 767px)").matches;
 }
 
+/**
+ * Compute border color based on screenshot age and error state.
+ * @param {number} ageMinutes - Minutes since last screenshot.
+ * @param {boolean} isError - Whether capture failed.
+ * @returns {string} RGBA color string.
+ */
 export function computeBorderColor(ageMinutes, isError) {
   const base = isError ? [128, 128, 128] : [26, 115, 232];
   let step = 0;
@@ -14,6 +25,14 @@ export function computeBorderColor(ageMinutes, isError) {
   return `rgba(${base[0]}, ${base[1]}, ${base[2]}, ${alpha})`;
 }
 
+/**
+ * Build a DOM node representing a camera template card.
+ * @param {string} name - Camera name.
+ * @param {Record<string, any>} template - Metadata for the camera.
+ * @param {number} index - Position in the list.
+ * @param {boolean} mobile - Whether to add mobile styling.
+ * @returns {HTMLDivElement} Constructed card element.
+ */
 export function createTemplateCard(name, template, index, mobile) {
   const lastScreenshotTime =
     template.last_screenshot_time || NO_TIMESTAMP_PLACEHOLDER;
@@ -62,6 +81,10 @@ export function createTemplateCard(name, template, index, mobile) {
 
 let captionsVisible = localStorage.getItem("showCaptions") !== "false";
 
+/**
+ * Persist and apply caption visibility toggle.
+ * @param {boolean} value - Desired visibility state.
+ */
 export function setCaptionsVisibility(value) {
   const slider = document.getElementById("grid-width-slider");
   captionsVisible = value;
@@ -70,10 +93,18 @@ export function setCaptionsVisibility(value) {
   updateTableLayout(parseFloat(slider?.value || "0"));
 }
 
+/**
+ * Current caption visibility state.
+ * @returns {boolean} Whether captions are shown.
+ */
 export function getCaptionsVisibility() {
   return captionsVisible;
 }
 
+/**
+ * Apply caption visibility based on tile width.
+ * @param {number} width - Current tile width.
+ */
 export function applyCaptionVisibility(width) {
   const templateList = document.getElementById("template-list");
   const captionToggle = document.getElementById("caption-toggle");
@@ -95,6 +126,10 @@ export function applyCaptionVisibility(width) {
   }
 }
 
+/**
+ * Align table rows with preview card heights.
+ * @param {number} width - Current tile width.
+ */
 export function updateTableLayout(width) {
   const rows = document.querySelectorAll("#camera-table .camera-row");
   rows.forEach((row) => {
@@ -113,6 +148,9 @@ export function updateTableLayout(width) {
   });
 }
 
+/**
+ * Recompute the responsive grid column layout.
+ */
 export function updateGridLayout() {
   const templateList = document.getElementById("template-list");
   if (!templateList) return;
@@ -124,6 +162,10 @@ export function updateGridLayout() {
   }
 }
 
+/**
+ * Enable dragging to resize the grid slider.
+ * @param {HTMLInputElement} slider - Range input controlling tile width.
+ */
 export function setupTileResizeDrag(slider) {
   if (!slider) return;
   const handle = document.createElement("div");

--- a/app/static/js/group_utils.js
+++ b/app/static/js/group_utils.js
@@ -1,3 +1,9 @@
+// Manage dropdowns showing available camera groups
+
+/**
+ * Populate group selectors with options from the server.
+ * @returns {Promise<void>} Resolved when options are loaded.
+ */
 export async function loadGroups() {
   const groupDropdown =
     document.getElementById("group-dropdown") ||
@@ -50,6 +56,10 @@ export async function loadGroups() {
   }
 }
 
+/**
+ * Determine the group currently selected by the user.
+ * @returns {string} Selected group name or 'all' when none.
+ */
 export function getSelectedGroup() {
   const dropdown = document.getElementById("group-dropdown");
   if (dropdown && dropdown.value) return dropdown.value;

--- a/app/static/js/time_utils.js
+++ b/app/static/js/time_utils.js
@@ -1,5 +1,11 @@
+// Utilities for humanizing timestamps and displaying elapsed time
 export const NO_TIMESTAMP_PLACEHOLDER = "no timestamp";
 
+/**
+ * Convert an ISO timestamp to a short relative string.
+ * @param {string|Date} dateString - Timestamp value.
+ * @returns {string} Human readable elapsed time.
+ */
 export function timeAgo(dateString) {
   if (!dateString) return "just now";
   const now = new Date();
@@ -32,6 +38,11 @@ export function timeAgo(dateString) {
   return "just now";
 }
 
+/**
+ * Format a timestamp into a readable string.
+ * @param {string|Date} dateString - Timestamp value.
+ * @returns {string} Browser-formatted date string.
+ */
 export function formatExactTime(dateString) {
   const date =
     dateString instanceof Date
@@ -46,6 +57,10 @@ export function formatExactTime(dateString) {
   return date.toString();
 }
 
+/**
+ * Update all elements that display humanized times.
+ * @returns {void}
+ */
 export function updateHumanizedTimes() {
   document.querySelectorAll(".humanized-time").forEach((element) => {
     const timestamp = element.getAttribute("data-time");

--- a/app/static/js/timestamp_utils.js
+++ b/app/static/js/timestamp_utils.js
@@ -1,5 +1,11 @@
+// Helpers to update screenshot timestamp overlays
 import { timeAgo, formatExactTime } from "./templates.js";
 
+/**
+ * Write the latest screenshot timestamp into the video container.
+ * @param {Record<string, any>} details - Data keyed by camera.
+ * @param {string} camera - Target camera name.
+ */
 export function updateFrameTimestamp(details, camera) {
   const container = document.querySelector(".video-container");
   if (!container) return;
@@ -19,6 +25,12 @@ export function updateFrameTimestamp(details, camera) {
   );
 }
 
+/**
+ * Toggle the visibility of frame timestamps.
+ * @param {Record<string, any>} details - Data keyed by camera.
+ * @param {string} camera - Target camera.
+ * @param {boolean} show - Whether to show the timestamp.
+ */
 export function setTimestampVisibility(details, camera, show) {
   const container = document.querySelector(".video-container");
   if (!container) return;

--- a/app/static/js/video_utils.js
+++ b/app/static/js/video_utils.js
@@ -1,6 +1,11 @@
+// Helpers for playing and switching video clips
 export const CLIP_THROTTLE_MS = 30000;
 let lastClipTime = 0;
 
+/**
+ * Play a video element and ignore abort/permission errors.
+ * @param {HTMLMediaElement} el - Video or audio element.
+ */
 export function safePlay(el) {
   const promise = el.play();
   if (promise && typeof promise.catch === "function") {
@@ -12,6 +17,11 @@ export function safePlay(el) {
   }
 }
 
+/**
+ * Load a clip or stream source onto a video element.
+ * @param {HTMLVideoElement} videoEl - Video element to update.
+ * @param {string} cameraName - Target camera name.
+ */
 export function setClipSrc(videoEl, cameraName) {
   const now = Date.now();
   if (now - lastClipTime >= CLIP_THROTTLE_MS) {


### PR DESCRIPTION
## Summary
- document helper utilities in static JS
- add JSDoc for exported functions

## Testing
- `flake8`
- `pytest -q`
- `npm test`
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68608f5062f88333b53e3655eeecae62