### PR TITLE
Fix zombie processes from scheduler jobs

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -180,6 +180,12 @@ class GracefulAPScheduler(APScheduler):
         except Exception as e:
             logging.error(f"Error during scheduler shutdown: {e}")
         finally:
+            with active_jobs_lock:
+                for proc in active_jobs.values():
+                    if proc.is_alive():
+                        proc.terminate()
+                        proc.join()
+                active_jobs.clear()
             logging.info("Scheduler shutdown complete.")
 
 

--- a/tests/test_scheduler_cleanup.py
+++ b/tests/test_scheduler_cleanup.py
@@ -8,3 +8,27 @@ def test_start_scheduler():
 
 def test_scheduler_reset():
     assert not scheduler.running
+
+
+def test_shutdown_terminates_active_jobs(monkeypatch):
+    class DummyProc:
+        def __init__(self):
+            self.terminated = False
+            self.joined = False
+
+        def is_alive(self):
+            return True
+
+        def terminate(self):
+            self.terminated = True
+
+        def join(self, timeout=None):
+            self.joined = True
+
+    proc = DummyProc()
+    from app.utils import scheduling as sched
+
+    sched.active_jobs["cam1"] = proc
+    scheduler.shutdown(wait=False)
+    assert not sched.active_jobs
+    assert proc.terminated and proc.joined


### PR DESCRIPTION
## Summary
- clean up active multiprocessing jobs when scheduler shuts down
- test that active jobs are terminated during shutdown

## Testing
- `pytest tests/test_scheduler_cleanup.py::test_shutdown_terminates_active_jobs -q`

------
https://chatgpt.com/codex/tasks/task_e_6860d10fb220833384d0d0f0d362e74a