### PR TITLE
Fix template manager tests

### DIFF
--- a/tests/test_log_summary.py
+++ b/tests/test_log_summary.py
@@ -25,6 +25,13 @@ class TestLogSummary(unittest.TestCase):
 
     def tearDown(self):
         patch.stopall()
+        import importlib
+
+        importlib.reload(db)
+        importlib.reload(scheduling)
+        import app.utils.template_manager as template_manager
+
+        importlib.reload(template_manager)
         self.tmpdir.cleanup()
 
     @patch("app.utils.scheduling.summarize", return_value='{"1": "ok"}')


### PR DESCRIPTION
## Summary
- reload template manager module in log summary teardown to reset db engine

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687020ced810833383d966c44dbd796d