### PR TITLE
Handle empty email recipient configuration

### DIFF
--- a/app/utils/email_alerts.py
+++ b/app/utils/email_alerts.py
@@ -36,7 +36,15 @@ def send_email_alert(subject: str, body: str) -> None:
         return
 
     sender_email = EMAIL_SENDER
-    receiver_emails = EMAIL_RECIPIENTS.split(",")
+    receiver_emails = [
+        email.strip()
+        for email in EMAIL_RECIPIENTS.split(",")
+        if email.strip()
+    ]
+
+    if not receiver_emails:
+        logging.info("No email recipients configured; skipping email alert.")
+        return
 
     message = MIMEMultipart()
     message["From"] = sender_email

--- a/tests/test_email_alerts.py
+++ b/tests/test_email_alerts.py
@@ -50,6 +50,26 @@ class TestEmailAlerts(unittest.TestCase):
             self.assertIn("Subject: Subject", args[2])
             self.assertIn("Body", args[2])
 
+    def test_send_email_alert_no_recipients(self):
+        with (
+            patch("smtplib.SMTP") as mock_smtp,
+            patch("app.utils.email_alerts.EMAIL_ENABLED", "True"),
+            patch("app.utils.email_alerts.EMAIL_SENDER", "sender@example.com"),
+            patch("app.utils.email_alerts.EMAIL_RECIPIENTS", " , ,  "),
+            patch("app.utils.email_alerts.EMAIL_SMTP_SERVER", "smtp.example.com"),
+            patch("app.utils.email_alerts.EMAIL_SMTP_PORT", "587"),
+            patch("app.utils.email_alerts.EMAIL_SMTP_TIMEOUT", 5),
+            patch("app.utils.email_alerts.EMAIL_USE_TLS", "true"),
+            patch("app.utils.email_alerts.EMAIL_USERNAME", "user"),
+            patch("app.utils.email_alerts.EMAIL_PASSWORD", "pass"),
+            patch("logging.info") as mock_log_info,
+        ):
+            send_email_alert("Subject", "Body")
+            mock_smtp.assert_not_called()
+            mock_log_info.assert_called_once_with(
+                "No email recipients configured; skipping email alert."
+            )
+
     def test_send_email_alert_timeout(self):
         smtp_mock = MagicMock()
         mock_cm = MagicMock()


### PR DESCRIPTION
## Summary
- normalize the email recipient configuration by trimming entries and skipping empty strings
- log and exit early when no recipients remain to avoid attempting delivery
- add unit coverage asserting that blank recipients do not trigger SMTP usage

## Testing
- flake8
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ada04c6c833399b9cc61fc2c4c39)