### PR TITLE
Normalize status cache path persistence

### DIFF
--- a/app/utils/status_cache.py
+++ b/app/utils/status_cache.py
@@ -37,7 +37,8 @@ def _load_status_cache() -> None:
 
 def _persist_status_cache() -> None:
     """Write ``status_code_cache`` to ``STATUS_CACHE_PATH``."""
-    os.makedirs(os.path.dirname(STATUS_CACHE_PATH), exist_ok=True)
+    dir_name = os.path.dirname(STATUS_CACHE_PATH) or "."
+    os.makedirs(dir_name, exist_ok=True)
     data = {
         url: {"code": code, "time": status_code_cache_time.get(url, 0)}
         for url, code in status_code_cache.items()

--- a/tests/test_status_cache.py
+++ b/tests/test_status_cache.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -5,6 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from app.utils import screenshots as ss
+from app.utils import status_cache as sc
 
 
 class TestStatusCodeCache(unittest.TestCase):
@@ -52,6 +54,35 @@ class TestStatusCodeCache(unittest.TestCase):
         ss.status_code_cache_time.clear()
         ss._load_status_cache()
         self.assertEqual(ss.get_cached_status_code("u"), 500)
+
+
+class TestStatusCachePersistenceNoDirectory(unittest.TestCase):
+    def test_persist_status_cache_without_directory_component(self):
+        original_cache = sc.status_code_cache.copy()
+        original_time_cache = sc.status_code_cache_time.copy()
+        original_cwd = os.getcwd()
+
+        sc.status_code_cache.clear()
+        sc.status_code_cache_time.clear()
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                os.chdir(tmpdir)
+                try:
+                    with patch("app.utils.status_cache.STATUS_CACHE_PATH", "cache.json"):
+                        sc.status_code_cache["example"] = 201
+                        sc.status_code_cache_time["example"] = 123.0
+                        sc._persist_status_cache()
+                        with open("cache.json") as cache_file:
+                            data = json.load(cache_file)
+                    self.assertEqual(data["example"]["code"], 201)
+                finally:
+                    os.chdir(original_cwd)
+        finally:
+            sc.status_code_cache.clear()
+            sc.status_code_cache.update(original_cache)
+            sc.status_code_cache_time.clear()
+            sc.status_code_cache_time.update(original_time_cache)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure status cache persistence handles paths without directory components
- add regression coverage for persisting cache files created in the current working directory

## Testing
- pytest tests/test_status_cache.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916adab8bb48333a66c75421710b158)