### PR TITLE
Ensure ColorFormatter restores original levelname for sibling handlers

### DIFF
--- a/app/utils/logging_utils.py
+++ b/app/utils/logging_utils.py
@@ -35,9 +35,14 @@ class ColorFormatter(logging.Formatter):
             Formatted log message including ANSI color codes.
         """
 
+        original_levelname = record.levelname
         level_color = self.COLORS.get(record.levelno, "")
-        record.levelname = f"{level_color}{record.levelname}{self.RESET}"
-        return super().format(record)
+        if level_color:
+            record.levelname = f"{level_color}{record.levelname}{self.RESET}"
+        try:
+            return super().format(record)
+        finally:
+            record.levelname = original_levelname
 
 
 class RateLimitFilter(logging.Filter):

--- a/tests/test_color_formatter.py
+++ b/tests/test_color_formatter.py
@@ -24,6 +24,37 @@ class TestColorFormatter(unittest.TestCase):
         self.assertIn("\033[", output)
         self.assertIn("boom", output)
 
+    def test_plain_handler_is_uncolored_with_colored_sibling(self):
+        logger = logging.getLogger("color_test_plain")
+        colored_stream = io.StringIO()
+        plain_stream = io.StringIO()
+        colored_handler = logging.StreamHandler(colored_stream)
+        colored_handler.setFormatter(ColorFormatter("%(levelname)s:%(message)s"))
+        plain_handler = logging.StreamHandler(plain_stream)
+        plain_handler.setFormatter(logging.Formatter("%(levelname)s:%(message)s"))
+        logger.setLevel(logging.INFO)
+        original_propagate = logger.propagate
+        logger.propagate = False
+        logger.addHandler(colored_handler)
+        logger.addHandler(plain_handler)
+
+        try:
+            logger.warning("mixed output")
+        finally:
+            logger.removeHandler(colored_handler)
+            logger.removeHandler(plain_handler)
+            colored_handler.close()
+            plain_handler.close()
+            logger.propagate = original_propagate
+
+        colored_output = colored_stream.getvalue().strip()
+        plain_output = plain_stream.getvalue().strip()
+
+        self.assertIn("\033[", colored_output)
+        self.assertIn("mixed output", colored_output)
+        self.assertNotIn("\033[", plain_output)
+        self.assertIn("mixed output", plain_output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- update ColorFormatter to temporarily colorize the level name and restore the original value after formatting
- add a regression test that ensures a plain handler stays uncolored when paired with a colored handler on the same logger

## Testing
- pytest tests/test_color_formatter.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ae56557c8333a0bb9a42af550feb)