### PR TITLE
Fix screenshot caching validation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1207,6 +1207,9 @@ def generate(
                         last_shot = most_recent_file
 
                         try:
+                            if not screenshots._is_valid_png(most_recent_file):
+                                raise ValueError("invalid screenshot")
+
                             with open(most_recent_file, "rb") as f:
                                 data = f.read()
                             with Image.open(io.BytesIO(data)) as img:


### PR DESCRIPTION
## Summary
- validate screenshot before caching in the stream generator

## Testing
- `flake8`
- `pre-commit run --all-files` *(fails: Failed to download iniconfig)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687092243b208333b571203e960279ae