### PR TITLE
fix: relax hypothesis deadline

### DIFF
--- a/tests/test_fuzz_update_summary.py
+++ b/tests/test_fuzz_update_summary.py
@@ -15,7 +15,8 @@ import app.utils.scheduling as scheduling
 
 LETTERS = string.ascii_letters + string.digits + string.punctuation + " "
 MAX_EXAMPLES = int(os.getenv("HYPOTHESIS_MAX_EXAMPLES", "20"))
-DEADLINE_MS = int(os.getenv("HYPOTHESIS_DEADLINE_MS", "1000"))
+deadline_env = os.getenv("HYPOTHESIS_DEADLINE_MS")
+DEADLINE_MS = int(deadline_env) if deadline_env is not None else None
 
 
 @st.composite


### PR DESCRIPTION
## Summary
- avoid hypothesis flakiness by disabling the default deadline

## Testing
- `flake8 tests/test_fuzz_update_summary.py`
- `black tests/test_fuzz_update_summary.py --line-length 88`
- `pre-commit run --files tests/test_fuzz_update_summary.py` *(fails: unsuccessful tunnel)*
- `pytest tests/test_fuzz_update_summary.py::test_fuzz_update_summary -vv`

------
https://chatgpt.com/codex/tasks/task_e_6865af48bc58833381a16dec7eec75f3