### PR TITLE
Fix service worker cache bug

### DIFF
--- a/app/static/sw.js
+++ b/app/static/sw.js
@@ -55,9 +55,11 @@ self.addEventListener("push", (event) => {
 function networkFirst(request) {
   return promiseTimeout(fetch(request), 5000)
     .then((response) => {
-      caches
-        .open(CACHE_NAME)
-        .then((cache) => cache.put(request, response.clone()));
+      if (response.ok) {
+        caches
+          .open(CACHE_NAME)
+          .then((cache) => cache.put(request, response.clone()));
+      }
       return response;
     })
     .catch(() => caches.match(request));

--- a/tests/js/offline_sw.test.js
+++ b/tests/js/offline_sw.test.js
@@ -6,3 +6,9 @@ test("service worker caches offline page", () => {
   const swText = fs.readFileSync(swPath, "utf8");
   expect(swText.includes("/offline")).toBe(true);
 });
+
+test("service worker caches only successful responses", () => {
+  const swPath = path.join("app", "static", "sw.js");
+  const swText = fs.readFileSync(swPath, "utf8");
+  expect(swText.includes("if (response.ok)")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- avoid caching non-successful network responses in the service worker
- check for new test verifying the service worker logic

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686165c586ac8333b7f1cb2778861248