### PR TITLE
Handle missing browser driver gracefully

### DIFF
--- a/app/utils/screenshots.py
+++ b/app/utils/screenshots.py
@@ -2272,8 +2272,8 @@ def capture_screenshot_and_har(
             _purge_driver_cache()
             driver = launch_headless_chrome(driver_options, version)
             if driver is None:
-                logging.error("missing driver!")
-                raise ValueError("missing driver!")
+                logging.warning("missing driver; skipping screenshot capture")
+                return False
 
         driver.set_page_load_timeout(timeout)
         # Attempt dark mode for the loaded page, if desired

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -85,6 +85,18 @@ class TestScreenshotCapture(unittest.TestCase):
         self.assertFalse(result)
         self.assertFalse(os.path.exists(self.output_path))
 
+    @patch("app.utils.screenshots.launch_headless_chrome", return_value=None)
+    @patch("app.utils.screenshots._purge_driver_cache")
+    @patch("app.utils.screenshots.get_chrome_version", return_value=120)
+    @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")
+    @patch("app.utils.screenshots.is_system_online", return_value=True)
+    def test_capture_screenshot_missing_driver(
+        self, mock_online, mock_path, mock_version, mock_purge, mock_launch
+    ):
+        result = capture_screenshot_and_har("http://example.com", self.output_path)
+        self.assertFalse(result)
+        mock_purge.assert_called_once()
+
     @patch("app.utils.screenshots.launch_headless_chrome")
     @patch("app.utils.screenshots.get_chrome_version", return_value=120)
     @patch("app.utils.screenshots.get_chrome_path", return_value="/usr/bin/chrome")


### PR DESCRIPTION
## Summary
- avoid raising errors when headless Chrome driver is unavailable
- cover missing driver case in screenshot capture tests

## Testing
- `black app/utils/screenshots.py tests/test_screenshot_capture.py`
- `flake8 app/utils/screenshots.py tests/test_screenshot_capture.py`
- `pre-commit run --all-files` *(fails: Failed to download `bandit==1.8.5`)*
- `pytest tests/test_screenshot_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_689f65234c2083338cd41ef8cb8fff54