### PR TITLE
Fix compile_videos rename behavior

### DIFF
--- a/app/utils/video_archiver.py
+++ b/app/utils/video_archiver.py
@@ -286,7 +286,9 @@ def compile_videos(input_file, output_file):
         if os.path.exists(output_file) and os.path.getsize(output_file) > 300:
             if is_video_expired(output_file, MAX_COMPRESSED_VIDEO_AGE):
                 logging.info("Rotating expired output %s", output_file)
-            os.rename(output_file, output_file.replace(".tmp", ""))
+            target_output = output_file.removesuffix(".tmp")
+            if target_output != output_file:
+                os.rename(output_file, target_output)
             return True
         # otherwise, do something? clean up the file maybe?
     except Exception as e:

--- a/tests/test_video_archiver.py
+++ b/tests/test_video_archiver.py
@@ -94,6 +94,31 @@ class TestVideoArchiver(unittest.TestCase):
         self.assertTrue(result)
 
     @patch("subprocess.run")
+    def test_compile_videos_no_rename_for_final_output(self, mock_subprocess_run):
+        mock_subprocess_run.return_value.returncode = 0
+        with tempfile.NamedTemporaryFile(mode="w+") as temp_file:
+            temp_file.write("dummy content")
+            temp_file.flush()
+            output_path = os.path.join(VIDEO_DIRECTORY, "all_in_process.mp4")
+
+            def exists_side_effect(path):
+                if path == temp_file.name:
+                    return True
+                if path == output_path:
+                    return True
+                return False
+
+            with (
+                patch("os.path.exists", side_effect=exists_side_effect),
+                patch("os.path.getsize", return_value=500),
+                patch("os.rename") as mock_rename,
+            ):
+                result = compile_videos(temp_file.name, output_path)
+
+        self.assertTrue(result)
+        mock_rename.assert_not_called()
+
+    @patch("subprocess.run")
     def test_compile_videos_missing_input(self, mock_subprocess_run):
         result = compile_videos("missing.txt", "out.mp4")
         self.assertFalse(result)


### PR DESCRIPTION
## Summary
- avoid renaming the compiled video when the output already matches its target path
- add a regression test covering direct writes to `all_in_process.mp4`

## Testing
- pytest tests/test_video_archiver.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e26317578833380fca4eed14a22fc)