### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Glimpser
 
 [![Python application](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/python-app.yml)
-[![Pylint 3.8 - 3.13](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.8)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)
+[![Pylint 3.10 - 3.13](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml/badge.svg?label=pylint%203.10)](https://github.com/KristopherKubicki/glimpser/actions/workflows/pylint.yml)
 [![CodeQL](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/codeql.yml)
 [![Docs Build](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml/badge.svg)](https://github.com/KristopherKubicki/glimpser/actions/workflows/docs-build.yml)
 [![GitHub release](https://img.shields.io/github/v/release/KristopherKubicki/glimpser)](https://github.com/KristopherKubicki/glimpser/releases/latest)
@@ -61,7 +61,7 @@ See [OpenSSF Scorecard](docs/scorecard.md) for details on the security badge.
 
 ### Prerequisites
 
-- Python 3.8 to 3.13
+- Python 3.10 to 3.13
 
 ### Steps
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of setting up Glimpser and running 
 
 ## Prerequisites
 
-- Python 3.8 to 3.13
+- Python 3.10 to 3.13
 - Git (for cloning the repository)
 
 ## Installation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ This guide provides detailed instructions for installing and setting up Glimpser
 - **Architecture**: Glimpser is primarily designed for x86 architecture.
   - ARM support may require additional work and is not guaranteed.
 - **Operating System**: Linux (Ubuntu 20.04 LTS or later recommended)
-- **Python**: Version 3.8 to 3.13
+- **Python**: Version 3.10 to 3.13
 
 ## Installation Steps
 

--- a/docs/pylint_checks.md
+++ b/docs/pylint_checks.md
@@ -1,6 +1,6 @@
 # Pylint Checks
 
-The workflow `.github/workflows/pylint.yml` runs Pylint on each push. It sets up a matrix of Python versions `3.8` through `3.13`. For every version it:
+The workflow `.github/workflows/pylint.yml` runs Pylint on each push. It sets up a matrix of Python versions `3.10` through `3.13`. For every version it:
 
 1. Checks out the repository.
 2. Installs Pylint using `pip`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ This guide addresses common issues that users might encounter while using Glimps
 
 -**Solution:**
 
-- Ensure you're using Python 3.8 or newer (tested up to 3.13): `python --version`
+- Ensure you're using Python 3.10 or newer (tested up to 3.13): `python --version`
 - Update pip: `pip install --upgrade pip`
 - If you're on Windows, make sure you have the necessary C++ build tools installed for certain packages.
 - Double-check that you're working in the correct virtual environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name            = "glimpser"
 version         = "0.2.9"
 description     = "A real-time monitoring application for capturing and analyzing live data from various sources"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme          = "README.md"
 
 authors = [
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- drop Python 3.8 classifier and require Python >=3.10
- document supported Python versions in docs

## Testing
- `pre-commit run --all-files` *(fails: failed to fetch flake8)*
- `pytest -q` *(fails: TestAutoTagRelease::test_tag_exists_true_and_false)*

------
https://chatgpt.com/codex/tasks/task_e_6869fc1d9dd08333987758a4375573a9