### PR TITLE
Fix group name validation

### DIFF
--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -134,12 +134,18 @@ def validate_template_name(template_name: str):
 
 
 def validate_group_name(group_name: str | None) -> str | None:
-    """Return sanitized group name if valid, otherwise ``None``."""
+    """Return sanitized group name if valid, otherwise ``None``.
+
+    Group names must be at least two characters after trimming
+    whitespace and replacing it with underscores.
+    """
 
     if group_name is None or not isinstance(group_name, str):
         return None
 
-    sanitized = group_name.strip().replace(" ", "_").lower()
+    sanitized = re.sub(r"\s+", "_", group_name.strip()).lower()
+    if len(sanitized) < 2:
+        return None
     if not sanitized:
         return None
 

--- a/tests/test_validate_group_name.py
+++ b/tests/test_validate_group_name.py
@@ -7,11 +7,16 @@ class TestValidateGroupName(unittest.TestCase):
     def test_valid_names(self):
         self.assertEqual(validate_group_name("Group One"), "group_one")
         self.assertEqual(validate_group_name("group-1"), "group-1")
+        self.assertEqual(validate_group_name("ab"), "ab")
 
     def test_invalid_names(self):
         self.assertIsNone(validate_group_name("../evil"))
         self.assertIsNone(validate_group_name("bad/name"))
         self.assertIsNone(validate_group_name("bad..name"))
+        self.assertIsNone(validate_group_name(" "))
+        self.assertIsNone(validate_group_name("a"))
+        self.assertIsNone(validate_group_name(" b "))
+        self.assertIsNone(validate_group_name("\n"))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- enforce min length and whitespace trimming for group names
- expand tests for `validate_group_name`

## Testing
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6860c30b8de4833381b7a220f9fea577