### PR TITLE
Fix pip audit failure by upgrading pip in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,6 +33,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip to patched release
+        # Mitigate GHSA-4xh5-x5gv-qwph reported against pip 25.2
+        run: |
+          python -m pip install --upgrade "pip>=25.2.1" \
+            || python -m pip install --upgrade "pip<25.2"
       - name: Cache uv
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- update the Python workflow to upgrade pip to a patched release (or fall back below 25.2) before running pip-audit so the job no longer fails on GHSA-4xh5-x5gv-qwph

## Testing
- pre-commit run --all-files *(fails: offline environment cannot download hook dependencies)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e9e3e4cdd88333a21cff1a2c8a0915