### PR TITLE
Add configurable SSL verification for downloads

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -266,6 +266,7 @@ def sync_version(pkg_version: str) -> None:
 
 
 SCHEDULER_API_ENABLED = get_setting("SCHEDULER_API_ENABLED", "True") == "True"
+REQUEST_VERIFY_SSL = get_setting("REQUEST_VERIFY_SSL", "False") == "True"
 
 # be careful when mounting network devices
 SCREENSHOT_DIRECTORY = "data/screenshots/"

--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -258,7 +258,7 @@ def http_session():
     global _session
     if _session is None:
         _session = requests.Session()
-        _session.verify = False
+        _session.verify = config.REQUEST_VERIFY_SSL
         _session.headers.update({"user-agent": UA})
         _session.headers.update({"Accept": "*/*"})
         _session.mount("http://", requests.adapters.HTTPAdapter(pool_maxsize=20))
@@ -654,7 +654,7 @@ def download_image(
         request_kwargs = dict(
             stream=True,
             timeout=(timeout, timeout * 3),
-            verify=False,
+            verify=config.REQUEST_VERIFY_SSL,
             headers=headers,
             auth=auth,
         )
@@ -667,7 +667,7 @@ def download_image(
             request_kwargs = dict(
                 stream=True,
                 timeout=(timeout, timeout * 3),
-                verify=False,
+                verify=config.REQUEST_VERIFY_SSL,
                 headers=headers,
                 auth=auth,
             )
@@ -759,7 +759,7 @@ def download_pdf(
             url,
             stream=True,
             timeout=timeout,
-            verify=False,
+            verify=config.REQUEST_VERIFY_SSL,
             headers=headers,
             auth=auth,
             allow_redirects=True,
@@ -772,7 +772,7 @@ def download_pdf(
                 url,
                 stream=True,
                 timeout=timeout,
-                verify=False,
+                verify=config.REQUEST_VERIFY_SSL,
                 headers=headers,
                 auth=auth,
                 allow_redirects=True,
@@ -1259,7 +1259,7 @@ def get_content_type(
                 url,
                 stream=True,
                 timeout=5,
-                verify=False,
+                verify=config.REQUEST_VERIFY_SSL,
                 headers=headers,
                 auth=auth,
                 allow_redirects=True,
@@ -1270,7 +1270,7 @@ def get_content_type(
                 response = method(
                     url,
                     timeout=5,
-                    verify=False,
+                    verify=config.REQUEST_VERIFY_SSL,
                     headers=headers,
                     auth=auth,
                     allow_redirects=True,

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -194,5 +194,7 @@ Additional variables control AI behaviour and external tools:
   This setting is read-only until Advanced Options are enabled.
 - `CLIP_MODEL_PATH` – path to the ONNX model used for object filtering (default `models/clip-vit-b-32.onnx`). The runtime automatically selects CUDA or CPU providers when available. Non-macOS systems install `onnxruntime-gpu~=1.18` by default, while macOS falls back to the CPU-only `onnxruntime` package.
 - `SCHEDULER_API_ENABLED` – toggle the APScheduler REST API (default `True`)
+- `REQUEST_VERIFY_SSL` – verify HTTPS certificates for outbound downloads
+  (default `False`)
 
 Refer to the code comments in `app/config.py` for full details on each setting.

--- a/tests/test_auto_tag_release.py
+++ b/tests/test_auto_tag_release.py
@@ -14,7 +14,7 @@ class TestAutoTagRelease(unittest.TestCase):
             self.assertTrue(auto_tag_release.tag_exists("v1.0.0"))
             self.assertFalse(auto_tag_release.tag_exists("v3.0.0"))
         mock_run.assert_called_with(
-            ["git", "tag", "-l", "v3.0.0"], capture_output=True, text=True
+            ["git", "tag", "-l", "v3.0.0"], capture_output=True, text=True, check=False
         )
 
     def test_create_tag_invokes_git_commands(self):

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -147,6 +147,7 @@ class TestScreenshotCapture(unittest.TestCase):
         )
         mock_finalize.assert_called_once()
 
+    @patch("app.utils.screenshots.config.REQUEST_VERIFY_SSL", False)
     @patch("app.utils.screenshots.http_session")
     def test_download_image_uses_proxy(self, mock_session_factory):
         mock_session = MagicMock()
@@ -172,6 +173,7 @@ class TestScreenshotCapture(unittest.TestCase):
             {"http": "http://proxy:8080", "https": "http://proxy:8080"},
         )
 
+    @patch("app.utils.screenshots.config.REQUEST_VERIFY_SSL", False)
     @patch("app.utils.screenshots.http_session")
     def test_download_image_skips_invalid_proxy(self, mock_session_factory):
         mock_session = MagicMock()

--- a/tests/test_screenshots_misc.py
+++ b/tests/test_screenshots_misc.py
@@ -7,6 +7,7 @@ import app.utils.screenshots as ss
 
 
 class TestHttpSession(unittest.TestCase):
+    @patch("app.utils.screenshots.config.REQUEST_VERIFY_SSL", True)
     @patch("app.utils.screenshots.requests.Session")
     def test_http_session_singleton_and_headers(self, mock_session_cls):
         session_instance = MagicMock()
@@ -22,6 +23,7 @@ class TestHttpSession(unittest.TestCase):
         mock_session_cls.assert_called_once()
         self.assertIn("User-Agent", sess1.headers)
         self.assertIn("Accept", sess1.headers)
+        self.assertTrue(sess1.verify)
 
 
 class TestGetDriver(unittest.TestCase):


### PR DESCRIPTION
## Summary
- respect REQUEST_VERIFY_SSL for HTTP client
- test verify flag in session
- patch screenshot download tests for new flag
- document REQUEST_VERIFY_SSL in configuration guide

## Testing
- `pytest tests/test_screenshots_misc.py tests/test_screenshot_capture.py tests/test_auto_tag_release.py -q`
- `pre-commit run --all-files` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6869fcdd83d88333a1bd64d81f729a05