### PR TITLE
Add docstrings to tests

### DIFF
--- a/tests/test_allowed_filename.py
+++ b/tests/test_allowed_filename.py
@@ -1,3 +1,4 @@
+"""Tests for allowed filename."""
 import unittest
 
 from app.routes import allowed_filename

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,3 +1,4 @@
+"""Tests for api utils."""
 import unittest
 import unittest.mock
 from unittest.mock import MagicMock, patch

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,3 +1,4 @@
+"""Tests for authentication."""
 # tests/test_authentication.py
 
 import datetime

--- a/tests/test_auto_tag_release.py
+++ b/tests/test_auto_tag_release.py
@@ -1,3 +1,4 @@
+"""Tests for auto tag release."""
 import os
 import tempfile
 import unittest

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,3 +1,4 @@
+"""Tests for auto update."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_blank_frame_logging.py
+++ b/tests/test_blank_frame_logging.py
@@ -1,3 +1,4 @@
+"""Tests for blank frame logging."""
 import os
 import tempfile
 import unittest

--- a/tests/test_bool_settings.py
+++ b/tests/test_bool_settings.py
@@ -1,3 +1,4 @@
+"""Tests for bool settings."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_build_scripts.py
+++ b/tests/test_build_scripts.py
@@ -1,3 +1,4 @@
+"""Tests for build scripts."""
 import subprocess
 from pathlib import Path
 from unittest import TestCase

--- a/tests/test_camera_diagnostics_route.py
+++ b/tests/test_camera_diagnostics_route.py
@@ -1,3 +1,4 @@
+"""Tests for camera diagnostics route."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_camera_discovery.py
+++ b/tests/test_camera_discovery.py
@@ -1,3 +1,4 @@
+"""Tests for camera discovery."""
 import os
 import socket
 import tempfile

--- a/tests/test_camera_discovery_ouis.py
+++ b/tests/test_camera_discovery_ouis.py
@@ -1,3 +1,4 @@
+"""Tests for camera discovery ouis."""
 import os
 import tempfile
 import unittest

--- a/tests/test_camera_fix.py
+++ b/tests/test_camera_fix.py
@@ -1,3 +1,4 @@
+"""Tests for camera fix."""
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch

--- a/tests/test_cap_alerts.py
+++ b/tests/test_cap_alerts.py
@@ -1,3 +1,4 @@
+"""Tests for cap alerts."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_captions_chat_route.py
+++ b/tests/test_captions_chat_route.py
@@ -1,3 +1,4 @@
+"""Tests for captions chat route."""
 import os
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_capture_danger_mode.py
+++ b/tests/test_capture_danger_mode.py
@@ -1,3 +1,4 @@
+"""Tests for capture danger mode."""
 import os
 import tempfile
 import unittest

--- a/tests/test_capture_file_url.py
+++ b/tests/test_capture_file_url.py
@@ -1,3 +1,4 @@
+"""Tests for capture file url."""
 import os
 import tempfile
 import unittest

--- a/tests/test_capture_pipeline.py
+++ b/tests/test_capture_pipeline.py
@@ -1,3 +1,4 @@
+"""Tests for capture pipeline."""
 import os
 import shutil
 import threading

--- a/tests/test_capture_status_errors.py
+++ b/tests/test_capture_status_errors.py
@@ -1,3 +1,4 @@
+"""Tests for capture status errors."""
 import os
 import shutil
 import tempfile

--- a/tests/test_capture_stream_config.py
+++ b/tests/test_capture_stream_config.py
@@ -1,3 +1,4 @@
+"""Tests for capture stream config."""
 import importlib
 import os
 import tempfile

--- a/tests/test_chatgpt_compare.py
+++ b/tests/test_chatgpt_compare.py
@@ -1,3 +1,4 @@
+"""Tests for chatgpt compare."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_check_danger_mode.py
+++ b/tests/test_check_danger_mode.py
@@ -1,3 +1,4 @@
+"""Tests for check danger mode."""
 import importlib
 import os
 import unittest

--- a/tests/test_chrome_debug_port.py
+++ b/tests/test_chrome_debug_port.py
@@ -1,3 +1,4 @@
+"""Tests for chrome debug port."""
 import os
 import socket
 import unittest

--- a/tests/test_clean_logs.py
+++ b/tests/test_clean_logs.py
@@ -1,3 +1,4 @@
+"""Tests for clean logs."""
 import io
 
 from scripts.clean_logs import _read_lines, clean_lines

--- a/tests/test_cli_module.py
+++ b/tests/test_cli_module.py
@@ -1,3 +1,4 @@
+"""Tests for cli module."""
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_clip_config.py
+++ b/tests/test_clip_config.py
@@ -1,3 +1,4 @@
+"""Tests for clip config."""
 import os
 import tempfile
 import types

--- a/tests/test_clip_gpu_available.py
+++ b/tests/test_clip_gpu_available.py
@@ -1,3 +1,4 @@
+"""Tests for clip gpu available."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_clip_refresh.py
+++ b/tests/test_clip_refresh.py
@@ -1,3 +1,4 @@
+"""Tests for clip refresh."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_clip_route.py
+++ b/tests/test_clip_route.py
@@ -1,3 +1,4 @@
+"""Tests for clip route."""
 import os
 import tempfile
 import unittest

--- a/tests/test_clock_route.py
+++ b/tests/test_clock_route.py
@@ -1,3 +1,4 @@
+"""Tests for clock route."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,3 +1,4 @@
+"""Tests for cmd."""
 #!/usr/bin/env python3
 # tests/test_cmd.py
 

--- a/tests/test_color_formatter.py
+++ b/tests/test_color_formatter.py
@@ -1,3 +1,4 @@
+"""Tests for color formatter."""
 import io
 import logging
 import os

--- a/tests/test_commit_with_retry.py
+++ b/tests/test_commit_with_retry.py
@@ -1,3 +1,4 @@
+"""Tests for commit with retry."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_compile_teaser_route.py
+++ b/tests/test_compile_teaser_route.py
@@ -1,3 +1,4 @@
+"""Tests for compile teaser route."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_concat_copy.py
+++ b/tests/test_concat_copy.py
@@ -1,3 +1,4 @@
+"""Tests for concat copy."""
 import os
 import subprocess
 import tempfile

--- a/tests/test_config_backup.py
+++ b/tests/test_config_backup.py
@@ -1,3 +1,4 @@
+"""Tests for config backup."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_config_get_setting.py
+++ b/tests/test_config_get_setting.py
@@ -1,3 +1,4 @@
+"""Tests for config get setting."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_config_singleton.py
+++ b/tests/test_config_singleton.py
@@ -1,3 +1,4 @@
+"""Tests for config singleton."""
 import importlib
 import os
 import tempfile

--- a/tests/test_config_sync_version.py
+++ b/tests/test_config_sync_version.py
@@ -1,3 +1,4 @@
+"""Tests for config sync version."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_console_dashboard.py
+++ b/tests/test_console_dashboard.py
@@ -1,3 +1,4 @@
+"""Tests for console dashboard."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,3 +1,4 @@
+"""Tests for crawl."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_danger_status_endpoint.py
+++ b/tests/test_danger_status_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for danger status endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,3 +1,4 @@
+"""Tests for dashboard."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,4 @@
+"""Tests for db."""
 import importlib
 import os
 import tempfile

--- a/tests/test_db_ensure_column.py
+++ b/tests/test_db_ensure_column.py
@@ -1,3 +1,4 @@
+"""Tests for db ensure column."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_dir.py
+++ b/tests/test_dir.py
@@ -1,3 +1,4 @@
+"""Tests for dir."""
 import os
 import tempfile
 import unittest

--- a/tests/test_discover_subnets_endpoint.py
+++ b/tests/test_discover_subnets_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for discover subnets endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_discovery_status_endpoint.py
+++ b/tests/test_discovery_status_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for discovery status endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_docs_endpoint.py
+++ b/tests/test_docs_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for docs endpoint."""
 import os
 import tempfile
 import unittest

--- a/tests/test_docs_nav.py
+++ b/tests/test_docs_nav.py
@@ -1,3 +1,4 @@
+"""Tests for docs nav."""
 from scripts import check_docs_nav
 
 

--- a/tests/test_e2e_offline_login.py
+++ b/tests/test_e2e_offline_login.py
@@ -1,3 +1,4 @@
+"""Tests for e2e offline login."""
 import importlib
 import os
 from types import SimpleNamespace

--- a/tests/test_e2e_offline_page.py
+++ b/tests/test_e2e_offline_page.py
@@ -1,3 +1,4 @@
+"""Tests for e2e offline page."""
 import argparse
 import importlib
 import os

--- a/tests/test_e2e_screenshot_route.py
+++ b/tests/test_e2e_screenshot_route.py
@@ -1,3 +1,4 @@
+"""Tests for e2e screenshot route."""
 import os
 from threading import Thread
 from types import SimpleNamespace

--- a/tests/test_e2e_web.py
+++ b/tests/test_e2e_web.py
@@ -1,3 +1,4 @@
+"""Tests for e2e web."""
 import argparse
 import importlib
 import os

--- a/tests/test_email_alerts.py
+++ b/tests/test_email_alerts.py
@@ -1,3 +1,4 @@
+"""Tests for email alerts."""
 import os
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,3 +1,4 @@
+"""Tests for env."""
 import os
 import tempfile
 import unittest

--- a/tests/test_except.py
+++ b/tests/test_except.py
@@ -1,3 +1,4 @@
+"""Tests for except."""
 # tests/test_except.py
 
 import os

--- a/tests/test_exclude_docs.py
+++ b/tests/test_exclude_docs.py
@@ -1,3 +1,4 @@
+"""Tests for exclude docs."""
 import os
 import unittest
 from pathlib import Path

--- a/tests/test_fast_mjpg_route.py
+++ b/tests/test_fast_mjpg_route.py
@@ -1,3 +1,4 @@
+"""Tests for fast mjpg route."""
 import os
 import shutil
 import unittest

--- a/tests/test_feed_status_tooltip.py
+++ b/tests/test_feed_status_tooltip.py
@@ -1,3 +1,4 @@
+"""Tests for feed status tooltip."""
 import datetime
 import os
 import unittest

--- a/tests/test_ffmpeg_missing.py
+++ b/tests/test_ffmpeg_missing.py
@@ -1,3 +1,4 @@
+"""Tests for ffmpeg missing."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_ffmpeg_setup.py
+++ b/tests/test_ffmpeg_setup.py
@@ -1,3 +1,4 @@
+"""Tests for ffmpeg setup."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_file_location_metrics.py
+++ b/tests/test_file_location_metrics.py
@@ -1,3 +1,4 @@
+"""Tests for file location metrics."""
 import os
 import tempfile
 import unittest

--- a/tests/test_find_closest_image.py
+++ b/tests/test_find_closest_image.py
@@ -1,3 +1,4 @@
+"""Tests for find closest image."""
 import os
 import tempfile
 import unittest

--- a/tests/test_fuzz_update_summary.py
+++ b/tests/test_fuzz_update_summary.py
@@ -1,3 +1,4 @@
+"""Tests for fuzz update summary."""
 import datetime
 import importlib
 import json

--- a/tests/test_fuzz_validators.py
+++ b/tests/test_fuzz_validators.py
@@ -1,3 +1,4 @@
+"""Tests for fuzz validators."""
 import os
 import string
 

--- a/tests/test_generate_credentials.py
+++ b/tests/test_generate_credentials.py
@@ -1,3 +1,4 @@
+"""Tests for generate credentials."""
 import argparse
 import os
 import sqlite3

--- a/tests/test_generate_prompt_route.py
+++ b/tests/test_generate_prompt_route.py
@@ -1,3 +1,4 @@
+"""Tests for generate prompt route."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_generate_release_badges_script.py
+++ b/tests/test_generate_release_badges_script.py
@@ -1,3 +1,4 @@
+"""Tests for generate release badges script."""
 import os
 from pathlib import Path
 

--- a/tests/test_get_screenshots_for_template.py
+++ b/tests/test_get_screenshots_for_template.py
@@ -1,3 +1,4 @@
+"""Tests for get screenshots for template."""
 import os
 import shutil
 import unittest

--- a/tests/test_get_videos_for_template.py
+++ b/tests/test_get_videos_for_template.py
@@ -1,3 +1,4 @@
+"""Tests for get videos for template."""
 import os
 import shutil
 import unittest

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -1,3 +1,4 @@
+"""Tests for github utils."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_groovy_files.py
+++ b/tests/test_groovy_files.py
@@ -1,3 +1,4 @@
+"""Tests for groovy files."""
 import unittest
 
 

--- a/tests/test_html_templates.py
+++ b/tests/test_html_templates.py
@@ -1,3 +1,4 @@
+"""Tests for html templates."""
 import os
 import unittest
 from html.parser import HTMLParser

--- a/tests/test_http_callbacks.py
+++ b/tests/test_http_callbacks.py
@@ -1,3 +1,4 @@
+"""Tests for http callbacks."""
 import socket
 import unittest
 from unittest.mock import patch

--- a/tests/test_hw_encoder_detection.py
+++ b/tests/test_hw_encoder_detection.py
@@ -1,3 +1,4 @@
+"""Tests for hw encoder detection."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_hwaccel_support.py
+++ b/tests/test_hwaccel_support.py
@@ -1,3 +1,4 @@
+"""Tests for hwaccel support."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,3 +1,4 @@
+"""Tests for image."""
 import os
 import tempfile
 import unittest

--- a/tests/test_image_comparison.py
+++ b/tests/test_image_comparison.py
@@ -1,3 +1,4 @@
+"""Tests for image comparison."""
 import os
 import tempfile
 import unittest

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,3 +1,4 @@
+"""Tests for image processing."""
 # Integration tests for image processing utilities and ChatGPT comparison
 
 import datetime

--- a/tests/test_import_integrity.py
+++ b/tests/test_import_integrity.py
@@ -1,3 +1,4 @@
+"""Tests for import integrity."""
 import ast
 import importlib.util
 from pathlib import Path

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,4 @@
+"""Tests for init."""
 # tests/test_init.py
 
 import os

--- a/tests/test_inject_footer_logging.py
+++ b/tests/test_inject_footer_logging.py
@@ -1,3 +1,4 @@
+"""Tests for inject footer logging."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_installation_and_first_use.py
+++ b/tests/test_installation_and_first_use.py
@@ -1,3 +1,4 @@
+"""Tests for installation and first use."""
 import os
 import shutil
 import tempfile

--- a/tests/test_internet_cameras.py
+++ b/tests/test_internet_cameras.py
@@ -1,3 +1,4 @@
+"""Tests for internet cameras."""
 import unittest
 
 from app.utils.internet_cameras import INTERNET_CAMERAS

--- a/tests/test_jinja_macros.py
+++ b/tests/test_jinja_macros.py
@@ -1,3 +1,4 @@
+"""Tests for jinja macros."""
 import unittest
 
 from jinja2 import Environment, FileSystemLoader

--- a/tests/test_last_teaser_route.py
+++ b/tests/test_last_teaser_route.py
@@ -1,3 +1,4 @@
+"""Tests for last teaser route."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,3 +1,4 @@
+"""Tests for list."""
 import unittest
 
 

--- a/tests/test_listing_endpoints.py
+++ b/tests/test_listing_endpoints.py
@@ -1,3 +1,4 @@
+"""Tests for listing endpoints."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_live_connectivity.py
+++ b/tests/test_live_connectivity.py
@@ -1,3 +1,4 @@
+"""Tests for live connectivity."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,3 +1,4 @@
+"""Tests for llm."""
 # tests/test_llm.py
 
 import datetime

--- a/tests/test_llm_cache_module.py
+++ b/tests/test_llm_cache_module.py
@@ -1,3 +1,4 @@
+"""Tests for llm cache module."""
 import os
 import tempfile
 import unittest

--- a/tests/test_llm_cache_usage.py
+++ b/tests/test_llm_cache_usage.py
@@ -1,3 +1,4 @@
+"""Tests for llm cache usage."""
 import os
 import tempfile
 import unittest

--- a/tests/test_llm_cost.py
+++ b/tests/test_llm_cost.py
@@ -1,3 +1,4 @@
+"""Tests for llm cost."""
 import json
 import os
 import unittest

--- a/tests/test_llm_cost_summary.py
+++ b/tests/test_llm_cost_summary.py
@@ -1,3 +1,4 @@
+"""Tests for llm cost summary."""
 import json
 import os
 import unittest

--- a/tests/test_llm_question.py
+++ b/tests/test_llm_question.py
@@ -1,3 +1,4 @@
+"""Tests for llm question."""
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_llm_response_count.py
+++ b/tests/test_llm_response_count.py
@@ -1,3 +1,4 @@
+"""Tests for llm response count."""
 import json
 import os
 import unittest

--- a/tests/test_log_caching.py
+++ b/tests/test_log_caching.py
@@ -1,3 +1,4 @@
+"""Tests for log caching."""
 import datetime
 import os
 import threading

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -1,3 +1,4 @@
+"""Tests for log filter."""
 import datetime
 import os
 import unittest

--- a/tests/test_log_summary.py
+++ b/tests/test_log_summary.py
@@ -1,3 +1,4 @@
+"""Tests for log summary."""
 import datetime
 import importlib
 import os

--- a/tests/test_login_flow.py
+++ b/tests/test_login_flow.py
@@ -1,3 +1,4 @@
+"""Tests for login flow."""
 import importlib
 import os
 from types import SimpleNamespace

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+"""Tests for main."""
 import io
 import logging
 import os

--- a/tests/test_main_utilities.py
+++ b/tests/test_main_utilities.py
@@ -1,3 +1,4 @@
+"""Tests for main utilities."""
 import os
 import signal
 import unittest

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,3 +1,4 @@
+"""Tests for mcp client."""
 import asyncio
 import os
 import unittest

--- a/tests/test_mcp_endpoints.py
+++ b/tests/test_mcp_endpoints.py
@@ -1,3 +1,4 @@
+"""Tests for mcp endpoints."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_micro_barcode.py
+++ b/tests/test_micro_barcode.py
@@ -1,3 +1,4 @@
+"""Tests for micro barcode."""
 import os
 import tempfile
 

--- a/tests/test_mkdocs_nav.py
+++ b/tests/test_mkdocs_nav.py
@@ -1,3 +1,4 @@
+"""Tests for mkdocs nav."""
 import unittest
 from pathlib import Path
 

--- a/tests/test_motion_endpoint.py
+++ b/tests/test_motion_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for motion endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,3 +1,4 @@
+"""Tests for network."""
 # tests/test_network.py
 
 import os

--- a/tests/test_network_helpers.py
+++ b/tests/test_network_helpers.py
@@ -1,3 +1,4 @@
+"""Tests for network helpers."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_network_online.py
+++ b/tests/test_network_online.py
@@ -1,3 +1,4 @@
+"""Tests for network online."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_network_status_endpoint.py
+++ b/tests/test_network_status_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for network status endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_network_testing_utils.py
+++ b/tests/test_network_testing_utils.py
@@ -1,3 +1,4 @@
+"""Tests for network testing utils."""
 import json
 import os
 import threading

--- a/tests/test_noop.py
+++ b/tests/test_noop.py
@@ -1,3 +1,4 @@
+"""Tests for noop."""
 import unittest
 
 

--- a/tests/test_notification_settings.py
+++ b/tests/test_notification_settings.py
@@ -1,3 +1,4 @@
+"""Tests for notification settings."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_oui_map.py
+++ b/tests/test_oui_map.py
@@ -1,3 +1,4 @@
+"""Tests for oui map."""
 import os
 import unittest
 

--- a/tests/test_parse_cache_delay.py
+++ b/tests/test_parse_cache_delay.py
@@ -1,3 +1,4 @@
+"""Tests for parse cache delay."""
 import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,4 @@
+"""Tests for placeholder."""
 import os
 import tempfile
 import unittest

--- a/tests/test_png_validation.py
+++ b/tests/test_png_validation.py
@@ -1,3 +1,4 @@
+"""Tests for png validation."""
 # tests/test_png_validation.py
 
 import os

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,3 +1,4 @@
+"""Tests for profiling."""
 import json
 import os
 import tempfile

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -1,3 +1,4 @@
+"""Tests for prompt optimizer."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_push_alerts.py
+++ b/tests/test_push_alerts.py
@@ -1,3 +1,4 @@
+"""Tests for push alerts."""
 import os
 import unittest
 from unittest.mock import call, patch

--- a/tests/test_push_routes.py
+++ b/tests/test_push_routes.py
@@ -1,3 +1,4 @@
+"""Tests for push routes."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_rate_limit_filter.py
+++ b/tests/test_rate_limit_filter.py
@@ -1,3 +1,4 @@
+"""Tests for rate limit filter."""
 import io
 import logging
 import os

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -1,3 +1,4 @@
+"""Tests for retention policy."""
 # Integration tests for retention_policy cleanup logic
 
 import os

--- a/tests/test_robots_txt_endpoint.py
+++ b/tests/test_robots_txt_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for robots txt endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,4 @@
+"""Tests for routes."""
 # tests/test_routes.py
 
 import importlib

--- a/tests/test_routes_more.py
+++ b/tests/test_routes_more.py
@@ -1,3 +1,4 @@
+"""Tests for routes more."""
 import os
 import unittest  # noqa: E402
 from unittest.mock import patch  # noqa: E402

--- a/tests/test_routes_utils.py
+++ b/tests/test_routes_utils.py
@@ -1,3 +1,4 @@
+"""Tests for routes utils."""
 import hashlib
 import os
 import sys

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -1,3 +1,4 @@
+"""Tests for rtsp."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_safe_redirect_url.py
+++ b/tests/test_safe_redirect_url.py
@@ -1,3 +1,4 @@
+"""Tests for safe redirect url."""
 import unittest
 
 from app.routes import is_safe_redirect_url

--- a/tests/test_safe_symlink.py
+++ b/tests/test_safe_symlink.py
@@ -1,3 +1,4 @@
+"""Tests for safe symlink."""
 import os
 import tempfile
 import unittest

--- a/tests/test_sanitize_url.py
+++ b/tests/test_sanitize_url.py
@@ -1,3 +1,4 @@
+"""Tests for sanitize url."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -1,3 +1,4 @@
+"""Tests for scheduler cleanup."""
 from app.utils.scheduling import scheduler
 
 

--- a/tests/test_scheduler_simple_job.py
+++ b/tests/test_scheduler_simple_job.py
@@ -1,3 +1,4 @@
+"""Tests for scheduler simple job."""
 import time
 from datetime import datetime
 from unittest.mock import patch

--- a/tests/test_scheduler_start_once.py
+++ b/tests/test_scheduler_start_once.py
@@ -1,3 +1,4 @@
+"""Tests for scheduler start once."""
 import os
 import time
 from unittest.mock import patch

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1,3 +1,4 @@
+"""Tests for scheduling."""
 # test/test_scheduling.py
 
 import os

--- a/tests/test_scheduling_more.py
+++ b/tests/test_scheduling_more.py
@@ -1,3 +1,4 @@
+"""Tests for scheduling more."""
 import json
 import multiprocessing
 import os

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -1,3 +1,4 @@
+"""Tests for screenshot capture."""
 # tests/test_screenshot_capture.py
 
 import io

--- a/tests/test_screenshot_light.py
+++ b/tests/test_screenshot_light.py
@@ -1,3 +1,4 @@
+"""Tests for screenshot light."""
 import os
 import tempfile
 import unittest

--- a/tests/test_screenshots_additional.py
+++ b/tests/test_screenshots_additional.py
@@ -1,3 +1,4 @@
+"""Tests for screenshots additional."""
 import os
 import shutil
 import tempfile

--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -1,3 +1,4 @@
+"""Tests for screenshots misc."""
 import os
 import unittest
 from unittest.mock import MagicMock, patch, sentinel

--- a/tests/test_screenshots_utils.py
+++ b/tests/test_screenshots_utils.py
@@ -1,3 +1,4 @@
+"""Tests for screenshots utils."""
 import os
 import shutil
 import tempfile

--- a/tests/test_search_suggestions.py
+++ b/tests/test_search_suggestions.py
@@ -1,3 +1,4 @@
+"""Tests for search suggestions."""
 import os
 import unittest
 from pathlib import Path

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,3 +1,4 @@
+"""Tests for security headers."""
 import os
 import unittest
 

--- a/tests/test_serve_screenshot.py
+++ b/tests/test_serve_screenshot.py
@@ -1,3 +1,4 @@
+"""Tests for serve screenshot."""
 import io
 import os
 import shutil

--- a/tests/test_setting_validation.py
+++ b/tests/test_setting_validation.py
@@ -1,3 +1,4 @@
+"""Tests for setting validation."""
 import os
 import socket
 import unittest

--- a/tests/test_settings_download_route.py
+++ b/tests/test_settings_download_route.py
@@ -1,3 +1,4 @@
+"""Tests for settings download route."""
 import os
 import tempfile
 import unittest

--- a/tests/test_settings_route.py
+++ b/tests/test_settings_route.py
@@ -1,3 +1,4 @@
+"""Tests for settings route."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_settings_tooltips.py
+++ b/tests/test_settings_tooltips.py
@@ -1,3 +1,4 @@
+"""Tests for settings tooltips."""
 import os
 import unittest
 

--- a/tests/test_shortcuts_need_patch.py
+++ b/tests/test_shortcuts_need_patch.py
@@ -1,3 +1,4 @@
+"""Tests for shortcuts need patch."""
 import os
 import tempfile
 import unittest

--- a/tests/test_sms_alerts.py
+++ b/tests/test_sms_alerts.py
@@ -1,3 +1,4 @@
+"""Tests for sms alerts."""
 import os
 import unittest
 from unittest.mock import MagicMock, patch

--- a/tests/test_status_cache.py
+++ b/tests/test_status_cache.py
@@ -1,3 +1,4 @@
+"""Tests for status cache."""
 import os
 import shutil
 import tempfile

--- a/tests/test_stream_png_route.py
+++ b/tests/test_stream_png_route.py
@@ -1,3 +1,4 @@
+"""Tests for stream png route."""
 import os
 import shutil
 import tempfile

--- a/tests/test_submit_image_route.py
+++ b/tests/test_submit_image_route.py
@@ -1,3 +1,4 @@
+"""Tests for submit image route."""
 import io
 import os
 import shutil

--- a/tests/test_suggest_fix_route.py
+++ b/tests/test_suggest_fix_route.py
@@ -1,3 +1,4 @@
+"""Tests for suggest fix route."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_summary_storage.py
+++ b/tests/test_summary_storage.py
@@ -1,3 +1,4 @@
+"""Tests for summary storage."""
 import importlib
 import os
 import tempfile

--- a/tests/test_system_metrics.py
+++ b/tests/test_system_metrics.py
@@ -1,3 +1,4 @@
+"""Tests for system metrics."""
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch

--- a/tests/test_take_screenshot_route.py
+++ b/tests/test_take_screenshot_route.py
@@ -1,3 +1,4 @@
+"""Tests for take screenshot route."""
 import os
 import shutil
 import unittest

--- a/tests/test_template_manager.py
+++ b/tests/test_template_manager.py
@@ -1,3 +1,4 @@
+"""Tests for template manager."""
 import os
 import tempfile
 import unittest

--- a/tests/test_template_validators.py
+++ b/tests/test_template_validators.py
@@ -1,3 +1,4 @@
+"""Tests for template validators."""
 import pytest
 
 from app.utils.template_manager import Template, is_snapshot_url

--- a/tests/test_test_mjpg_route.py
+++ b/tests/test_test_mjpg_route.py
@@ -1,3 +1,4 @@
+"""Tests for mjpg route."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_test_pattern.py
+++ b/tests/test_test_pattern.py
@@ -1,3 +1,4 @@
+"""Tests for pattern."""
 import datetime
 import hashlib
 import io

--- a/tests/test_throttle_routes.py
+++ b/tests/test_throttle_routes.py
@@ -1,3 +1,4 @@
+"""Tests for throttle routes."""
 import os
 import tempfile
 import unittest

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,3 +1,4 @@
+"""Tests for timeline."""
 import unittest
 from types import SimpleNamespace
 from unittest import mock

--- a/tests/test_toggle_discovery_endpoint.py
+++ b/tests/test_toggle_discovery_endpoint.py
@@ -1,3 +1,4 @@
+"""Tests for toggle discovery endpoint."""
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_update_camera_symlink.py
+++ b/tests/test_update_camera_symlink.py
@@ -1,3 +1,4 @@
+"""Tests for update camera symlink."""
 import os
 import tempfile
 import unittest

--- a/tests/test_update_validation.py
+++ b/tests/test_update_validation.py
@@ -1,3 +1,4 @@
+"""Tests for update validation."""
 import os
 import unittest
 

--- a/tests/test_upload_nav_icon.py
+++ b/tests/test_upload_nav_icon.py
@@ -1,3 +1,4 @@
+"""Tests for upload nav icon."""
 import io
 import os
 import shutil

--- a/tests/test_url_test_route.py
+++ b/tests/test_url_test_route.py
@@ -1,3 +1,4 @@
+"""Tests for url route."""
 import http.server
 import os
 import threading

--- a/tests/test_user_activity.py
+++ b/tests/test_user_activity.py
@@ -1,3 +1,4 @@
+"""Tests for user activity."""
 import unittest
 from unittest.mock import patch
 

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,3 +1,4 @@
+"""Tests for utils misc."""
 import socket
 import unittest
 from collections import namedtuple

--- a/tests/test_validate_group_name.py
+++ b/tests/test_validate_group_name.py
@@ -1,3 +1,4 @@
+"""Tests for validate group name."""
 import unittest
 
 from app.utils.validators import validate_group_name

--- a/tests/test_validate_proxy.py
+++ b/tests/test_validate_proxy.py
@@ -1,3 +1,4 @@
+"""Tests for validate proxy."""
 import os
 import unittest
 

--- a/tests/test_validate_url.py
+++ b/tests/test_validate_url.py
@@ -1,3 +1,4 @@
+"""Tests for validate url."""
 import os
 import unittest
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,3 +1,4 @@
+"""Tests for version sync."""
 import importlib
 import os
 import sqlite3

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -1,3 +1,4 @@
+"""Tests for video archiver."""
 import os
 import subprocess
 import tempfile

--- a/tests/test_video_dates.py
+++ b/tests/test_video_dates.py
@@ -1,3 +1,4 @@
+"""Tests for video dates."""
 import datetime
 import types
 

--- a/tests/test_video_details.py
+++ b/tests/test_video_details.py
@@ -1,3 +1,4 @@
+"""Tests for video details."""
 import importlib.util
 import os
 from datetime import datetime, timedelta, timezone

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -1,3 +1,4 @@
+"""Tests for wsgi."""
 import importlib
 import unittest
 from unittest.mock import patch


### PR DESCRIPTION
## Summary
- add module docstrings for every test module to clarify intent

## Testing
- `pre-commit run --all-files` *(fails: failed to download dependencies)*
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68608f56ac748333bfe5cea783423ed6