### PR TITLE
Switch CI lint step to ruff

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -31,12 +31,8 @@ jobs:
         run: python -m pip install --upgrade uv
       - name: Install dependencies with uv
         run: uv pip install --system --editable . --group dev
-      - name: Lint with flake8
-        run: |
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Lint with ruff
-        run: ruff check --exit-zero .
+        run: ruff check .
       - name: Test with pytest
         run: |
           pytest

--- a/docs/ci_checks.md
+++ b/docs/ci_checks.md
@@ -6,7 +6,7 @@ and on pull requests targeting those branches.
 The workflow located at `.github/workflows/python-app.yml` performs the
 following tasks:
 
-- Formats Python code with `black`, sorts imports with `isort`, and lints with `ruff` and `flake8`.
+- Formats Python code with `black`, sorts imports with `isort`, and lints with `ruff`.
 - Checks type hints with `mypy`.
 - Lints JavaScript with `eslint` and verifies formatting with `prettier`.
 - Executes `pytest` and `jest` test suites and uploads coverage.
@@ -16,7 +16,7 @@ following tasks:
 - Skips the workflow when only documentation files change.
 
 Running `pre-commit run --all-files` locally will execute the same Black,
-isort, Flake8, and mypy checks before they fail in CI. These checks help catch
+isort, Ruff, and mypy checks before they fail in CI. These checks help catch
 regressions and security issues before code is merged.
 On pull requests the workflow lints only the files that changed, while pushes
 to `staging` or `main` run the linter across the entire repository.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -49,11 +49,10 @@ to the web interface.
 
 ## Running Tests
 
-The project uses `pytest` for testing and lints Python with `ruff` and `flake8`. After activating your environment, run:
+The project uses `pytest` for testing and lints Python with `ruff`. After activating your environment, run:
 
 ```sh
 ruff check --exit-zero .
-flake8
 pytest  # runs in parallel via pytest-xdist
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,11 +9,10 @@ python -m coverage html
 
 The HTML report will be generated in `htmlcov/index.html`.
 
-Before submitting a patch, lint the code with `ruff` and `flake8`:
+Before submitting a patch, lint the code with `ruff`:
 
 ```sh
 ruff check --exit-zero .
-flake8
 ```
 
 Refer to [developer_guide.md](developer_guide.md) for setting up your environment.


### PR DESCRIPTION
## Summary
- drop flake8 step from `release-packages.yml`
- document ruff-only linting in developer docs

## Testing
- `flake8`
- `pytest`
- `pre-commit run --all-files` *(fails: could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_687083e93e7483339c5bfe75e9484088