### PR TITLE
Handle missing directories in retention cleanup

### DIFF
--- a/app/utils/retention_policy.py
+++ b/app/utils/retention_policy.py
@@ -142,15 +142,21 @@ def cleanup_clips(max_age_minutes: int = MAX_CLIP_AGE_MINUTES) -> None:
 
 def retention_cleanup():
     # For each camera, delete old or excess videos
-    for camera_name in os.listdir(VIDEO_DIRECTORY):
-        camera_dir = os.path.join(VIDEO_DIRECTORY, camera_name)
-        video_files = get_files_sorted_by_creation_time(camera_dir)
-        delete_old_files(video_files, MAX_COMPRESSED_VIDEO_AGE, MAX_RAW_DATA_SIZE)
+    if os.path.isdir(VIDEO_DIRECTORY):
+        for camera_name in os.listdir(VIDEO_DIRECTORY):
+            camera_dir = os.path.join(VIDEO_DIRECTORY, camera_name)
+            video_files = get_files_sorted_by_creation_time(camera_dir)
+            delete_old_files(
+                video_files, MAX_COMPRESSED_VIDEO_AGE, MAX_RAW_DATA_SIZE
+            )
 
     # For each camera, delete old or excess screenshots
-    for camera_name in os.listdir(SCREENSHOT_DIRECTORY):
-        camera_dir = os.path.join(SCREENSHOT_DIRECTORY, camera_name)
-        image_files = get_files_sorted_by_creation_time(camera_dir)
-        delete_old_files(image_files, MAX_COMPRESSED_VIDEO_AGE, MAX_RAW_DATA_SIZE)
+    if os.path.isdir(SCREENSHOT_DIRECTORY):
+        for camera_name in os.listdir(SCREENSHOT_DIRECTORY):
+            camera_dir = os.path.join(SCREENSHOT_DIRECTORY, camera_name)
+            image_files = get_files_sorted_by_creation_time(camera_dir)
+            delete_old_files(
+                image_files, MAX_COMPRESSED_VIDEO_AGE, MAX_RAW_DATA_SIZE
+            )
 
     cleanup_clips()

--- a/tests/test_retention_policy.py
+++ b/tests/test_retention_policy.py
@@ -84,11 +84,12 @@ class TestRetentionPolicy(unittest.TestCase):
             # Symlinks are excluded and files are sorted oldest -> newest
             self.assertEqual(result, file_paths)
 
+    @patch("app.utils.retention_policy.os.path.isdir", return_value=True)
     @patch("app.utils.retention_policy.os.listdir")
     @patch("app.utils.retention_policy.get_files_sorted_by_creation_time")
     @patch("app.utils.retention_policy.delete_old_files")
     def test_retention_cleanup_invokes_deletion(
-        self, mock_delete, mock_get_files, mock_listdir
+        self, mock_delete, mock_get_files, mock_listdir, _mock_isdir
     ):
         mock_listdir.side_effect = [["cam1"], ["cam1"], ["cam1"]]
         mock_get_files.return_value = ["f1", "f2"]
@@ -145,6 +146,22 @@ class TestRetentionPolicy(unittest.TestCase):
                 len(os.listdir(os.path.join(shot_dir, "cam1"))),
                 10,
             )
+
+    def test_retention_cleanup_missing_directories_no_error(self):
+        with tempfile.TemporaryDirectory() as base_dir:
+            missing_video = os.path.join(base_dir, "video")
+            missing_shots = os.path.join(base_dir, "shots")
+
+            self.assertFalse(os.path.exists(missing_video))
+            self.assertFalse(os.path.exists(missing_shots))
+
+            with (
+                patch.object(retention_policy, "VIDEO_DIRECTORY", missing_video),
+                patch.object(
+                    retention_policy, "SCREENSHOT_DIRECTORY", missing_shots
+                ),
+            ):
+                self.assertIsNone(retention_cleanup())
 
     def test_cleanup_clips_removes_expired(self):
         with tempfile.TemporaryDirectory() as clip_dir:


### PR DESCRIPTION
## Summary
- skip retention cleanup loops when video or screenshot directories are absent
- add regression test confirming retention cleanup exits cleanly when directories are missing
- update existing invocation test to mock directory existence

## Testing
- pytest tests/test_retention_policy.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ad99a34c83338d7dcde543916254)