### PR TITLE
Fix race in safe_symlink

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -356,7 +356,12 @@ def safe_symlink(src: str, dst: str) -> None:
     if os.path.lexists(dst_path):
         os.remove(dst_path)
     os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-    os.symlink(src_path, dst_path)
+    try:
+        os.symlink(src_path, dst_path)
+    except FileExistsError:
+        # Another process recreated the link after we removed it.
+        os.remove(dst_path)
+        os.symlink(src_path, dst_path)
 
 
 def update_camera(name, template, image_file=None, motion=False):

--- a/tests/test_safe_symlink.py
+++ b/tests/test_safe_symlink.py
@@ -47,6 +47,28 @@ class TestSafeSymlink(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     safe_symlink(src, dst)
 
+    def test_recovers_from_race(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "f")
+            dst = os.path.join(tmp, "link")
+            open(src, "w").close()
+
+            def flaky_symlink(s, d):
+                if not hasattr(flaky_symlink, "called"):
+                    flaky_symlink.called = True
+                    original(s, d)
+                    raise FileExistsError
+                return original(s, d)
+
+            original = os.symlink
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("os.symlink", side_effect=flaky_symlink) as m,
+            ):
+                safe_symlink(src, dst)
+            self.assertEqual(m.call_count, 2)
+            self.assertEqual(os.readlink(dst), os.path.abspath(src))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle FileExistsError in `safe_symlink`
- add regression test for concurrent symlink creation

## Testing
- `flake8 app/utils/scheduling.py tests/test_safe_symlink.py`
- `pytest -q tests/test_safe_symlink.py`
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6860aacb2cac8333ac1d8aa03147efcf