### PR TITLE
Fix safe_symlink race error

### DIFF
--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -357,13 +357,20 @@ def safe_symlink(src: str, dst: str) -> None:
         raise ValueError("symlink paths must stay within screenshot directory")
 
     if os.path.lexists(dst_path):
-        os.remove(dst_path)
+        try:
+            os.remove(dst_path)
+        except FileNotFoundError:
+            # The link vanished after the existence check
+            pass
     os.makedirs(os.path.dirname(dst_path), exist_ok=True)
     try:
         os.symlink(src_path, dst_path)
     except FileExistsError:
         # Another process recreated the link after we removed it.
-        os.remove(dst_path)
+        try:
+            os.remove(dst_path)
+        except FileNotFoundError:
+            pass
         os.symlink(src_path, dst_path)
 
 

--- a/tests/test_safe_symlink.py
+++ b/tests/test_safe_symlink.py
@@ -69,6 +69,30 @@ class TestSafeSymlink(unittest.TestCase):
             self.assertEqual(m.call_count, 2)
             self.assertEqual(os.readlink(dst), os.path.abspath(src))
 
+    def test_ignores_missing_unlink(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = os.path.join(tmp, "f")
+            dst = os.path.join(tmp, "link")
+            open(src, "w").close()
+            os.symlink(src, dst)
+
+            calls = []
+
+            def flaky_remove(path):
+                calls.append(path)
+                if len(calls) == 1:
+                    raise FileNotFoundError
+                os.unlink(path)
+
+            with (
+                patch("app.utils.scheduling.SCREENSHOT_DIRECTORY", tmp),
+                patch("os.remove", side_effect=flaky_remove),
+            ):
+                # should not raise despite FileNotFoundError
+                safe_symlink(src, dst)
+
+            self.assertEqual(os.readlink(dst), os.path.abspath(src))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle FileNotFoundError in `safe_symlink`
- test handling of missing unlink during races

## Testing
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*
- `flake8`
- `pytest -vv tests/test_safe_symlink.py::TestSafeSymlink::test_ignores_missing_unlink`

------
https://chatgpt.com/codex/tasks/task_e_6862fc2b3cd08333b8e1cc8356e46b9f