### PR TITLE
Add backup server URL validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ from importlib.metadata import PackageNotFoundError, version
 from ipaddress import ip_network
 from pathlib import Path
 
+
 from dotenv import find_dotenv, load_dotenv
 
 _ffmpeg_spec = importlib.util.spec_from_file_location(
@@ -101,6 +102,9 @@ _backup_path = Path(_backup_raw)
 BACKUP_PATH = str(
     _backup_path if _backup_path.is_absolute() else _BASE_DIR / _backup_path
 )
+
+# Optional remote backup server
+BACKUP_SERVER_URL = os.getenv("GLIMPSER_BACKUP_SERVER_URL", "")
 
 # ``SessionLocal`` and ``_engine`` are created lazily and cached so repeated
 # imports or function calls don't open additional connections.  Tests may patch
@@ -199,6 +203,23 @@ def backup_config() -> bool:
         os.makedirs(os.path.dirname(BACKUP_PATH), exist_ok=True)
         with open(BACKUP_PATH, "w") as f:
             json.dump(config_dict, f)
+        if BACKUP_SERVER_URL:
+            from app.utils.validators import is_public_url, validate_url
+            import requests
+
+            url = validate_url(BACKUP_SERVER_URL)
+            if url and is_public_url(url):
+                try:
+                    with open(BACKUP_PATH, "rb") as fh:
+                        requests.post(
+                            url,
+                            files={"file": fh},
+                            timeout=5,
+                        )
+                except Exception as exc:  # pragma: no cover - network varies
+                    logging.warning("backup upload failed: %s", exc)
+            else:
+                logging.warning("backup server URL invalid: %s", BACKUP_SERVER_URL)
     except (OperationalError, SQLAlchemyError, sqlite3.OperationalError, OSError) as e:
         logging.warning("backup failed: %s", e)
         success = False

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -15,6 +15,7 @@ are used.
 | `GLIMPSER_DATABASE_PATH` | `data/glimpser.db`        | Location of the SQLite database file    |
 | `GLIMPSER_LOGGING_PATH`  | `logs/glimpser.log`       | Path to the main log file               |
 | `GLIMPSER_BACKUP_PATH`   | `data/config_backup.json` | File used when backing up configuration |
+| `GLIMPSER_BACKUP_SERVER_URL` | _(empty)_ | Optional endpoint to receive uploaded backups |
 
 Relative paths are resolved from the application's root directory. Use an
 absolute path if the backup file should reside elsewhere.

--- a/tests/test_config_backup.py
+++ b/tests/test_config_backup.py
@@ -65,6 +65,31 @@ class TestBackupConfig(unittest.TestCase):
             with self.assertRaises(Exception):
                 self.config.backup_config()
 
+    @patch("app.config.validators.is_public_url", return_value=True)
+    @patch("app.config.requests.post")
+    def test_backup_upload_skips_invalid_url(self, mock_post, _mock_public):
+        with patch.dict(os.environ, {"GLIMPSER_BACKUP_SERVER_URL": "bad"}):
+            import importlib
+            import app.config as config
+
+            importlib.reload(config)
+            config.backup_config()
+        mock_post.assert_not_called()
+
+    @patch("app.config.validators.is_public_url", return_value=True)
+    @patch("app.config.requests.post")
+    def test_backup_upload_valid_url(self, mock_post, _mock_public):
+        with patch.dict(
+            os.environ,
+            {"GLIMPSER_BACKUP_SERVER_URL": "http://example.com/backup"},
+        ):
+            import importlib
+            import app.config as config
+
+            importlib.reload(config)
+            config.backup_config()
+        mock_post.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate `GLIMPSER_BACKUP_SERVER_URL` before uploading backups
- document new variable
- test backup upload logic

## Testing
- `pytest tests/test_config_backup.py -q`
- `pre-commit run --all-files` *(failed: aiohttp wheel download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6860c2306cb88333850ffa5ce0912575