### PR TITLE
Improve screenshot error handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -58,7 +58,7 @@ from flask import (
     stream_with_context,
     url_for,
 )
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, UnidentifiedImageError
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
@@ -1207,6 +1207,8 @@ def generate(
                         last_shot = most_recent_file
 
                         try:
+                            if not screenshots._is_valid_png(most_recent_file):
+                                raise UnidentifiedImageError(most_recent_file)
                             with open(most_recent_file, "rb") as f:
                                 data = f.read()
                             with Image.open(io.BytesIO(data)) as img:
@@ -1225,6 +1227,20 @@ def generate(
                                     f.write(frame)
                                 # Atomically move the temp file into place
                                 os.replace(temp_path, last_path)
+                        except UnidentifiedImageError:
+                            logging.warning(
+                                "Invalid screenshot %s removed",
+                                most_recent_file,
+                            )
+                            try:
+                                os.remove(most_recent_file)
+                            except OSError as remove_exc:
+                                logging.warning(
+                                    "Failed to remove invalid screenshot %s: %s",
+                                    most_recent_file,
+                                    remove_exc,
+                                )
+                            frame = None
                         except Exception as exc:
                             logging.error(
                                 "Failed to update screenshot cache: %s",


### PR DESCRIPTION
## Summary
- prevent PIL UnidentifiedImageError spam by validating PNGs before opening
- log and remove invalid screenshots without stack trace

## Testing
- `flake8 app/routes.py`
- `pre-commit run --all-files` *(failed: unable to download dependencies)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68710cceb63083338f9672108d485099