### PR TITLE
Ensure TCP probe sockets are closed

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -37,12 +37,19 @@ def _check_url(url: str, timeout: int) -> bool:
 def _try_connect(target: str, timeout: int, default_port: int) -> bool:
     """Return ``True`` if ``target`` can be reached via TCP."""
     host, port = _parse_target(target, default_port)
+    sock: socket.socket | None = None
     try:
-        socket.create_connection((host, port), timeout=timeout)
+        sock = socket.create_connection((host, port), timeout=timeout)
         return True
     except OSError as exc:  # pragma: no cover - network depends on environment
         logging.debug("offline check failed for %s:%s: %s", host, port, exc)
         return False
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:  # pragma: no cover - close failures should not bubble
+                logging.debug("offline check close failed for %s:%s", host, port)
 
 
 def _get_test_hosts():

--- a/tests/test_network_helpers.py
+++ b/tests/test_network_helpers.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from app.utils import network
 
@@ -27,10 +27,12 @@ class TestParseTarget(unittest.TestCase):
 class TestTryConnect(unittest.TestCase):
     @patch("app.utils.network.socket.create_connection")
     def test_try_connect_success(self, mock_conn):
-        mock_conn.return_value = None
+        mock_socket = MagicMock()
+        mock_conn.return_value = mock_socket
         result = network._try_connect("host.com:443", timeout=1, default_port=80)
         self.assertTrue(result)
         mock_conn.assert_called_once_with(("host.com", 443), timeout=1)
+        mock_socket.close.assert_called_once()
 
     @patch("app.utils.network.socket.create_connection", side_effect=OSError())
     def test_try_connect_failure(self, mock_conn):


### PR DESCRIPTION
## Summary
- ensure the TCP probe helper closes sockets after successful connections
- update the network helper test to assert the socket is closed

## Testing
- pytest tests/test_network_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ac556ed08333b1e24a834638ef19)