### PR TITLE
Add baseline caption support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,6 +31,7 @@ from app.utils.retention_policy import cleanup_clips, retention_cleanup
 from app.utils.scheduling import (
     refresh_clips,
     schedule_auto_update,
+    schedule_baseline_updates,
     schedule_clip_refresh,
     schedule_crawlers,
     schedule_discovery,
@@ -174,6 +175,7 @@ def create_app(
             )
             schedule_summarization()
             schedule_offline_job_processor()
+            schedule_baseline_updates()
             schedule_clip_refresh()
             schedule_auto_update()
             if DISCOVERY_AUTOSTART:
@@ -306,6 +308,7 @@ def create_app(
                 )
                 schedule_summarization()
                 schedule_offline_job_processor()
+                schedule_baseline_updates()
                 if DISCOVERY_AUTOSTART:
                     schedule_discovery()
 

--- a/app/utils/scheduling.py
+++ b/app/utils/scheduling.py
@@ -128,6 +128,7 @@ from .template_manager import (
     get_llm_cost_estimate,
     get_llm_response_count,
     get_screenshot_count,
+    get_screenshots_for_template,
     get_storage_usage,
     get_storage_usage_bytes,
     get_template,
@@ -1627,6 +1628,42 @@ def schedule_clip_refresh() -> None:
             trigger="interval",
             minutes=5,
             id="refresh_clips",
+            replace_existing=True,
+        )
+    except Exception as e:
+        logging.error("job schedule error: %s", e)
+
+
+def update_baselines(count: int = 10) -> None:
+    """Generate baseline captions for each template."""
+
+    templates = get_templates()
+    for name in templates:
+        shots = get_screenshots_for_template(name)
+        if not shots:
+            continue
+        step = max(len(shots) // count, 1)
+        selected = [shots[i] for i in range(0, len(shots), step)][:count]
+        image_paths = [os.path.join(SCREENSHOT_DIRECTORY, name, s) for s in selected]
+        caption = chatgpt_compare(
+            "Describe the typical baseline view.",
+            image_paths,
+            template_name=name,
+        )
+        if caption:
+            tmpl = get_template(name)
+            tmpl["baseline_caption"] = caption
+            save_template(name, tmpl)
+
+
+def schedule_baseline_updates() -> None:
+    """Run ``update_baselines`` once per day."""
+
+    try:
+        scheduler.add_job(
+            func=update_baselines,
+            trigger=CronTrigger(hour=0),
+            id="baseline_update",
             replace_existing=True,
         )
     except Exception as e:

--- a/app/utils/template_manager.py
+++ b/app/utils/template_manager.py
@@ -77,6 +77,7 @@ class Template(db.Base):
     url = Column(String, default="")
     thumbnail = Column(String, default="")
     groups = Column(String, default="")
+    baseline_caption = Column(Text, default="")
     invert = Column(Boolean, default=False)
     dark = Column(Boolean, default=False)
     headless = Column(Boolean, default=True)
@@ -145,6 +146,7 @@ class TemplateManager:
         ensure_column("templates", "auth_username", "VARCHAR(255)", "''")
         ensure_column("templates", "auth_password", "VARCHAR(255)", "''")
         ensure_column("templates", "thumbnail", "VARCHAR(255)", "''")
+        ensure_column("templates", "baseline_caption", "TEXT", "''")
 
     def get_session(self):
         """Return a new SQLAlchemy session bound to the app database."""

--- a/docs/baseline_caption.md
+++ b/docs/baseline_caption.md
@@ -1,0 +1,5 @@
+# Baseline Captions
+
+The daily baseline process samples ten historical images for each camera and
+generates a caption describing the typical view. The caption is stored in the
+`baseline_caption` field of each template and may be used for future alerting.

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -64,6 +64,7 @@ def create_tables(conn: sqlite3.Connection) -> None:
             url TEXT DEFAULT '',
             thumbnail TEXT DEFAULT '',
             groups TEXT DEFAULT '',
+            baseline_caption TEXT DEFAULT '',
             invert BOOLEAN DEFAULT 0,
             dark BOOLEAN DEFAULT 0,
             headless BOOLEAN DEFAULT 1,

--- a/tests/test_baseline_update.py
+++ b/tests/test_baseline_update.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+from app.utils import scheduling
+
+
+class TestBaselineUpdate(unittest.TestCase):
+    @patch("app.utils.scheduling.chatgpt_compare", return_value="desc")
+    @patch("app.utils.scheduling.save_template")
+    @patch("app.utils.scheduling.get_template", return_value={"name": "cam1"})
+    @patch("app.utils.scheduling.get_screenshots_for_template")
+    @patch(
+        "app.utils.scheduling.get_templates", return_value={"cam1": {"name": "cam1"}}
+    )
+    def test_update_baselines(
+        self, mock_templates, mock_shots, mock_get, mock_save, mock_compare
+    ):
+        mock_shots.return_value = [f"cam1_{i}.png" for i in range(12)]
+
+        scheduling.update_baselines()
+
+        mock_compare.assert_called_once()
+        self.assertEqual(mock_save.call_count, 1)
+
+
+class TestScheduleBaselineUpdates(unittest.TestCase):
+    @patch("app.utils.scheduling.scheduler.add_job")
+    def test_schedule_baseline_updates(self, mock_add):
+        scheduling.schedule_baseline_updates()
+        mock_add.assert_called_once()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `baseline_caption` column to Template model
- schedule a daily baseline update job
- document baseline captions
- test baseline scheduling logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712206ad208333926c2c907f6d6431