### PR TITLE
Fix auto tag release call

### DIFF
--- a/scripts/auto_tag_release.py
+++ b/scripts/auto_tag_release.py
@@ -26,6 +26,7 @@ def tag_exists(tag):
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     return tag in result.stdout.split()
 


### PR DESCRIPTION
## Summary
- ensure `subprocess.run` doesn't error when checking git tags

## Testing
- `flake8`
- `pytest tests/test_auto_tag_release.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_686a7ca214788333b36d89db968bfd0e