### PR TITLE
Improve validator helpers

### DIFF
--- a/app/utils/validators.py
+++ b/app/utils/validators.py
@@ -15,21 +15,32 @@ from zoneinfo import ZoneInfo
 from werkzeug.utils import secure_filename
 
 
+TRUTHY_STRINGS = {"true", "1", "t", "y", "yes", "on"}
+FALSEY_STRINGS = {"false", "0", "f", "n", "no", "off"}
+BOOL_STRINGS = {
+    "true",
+    "false",
+    "on",
+    "off",
+    "yes",
+    "no",
+    "y",
+    "n",
+    "t",
+    "f",
+}
+
+
+def to_bool(value: object) -> bool:
+    """Return ``True`` when *value* represents a truthy string."""
+
+    return str(value).strip().lower() in TRUTHY_STRINGS
+
+
 def is_bool_string(value: object) -> bool:
     """Return ``True`` when ``value`` looks like a boolean string."""
 
-    return str(value).strip().lower() in {
-        "true",
-        "false",
-        "on",
-        "off",
-        "yes",
-        "no",
-        "y",
-        "n",
-        "t",
-        "f",
-    }
+    return str(value).strip().lower() in BOOL_STRINGS
 
 
 def validate_proxy(proxy: str | None) -> str | None:
@@ -48,6 +59,10 @@ def validate_proxy(proxy: str | None) -> str | None:
         return None
 
     if not re.match(r"^https?://", proxy, flags=re.IGNORECASE):
+        return None
+
+    parsed = urlparse(proxy)
+    if not parsed.netloc:
         return None
 
     return proxy
@@ -73,7 +88,11 @@ def validate_url(url: str | None) -> str | None:
     if "\n" in url or "\r" in url:
         return None
 
-    if urlparse(url).scheme not in {"http", "https"}:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return None
+
+    if not parsed.netloc:
         return None
 
     return url
@@ -264,7 +283,7 @@ def validate_update_data(data: dict) -> dict:
     # Boolean flags are already converted by the route but we handle them
     # here as a fallback for direct API use.
     def _to_bool(value: object) -> bool:
-        return str(value).lower() in {"true", "1", "t", "y", "yes", "on"}
+        return to_bool(value)
 
     for key in [
         "invert",
@@ -349,16 +368,10 @@ def validate_setting(name: str, value: str) -> str | None:
         return None
 
     if key == "FFMPEG_HWACCEL":
-        return (
-            "auto"
-            if val.lower() in {"true", "1", "t", "y", "yes", "on", "auto"}
-            else "False"
-        )
+        return "auto" if to_bool(val) or val.lower() == "auto" else "False"
 
     if key in BOOLEAN_SETTINGS:
-        return (
-            "True" if val.lower() in {"true", "1", "t", "y", "yes", "on"} else "False"
-        )
+        return "True" if to_bool(val) else "False"
 
     if key in INTEGER_RANGES:
         try:

--- a/tests/test_validate_proxy.py
+++ b/tests/test_validate_proxy.py
@@ -20,6 +20,9 @@ class TestValidateProxy(unittest.TestCase):
     def test_valid_https(self):
         self.assertEqual(validate_proxy("https://example.com"), "https://example.com")
 
+    def test_missing_netloc(self):
+        self.assertIsNone(validate_proxy("http:///"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_url.py
+++ b/tests/test_validate_url.py
@@ -29,6 +29,9 @@ class TestValidateURL(unittest.TestCase):
             "https://example.com",
         )
 
+    def test_missing_netloc(self):
+        self.assertIsNone(validate_url("http:///path"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- unify boolean handling with `to_bool` helper
- tighten URL and proxy validation
- test missing netloc cases

## Testing
- `flake8`
- `pytest -q`
- `pre-commit run --files app/utils/validators.py tests/test_validate_url.py tests/test_validate_proxy.py` *(failed: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6860c45dff608333a565fa12342ecf4c