### PR TITLE
Fix zombie processes on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a crash on the login page caused by missing clock elements in `nav.js`.
 - Prevented undefined camera requests from returning 404 errors when switching
   live sources.
+- Child processes from scheduled jobs are terminated on shutdown, preventing
+  zombie `spawn_main` tasks.
 
 ## [0.2.7] - 2025-06-02
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Dependencies fail to install
 
 **Solution:**
+
 - Ensure you're using Python 3.8 or newer (tested up to 3.12): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
@@ -18,6 +19,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Can't connect to data sources
 
 **Solution:**
+
 - Check your internet connection
 - Verify the URL of the data source
 - Ensure you have the necessary permissions to access the data source
@@ -27,12 +29,14 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: API key not working
 
 **Solution:**
+
 - Regenerate your API key in the Glimpser web interface
 - Ensure you're using the correct API key format in your requests
 
 ### Problem: Invalid proxy values
 
 **Solution:**
+
 - Ensure the proxy string begins with `http://` or `https://`.
 - Blank or malformed proxy values are ignored by Glimpser.
 
@@ -41,14 +45,16 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: High CPU usage
 
 **Solution:**
+
 - Reduce the number of concurrent data sources
 - Increase the refresh interval for less critical sources
 - Check the `MAX_WORKERS` setting and adjust if necessary
-- Open the *System Status* tab under Settings to watch CPU and memory usage in real time
+- Open the _System Status_ tab under Settings to watch CPU and memory usage in real time
 
 ### Problem: Out of memory errors
 
 **Solution:**
+
 - Reduce the `MAX_RAW_DATA_SIZE` setting
 - Increase the system's available memory
 - Consider using a database instead of in-memory storage for large datasets
@@ -59,6 +65,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Inaccurate or missing captions
 
 **Solution:**
+
 - Check the `LLM_CAPTION_PROMPT` setting and adjust if necessary
 - Ensure your CHATGPT_KEY is valid and has sufficient credits
 - Verify that the image data is being correctly captured and processed
@@ -66,6 +73,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Summaries not generating
 
 **Solution:**
+
 - Check the `LLM_SUMMARY_PROMPT` setting
 - Ensure there's enough data collected to generate a meaningful summary
 - Verify that the CHATGPT_KEY is working correctly
@@ -79,6 +87,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Web interface not loading
 
 **Solution:**
+
 - Check if the Glimpser server is running
 - Verify you're using the correct port (default is 8082)
 - Ensure the `HOST` setting is `0.0.0.0` so the server is reachable from other devices
@@ -88,6 +97,7 @@ This guide addresses common issues that users might encounter while using Glimps
 ### Problem: Can't log in to the web interface
 
 **Solution:**
+
 - Ensure you're using the correct username and password
 - Verify that the account exists in the `users` table
 - Try resetting your password through the recovery process
@@ -99,7 +109,6 @@ This guide addresses common issues that users might encounter while using Glimps
   cookie is missing. Running without HTTPS? Disable `SESSION_COOKIE_SECURE` so
   your browser accepts the cookie. See [Startup Tips](startup_tips.md) for a
   quick reminder of this and other common gotchas.
-
 
 ## Getting Further Help
 
@@ -117,6 +126,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Unable to connect to the database
 
 **Solution:**
+
 - Ensure the database path in `GLIMPSER_DB` is correct.
 - Check file permissions so the process can read and write to the database.
 - For remote servers verify network connectivity and credentials.
@@ -124,6 +134,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Database locked errors
 
 **Solution:**
+
 - Stop other Glimpser instances that might be using the same database file.
 - If using SQLite, ensure the volume is mounted with proper locking support.
 - Consider switching to a server database like PostgreSQL for multi‑user setups.
@@ -135,6 +146,7 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Containers fail to start
 
 **Solution:**
+
 - Build images again with `docker compose build --no-cache`.
 - Inspect the container logs with `docker compose logs` for errors.
 - Confirm that environment variables in `docker-compose.yaml` match your setup.
@@ -142,12 +154,14 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Port conflicts
 
 **Solution:**
+
 - Make sure no other service is using port 8082.
 - Change the `ports` mapping in `docker-compose.yaml` if needed.
 
 ### Problem: Permission denied on volumes
 
 **Solution:**
+
 - Verify that the host directories mapped as volumes are writable by Docker.
 - On Linux you may need to adjust ownership with `chown` or use Docker's `user` option.
 
@@ -156,18 +170,21 @@ Remember to always include relevant log files, error messages, and your Glimpser
 ### Problem: Settings not loading
 
 **Solution:**
+
 - Confirm variables are defined in your shell or `.env` file before starting.
 - Use `printenv | grep GLIMPSER` to check that values are present.
 
 ### Problem: Missing secrets
 
 **Solution:**
+
 - Ensure `CHATGPT_KEY` and any other credentials are exported in your environment.
 - When running under Docker, set these values in `docker-compose.yaml`.
 
 ## 9. Logging and Debugging Tips
 
-Glimpser writes logs to the console and exposes them via the *System Status* tab. If something goes wrong:
+Glimpser writes logs to the console and exposes them via the _System Status_ tab. If something goes wrong:
+
 - Use the **System Monitoring and Logs** guide to access live logs.
 - Increase the `LOG_LEVEL` or `FLASK_LOG_LEVEL` environment variable to `DEBUG` for more details.
 - Review recent entries for stack traces or connection errors.
@@ -179,6 +196,7 @@ Glimpser writes logs to the console and exposes them via the *System Status* tab
 ### Problem: Errors after pulling a new version
 
 **Solution:**
+
 - Run `pip install -r requirements.txt --upgrade` to update dependencies.
 - Apply any new database migrations as described in the release notes.
 - The `capture_failed` column is added automatically if missing.
@@ -187,6 +205,7 @@ Glimpser writes logs to the console and exposes them via the *System Status* tab
 ### Problem: Search bar does not filter templates
 
 **Solution:**
+
 - Ensure you are running the latest Glimpser version.
 - Refresh the page to load the updated JavaScript.
 
@@ -199,6 +218,7 @@ If the logs repeat messages like `No frames captured from stream` or
 snapshot image rather than a true video stream.
 
 **Solution:**
+
 - Use the camera's RTSP or HTTP video stream URL when available.
 - Snapshot-only URLs now fall back to an MJPEG feed so the live view
   behaves like a regular video stream.
@@ -217,6 +237,7 @@ Older versions kept preloading the previous stream when you changed the video
 source. That could cause extra network requests and confusing behavior.
 
 **Solution:**
+
 - Update to the latest version.
 - The player now destroys any active HLS or looping handlers before starting the
   new stream, so switching sources cleanly stops the old one.
@@ -224,10 +245,11 @@ source. That could cause extra network requests and confusing behavior.
 ### Problem: Loop video or the "All" camera shows `Format error`
 
 This typically happens when Glimpser cannot locate a recent MP4 clip for a
-camera. The player attempts to load the file and the browser reports a *Format
-error* because the response is missing or invalid.
+camera. The player attempts to load the file and the browser reports a _Format
+error_ because the response is missing or invalid.
 
 **Solution:**
+
 - Ensure the `compile_to_teaser` job is running so group videos are generated.
 - When a clip fails to load, the live player now skips to the next camera
   instead of stalling on the error message.
@@ -240,6 +262,7 @@ The footer uses a fixed position at the bottom of the screen. On long pages this
 could overlap the last buttons.
 
 **Solution:**
+
 - Glimpser now adds extra padding to the `main` element so page content scrolls
   fully above the footer. Update to the latest version or add a similar rule in
   your custom CSS.
@@ -249,6 +272,7 @@ could overlap the last buttons.
 ### Problem: Discovery page times out or stops on "Scanning SSDP"
 
 **Solution:**
+
 - Networks with many SSDP devices can delay this step. Wait a little longer or restrict scanning using the CIDR field (e.g., `192.168.1.0/24`).
 - Since v0.9.1 SSDP scanning stops after five seconds so discovery continues even on busy networks.
 - Ensure UDP multicast traffic is allowed; blocked multicast causes timeouts.
@@ -261,7 +285,10 @@ could overlap the last buttons.
 If shutdown is interrupted it can leave background threads running.
 
 **Solution:**
+
 - Glimpser now manages cleanup through `CleanupManager`, ensuring shutdown only runs once.
 - Calling `main.shutdown_manager.cleanup()` manually will join any remaining threads.
 - If threads still refuse to exit, call `app.utils.scheduling.stop_background_tasks()` to signal the
   metrics and logging loops to terminate.
+- Child processes spawned for scheduled jobs are also terminated during
+  shutdown to prevent zombie tasks.

--- a/main.py
+++ b/main.py
@@ -7,8 +7,12 @@ import subprocess
 import argparse
 import random
 import time
-import signal, sys, threading, atexit
+import signal
+import sys
+import threading
+import atexit
 import socket
+import multiprocessing
 
 import app.config as config
 from app import create_app
@@ -261,6 +265,20 @@ class CleanupManager:
             logging.error("Error shutting down scheduler: %s", e)
 
         stop_background_tasks()
+
+        # Terminate any remaining child processes to avoid zombies
+        for process in multiprocessing.active_children():
+            try:
+                process.terminate()
+                process.join(timeout=1)
+                if process.is_alive():
+                    logging.warning(
+                        "Process %s is still alive after terminate", process.pid
+                    )
+            except Exception as e:
+                logging.error(
+                    "Error terminating process %s: %s", getattr(process, "pid", "?"), e
+                )
 
         time.sleep(0.01)
         for thread in threading.enumerate():


### PR DESCRIPTION
## Summary
- terminate child processes in cleanup
- note process cleanup in troubleshooting docs
- document fix in changelog

## Testing
- `flake8`
- `pytest -q` *(fails: No module named 'nodriver')*
- `black main.py`
- `npx prettier -w docs/troubleshooting.md CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_6860aaae96988333b6f70de8fd8f58a3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Child processes spawned by scheduled jobs are now properly terminated during shutdown, preventing accumulation of zombie tasks.

* **Documentation**
  * Updated changelog to reflect the fix for terminating child processes on shutdown.
  * Improved troubleshooting documentation for clarity, formatting, and added details about child process termination during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->