### PR TITLE
Handle deleted screenshot during sort

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1174,15 +1174,20 @@ def generate(
                         else:
                             # fall back to the oldest screenshot so the MJPEG
                             # stream always has an initial frame
-                            pngs = [
-                                os.path.join(path, f)
-                                for f in os.listdir(path)
-                                if f.endswith(".png")
-                                and os.path.isfile(os.path.join(path, f))
-                            ]
+                            pngs = []
+                            for f in os.listdir(path):
+                                full = os.path.join(path, f)
+                                if f.endswith(".png") and os.path.isfile(full):
+                                    try:
+                                        ctime = os.path.getctime(full)
+                                    except FileNotFoundError:
+                                        # file vanished between listdir and stat
+                                        continue
+                                    pngs.append((ctime, full))
+
                             if pngs:
-                                pngs.sort(key=os.path.getctime)
-                                lfiles = [pngs[0]]
+                                pngs.sort(key=lambda t: t[0])
+                                lfiles = [pngs[0][1]]
 
                         last_file = lfiles[-1] if lfiles else None
                         if (

--- a/tests/test_deleted_screenshot_handling.py
+++ b/tests/test_deleted_screenshot_handling.py
@@ -1,0 +1,19 @@
+import os
+from unittest.mock import patch
+
+from app import routes
+
+
+def test_generate_handles_deleted_file(tmp_path):
+    shots = tmp_path / "cam"
+    shots.mkdir()
+    target = shots / "cap1.png"
+    target.write_bytes(b"x")
+
+    with patch("app.routes.SCREENSHOT_DIRECTORY", str(tmp_path)):
+        with patch("os.listdir", return_value=["cap1.png"]):
+            with patch("os.path.isfile", return_value=True):
+                with patch("os.path.getctime", side_effect=FileNotFoundError):
+                    gen = routes.generate(camera="cam")
+                    frame = next(gen)
+                    assert isinstance(frame, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- avoid FileNotFoundError when sorting screenshots
- test resilience when screenshot disappears

## Testing
- `pre-commit run --files app/routes.py tests/test_deleted_screenshot_handling.py` *(fails: Failed to download pip requirements)*
- `pytest -q tests/test_deleted_screenshot_handling.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705b62de74833380541ee847a715e3