### PR TITLE
Fix screenshot handling race

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1202,30 +1202,15 @@ def generate(
                         last_shot = most_recent_file
 
                         try:
-                            if screenshots._is_valid_png(most_recent_file):
-                                with Image.open(most_recent_file) as img:
-                                    img = resize_and_pad(img, (1280, 720))
-                                    buffer = io.BytesIO()
-                                    img.save(buffer, format="JPEG")
-                                    frame = buffer.getvalue()
-                            else:
-                                logging.error(
-                                    "Failed to open last shot %s: invalid image",
-                                    most_recent_file,
-                                )
-                                try:
-                                    os.remove(most_recent_file)
-                                except OSError as exc:
-                                    logging.warning(
-                                        "Failed to remove invalid screenshot %s: %s",
-                                        most_recent_file,
-                                        exc,
-                                    )
-                                frame = None
+                            with open(most_recent_file, "rb") as f:
+                                data = f.read()
+                            with Image.open(io.BytesIO(data)) as img:
+                                img = resize_and_pad(img, (1280, 720))
+                                buffer = io.BytesIO()
+                                img.save(buffer, format="JPEG")
+                                frame = buffer.getvalue()
 
                             if frame is not None:
-                                # file sizes the same size?  maybe just touch the file instead?
-
                                 # Write to a temporary file first, then atomically
                                 # replace the cached JPEG. This avoids serving
                                 # partially written files when new screenshots
@@ -1249,6 +1234,7 @@ def generate(
                                     most_recent_file,
                                     remove_exc,
                                 )
+                            frame = None
 
         if not frame:
             frame = _placeholder_frame()


### PR DESCRIPTION
## Summary
- avoid race when generating screenshots by reading file before opening with PIL

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: failed to download dependencies)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68705577bc108333964fabd3b630a0a6