### PR TITLE
Handle IPv6 literal parsing in network utilities

### DIFF
--- a/app/utils/network.py
+++ b/app/utils/network.py
@@ -6,6 +6,7 @@ network operations in tests and handle custom hosts provided via
 environment variables.
 """
 
+import ipaddress
 import logging
 import os
 import socket
@@ -15,13 +16,43 @@ from app.utils.api_utils import request_with_retry
 
 def _parse_target(target: str, default_port: int) -> tuple[str, int]:
     """Return ``(host, port)`` tuple for ``target``."""
-    if ":" in target:
-        host, p = target.rsplit(":", 1)
-        try:
-            return host, int(p)
-        except ValueError:
+
+    if target.startswith("["):
+        end = target.find("]")
+        if end != -1:
+            host = target[1:end]
+            port_candidate = target[end + 1 :]
+            if port_candidate.startswith(":"):
+                port_str = port_candidate[1:]
+                if port_str:
+                    try:
+                        return host, int(port_str)
+                    except ValueError:
+                        return host, default_port
             return host, default_port
+
+    if ":" in target:
+        host_candidate, port_candidate = target.rsplit(":", 1)
+        if port_candidate.isdigit():
+            if ":" not in host_candidate or _is_ipv6_literal(host_candidate):
+                try:
+                    return host_candidate, int(port_candidate)
+                except ValueError:
+                    return host_candidate, default_port
+            return target, default_port
+        if ":" not in host_candidate:
+            return host_candidate, default_port
     return target, default_port
+
+
+def _is_ipv6_literal(value: str) -> bool:
+    """Return ``True`` if ``value`` is a valid IPv6 literal."""
+
+    try:
+        ipaddress.IPv6Address(value)
+    except ValueError:
+        return False
+    return True
 
 
 def _check_url(url: str, timeout: int) -> bool:

--- a/tests/test_network_helpers.py
+++ b/tests/test_network_helpers.py
@@ -23,6 +23,11 @@ class TestParseTarget(unittest.TestCase):
             network._parse_target("2001:db8::1:8443", 443), ("2001:db8::1", 8443)
         )
 
+    def test_ipv6_literal_without_port_uses_default(self):
+        self.assertEqual(
+            network._parse_target("2001:db8::1", 443), ("2001:db8::1", 443)
+        )
+
 
 class TestTryConnect(unittest.TestCase):
     @patch("app.utils.network.socket.create_connection")


### PR DESCRIPTION
## Summary
- treat bracketed and literal IPv6 addresses without ports as using the default port
- keep support for explicit numeric ports by validating IPv6 host candidates
- add coverage for IPv6 literals without ports

## Testing
- pytest tests/test_network_helpers.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ac5fcf1c833386de731d155298ee)