### PR TITLE
Fix screenshot cache for bad images

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,7 +58,7 @@ from flask import (
     stream_with_context,
     url_for,
 )
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
@@ -1207,6 +1207,9 @@ def generate(
                         last_shot = most_recent_file
 
                         try:
+                            if not screenshots._is_valid_png(most_recent_file):
+                                raise UnidentifiedImageError("invalid image")
+
                             with open(most_recent_file, "rb") as f:
                                 data = f.read()
                             with Image.open(io.BytesIO(data)) as img:

--- a/tests/test_invalid_image_handling.py
+++ b/tests/test_invalid_image_handling.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+from app import routes
+
+
+def test_generate_handles_invalid_image(tmp_path):
+    shots = tmp_path / "cam"
+    shots.mkdir()
+    target = shots / "cap1.png"
+    target.write_bytes(b"x")
+
+    with patch("app.routes.SCREENSHOT_DIRECTORY", str(tmp_path)):
+        with patch("os.listdir", return_value=["cap1.png"]):
+            with patch("os.path.isfile", return_value=True):
+                with patch("os.path.getctime", return_value=0):
+                    with patch(
+                        "app.routes.screenshots._is_valid_png", return_value=False
+                    ):
+                        gen = routes.generate(camera="cam")
+                        frame = next(gen)
+                        assert isinstance(frame, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- avoid PIL errors when cached screenshot is corrupted
- test invalid screenshot handling

## Testing
- `pre-commit run --all-files` *(fails: failed to download idna==3.10)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707e5db0f483338e171b72a4da551c