### PR TITLE
Fix screenshot cache cleanup for invalid images

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1239,6 +1239,14 @@ def generate(
                                     most_recent_file,
                                     remove_exc,
                                 )
+                            try:
+                                os.remove(last_path)
+                            except OSError as exc2:  # pragma: no cover - cleanup failures are ok
+                                logging.debug(
+                                    "Failed to remove cached screenshot %s: %s",
+                                    last_path,
+                                    exc2,
+                                )
                             frame = None
 
         if not frame:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -193,8 +193,8 @@ Glimpser writes logs to the console and exposes them via the _Status_ tab. If so
 - Use the **System Monitoring and Logs** guide to access live logs.
 - Increase the `LOG_LEVEL` or `FLASK_LOG_LEVEL` environment variable to `DEBUG` for more details.
 - Review recent entries for stack traces or connection errors.
-- If logs show "Failed to open last shot ... invalid image", the screenshot file
-  is corrupted. Delete the file so a new capture can replace it.
+- If logs show "Failed to open last shot ... invalid image", the corrupted
+  screenshot is now removed automatically, along with any cached copy.
 
 ## 10. Upgrade Issues
 

--- a/tests/test_invalid_image_handling.py
+++ b/tests/test_invalid_image_handling.py
@@ -1,0 +1,29 @@
+import os
+import time
+from unittest.mock import patch
+
+from app import routes
+
+
+def test_generate_removes_invalid_image_and_cache(tmp_path):
+    shots = tmp_path / "cam"
+    shots.mkdir()
+    bad_png = shots / "cap1.png"
+    bad_png.write_bytes(b"bad")
+
+    last_jpg = tmp_path / "latest_camera.jpg"
+    last_jpg.write_bytes(b"old")
+    old = time.time() - 5
+    os.utime(last_jpg, (old, old))
+
+    with patch("app.routes.SCREENSHOT_DIRECTORY", str(tmp_path)):
+        with patch("app.routes.template_manager.get_templates", return_value={"cam": {"name": "cam"}}):
+            with patch("os.listdir", side_effect=lambda p: ["cap1.png"] if p.endswith("cam") else []):
+                with patch("os.path.isfile", side_effect=lambda p: p.endswith("cap1.png")):
+                    with patch("os.path.getctime", side_effect=lambda p: time.time() if p.endswith("cap1.png") else 0):
+                        gen = routes.generate(camera="cam")
+                        frame = next(gen)
+
+    assert isinstance(frame, (bytes, bytearray))
+    assert not bad_png.exists()
+    assert not last_jpg.exists()


### PR DESCRIPTION
## Summary
- remove cached JPEG when screenshot is invalid
- document automatic cleanup
- add regression test for invalid screenshot handling

## Testing
- `flake8 app/routes.py tests/test_invalid_image_handling.py`
- `pytest tests/test_invalid_image_handling.py`
- `pre-commit run --files app/routes.py tests/test_invalid_image_handling.py docs/troubleshooting.md` *(fails: Failed to download `mkdocs==1.6.1`)*

------
https://chatgpt.com/codex/tasks/task_e_687084072fe08333a01384203ed83302