### PR TITLE
Remove duplicate header navigation sentence

### DIFF
--- a/docs/responsive_design.md
+++ b/docs/responsive_design.md
@@ -4,7 +4,6 @@ Glimpser now adapts to phones and tablets. Tables reflow vertically to avoid hor
 
 The main template view scales thumbnails with a width slider on desktop screens and the page now uses smooth scrolling for longer lists. A slim drag region on the right edge offers the same control so you can resize tiles without aiming for the slider. Previews resize by adjusting their width and height, ensuring the full image remains visible without shifting or cropping. Tiles now center each player with flexbox so videos shrink to fit on narrow screens without cropping. Camera detail views enforce a 16:9 aspect ratio so the player scales consistently across phones, tablets and desktops. When a group is opened, the slider defaults to the smallest width that keeps all cameras visible without scrolling. On narrow devices, the slider hides automatically to keep the interface simple. Mobile tiles still show the last screenshot and start playing live video after a brief hold.
 
-The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop.
 The main content now has less top padding so on‑page controls like the search bar sit closer to the navigation.
 The template control panel now compresses on phones with Search, Play All and Sort in one row while the status legend hides.
 The header navigation also uses smaller padding so it stays out of the way on both mobile and desktop. The header now sticks to the top of the screen as you scroll so navigation is always accessible.


### PR DESCRIPTION
## Summary
- remove a repeated line about header navigation in `responsive_design.md`

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: unable to download prompt-toolkit)*
- `pytest -q` *(fails: TestAutoTagRelease::test_tag_exists_true_and_false)*

------
https://chatgpt.com/codex/tasks/task_e_6869fcc7f9f8833383cd784bb2dcc1a9