### PR TITLE
Bump version to v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build details are hidden on small screens to avoid clutter.
 - Sanitized log messages in the UI to prevent XSS vulnerabilities
 
+## [0.2.9] - 2025-06-29
+
+### Changed
+
+- Bumped package version in pyproject.toml to 0.2.9.
+
 ## [0.2.8] - 2025-06-17
 
 ### Changed
@@ -141,7 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appears blank.
 - Fixed timezone handling so feed status timestamps no longer show "in the future".
 
-[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.8...HEAD
+[Unreleased]: https://github.com/KristopherKubicki/glimpser/compare/v0.2.9...HEAD
+[0.2.9]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.9
 [0.2.8]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.8
 [0.2.7]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.7
 [0.2.6]: https://github.com/KristopherKubicki/glimpser/releases/tag/v0.2.6

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: Kubicki
     given-names: Kristopher
 title: Glimpser
-version: "0.2.8"
+version: "0.2.9"
 date-released: 2025-06-03
 url: https://github.com/KristopherKubicki/glimpser
 repository-code: https://github.com/KristopherKubicki/glimpser

--- a/app/config.py
+++ b/app/config.py
@@ -288,7 +288,7 @@ TZ = get_setting("TZ", "UTC")
 try:
     _PKG_VERSION = version("glimpser")
 except PackageNotFoundError:
-    _PKG_VERSION = "0.2.8"
+    _PKG_VERSION = "0.2.9"
 sync_version(_PKG_VERSION)
 # Default to the package version if not overridden in the database
 VERSION = get_setting("VERSION", _PKG_VERSION)

--- a/docs/release_workflow.md
+++ b/docs/release_workflow.md
@@ -22,7 +22,7 @@ PyPI.
 
 Tags are normally created automatically when the version in `pyproject.toml` is bumped
 on the `main` branch. The `Tag Release` workflow runs
-`scripts/auto_tag_release.py` to create a tag like `v0.2.8` and push it to
+`scripts/auto_tag_release.py` to create a tag like `v0.2.9` and push it to
 GitHub, which then triggers the build jobs above. Before tagging, the workflow
 runs `scripts/update_version_files.py` so that `CITATION.cff` and the fallback
 version in `app/config.py` stay aligned with the version from `pyproject.toml`.
@@ -33,8 +33,8 @@ permissions so that the subsequent release workflow is triggered.
 You can still trigger a release manually by creating and pushing a tag:
 
 ```sh
-git tag v0.2.8
-git push origin v0.2.8
+git tag v0.2.9
+git push origin v0.2.9
 ```
 
 Alternatively, run `scripts/auto_tag_release.py` to create and push the tag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "glimpser",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "type": "module",
     "private": true,
     "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name            = "glimpser"
-version         = "0.2.8"
+version         = "0.2.9"
 description     = "A real-time monitoring application for capturing and analyzing live data from various sources"
 requires-python = ">=3.9"
 readme          = "README.md"
@@ -159,7 +159,7 @@ skips = ["B101"]  # assert-used
 # commitizen – keep Conventional Commits & changelog automation tidy
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.8"
+version = "0.2.9"
 tag_format = "v$version"
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- update version references to v0.2.9
- refresh citation and config files
- document new release in CHANGELOG
- update docs for manual tagging instructions

## Testing
- `pre-commit run --all-files` *(failed: unable to fetch packages)*
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616697f1fc83339f6f9fd119b4a91a